### PR TITLE
Flux v1.20.0

### DIFF
--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -2715,7 +2715,7 @@ async function availableApps(req, res) {
         + 'Chainweb is a braided, parallelized Proof Of Work consensus mechanism that improves throughput and scalability in executing transactions on the blockchain while maintaining the security and integrity found in Bitcoin. '
         + 'The healthy information tells you if your node is running and synced. If you just installed the docker it can say unhealthy for long time because on first run a bootstrap is downloaded and extracted to make your node sync faster before the node is started. '
         + 'Do not stop or restart the docker in the first hour after installation. You can also check if your kadena node is synced, by going to running apps and press visit button on kadena and compare your node height with Kadena explorer. Thank you.',
-      repotag: 'runonflux/kadena-chainweb-node:2.8',
+      repotag: 'runonflux/kadena-chainweb-node:2.9',
       owner: '1hjy4bCYBJr4mny4zCE85J94RXa8W6q37',
       ports: [30004, 30005],
       containerPorts: [30004, 30005],
@@ -2727,7 +2727,7 @@ async function availableApps(req, res) {
       enviromentParameters: ['CHAINWEB_P2P_PORT=30004', 'CHAINWEB_SERVICE_PORT=30005', 'LOGLEVEL=warn'],
       commands: ['/bin/bash', '-c', '(test -d /data/chainweb-db/0 && ./run-chainweb-node.sh) || (/chainweb/initialize-db.sh && ./run-chainweb-node.sh)'],
       containerData: '/data', // cannot be root todo in verification
-      hash: 'localSpecificationsVersion9', // hash of app message
+      hash: 'localSpecificationsVersion10', // hash of app message
       height: 680000, // height of tx on which it was
     },
     {

--- a/ZelBack/src/services/fluxCommunication.js
+++ b/ZelBack/src/services/fluxCommunication.js
@@ -1122,16 +1122,7 @@ async function checkMyFluxAvailability(nodelist) {
         const benchMyIP = benchIpResponse.data.length > 5 ? benchIpResponse.data : null;
         if (benchMyIP && benchMyIP !== myIP) {
           myIP = benchMyIP;
-          const restartNodeResponse = await daemonService.restartNodeBenchmarks();
-          if (restartNodeResponse.status !== 'success') {
-            dosMessage = benchIpResponse.data;
-            dosState += 10;
-          }
-          await serviceHelper.delay(2 * 60 * 1000); // lets wait two minutes
-          setTimeout(() => {
-            // it will try to create a confirmation transaction after 10 minutes of ask bench to restart, should be enough to restart and finish the bench.
-            daemonService.createConfirmationTransaction(); // on my pi for reference, running restarnodebench on micro sd card takes 5 minutes to finish
-          }, 8 * 60 * 1000);
+          daemonService.createConfirmationTransaction();
           return;
         }
       } else {

--- a/ZelBack/src/services/fluxCommunication.js
+++ b/ZelBack/src/services/fluxCommunication.js
@@ -11,6 +11,7 @@ const util = require('util');
 const log = require('../lib/log');
 const serviceHelper = require('./serviceHelper');
 const daemonService = require('./daemonService');
+const benchmarkService = require('./benchmarkService');
 const userconfig = require('../../../config/userconfig');
 
 const outgoingConnections = []; // websocket list
@@ -21,6 +22,8 @@ const incomingPeers = []; // array of objects containing ip
 
 let dosState = 0; // we can start at bigger number later
 let dosMessage = null;
+
+const minimumFluxBenchAllowedVersion = 223;
 
 // my external Flux IP from benchmark
 let myFluxIP = null;
@@ -1051,9 +1054,41 @@ async function removeIncomingPeer(req, res, expressWS) {
   return res.json(response);
 }
 
+async function checkFluxbenchVersionAllowed() {
+  try {
+    const benchmarkInfoResponse = await benchmarkService.getInfo();
+    if (benchmarkInfoResponse.status === 'success') {
+      log.info(benchmarkInfoResponse);
+      let benchmarkVersion = benchmarkInfoResponse.data.version;
+      benchmarkVersion = benchmarkVersion.replace(/\./g, '');
+      if (benchmarkVersion >= minimumFluxBenchAllowedVersion) {
+        return true;
+      }
+      dosState += 2;
+      dosMessage = `Fluxbench Version Error. Current lower version allowed is v${minimumFluxBenchAllowedVersion} found v${benchmarkVersion}`;
+      log.error(dosMessage);
+      return false;
+    }
+    dosState += 2;
+    dosMessage = 'Fluxbench Version Error. Error obtaining Flux Version.';
+    log.error(dosMessage);
+    return false;
+  } catch (err) {
+    log.error(err);
+    log.error(`Error on checkFluxBenchVersion: ${err.message}`);
+    dosState += 2;
+    dosMessage = 'Fluxbench Version Error. Error obtaining Flux Version.';
+    return false;
+  }
+}
+
 async function checkMyFluxAvailability(nodelist) {
   // run if at least 10 available nodes
   if (nodelist.length > 10) {
+    const fluxBenchVersionAllowed = await checkFluxbenchVersionAllowed();
+    if (!fluxBenchVersionAllowed) {
+      return;
+    }
     let askingIP = await getRandomConnection();
     if (typeof askingIP !== 'string' || typeof myFluxIP !== 'string' || myFluxIP === askingIP) {
       return;

--- a/ZelFront/src/components/Benchmark.vue
+++ b/ZelFront/src/components/Benchmark.vue
@@ -109,6 +109,9 @@
           Status: {{ callResponse.data.status }}
         </p>
         <p>
+          Architecture: {{ callResponse.data.architecture }}
+        </p>
+        <p>
           Time: {{ new Date(callResponse.data.time * 1000).toLocaleString('en-GB', timeoptions) }}
         </p>
         <p>
@@ -127,10 +130,13 @@
           HDD (GB): {{ callResponse.data.hdd }}
         </p>
         <p>
-          Write Speed (MB/s): {{ callResponse.data.ddwrite }}
+          Best Write Speed (MB/s): {{ callResponse.data.ddwrite }}
         </p>
         <p>
-          CPU Speed (eps): {{ callResponse.data.eps }}
+          CPU Speed (EPS): {{ callResponse.data.eps }}
+        </p>
+        <p>
+          Error: {{ callResponse.data.error }}
         </p>
       </div>
     </div>

--- a/ZelFront/src/components/Dashboard.vue
+++ b/ZelFront/src/components/Dashboard.vue
@@ -501,7 +501,7 @@ export default {
         const cumuluses = zelnodecounts['cumulus-enabled'];
         const resKDAEligible = await axios.get('https://stats.runonflux.io/kadena/eligiblestats/7');
         const kdaData = resKDAEligible.data.data;
-        const kdaCoins = 5749.77;
+        const kdaCoins = 2800;
         const totalNimbuss = kdaData.nimbus;
         const totalStratuss = kdaData.stratus;
         const overallTotal = totalNimbuss + (4 * totalStratuss);

--- a/ZelFront/src/components/Dashboard.vue
+++ b/ZelFront/src/components/Dashboard.vue
@@ -327,8 +327,6 @@
 import Vuex, { mapState } from 'vuex';
 import Vue from 'vue';
 
-import DashboardService from '@/services/DashboardService';
-
 import * as am4charts from '@amcharts/amcharts4/charts';
 import * as am4core from '@amcharts/amcharts4/core';
 import * as am4maps from '@amcharts/amcharts4/maps';
@@ -336,6 +334,8 @@ import * as am4maps from '@amcharts/amcharts4/maps';
 import am4geodata_worldLow from '@amcharts/amcharts4-geodata/worldLow';
 // eslint-disable-next-line camelcase
 import am4themes_dark from '@amcharts/amcharts4/themes/dark';
+
+import DashboardService from '@/services/DashboardService';
 
 const axios = require('axios');
 

--- a/ZelFront/src/components/Dashboard.vue
+++ b/ZelFront/src/components/Dashboard.vue
@@ -76,7 +76,7 @@
           label="Resources"
           name="resources"
         >
-          <div class="gridThree">
+          <div class="gridFour">
             <div
               v-show="!cpuLoading"
               id="cpucurrent"
@@ -96,6 +96,13 @@
               id="ssdcurrent"
             />
             <div v-show="ssdLoading">
+              loading...
+            </div>
+            <div
+              v-show="!hddLoading"
+              id="hddcurrent"
+            />
+            <div v-show="hddLoading">
               loading...
             </div>
           </div>
@@ -383,6 +390,7 @@ export default {
       fluxHistoryLoading: true,
       supplyLoading: true,
       ssdLoading: true,
+      hddLoading: true,
       ramLoading: true,
       cpuLoading: true,
       ssdHistoryLoading: true,
@@ -406,9 +414,12 @@ export default {
       cumulusRamValue: 0,
       nimbusRamValue: 0,
       stratusRamValue: 0,
-      cumulusStorageValue: 0,
-      nimbusStorageValue: 0,
-      stratusStorageValue: 0,
+      cumulusSSDStorageValue: 0,
+      nimbusSSDStorageValue: 0,
+      stratusSSDStorageValue: 0,
+      cumulusHDDStorageValue: 0,
+      nimbusHDDStorageValue: 0,
+      stratusHDDStorageValue: 0,
     };
   },
   computed: {
@@ -655,35 +666,39 @@ export default {
           this.cumulusCpuValue += node.benchmark.bench.cores === 0 ? 2 : node.benchmark.bench.cores;
           this.cumulusRamValue += node.benchmark.bench.ram < 4 ? 4 : Math.round(node.benchmark.bench.ram);
           // const auxStorage = Number.isNaN(node.benchmark.bench.ssd) || Number.isNaN(node.benchmark.bench.hdd) ? 0 : node.benchmark.bench.ssd + node.benchmark.bench.hdd;
-          this.cumulusStorageValue += node.benchmark.bench.ssd + node.benchmark.bench.hdd < 50 ? 50 : node.benchmark.bench.ssd + node.benchmark.bench.hdd;
+          this.cumulusSSDStorageValue += node.benchmark.bench.ssd;
+          this.cumulusHDDStorageValue += node.benchmark.bench.hdd;
         } else if (node.tier === 'CUMULUS') {
           this.cumulusCpuValue += 2;
           this.cumulusRamValue += 4;
-          this.cumulusStorageValue += 50;
+          this.cumulusHDDStorageValue += 50;
         } else if (node.tier === 'NIMBUS' && node.benchmark && node.benchmark.bench) {
           this.nimbusCpuValue += node.benchmark.bench.cores === 0 ? 4 : node.benchmark.bench.cores;
           this.nimbusRamValue += node.benchmark.bench.ram < 8 ? 8 : Math.round(node.benchmark.bench.ram);
           // const auxStorage = Number.isNaN(node.benchmark.bench.ssd) || Number.isNaN(node.benchmark.bench.hdd) ? 0 : node.benchmark.bench.ssd + node.benchmark.bench.hdd;
-          this.nimbusStorageValue += node.benchmark.bench.ssd + node.benchmark.bench.hdd < 150 ? 150 : node.benchmark.bench.ssd + node.benchmark.bench.hdd;
+          this.nimbusSSDStorageValue += node.benchmark.bench.ssd;
+          this.nimbusHDDStorageValue += node.benchmark.bench.hdd;
         } else if (node.tier === 'NIMBUS') {
           this.nimbusCpuValue += 4;
           this.nimbusRamValue += 8;
-          this.nimbusStorageValue += 150;
+          this.nimbusSSDStorageValue += 150;
         } else if (node.tier === 'STRATUS' && node.benchmark && node.benchmark.bench) {
           this.stratusCpuValue += node.benchmark.bench.cores === 0 ? 8 : node.benchmark.bench.cores;
           this.stratusRamValue += node.benchmark.bench.ram < 32 ? 32 : Math.round(node.benchmark.bench.ram);
           // const auxStorage = Number.isNaN(node.benchmark.bench.ssd) || Number.isNaN(node.benchmark.bench.hdd) ? 0 : node.benchmark.bench.ssd + node.benchmark.bench.hdd;
-          this.stratusStorageValue += node.benchmark.bench.ssd + node.benchmark.bench.hdd < 600 ? 600 : node.benchmark.bench.ssd + node.benchmark.bench.hdd;
+          this.stratusSSDStorageValue += node.benchmark.bench.ssd;
+          this.stratusHDDStorageValue += node.benchmark.bench.hdd;
         } else if (node.tier === 'STRATUS') {
           this.stratusCpuValue += 8;
           this.stratusRamValue += 32;
-          this.stratusStorageValue += 600;
+          this.stratusSSDStorageValue += 600;
         }
       });
 
       this.generateCPU();
       this.generateRAM();
       this.generateSSD();
+      this.generateHDD();
     },
     generateCPU() {
       am4core.useTheme(am4themes_dark);
@@ -792,21 +807,21 @@ export default {
       // Create chart instance
       const chart = am4core.create('ssdcurrent', am4charts.XYChart);
 
-      const total = this.stratusStorageValue + this.nimbusStorageValue + this.cumulusStorageValue;
+      const total = this.stratusSSDStorageValue + this.nimbusSSDStorageValue + this.cumulusSSDStorageValue;
 
       // Add data
       chart.data = [
         {
           category: 'Cumulus',
-          value: this.cumulusStorageValue,
+          value: this.cumulusSSDStorageValue,
         },
         {
           category: 'Nimbus',
-          value: this.nimbusStorageValue,
+          value: this.nimbusSSDStorageValue,
         },
         {
           category: 'Stratus',
-          value: this.stratusStorageValue,
+          value: this.stratusSSDStorageValue,
         },
       ];
 
@@ -834,6 +849,56 @@ export default {
       const self = this;
       setTimeout(() => {
         self.ssdLoading = false;
+      }, 1000);
+    },
+    generateHDD() {
+      am4core.useTheme(am4themes_dark);
+      am4core.useTheme(am4themes_myTheme);
+      // Create chart instance
+      const chart = am4core.create('hddcurrent', am4charts.XYChart);
+
+      const total = this.stratusHDDStorageValue + this.nimbusHDDStorageValue + this.cumulusHDDStorageValue;
+
+      // Add data
+      chart.data = [
+        {
+          category: 'Cumulus',
+          value: this.cumulusHDDStorageValue,
+        },
+        {
+          category: 'Nimbus',
+          value: this.nimbusHDDStorageValue,
+        },
+        {
+          category: 'Stratus',
+          value: this.stratusHDDStorageValue,
+        },
+      ];
+
+      // Create axes
+      const categoryAxis = chart.xAxes.push(new am4charts.CategoryAxis());
+      categoryAxis.dataFields.category = 'category';
+      categoryAxis.renderer.grid.template.location = 0;
+      categoryAxis.renderer.minGridDistance = 30;
+
+      const valueAxis = chart.yAxes.push(new am4charts.ValueAxis());
+
+      valueAxis.title.text = 'HDD (GB)';
+
+      // Create series
+      const series = chart.series.push(new am4charts.ColumnSeries());
+      series.dataFields.valueY = 'value';
+      series.dataFields.categoryX = 'category';
+      series.tooltipText = '{category}: [bold]{value}[/]';
+      // Add cursor
+      chart.cursor = new am4charts.XYCursor();
+      const title = chart.titles.create();
+      title.text = `Total HDD: ${this.beautifyValue(total / 1000)} TB`;
+      title.fontSize = 20;
+      title.marginBottom = 15;
+      const self = this;
+      setTimeout(() => {
+        self.hddLoading = false;
       }, 1000);
     },
     generateCPUHistory() {
@@ -1072,7 +1137,7 @@ export default {
       chart.legend = new am4charts.Legend();
       chart.legend.position = 'top';
       const title = chart.titles.create();
-      title.text = 'SSD History (Based min. req. specs)';
+      title.text = 'Storage History (Based min. req. specs)';
       title.fontSize = 20;
       title.marginBottom = 15;
       const self = this;
@@ -1602,6 +1667,15 @@ export default {
   align-items: center;
 }
 
+.gridFour {
+  text-align: center;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 1fr;
+  grid-template-rows: 1fr;
+  justify-items: center;
+  align-items: center;
+}
+
 @media (max-width: 699px) {
   .gridTwo {
     text-align: center;
@@ -1620,6 +1694,15 @@ export default {
     justify-items: center;
     align-items: center;
   }
+
+  .gridFour {
+    text-align: center;
+    display: grid;
+    grid-template-columns: auto;
+    grid-template-rows: auto auto auto auto;
+    justify-items: center;
+    align-items: center;
+  }
 }
 
 #mapchart {
@@ -1635,6 +1718,7 @@ export default {
 #cpucurrent,
 #ramcurrent,
 #ssdcurrent,
+#hddcurrent,
 #cpuhistory,
 #ramhistory,
 #ssdhistory,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flux",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "Flux, Your Gateway to a Decentralized World",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Fluxbench min allowe version v2.2.3;
- Update KadenChainWebNode to runonflux/kadena-chainweb-node:2.9;
- Add extra information to getBenchmark section;
- Add/Separate SSD and HDD Node resource information on Dashboard;
- Update Kda Economics on Dashboard;
- Other small improvements.