### PR TITLE
v2.1.5

### DIFF
--- a/HomeUI/src/@core/layouts/components/AppFooter.vue
+++ b/HomeUI/src/@core/layouts/components/AppFooter.vue
@@ -8,7 +8,7 @@
       >Flux, Your Gateway to a Decentralized World</b-link>
     </span>
 
-    <span class="float-md-right d-none d-md-block">Flux {{ 'v' + fluxVersion }}
+    <span class="float-md-right d-none d-md-block">FluxOS {{ 'v' + fluxVersion }}
     </span>
   </p>
 </template>

--- a/ZelBack/src/services/fluxCommunication.js
+++ b/ZelBack/src/services/fluxCommunication.js
@@ -23,7 +23,7 @@ const incomingPeers = []; // array of objects containing ip
 let dosState = 0; // we can start at bigger number later
 let dosMessage = null;
 
-const minimumFluxBenchAllowedVersion = 223;
+const minimumFluxBenchAllowedVersion = 231;
 let storedFluxBenchAllowed = null;
 
 // my external Flux IP from benchmark
@@ -52,7 +52,20 @@ async function isFluxAvailable(ip) {
   try {
     const fluxResponse = await serviceHelper.axiosGet(`http://${ip}:${config.server.apiport}/flux/version`, axiosConfig);
     if (fluxResponse.data.status === 'success') {
-      return true;
+      try {
+        const fluxBenchInfoResponse = await serviceHelper.axiosGet(`http://${ip}:${config.server.apiport}/benchmark/getinfo`, axiosConfig);
+        if (fluxBenchInfoResponse.data.status === 'success') {
+          let benchmarkVersion = fluxBenchInfoResponse.data.version;
+          benchmarkVersion = benchmarkVersion.replace(/\./g, '');
+          storedFluxBenchAllowed = benchmarkVersion;
+          if (benchmarkVersion >= minimumFluxBenchAllowedVersion) {
+            return true;
+          }
+        }
+        return false;
+      } catch (e) {
+        return false;
+      }
     }
     return false;
   } catch (e) {
@@ -1103,7 +1116,7 @@ async function checkMyFluxAvailability(retryNumber = 0) {
   }
   let availabilityError = null;
   const axiosConfig = {
-    timeout: 7000,
+    timeout: 11000,
   };
   const resMyAvailability = await serviceHelper.axiosGet(`http://${askingIP}:${config.server.apiport}/flux/checkfluxavailability/${myIP}`, axiosConfig).catch((error) => {
     log.error(`${askingIP} is not reachable`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flux",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Flux, Your Gateway to a Decentralized World",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Update FluxBench min version allowed 2.3.1;
- New Anti-Cheating Measures;
- Show on bottom right FluxOs instead of Flux version.

This version should be released after enforcement of FluxBench 2.3.1;