### PR TITLE
v3.6.0

### DIFF
--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -5305,12 +5305,14 @@ async function trySpawningGlobalApplication() {
 
     // Check if App was checked in the last 30m.
     // This is a small help because random can be getting the same app over and over
-    if (trySpawningGlobalAppCache.has(serviceHelper.ensureString(randomApp))) {
+    if (trySpawningGlobalAppCache.has(randomApp)) {
       log.info(`App ${randomApp} was already evaluated in the last 30m.`);
+      if (numberOfGlobalApps < 20) {
+        await serviceHelper.delay(config.fluxapps.installation.delay * 1000);
+      }
       trySpawningGlobalApplication();
       return;
     }
-    trySpawningGlobalAppCache.set(randomApp, null);
 
     // check if there is < 5 instances of nodes running the app
     // TODO evaluate if its not better to check locally running applications!
@@ -5323,6 +5325,7 @@ async function trySpawningGlobalApplication() {
     if (runningAppList.length >= config.fluxapps.minimumInstances) {
       log.info(`Application ${randomApp} is already spawned on ${runningAppList.length} instances`);
       await serviceHelper.delay(adjustedDelay);
+      trySpawningGlobalAppCache.set(randomApp, randomApp);
       trySpawningGlobalApplication();
       return;
     }

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -5346,6 +5346,7 @@ async function trySpawningGlobalApplication() {
     if (runningAppList.find((document) => document.ip === myIP)) {
       log.info(`Application ${randomApp} is reported as already running on this Flux`);
       await serviceHelper.delay(adjustedDelay);
+      trySpawningGlobalAppCache.set(randomApp, randomApp);
       trySpawningGlobalApplication();
       return;
     }
@@ -5357,6 +5358,7 @@ async function trySpawningGlobalApplication() {
     if (runningApps.data.find((app) => app.Names[0].substr(5, app.Names[0].length) === randomApp)) {
       log.info(`${randomApp} application is already running on this Flux`);
       await serviceHelper.delay(adjustedDelay);
+      trySpawningGlobalAppCache.set(randomApp, randomApp);
       trySpawningGlobalApplication();
       return;
     }
@@ -5364,6 +5366,7 @@ async function trySpawningGlobalApplication() {
     // get app specifications
     const appSpecifications = await getApplicationGlobalSpecifications(randomApp);
     if (!appSpecifications) {
+      trySpawningGlobalAppCache.set(randomApp, randomApp);
       throw new Error(`Specifications for application ${randomApp} were not found!`);
     }
 
@@ -5385,6 +5388,7 @@ async function trySpawningGlobalApplication() {
     if (appExists) { // double checked in installation process.
       log.info(`Application ${appSpecifications.name} is already installed`);
       await serviceHelper.delay(adjustedDelay);
+      trySpawningGlobalAppCache.set(randomApp, randomApp);
       trySpawningGlobalApplication();
       return;
     }
@@ -5401,6 +5405,7 @@ async function trySpawningGlobalApplication() {
             log.info(`${componentToInstall.repotag} Image is already running on this Flux`);
             // eslint-disable-next-line no-await-in-loop
             await serviceHelper.delay(adjustedDelay);
+            trySpawningGlobalAppCache.set(randomApp, randomApp);
             trySpawningGlobalApplication();
             return;
           }

--- a/ZelBack/src/services/fluxCommunication.js
+++ b/ZelBack/src/services/fluxCommunication.js
@@ -150,7 +150,7 @@ async function deterministicFluxList(filter) {
       fluxList = myCache.get('fluxList');
     }
     if (!fluxList) {
-      const generalFluxList = myCache.get('fluxList');
+      let generalFluxList = myCache.get('fluxList');
       addingNodesToCache = true;
       if (!generalFluxList) {
         const request = {
@@ -159,16 +159,15 @@ async function deterministicFluxList(filter) {
         };
         const daemonFluxNodesList = await daemonService.viewDeterministicZelNodeList(request);
         if (daemonFluxNodesList.status === 'success') {
-          fluxList = daemonFluxNodesList.data || [];
-          myCache.set('fluxList', fluxList);
+          generalFluxList = daemonFluxNodesList.data || [];
+          myCache.set('fluxList', generalFluxList);
+          if (filter) {
+            const filterFluxList = generalFluxList.filter((node) => node.pubkey === filter);
+            myCache.set(`fluxList${serviceHelper.ensureString(filter)}`, filterFluxList);
+          }
         }
       } else { // surely in filtered branch too
         const filterFluxList = generalFluxList.filter((node) => node.pubkey === filter);
-        myCache.set(`fluxList${serviceHelper.ensureString(filter)}`, filterFluxList);
-      }
-
-      if (filter) {
-        const filterFluxList = fluxList.filter((node) => node.pubkey === filter);
         myCache.set(`fluxList${serviceHelper.ensureString(filter)}`, filterFluxList);
       }
       addingNodesToCache = false;

--- a/ZelBack/src/services/fluxCommunication.js
+++ b/ZelBack/src/services/fluxCommunication.js
@@ -245,6 +245,7 @@ async function verifyFluxBroadcast(data, obtainedFluxNodesList, currentTimeStamp
     }
   }
   if (!node) {
+    log.warn(data, ip);
     return false;
   }
   const messageToVerify = version + message + timestamp;
@@ -252,6 +253,7 @@ async function verifyFluxBroadcast(data, obtainedFluxNodesList, currentTimeStamp
   if (verified === true) {
     return true;
   }
+  log.warn(data, ip);
   return false;
 }
 
@@ -574,7 +576,7 @@ function handleIncomingConnection(ws, req, expressWS) {
     const { pubKey } = dataObj;
     if (blockedPubKeysCache.has(pubKey)) {
       try {
-        log.info('Closing connection, peer is on blockedList');
+        log.info('Closing incoming connection, peer is on blockedList');
         ws.close(1000, 'blocked list'); // close as of policy violation?
       } catch (e) {
         console.error(e);
@@ -625,7 +627,7 @@ function handleIncomingConnection(ws, req, expressWS) {
           }
         }
         blockedPubKeysCache.set(pubKey, pubKey); // blocks ALL the nodes corresponding to the pubKey
-        log.warn(`closing connection, adding peers ${pubKey} to the blockedList`);
+        log.warn(`closing incoming connection, adding peers ${pubKey} to the blockedList. Originated from ${peer.ip}.`);
         ws.close(1000, 'invalid message, blocked'); // close as of policy violation?
       } catch (e) {
         console.error(e);
@@ -935,7 +937,7 @@ async function initiateAndHandleConnection(ip) {
     const { pubKey } = msgObj;
     if (blockedPubKeysCache.has(pubKey)) {
       try {
-        log.info('Closing connection, peer is on blockedList');
+        log.info('Closing outgoing connection, peer is on blockedList');
         websocket.close(1000, 'blocked list'); // close as of policy violation?
       } catch (e) {
         console.error(e);
@@ -978,7 +980,7 @@ async function initiateAndHandleConnection(ip) {
           }
         }
         blockedPubKeysCache.set(pubKey, pubKey); // blocks ALL the nodes corresponding to the pubKey
-        log.warn(`closing connection, adding peers ${pubKey} to the blockedList`);
+        log.warn(`closing outgoing connection, adding peers ${pubKey} to the blockedList. Originated from ${ip}.`);
         websocket.close(1000, 'invalid message, blocked'); // close as of policy violation?
       } catch (e) {
         console.error(e);

--- a/ZelBack/src/services/fluxCommunication.js
+++ b/ZelBack/src/services/fluxCommunication.js
@@ -225,17 +225,20 @@ async function verifyFluxBroadcast(data, obtainedFluxNodesList, currentTimeStamp
     return false;
   }
 
+  let node = null;
   if (obtainedFluxNodesList) { // for test purposes.
-    // node that broadcasted the message has to be on list
-    // pubkey of the broadcast has to be on the list
-    const nodeExistsA = obtainedFluxNodesList.find((key) => key.pubkey === pubKey);
-    if (!nodeExistsA) {
+    node = obtainedFluxNodesList.find((key) => key.pubkey === pubKey);
+    if (!node) {
       return false;
     }
   }
-  const zl = await deterministicFluxList(pubKey); // this itself is sufficient.
-  const nodeExistsA = zl.find((key) => key.pubkey === pubKey); // another check in case sufficient check failed on daemon level
-  if (!nodeExistsA) {
+  if (!node) {
+    // node that broadcasted the message has to be on list
+    // pubkey of the broadcast has to be on the list
+    const zl = await deterministicFluxList(pubKey); // this itself is sufficient.
+    node = zl.find((key) => key.pubkey === pubKey); // another check in case sufficient check failed on daemon level
+  }
+  if (!node) {
     return false;
   }
   const messageToVerify = version + message + timestamp;

--- a/ZelBack/src/services/fluxCommunication.js
+++ b/ZelBack/src/services/fluxCommunication.js
@@ -540,7 +540,7 @@ function checkRateLimit(ip, perSecond = 10, maxBurst = 15) {
 function handleIncomingConnection(ws, req, expressWS) {
   // now we are in connections state. push the websocket to our incomingconnections
   const maxPeers = 20;
-  const maxNumberOfConnections = numberOfFluxNodes / 40;
+  const maxNumberOfConnections = numberOfFluxNodes / 40 < 120 ? numberOfFluxNodes / 40 : 120;
   const maxCon = Math.max(maxPeers, maxNumberOfConnections);
   if (incomingConnections.length > maxCon) {
     setTimeout(() => {
@@ -1001,8 +1001,8 @@ async function fluxDiscovery() {
     const maxPeers = 20;
     numberOfFluxNodes = nodeList.length;
     const currentIpsConnTried = [];
-    const requiredNumberOfConnections = numberOfFluxNodes / 100; // 1%
-    const maxNumberOfConnections = numberOfFluxNodes / 50; // 2%
+    const requiredNumberOfConnections = numberOfFluxNodes / 100 < 40 ? numberOfFluxNodes / 100 : 40; // 1%
+    const maxNumberOfConnections = numberOfFluxNodes / 75 < 50 ? numberOfFluxNodes / 75 : 50; // 1.5%
     const minCon = Math.max(minPeers, requiredNumberOfConnections); // awlays maintain at least 10 or 1% of nodes whatever is higher
     const maxCon = Math.max(maxPeers, maxNumberOfConnections); // have a maximum of 20 or 2% of nodes whatever is higher
     log.info(`Current number of outgoing connections:${outgoingConnections.length}`);

--- a/ZelBack/src/services/fluxCommunication.js
+++ b/ZelBack/src/services/fluxCommunication.js
@@ -159,10 +159,11 @@ async function deterministicFluxList(filter) {
       const daemonFluxNodesList = await daemonService.viewDeterministicZelNodeList(request);
       if (daemonFluxNodesList.status === 'success') {
         fluxList = daemonFluxNodesList.data || [];
-        fluxList.forEach((item) => {
-          myCache.set(`fluxList${serviceHelper.ensureString(item.pubkey)}`, [item]);
-        });
         myCache.set('fluxList', fluxList);
+        if (filter) {
+          const filterFluxList = fluxList.filter((node) => node.pubkey === filter);
+          myCache.set(`fluxList${serviceHelper.ensureString(filter)}`, filterFluxList);
+        }
       }
       addingNodesToCache = false;
       if (filter) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flux",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "Flux, Your Gateway to a Decentralized World",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Fix flux communication issues where multiple nodes can share the same node key

Previous system did not expected light node addition that share the same node key. Current expansion of zelcore light nodes has a bigger impact where many nodes have the same pubKey resulting in finding wrong node, refusing their messages and adding them to blocked list.