### PR TITLE
v3.7.0

### DIFF
--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -2640,7 +2640,7 @@ async function availableApps(req, res) {
         + 'Chainweb is a braided, parallelized Proof Of Work consensus mechanism that improves throughput and scalability in executing transactions on the blockchain while maintaining the security and integrity found in Bitcoin. '
         + 'The healthy information tells you if your node is running and synced. If you just installed the docker it can say unhealthy for long time because on first run a bootstrap is downloaded and extracted to make your node sync faster before the node is started. '
         + 'Do not stop or restart the docker in the first hour after installation. You can also check if your kadena node is synced, by going to running apps and press visit button on kadena and compare your node height with Kadena explorer. Thank you.',
-      repotag: 'runonflux/kadena-chainweb-node:2.12.0',
+      repotag: 'runonflux/kadena-chainweb-node:2.12.1',
       owner: '1hjy4bCYBJr4mny4zCE85J94RXa8W6q37',
       ports: [30004, 30005],
       containerPorts: [30004, 30005],
@@ -2652,7 +2652,7 @@ async function availableApps(req, res) {
       enviromentParameters: ['CHAINWEB_P2P_PORT=30004', 'CHAINWEB_SERVICE_PORT=30005', 'LOGLEVEL=warn'],
       commands: ['/bin/bash', '-c', '(test -d /data/chainweb-db/0 && ./run-chainweb-node.sh) || (/chainweb/initialize-db.sh && ./run-chainweb-node.sh)'],
       containerData: '/data', // cannot be root todo in verification
-      hash: 'localSpecificationsVersion15', // hash of app message
+      hash: 'localSpecificationsVersion16', // hash of app message
       height: 680000, // height of tx on which it was
     },
     {
@@ -5364,7 +5364,8 @@ async function trySpawningGlobalApplication() {
     }
 
     // check if app is installed on the number of instances requested
-    if (runningAppList.length >= appSpecifications.instances) {
+    const minInstances = appSpecifications.instances || config.fluxapps.minimumInstances; // introduced in v3 of apps specs
+    if (runningAppList.length >= minInstances) {
       log.info(`Application ${randomApp} is already spawned on ${runningAppList.length} instances`);
       await serviceHelper.delay(adjustedDelay);
       trySpawningGlobalAppCache.set(randomApp, randomApp);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flux",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "Flux, Your Gateway to a Decentralized World",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Fix installation of application on additional instances
- Update Kadena Chainweb Node application

TBD: Next week we will be releasing another update of Kadena Chainweb Node - we will use latest tag, change our monitoring system and mainly bump the space requirements to recommended 150GB of SSD. 
After that preparation for global launch will happen in 2 ways - 2 x 100 instances for composed app consisting of chainweb node and chainweb data. 3 x 100 instances of chainweb node only. Exact specs TBD.