### PR TITLE
small correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ sudo ufw allow 16127/tcp
 Install Flux dependancies (Ubuntu/CentOS/Redhat):
 
 ```bash
-cd Flux
+cd flux
 
 npm install
 ```


### PR DESCRIPTION
Hi!

The "cd Flux" should be cd flux :)
Here:

"Install Flux dependancies (Ubuntu/CentOS/Redhat):

```bash
cd Flux"

-->
"Install Flux dependancies (Ubuntu/CentOS/Redhat):

```bash
cd flux"