### PR TITLE
v3.14.0

### DIFF
--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -3564,6 +3564,9 @@ async function assignedPortsGlobalApps(appNames) {
       name: app,
     });
   });
+  if (!appsQuery.length) {
+    return [];
+  }
   const query = {
     $or: appsQuery,
   };
@@ -3603,7 +3606,7 @@ async function assignedPortsGlobalApps(appNames) {
 
 async function ensureApplicationPortsNotUsed(appSpecFormatted, globalCheckedApps) {
   let currentAppsPorts = await assignedPortsInstalledApps();
-  if (globalCheckedApps) {
+  if (globalCheckedApps && globalCheckedApps.length) {
     const globalAppsPorts = await assignedPortsGlobalApps(globalCheckedApps);
     currentAppsPorts = currentAppsPorts.concat(globalAppsPorts);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flux",
-  "version": "3.13.0",
+  "version": "3.14.0",
   "description": "Flux, Your Gateway to a Decentralized World",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- fix app spawning on nodes without any app running

$and/$or/$nor must be a nonempty array
- If no running app was present on a node, our query to mongo was following
```
const query = {
    $or: appsQuery,
  };
  ```