### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/HomeUI/src/views/apps/LocalApps.vue
+++ b/HomeUI/src/views/apps/LocalApps.vue
@@ -1779,7 +1779,7 @@ export default {
         const runningAppsSpecifics = [];
         apps.forEach((app) => {
           // get application specification IF it is composed app
-          const appName = app.Names[0].startsWith('/flux') ? app.Names[0].substr(5, app.Names[0].length) : app.Names[0].substr(4, app.Names[0].length);
+          const appName = app.Names[0].startsWith('/flux') ? app.Names[0].slice(5) : app.Names[0].slice(4);
           if (appName.includes('_')) {
             runningAppsNames.push(appName.split('_')[1]);
           } else {
@@ -2020,10 +2020,10 @@ export default {
     getAppName(appName) {
       // this id is used for volumes, docker names so we know it reall belongs to flux
       if (appName && appName.startsWith('zel')) {
-        return appName.substr(3, appName.length);
+        return appName.slice(3);
       }
       if (appName && appName.startsWith('flux')) {
-        return appName.substr(4, appName.length);
+        return appName.slice(4);
       }
       return appName;
     },

--- a/HomeUI/src/views/daemon/fluxnode/CurrentWinner.vue
+++ b/HomeUI/src/views/daemon/fluxnode/CurrentWinner.vue
@@ -92,8 +92,8 @@ export default {
       let i;
       let l;
       for (i = 0, l = arr.length; i < l; i += 1) {
-        arr[i] = arr[i].substr(0, 1).toUpperCase()
-                 + (arr[i].length > 1 ? arr[i].substr(1).toLowerCase() : '');
+        arr[i] = arr[i].slice(0, 1).toUpperCase()
+                 + (arr[i].length > 1 ? arr[i].slice(1).toLowerCase() : '');
       }
       return arr.join(' ');
     },

--- a/HomeUI/src/views/explorer/Transaction.vue
+++ b/HomeUI/src/views/explorer/Transaction.vue
@@ -319,9 +319,9 @@ export default {
       if (parts[1]) {
         const encodedMessage = parts[1];
         const hexx = encodedMessage.toString(); // force conversion
-        for (let k = 0; k < hexx.length && hexx.substr(k, 2) !== '00'; k += 2) {
+        for (let k = 0; k < hexx.length && hexx.slice(k, k + 2) !== '00'; k += 2) {
           message += String.fromCharCode(
-            parseInt(hexx.substr(k, 2), 16),
+            parseInt(hexx.slice(k, k + 2), 16),
           );
         }
       }

--- a/HomeUI/src/views/flux/Debug.vue
+++ b/HomeUI/src/views/flux/Debug.vue
@@ -290,7 +290,7 @@ export default {
         });
     },
     capitalizeWord(word) {
-      return word[0].toUpperCase() + word.substr(1);
+      return word[0].toUpperCase() + word.slice(1);
     },
   },
 };

--- a/HomeUI/src/views/fluxadmin/ManageFlux.vue
+++ b/HomeUI/src/views/fluxadmin/ManageFlux.vue
@@ -525,7 +525,7 @@ export default {
       if (response.data.status === 'success' && response.data.data) {
         const acc = response.data.data.split('?chainid=');
         const chainID = acc.pop();
-        const account = acc.join('?chainid=').substr(7);
+        const account = acc.join('?chainid=').slice(7);
         this.kadenaAccountInput = account;
         this.kadenaChainIDInput = Number(chainID);
       }

--- a/HomeUI/src/views/xdao/ProposalView.vue
+++ b/HomeUI/src/views/xdao/ProposalView.vue
@@ -600,7 +600,7 @@ export default {
       let backendURL = store.get('backendURL') || mybackend;
       backendURL = backendURL.replace('https://', 'wss://');
       backendURL = backendURL.replace('http://', 'ws://');
-      const signatureMessage = userZelid.value + dataToSign.value.substr(dataToSign.value.length - 13);
+      const signatureMessage = userZelid.value + dataToSign.value.slice(-13);
       const wsuri = `${backendURL}/ws/sign/${signatureMessage}`;
       const websocket = new WebSocket(wsuri);
       // const websocket = websocket

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -63,7 +63,7 @@ async function listRunningApps(req, res) {
   try {
     let apps = await dockerService.dockerListContainers(false);
     if (apps.length > 0) {
-      apps = apps.filter((app) => (app.Names[0].substr(1, 3) === 'zel' || app.Names[0].substr(1, 4) === 'flux'));
+      apps = apps.filter((app) => (app.Names[0].slice(1, 4) === 'zel' || app.Names[0].slice(1, 5) === 'flux'));
     }
     const modifiedApps = [];
     apps.forEach((app) => {
@@ -93,7 +93,7 @@ async function listAllApps(req, res) {
   try {
     let apps = await dockerService.dockerListContainers(true);
     if (apps.length > 0) {
-      apps = apps.filter((app) => (app.Names[0].substr(1, 3) === 'zel' || app.Names[0].substr(1, 4) === 'flux'));
+      apps = apps.filter((app) => (app.Names[0].slice(1, 4) === 'zel' || app.Names[0].slice(1, 5) === 'flux'));
     }
     const modifiedApps = [];
     apps.forEach((app) => {
@@ -5648,7 +5648,7 @@ async function trySpawningGlobalApplication() {
     if (runningApps.status !== 'success') {
       throw new Error('Unable to check running apps on this Flux');
     }
-    if (runningApps.data.find((app) => app.Names[0].substr(5, app.Names[0].length) === randomApp)) {
+    if (runningApps.data.find((app) => app.Names[0].slice(5) === randomApp)) {
       log.info(`${randomApp} application is already running on this Flux`);
       await serviceHelper.delay(adjustedDelay);
       trySpawningGlobalAppCache.set(randomApp, randomApp);
@@ -5819,9 +5819,9 @@ async function checkAndNotifyPeersOfRunningApps() {
     // kadena and folding is old naming scheme having /zel.  all global application start with /flux
     const runningAppsNames = runningApps.map((app) => {
       if (app.Names[0].startsWith('/zel')) {
-        return app.Names[0].substr(4, app.Names[0].length);
+        return app.Names[0].slice(4);
       }
-      return app.Names[0].substr(5, app.Names[0].length);
+      return app.Names[0].slice(5);
     });
     // installed always is bigger array than running
     const runningSet = new Set(runningAppsNames);
@@ -6566,7 +6566,7 @@ async function stopAllNonFluxRunningApps() {
   try {
     log.info('Running non Flux apps check...');
     let apps = await dockerService.dockerListContainers(false);
-    apps = apps.filter((app) => (app.Names[0].substr(1, 3) !== 'zel' && app.Names[0].substr(1, 4) !== 'flux'));
+    apps = apps.filter((app) => (app.Names[0].slice(1, 4) !== 'zel' && app.Names[0].slice(1, 5) !== 'flux'));
     if (apps.length > 0) {
       log.info(`Found ${apps.length} apps to be stopped...`);
       // eslint-disable-next-line no-restricted-syntax

--- a/ZelBack/src/services/explorerService.js
+++ b/ZelBack/src/services/explorerService.js
@@ -346,9 +346,9 @@ function decodeMessage(asm) {
   if (parts[1]) {
     const encodedMessage = parts[1];
     const hexx = encodedMessage.toString(); // force conversion
-    for (let k = 0; k < hexx.length && hexx.substr(k, 2) !== '00'; k += 2) {
+    for (let k = 0; k < hexx.length && hexx.slice(k, k + 2) !== '00'; k += 2) {
       message += String.fromCharCode(
-        parseInt(hexx.substr(k, 2), 16),
+        parseInt(hexx.slice(k, k + 2), 16),
       );
     }
   }

--- a/ZelBack/src/services/generalService.js
+++ b/ZelBack/src/services/generalService.js
@@ -23,7 +23,7 @@ let storedCollateral = null;
 function getCollateralInfo(collateralOutpoint) {
   const a = collateralOutpoint;
   const b = a.split(', ');
-  const txhash = b[0].substr(10, b[0].length);
+  const txhash = b[0].slice(10);
   const txindex = serviceHelper.ensureNumber(b[1].split(')')[0]);
   return { txhash, txindex };
 }

--- a/ZelBack/src/services/idService.js
+++ b/ZelBack/src/services/idService.js
@@ -349,7 +349,7 @@ async function provideSign(req, res) {
       }
       const timestamp = new Date().getTime();
       const validTill = timestamp + (15 * 60 * 1000); // 15 minutes
-      const identifier = address + message.substr(message.length - 13);
+      const identifier = address + message.slice(-13);
 
       const db = dbHelper.databaseConnection();
       const database = db.db(config.database.local.database);

--- a/docs/explorerService.js.html
+++ b/docs/explorerService.js.html
@@ -374,9 +374,9 @@ function decodeMessage(asm) {
   if (parts[1]) {
     const encodedMessage = parts[1];
     const hexx = encodedMessage.toString(); // force conversion
-    for (let k = 0; k &lt; hexx.length &amp;&amp; hexx.substr(k, 2) !== '00'; k += 2) {
+    for (let k = 0; k &lt; hexx.length &amp;&amp; hexx.slice(k, k + 2) !== '00'; k += 2) {
       message += String.fromCharCode(
-        parseInt(hexx.substr(k, 2), 16),
+        parseInt(hexx.slice(k, k + 2), 16),
       );
     }
   }

--- a/docs/generalService.js.html
+++ b/docs/generalService.js.html
@@ -51,7 +51,7 @@ let storedCollateral = null;
 function getCollateralInfo(collateralOutpoint) {
   const a = collateralOutpoint;
   const b = a.split(', ');
-  const txhash = b[0].substr(10, b[0].length);
+  const txhash = b[0].slice(10);
   const txindex = serviceHelper.ensureNumber(b[1].split(')')[0]);
   return { txhash, txindex };
 }

--- a/docs/idService.js.html
+++ b/docs/idService.js.html
@@ -377,7 +377,7 @@ async function provideSign(req, res) {
       }
       const timestamp = new Date().getTime();
       const validTill = timestamp + (15 * 60 * 1000); // 15 minutes
-      const identifier = address + message.substr(message.length - 13);
+      const identifier = address + message.slice(-13);
 
       const db = dbHelper.databaseConnection();
       const database = db.db(config.database.local.database);


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.