### PR TITLE
Authentication

### DIFF
--- a/HomeUI/src/router/index.js
+++ b/HomeUI/src/router/index.js
@@ -77,7 +77,7 @@ router.beforeEach(async (to, from, next) => {
   const zelidauth = localStorage.getItem('zelidauth');
   const auth = qs.parse(zelidauth);
   store.commit('flux/setPrivilege', 'none');
-  if (auth && auth.zelid && auth.signature) {
+  if (auth && auth.zelid && auth.signature && auth.loginPhrase) {
     try {
       const response = await IDService.checkUserLogged(auth.zelid, auth.signature);
       const privilege = response.data.data.message;

--- a/ZelBack/src/services/idService.js
+++ b/ZelBack/src/services/idService.js
@@ -770,9 +770,13 @@ async function checkLoggedUser(req, res) {
     try {
       const processedBody = serviceHelper.ensureObject(body);
       const { zelid } = processedBody;
+      const loggedPhrase = processedBody.loginPhrase;
       const { signature } = processedBody;
       if (!zelid) {
         throw new Error('No user ZelID specificed');
+      }
+      if (!zelid) {
+        throw new Error('No user loginPhrase specificed');
       }
       if (!signature) {
         throw new Error('No user ZelID signature specificed');
@@ -781,6 +785,7 @@ async function checkLoggedUser(req, res) {
         headers: {
           zelidauth: {
             zelid,
+            loginPhrase: loggedPhrase,
             signature,
           },
         },

--- a/ZelBack/src/services/idService.js
+++ b/ZelBack/src/services/idService.js
@@ -254,18 +254,15 @@ async function verifyLogin(req, res) {
             throw new Error('Invalid signature');
           }
           if (valid) {
-            // Third associate that address, signature and message with our database
-            // TODO signature hijacking? What if middleware guy knows all of this?
-            // TODO do we want to have some timelimited logins? not needed now
-            // Do we want to store sighash too? Nope we are verifying if provided signature is ok. In localStorage we are storing zelid, message, signature
-            // const sighash = crypto
-            //   .createHash('sha256')
-            //   .update(signature)
-            //   .digest('hex')
+            // Third associate address with message in our database
+            const createdAt = new Date(result.loginPhrase.substring(0, 13));
+            const validTill = +result.loginPhrase.substring(0, 13) + (14 * 24 * 60 * 60 * 1000); // valid for 14 days
+            const expireAt = new Date(validTill);
             const newLogin = {
               zelid: address,
               loginPhrase: message,
-              signature,
+              createdAt,
+              expireAt,
             };
             let privilage = 'user';
             if (address === config.fluxTeamZelId) {
@@ -282,6 +279,8 @@ async function verifyLogin(req, res) {
               loginPhrase: message,
               signature,
               privilage,
+              createdAt,
+              expireAt,
             };
             const resMessage = messageHelper.createDataMessage(resData);
             res.json(resMessage);
@@ -419,7 +418,11 @@ async function loggedUsers(req, res) {
       const database = db.db(config.database.local.database);
       const collection = config.database.local.collections.loggedUsers;
       const query = {};
-      const projection = { projection: { _id: 0, zelid: 1, loginPhrase: 1 } };
+      const projection = {
+        projection: {
+          _id: 0, zelid: 1, loginPhrase: 1, createdAt: 1, expireAt: 1,
+        },
+      };
       const results = await dbHelper.findInDatabase(database, collection, query, projection);
       const resultsResponse = messageHelper.createDataMessage(results);
       res.json(resultsResponse);
@@ -450,7 +453,11 @@ async function loggedSessions(req, res) {
       const database = db.db(config.database.local.database);
       const collection = config.database.local.collections.loggedUsers;
       const query = { zelid: queryZelID };
-      const projection = { projection: { _id: 0, zelid: 1, loginPhrase: 1 } };
+      const projection = {
+        projection: {
+          _id: 0, zelid: 1, loginPhrase: 1, createdAt: 1, expireAt: 1,
+        },
+      };
       const results = await dbHelper.findInDatabase(database, collection, query, projection);
       const resultsResponse = messageHelper.createDataMessage(results);
       res.json(resultsResponse);
@@ -478,7 +485,7 @@ async function logoutCurrentSession(req, res) {
       const db = dbHelper.databaseConnection();
       const database = db.db(config.database.local.database);
       const collection = config.database.local.collections.loggedUsers;
-      const query = { $and: [{ signature: auth.signature }, { zelid: auth.zelid }] };
+      const query = { $and: [{ loginPhrase: auth.loginPhrase }, { zelid: auth.zelid }] };
       const projection = {};
       await dbHelper.findOneAndDeleteInDatabase(database, collection, query, projection);
       // console.log(results)
@@ -642,6 +649,8 @@ async function wsRespondLoginPhrase(ws, req) {
           loginPhrase: result.loginPhrase,
           signature: result.signature,
           privilage,
+          createdAt: result.createdAt,
+          expireAt: result.expireAt,
         };
         const message = messageHelper.createDataMessage(resData);
         if (!connclosed) {

--- a/ZelBack/src/services/serviceHelper.js
+++ b/ZelBack/src/services/serviceHelper.js
@@ -95,8 +95,8 @@ async function getApplicationOwner(appName) {
     return appSpecs.owner;
   }
   // eslint-disable-next-line global-require
-  const { availableApps } = require('./appsService');
-  const allApps = await availableApps();
+  const appsService = require('./appsService');
+  const allApps = await appsService.availableApps();
   const appInfo = allApps.find((app) => app.name.toLowerCase() === appName.toLowerCase());
   if (appInfo) {
     return appInfo.owner;

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -41,6 +41,11 @@ async function startFluxFunctions() {
     log.info('Preparing local database...');
     const db = dbHelper.databaseConnection();
     const database = db.db(config.database.local.database);
+    await dbHelper.dropCollection(database, config.database.local.collections.loggedUsers).catch((error) => { // drop currently logged users
+      if (error.message !== 'ns not found') {
+        log.error(error);
+      }
+    });
     await dbHelper.dropCollection(database, config.database.local.collections.activeLoginPhrases).catch((error) => {
       if (error.message !== 'ns not found') {
         log.error(error);
@@ -51,6 +56,7 @@ async function startFluxFunctions() {
         log.error(error);
       }
     });
+    await database.collection(config.database.local.collections.loggedUsers).createIndex({ createdAt: 1 }, { expireAfterSeconds: 14 * 24 * 60 * 60 }); // 2days
     await database.collection(config.database.local.collections.activeLoginPhrases).createIndex({ createdAt: 1 }, { expireAfterSeconds: 900 });
     await database.collection(config.database.local.collections.activeSignatures).createIndex({ createdAt: 1 }, { expireAfterSeconds: 900 });
     log.info('Local database prepared');

--- a/ZelBack/src/services/verificationHelperUtils.js
+++ b/ZelBack/src/services/verificationHelperUtils.js
@@ -61,7 +61,15 @@ async function verifyUserSession(headers) {
   const query = { $and: [{ loginPhrase: auth.loginPhrase }, { zelid: auth.zelid }] };
   const projection = {};
   const loggedUser = await dbHelper.findOneInDatabase(database, collection, query, projection);
-  if (!loggedUser) return false;
+  // if not logged, check if not older than 16 hours
+  if (!loggedUser) {
+    const timestamp = new Date().getTime();
+    const message = auth.loginPhrase;
+    const sixteenHours = 16 * 60 * 60 * 1000;
+    if (Number(message.substring(0, 13)) < (timestamp - sixteenHours) || Number(message.substring(0, 13)) > timestamp || message.length > 70 || message.length < 40) {
+      return false;
+    }
+  }
 
   // check if signature corresponds to message with that zelid
   let valid = false;
@@ -165,7 +173,15 @@ async function verifyAppOwnerSession(headers, appName) {
   const query = { $and: [{ loginPhrase: auth.loginPhrase }, { zelid: auth.zelid }] };
   const projection = {};
   const loggedUser = await dbHelper.findOneInDatabase(database, collection, query, projection);
-  if (!loggedUser) return false;
+  // if not logged, check if not older than 2 hours
+  if (!loggedUser) {
+    const timestamp = new Date().getTime();
+    const message = auth.loginPhrase;
+    const sixteenHours = 2 * 60 * 60 * 1000;
+    if (Number(message.substring(0, 13)) < (timestamp - sixteenHours) || Number(message.substring(0, 13)) > timestamp || message.length > 70 || message.length < 40) {
+      return false;
+    }
+  }
   // check if signature corresponds to message with that zelid
   let valid = false;
   try {
@@ -199,7 +215,15 @@ async function verifyAppOwnerOrHigherSession(headers, appName) {
   const query = { $and: [{ loginPhrase: auth.loginPhrase }, { zelid: auth.zelid }] };
   const projection = {};
   const loggedUser = await dbHelper.findOneInDatabase(database, collection, query, projection);
-  if (!loggedUser) return false;
+  // if not logged, check if not older than 2 hours
+  if (!loggedUser) {
+    const timestamp = new Date().getTime();
+    const message = auth.loginPhrase;
+    const sixteenHours = 2 * 60 * 60 * 1000;
+    if (Number(message.substring(0, 13)) < (timestamp - sixteenHours) || Number(message.substring(0, 13)) > timestamp || message.length > 70 || message.length < 40) {
+      return false;
+    }
+  }
 
   // check if signature corresponds to message with that zelid
   let valid = false;

--- a/ZelBack/src/services/verificationHelperUtils.js
+++ b/ZelBack/src/services/verificationHelperUtils.js
@@ -19,13 +19,13 @@ const userconfig = require('../../../config/userconfig');
 async function verifyAdminSession(headers) {
   if (!headers || !headers.zelidauth) return false;
   const auth = serviceHelper.ensureObject(headers.zelidauth);
-  if (!auth.zelid || !auth.signature) return false;
+  if (!auth.zelid || !auth.signature || !auth.loginPhrase) return false;
   if (auth.zelid !== userconfig.initial.zelid) return false;
 
   const db = dbHelper.databaseConnection();
   const database = db.db(config.database.local.database);
   const collection = config.database.local.collections.loggedUsers;
-  const query = { $and: [{ signature: auth.signature }, { zelid: auth.zelid }] };
+  const query = { $and: [{ loginPhrase: auth.loginPhrase }, { zelid: auth.zelid }] };
   const projection = {};
   const loggedUser = await dbHelper.findOneInDatabase(database, collection, query, projection);
   if (!loggedUser) return false;
@@ -53,12 +53,12 @@ async function verifyAdminSession(headers) {
 async function verifyUserSession(headers) {
   if (!headers || !headers.zelidauth) return false;
   const auth = serviceHelper.ensureObject(headers.zelidauth);
-  if (!auth.zelid || !auth.signature) return false;
+  if (!auth.zelid || !auth.signature || !auth.loginPhrase) return false;
 
   const db = dbHelper.databaseConnection();
   const database = db.db(config.database.local.database);
   const collection = config.database.local.collections.loggedUsers;
-  const query = { $and: [{ signature: auth.signature }, { zelid: auth.zelid }] };
+  const query = { $and: [{ loginPhrase: auth.loginPhrase }, { zelid: auth.zelid }] };
   const projection = {};
   const loggedUser = await dbHelper.findOneInDatabase(database, collection, query, projection);
   if (!loggedUser) return false;
@@ -87,13 +87,13 @@ async function verifyUserSession(headers) {
 async function verifyFluxTeamSession(headers) {
   if (!headers || !headers.zelidauth) return false;
   const auth = serviceHelper.ensureObject(headers.zelidauth);
-  if (!auth.zelid || !auth.signature) return false;
+  if (!auth.zelid || !auth.signature || !auth.loginPhrase) return false;
   if (auth.zelid !== config.fluxTeamZelId) return false;
 
   const db = dbHelper.databaseConnection();
   const database = db.db(config.database.local.database);
   const collection = config.database.local.collections.loggedUsers;
-  const query = { $and: [{ signature: auth.signature }, { zelid: auth.zelid }] };
+  const query = { $and: [{ loginPhrase: auth.loginPhrase }, { zelid: auth.zelid }] };
   const projection = {};
   const result = await dbHelper.findOneInDatabase(database, collection, query, projection);
   const loggedUser = result;
@@ -121,13 +121,13 @@ async function verifyFluxTeamSession(headers) {
 async function verifyAdminAndFluxTeamSession(headers) {
   if (!headers || !headers.zelidauth) return false;
   const auth = serviceHelper.ensureObject(headers.zelidauth);
-  if (!auth.zelid || !auth.signature) return false;
+  if (!auth.zelid || !auth.signature || !auth.loginPhrase) return false;
   if (auth.zelid !== config.fluxTeamZelId && auth.zelid !== userconfig.initial.zelid) return false; // admin is considered as fluxTeam
 
   const db = dbHelper.databaseConnection();
   const database = db.db(config.database.local.database);
   const collection = config.database.local.collections.loggedUsers;
-  const query = { $and: [{ signature: auth.signature }, { zelid: auth.zelid }] };
+  const query = { $and: [{ loginPhrase: auth.loginPhrase }, { zelid: auth.zelid }] };
   const projection = {};
   const loggedUser = await dbHelper.findOneInDatabase(database, collection, query, projection);
   if (!loggedUser) return false;
@@ -155,14 +155,14 @@ async function verifyAdminAndFluxTeamSession(headers) {
 async function verifyAppOwnerSession(headers, appName) {
   if (!headers || !headers.zelidauth || !appName) return false;
   const auth = serviceHelper.ensureObject(headers.zelidauth);
-  if (!auth.zelid || !auth.signature) return false;
+  if (!auth.zelid || !auth.signature || !auth.loginPhrase) return false;
   const ownerZelID = await serviceHelper.getApplicationOwner(appName);
   if (auth.zelid !== ownerZelID) return false;
 
   const db = dbHelper.databaseConnection();
   const database = db.db(config.database.local.database);
   const collection = config.database.local.collections.loggedUsers;
-  const query = { $and: [{ signature: auth.signature }, { zelid: auth.zelid }] };
+  const query = { $and: [{ loginPhrase: auth.loginPhrase }, { zelid: auth.zelid }] };
   const projection = {};
   const loggedUser = await dbHelper.findOneInDatabase(database, collection, query, projection);
   if (!loggedUser) return false;
@@ -189,14 +189,14 @@ async function verifyAppOwnerSession(headers, appName) {
 async function verifyAppOwnerOrHigherSession(headers, appName) {
   if (!headers || !headers.zelidauth || !appName) return false;
   const auth = serviceHelper.ensureObject(headers.zelidauth);
-  if (!auth.zelid || !auth.signature) return false;
+  if (!auth.zelid || !auth.signature || !auth.loginPhrase) return false;
   const ownerZelID = await serviceHelper.getApplicationOwner(appName);
   if (auth.zelid !== ownerZelID && auth.zelid !== config.fluxTeamZelId && auth.zelid !== userconfig.initial.zelid) return false;
 
   const db = dbHelper.databaseConnection();
   const database = db.db(config.database.local.database);
   const collection = config.database.local.collections.loggedUsers;
-  const query = { $and: [{ signature: auth.signature }, { zelid: auth.zelid }] };
+  const query = { $and: [{ loginPhrase: auth.loginPhrase }, { zelid: auth.zelid }] };
   const projection = {};
   const loggedUser = await dbHelper.findOneInDatabase(database, collection, query, projection);
   if (!loggedUser) return false;

--- a/tests/unit/benchmarkService.test.js
+++ b/tests/unit/benchmarkService.test.js
@@ -108,6 +108,7 @@ describe('benchmarkService tests', () => {
         headers: {
           zelidauth: {
             zelid: '1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC',
+            loginPhrase: '16125160820394ddsh5skgwv0ipodku92y0jbwvpyj17bh68lzrjlxq9',
             signature: 'IH9d68fk/dYQtuMlNN7ioc52MJ6ryRT0IYss6h/KCwVWGcbVNFoI8Jh6hIklRq+w2itV/6vs/xzCWp4TUdSWDBc=',
           },
         },
@@ -127,6 +128,7 @@ describe('benchmarkService tests', () => {
         headers: {
           zelidauth: {
             zelid: '1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC',
+            loginPhrase: '16125160820394ddsh5skgwv0ipodku92y0jbwvpyj17bh68lzrjlxq9',
             signature: 'IH9d68fk/dYQtuMlNN7ioc52MJ6ryRT0IYss6h/KCwVWGcbVNFoI8Jh6hIklRq+w2itV/6vs/xzCWp4TUdSWDBc=',
           },
         },
@@ -153,6 +155,7 @@ describe('benchmarkService tests', () => {
         headers: {
           zelidauth: {
             zelid: '1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uV',
+            loginPhrase: '16125160820394ddsh5skgwv0ipodku92y0jbwvpyj17bh68lzrjlxq9',
             signature: 'IH9d68fk/dYQtuMlNN7ioc52MJ6ryRT0IYss6h/KCwVWGcbVNFoI8Jh6hIklRq+w2itV/6vs/xzCWp4TUdSWDBx=',
           },
         },
@@ -185,6 +188,7 @@ describe('benchmarkService tests', () => {
         headers: {
           zelidauth: {
             zelid: '1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC',
+            loginPhrase: '16125160820394ddsh5skgwv0ipodku92y0jbwvpyj17bh68lzrjlxq9',
             signature: 'IH9d68fk/dYQtuMlNN7ioc52MJ6ryRT0IYss6h/KCwVWGcbVNFoI8Jh6hIklRq+w2itV/6vs/xzCWp4TUdSWDBc=',
           },
         },
@@ -208,6 +212,7 @@ describe('benchmarkService tests', () => {
         headers: {
           zelidauth: {
             zelid: '1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uZ',
+            loginPhrase: '16125160820394ddsh5skgwv0ipodku92y0jbwvpyj17bh68lzrjlxq9',
             signature: 'IH9d68fk/dYQtuMlNx7ioc52MJ6ryRT0IYss6h/KCwVWGcbVNFoI8Jh6hIklRq+w2itV/6vs/xzCWp4TUdSWDBc=',
           },
         },
@@ -238,6 +243,7 @@ describe('benchmarkService tests', () => {
         headers: {
           zelidauth: {
             zelid: '1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC',
+            loginPhrase: '16125160820394ddsh5skgwv0ipodku92y0jbwvpyj17bh68lzrjlxq9',
             signature: 'IH9d68fk/dYQtuMlNN7ioc52MJ6ryRT0IYss6h/KCwVWGcbVNFoI8Jh6hIklRq+w2itV/6vs/xzCWp4TUdSWDBc=',
           },
         },
@@ -276,6 +282,7 @@ describe('benchmarkService tests', () => {
         headers: {
           zelidauth: {
             zelid: '1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC',
+            loginPhrase: '16125160820394ddsh5skgwv0ipodku92y0jbwvpyj17bh68lzrjlxq9',
             signature: 'IH9d68fk/dYQtuMlNN7ioc52MJ6ryRT0IYss6h/KCwVWGcbVNFoI8Jh6hIklRq+w2itV/6vs/xzCWp4TUdSWDBc=',
           },
         },
@@ -419,6 +426,7 @@ describe('benchmarkService tests', () => {
         headers: {
           zelidauth: {
             zelid: '1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC',
+            loginPhrase: '16125160820394ddsh5skgwv0ipodku92y0jbwvpyj17bh68lzrjlxq9',
             signature: 'IH9d68fk/dYQtuMlNN7ioc52MJ6ryRT0IYss6h/KCwVWGcbVNFoI8Jh6hIklRq+w2itV/6vs/xzCWp4TUdSWDBc=',
           },
         },
@@ -439,6 +447,7 @@ describe('benchmarkService tests', () => {
         headers: {
           zelidauth: {
             zelid: '1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uZ',
+            loginPhrase: '16125160820394ddsh5skgwv0ipodku92y0jbwvpyj17bh68lzrjlxq9',
             signature: 'IH9d68fk/dYQtuMlNx7ioc52MJ6ryRT0IYss6h/KCwVWGcbVNFoI8Jh6hIklRq+w2itV/6vs/xzCWp4TUdSWDBc=',
           },
         },
@@ -465,6 +474,7 @@ describe('benchmarkService tests', () => {
         headers: {
           zelidauth: {
             zelid: '1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC',
+            loginPhrase: '16125160820394ddsh5skgwv0ipodku92y0jbwvpyj17bh68lzrjlxq9',
             signature: 'IH9d68fk/dYQtuMlNN7ioc52MJ6ryRT0IYss6h/KCwVWGcbVNFoI8Jh6hIklRq+w2itV/6vs/xzCWp4TUdSWDBc=',
           },
         },

--- a/tests/unit/dbHelper.test.js
+++ b/tests/unit/dbHelper.test.js
@@ -130,7 +130,7 @@ describe('dbHelper tests', () => {
           _id: new ObjectId('5fa25bf73ba9312a4d83712d'),
           name: 'App1',
           description: 'Test',
-          owner: '1KPKzyp9VyB9ouAA4spZ48x8g32sxLVK6g',
+          owner: '1KPKzyp9VyB9ouAA4spZ48x8g32sxLVK6d',
         },
       ];
 
@@ -155,7 +155,7 @@ describe('dbHelper tests', () => {
         },
         {
           name: 'App1',
-          owner: '1KPKzyp9VyB9ouAA4spZ48x8g32sxLVK6u',
+          owner: '1KPKzyp9VyB9ouAA4spZ48x8g32sxLVK6d',
         },
       ];
 

--- a/tests/unit/dbHelper.test.js
+++ b/tests/unit/dbHelper.test.js
@@ -10,22 +10,22 @@ const testInsert = [{
   _id: ObjectId('5f99562a09aef91cd19fbb93'),
   name: 'App1',
   description: 'Test',
-  owner: '1LZe3AUYQC4aT5YWLhgEcH1nLLdoKNBi9t',
+  owner: '1KPKzyp9VyB9ouAA4spZ48x8g32sxLVK6W',
 }, {
   _id: ObjectId('5fa25bf73ba9312a4d83712d'),
   name: 'App1',
   description: 'Test',
-  owner: '1LZe3AUYQC4aT5YWLhgEcH1nLLdoKNBi9u',
+  owner: '1KPKzyp9VyB9ouAA4spZ48x8g32sxLVK6d',
 }, {
   _id: ObjectId('5fb48e724b82682e2bd22269'),
   name: 'App2',
   description: 'Test3',
-  owner: '1LZe3AUYQC4aT5YWLhgEcH1nLLdoKNBi9w',
+  owner: '1KPKzyp9VyB9ouAA4spZ48x8g32sxLVK6h',
 }, {
   _id: ObjectId('5fec239ec4ef4d416e70ac61'),
   name: 'App3',
   description: 'Test3',
-  owner: '1LZe3AUYQC4aT5YWLhgEcH1nLLdoKNBi9x',
+  owner: '1KPKzyp9VyB9ouAA4spZ48x8g32sxLVK6w',
 }];
 
 describe('dbHelper tests', () => {
@@ -124,13 +124,13 @@ describe('dbHelper tests', () => {
           _id: new ObjectId('5f99562a09aef91cd19fbb93'),
           name: 'App1',
           description: 'Test',
-          owner: '1LZe3AUYQC4aT5YWLhgEcH1nLLdoKNBi9t',
+          owner: '1KPKzyp9VyB9ouAA4spZ48x8g32sxLVK6W',
         },
         {
           _id: new ObjectId('5fa25bf73ba9312a4d83712d'),
           name: 'App1',
           description: 'Test',
-          owner: '1LZe3AUYQC4aT5YWLhgEcH1nLLdoKNBi9u',
+          owner: '1KPKzyp9VyB9ouAA4spZ48x8g32sxLVK6g',
         },
       ];
 
@@ -151,11 +151,11 @@ describe('dbHelper tests', () => {
       const expectedResult = [
         {
           name: 'App1',
-          owner: '1LZe3AUYQC4aT5YWLhgEcH1nLLdoKNBi9t',
+          owner: '1KPKzyp9VyB9ouAA4spZ48x8g32sxLVK6W',
         },
         {
           name: 'App1',
-          owner: '1LZe3AUYQC4aT5YWLhgEcH1nLLdoKNBi9u',
+          owner: '1KPKzyp9VyB9ouAA4spZ48x8g32sxLVK6u',
         },
       ];
 
@@ -195,7 +195,7 @@ describe('dbHelper tests', () => {
         _id: ObjectId('5f99562a09aef91cd19fbb93'),
         name: 'App1',
         description: 'Test',
-        owner: '1LZe3AUYQC4aT5YWLhgEcH1nLLdoKNBi9t',
+        owner: '1KPKzyp9VyB9ouAA4spZ48x8g32sxLVK6W',
       };
 
       const findOneInDatabaseResult = await dbHelper.findOneInDatabase(database, collection, query);
@@ -214,7 +214,7 @@ describe('dbHelper tests', () => {
       };
       const expectedResult = {
         name: 'App1',
-        owner: '1LZe3AUYQC4aT5YWLhgEcH1nLLdoKNBi9t',
+        owner: '1KPKzyp9VyB9ouAA4spZ48x8g32sxLVK6W',
       };
 
       const findOneInDatabaseResult = await dbHelper.findOneInDatabase(database, collection, query, queryProjection);
@@ -602,7 +602,7 @@ describe('dbHelper tests', () => {
         _id: ObjectId('5f99562a09aef91cd19fbb93'),
         name: 'App1',
         description: 'Test',
-        owner: '1LZe3AUYQC4aT5YWLhgEcH1nLLdoKNBi9t',
+        owner: '1KPKzyp9VyB9ouAA4spZ48x8g32sxLVK6W',
       };
 
       const findOneAndDeleteInDatabaseResponse = await dbHelper.findOneAndDeleteInDatabase(database, collection, query);
@@ -617,7 +617,7 @@ describe('dbHelper tests', () => {
       const query = { _id: ObjectId('5f99562a09aef91cd19fbb93') };
       const expectedResult = {
         name: 'App1',
-        owner: '1LZe3AUYQC4aT5YWLhgEcH1nLLdoKNBi9t',
+        owner: '1KPKzyp9VyB9ouAA4spZ48x8g32sxLVK6W',
       };
       const queryProjection = {
         projection: {

--- a/tests/unit/verificationHelper.test.js
+++ b/tests/unit/verificationHelper.test.js
@@ -13,7 +13,8 @@ const req = {
   headers: {
     zelidauth: {
       zelid: 'testing1',
-      signature: 'testing2',
+      loginPhrase: 'testing2',
+      signature: 'testing3',
     },
   },
 };

--- a/tests/unit/verificationHelperUtils.test.js
+++ b/tests/unit/verificationHelperUtils.test.js
@@ -497,7 +497,7 @@ describe('verificationHelperUtils tests', () => {
         zelidauth: {
           zelid: '1KPKzyp9VyB9ouAA4spZ48x8g32sxLVK6W',
           loginPhrase: '1644935889016mtmbo4uah32tvvwrmzg4j8qzv04ba8g8n56cevn6b',
-          signature: 'H4bL1HhNXiYiHywCnUeptHtLQY/YiGmLt14N+BBNXRIKd6BkP+kFr9CvaGLELQxN1A31OXoy3SMBoHj2/OqiK6c=',
+          signature: 'H7xcWjpSt8jiAaPbkUsfY3ZutJJmI35MWkGsgWBj/fJHfk7ZKRoggzigdaESLGMDMb2MHlxAapr1sMYDbJkL/H4=',
         },
       };
       const appName = 'PolkadotNode';
@@ -598,12 +598,12 @@ describe('verificationHelperUtils tests', () => {
       await dbHelper.insertOneToDatabase(databaseGlobal, collectionApps, insertApp);
     });
 
-    it('should return true when requested by the app owner', async () => {
+    it('should return true when requested by the app owner or higher', async () => {
       const headers = {
         zelidauth: {
           zelid: '1KPKzyp9VyB9ouAA4spZ48x8g32sxLVK6W',
           loginPhrase: '1644935889016mtmbo4uah32tvvwrmzg4j8qzv04ba8g8n56cevn6b',
-          signature: 'H4bL1HhNXiYiHywCnUeptHtLQY/YiGmLt14N+BBNXRIKd6BkP+kFr9CvaGLELQxN1A31OXoy3SMBoHj2/OqiK6c=',
+          signature: 'H7xcWjpSt8jiAaPbkUsfY3ZutJJmI35MWkGsgWBj/fJHfk7ZKRoggzigdaESLGMDMb2MHlxAapr1sMYDbJkL/H4=',
         },
       };
       const appName = 'PolkadotNode';

--- a/tests/unit/verificationHelperUtils.test.js
+++ b/tests/unit/verificationHelperUtils.test.js
@@ -19,9 +19,9 @@ const verificationHelperUtils = proxyquire('../../ZelBack/src/services/verificat
 const insertUsers = [
   {
     _id: ObjectId('6108fbb9f04dfe1ef624b819'),
-    zelid: '1hjy4bCYBJr4mny4zCE85J94RXa8W6q37', // regular user
+    zelid: '1E1NSwDHtvCziYP4CtgiDMcgvgZL64PhkR', // regular user
     loginPhrase: '162797868130153vt9r89dzjjjfg6kf34ntf1d8aa5zqlk04j3zy8z40ni',
-    signature: 'H9oD/ZA7mEVQMWYWNIGDF7T2J++R/EG8tYPfB+fQ+XvQIbOXIcBEhxZwPYmh0HRj531oMc/HfcXPAYjWlN9wCn4=',
+    signature: 'IIwyGekXKejWRCnBKMb5Zn2ufi5ylnl3r/wmonoTDm7QCUoe5vZL0SXIwqxO7F8U3Q+kUJapRS2xlUe53KNmC9k=',
   },
   {
     _id: ObjectId('60cad0767247ac0a779fb3f0'),
@@ -31,9 +31,9 @@ const insertUsers = [
   },
   {
     _id: ObjectId('620bbc40c04b4966674013a8'),
-    zelid: '1LZe3AUYQC4aT5YWLhgEcH1nLLdoKNBi9t', // app owner
+    zelid: '1KPKzyp9VyB9ouAA4spZ48x8g32sxLVK6W', // app owner
     loginPhrase: '1644935889016mtmbo4uah32tvvwrmzg4j8qzv04ba8g8n56cevn6b',
-    signature: 'H4bL1HhNXiYiHywCnUeptHtLQY/YiGmLt14N+BBNXRIKd6BkP+kFr9CvaGLELQxN1A31OXoy3SMBoHj2/OqiK6c=',
+    signature: 'H7xcWjpSt8jiAaPbkUsfY3ZutJJmI35MWkGsgWBj/fJHfk7ZKRoggzigdaESLGMDMb2MHlxAapr1sMYDbJkL/H4=',
   },
   {
     _id: ObjectId('61967125f3178f082a296100'),
@@ -47,7 +47,7 @@ const insertApp = {
   _id: ObjectId('6147045cd774409b374d253d'),
   name: 'PolkadotNode',
   description: 'Polkadot is a heterogeneous multi-chain interchange.',
-  owner: '1LZe3AUYQC4aT5YWLhgEcH1nLLdoKNBi9t',
+  owner: '1KPKzyp9VyB9ouAA4spZ48x8g32sxLVK6W',
 };
 
 describe('verificationHelperUtils tests', () => {
@@ -71,6 +71,7 @@ describe('verificationHelperUtils tests', () => {
       const headers = {
         zelidauth: {
           zelid: '1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC',
+          loginPhrase: '16125160820394ddsh5skgwv0ipodku92y0jbwvpyj17bh68lzrjlxq9',
           signature: 'IH9d68fk/dYQtuMlNN7ioc52MJ6ryRT0IYss6h/KCwVWGcbVNFoI8Jh6hIklRq+w2itV/6vs/xzCWp4TUdSWDBc=',
         },
       };
@@ -83,8 +84,9 @@ describe('verificationHelperUtils tests', () => {
     it('should return false when requested by regular user', async () => {
       const headers = {
         zelidauth: {
-          zelid: '1hjy4bCYBJr4mny4zCE85J94RXa8W6q37',
-          signature: 'H9oD/ZA7mEVQMWYWNIGDF7T2J++R/EG8tYPfB+fQ+XvQIbOXIcBEhxZwPYmh0HRj531oMc/HfcXPAYjWlN9wCn4=',
+          zelid: '1E1NSwDHtvCziYP4CtgiDMcgvgZL64PhkR',
+          loginPhrase: '162797868130153vt9r89dzjjjfg6kf34ntf1d8aa5zqlk04j3zy8z40ni',
+          signature: 'IIwyGekXKejWRCnBKMb5Zn2ufi5ylnl3r/wmonoTDm7QCUoe5vZL0SXIwqxO7F8U3Q+kUJapRS2xlUe53KNmC9k=',
         },
       };
 
@@ -110,6 +112,7 @@ describe('verificationHelperUtils tests', () => {
       const headers = {
         zelidauth: {
           zelid: '2CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC',
+          loginPhrase: '16125160820394ddsh5skgwv0ipodku92y0jbwvpyj17bh68lzrjlxq9',
           signature: 'IH9d68fk/dYQtuMlNN7ioc52MJ6ryRT0IYss6h/KCwVWGcbVNFoI8Jh6hIklRq+w2itV/6vs/xzCWp4TUdSWDBc=',
         },
       };
@@ -122,6 +125,7 @@ describe('verificationHelperUtils tests', () => {
       const headers = {
         zelidauth: {
           zelid: '',
+          loginPhrase: '',
           signature: '',
         },
       };
@@ -159,8 +163,9 @@ describe('verificationHelperUtils tests', () => {
     it('should return true when requested by a logged user', async () => {
       const headers = {
         zelidauth: {
-          zelid: '1hjy4bCYBJr4mny4zCE85J94RXa8W6q37',
-          signature: 'H9oD/ZA7mEVQMWYWNIGDF7T2J++R/EG8tYPfB+fQ+XvQIbOXIcBEhxZwPYmh0HRj531oMc/HfcXPAYjWlN9wCn4=',
+          zelid: '1E1NSwDHtvCziYP4CtgiDMcgvgZL64PhkR',
+          loginPhrase: '162797868130153vt9r89dzjjjfg6kf34ntf1d8aa5zqlk04j3zy8z40ni',
+          signature: 'IIwyGekXKejWRCnBKMb5Zn2ufi5ylnl3r/wmonoTDm7QCUoe5vZL0SXIwqxO7F8U3Q+kUJapRS2xlUe53KNmC9k=',
         },
       };
 
@@ -172,7 +177,8 @@ describe('verificationHelperUtils tests', () => {
     it('should return false if called with a wrong zelid', async () => {
       const headers = {
         zelidauth: {
-          zelid: '1LZe3AUYQC4aT5YWLhgEcH1nLLdoKNBu9t',
+          zelid: '1KPKzyp9VyB9ouAA4spZ48x8g32sxLVK6a',
+          loginPhrase: '1644935889016mtmbo4uah32tvvwrmzg4j8qzv04ba8g8n56cevn6b',
           signature: 'IMDMG1GuDasjPMkrGaRQhkLpFO0saBV+v+N6h3wP6/QlF3J9ymLAPZy7DCBd/RnOSzUxmTHruenVeR7LghzRnHA=',
         },
       };
@@ -185,7 +191,8 @@ describe('verificationHelperUtils tests', () => {
     it('should return false if called with a wrong signature', async () => {
       const headers = {
         zelidauth: {
-          zelid: '1LZe3AUYQC4aT5YWLhgEcH1nLLdoKNBi9t',
+          zelid: '1KPKzyp9VyB9ouAA4spZ48x8g32sxLVK6W',
+          loginPhrase: '1644935889016mtmbo4uah32tvvwrmzg4j8qzv04ba8g8n56cevn6b',
           signature: 'IMDMG1GuDasjPMkrGaRQhkLpFO0saBZ+v+N6h3wP6/QlF3J9ymLAPZy7DCBd/RnOSzUxmTHruenVeR7LghzRnHA=',
         },
       };
@@ -204,6 +211,7 @@ describe('verificationHelperUtils tests', () => {
       const headers = {
         zelidauth: {
           zelid: '',
+          loginPhrase: '',
           signature: '',
         },
       };
@@ -234,6 +242,7 @@ describe('verificationHelperUtils tests', () => {
       const headers = {
         zelidauth: {
           zelid: '1NH9BP155Rp3HSf5ef6NpUbE8JcyLRruAM',
+          loginPhrase: '1623904359736pja76q7y68deb4264olbml6o8gyhot2yvj5oevgv9k2',
           signature: 'H4lWS4PcrR1tMo8RCLzeYYrd042tsJC9PteIKZvn091ZAYE4K9ydfri8M1KKWe905NHdS4LPPsClqvA4nY/G+II=',
         },
       };
@@ -246,8 +255,9 @@ describe('verificationHelperUtils tests', () => {
     it('should return false when zelid is not the flux team', async () => {
       const headers = {
         zelidauth: {
-          zelid: '1hjy4bCYBJr4mny4zCE85J94RXa8W6q37',
-          signature: 'H9oD/ZA7mEVQMWYWNIGDF7T2J++R/EG8tYPfB+fQ+XvQIbOXIcBEhxZwPYmh0HRj531oMc/HfcXPAYjWlN9wCn4=',
+          zelid: '1E1NSwDHtvCziYP4CtgiDMcgvgZL64PhkR',
+          loginPhrase: '162797868130153vt9r89dzjjjfg6kf34ntf1d8aa5zqlk04j3zy8z40ni',
+          signature: 'IIwyGekXKejWRCnBKMb5Zn2ufi5ylnl3r/wmonoTDm7QCUoe5vZL0SXIwqxO7F8U3Q+kUJapRS2xlUe53KNmC9k=',
         },
       };
 
@@ -260,6 +270,7 @@ describe('verificationHelperUtils tests', () => {
       const headers = {
         zelidauth: {
           zelid: '1NH9BP155Rp3HSf5ef6NpUbE8JcyLRruAM',
+          loginPhrase: '1623904359736pja76q7y68deb4264olbml6o8gyhot2yvj5oevgv9k2',
           signature: 'N4lWS4PcrR1tMo8RCLzeYYrd042tsJC9PteIKZvn091ZAYE4K9ydfri8M1KKWe905NHdS4LPPsClqvA4nY/G+II=',
         },
       };
@@ -273,6 +284,7 @@ describe('verificationHelperUtils tests', () => {
       const headers = {
         zelidauth: {
           zelid: '1NH9BP1z5Rp3HSf5ef6NpUbE8JcyLRruAM',
+          loginPhrase: '1623904359736pja76q7y68deb4264olbml6o8gyhot2yvj5oevgv9k2',
           signature: 'H4lWS4PcrR1tMo8RCLzeYYrd042tsJC9PteIKZvn091ZAYE4K9ydfri8M1KKWe905NHdS4LPPsClqvA4nY/G+II=',
         },
       };
@@ -286,6 +298,7 @@ describe('verificationHelperUtils tests', () => {
       const headers = {
         zelidauth: {
           zelid: '',
+          loginPhrase: '',
           signature: '',
         },
       };
@@ -299,6 +312,7 @@ describe('verificationHelperUtils tests', () => {
       const headers = {
         zelidauth: {
           zelid: true,
+          loginPhrase: true,
           signature: true,
         },
       };
@@ -343,6 +357,7 @@ describe('verificationHelperUtils tests', () => {
       const headers = {
         zelidauth: {
           zelid: '1NH9BP155Rp3HSf5ef6NpUbE8JcyLRruAM',
+          loginPhrase: '1623904359736pja76q7y68deb4264olbml6o8gyhot2yvj5oevgv9k2',
           signature: 'H4lWS4PcrR1tMo8RCLzeYYrd042tsJC9PteIKZvn091ZAYE4K9ydfri8M1KKWe905NHdS4LPPsClqvA4nY/G+II=',
         },
       };
@@ -356,6 +371,7 @@ describe('verificationHelperUtils tests', () => {
       const headers = {
         zelidauth: {
           zelid: '1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC',
+          loginPhrase: '16125160820394ddsh5skgwv0ipodku92y0jbwvpyj17bh68lzrjlxq9',
           signature: 'IH9d68fk/dYQtuMlNN7ioc52MJ6ryRT0IYss6h/KCwVWGcbVNFoI8Jh6hIklRq+w2itV/6vs/xzCWp4TUdSWDBc=',
         },
       };
@@ -368,8 +384,9 @@ describe('verificationHelperUtils tests', () => {
     it('should return false when zelid is not the flux team', async () => {
       const headers = {
         zelidauth: {
-          zelid: '1hjy4bCYBJr4mny4zCE85J94RXa8W6q37',
-          signature: 'H9oD/ZA7mEVQMWYWNIGDF7T2J++R/EG8tYPfB+fQ+XvQIbOXIcBEhxZwPYmh0HRj531oMc/HfcXPAYjWlN9wCn4=',
+          zelid: '1E1NSwDHtvCziYP4CtgiDMcgvgZL64PhkR',
+          loginPhrase: '162797868130153vt9r89dzjjjfg6kf34ntf1d8aa5zqlk04j3zy8z40ni',
+          signature: 'IIwyGekXKejWRCnBKMb5Zn2ufi5ylnl3r/wmonoTDm7QCUoe5vZL0SXIwqxO7F8U3Q+kUJapRS2xlUe53KNmC9k=',
         },
       };
 
@@ -382,6 +399,7 @@ describe('verificationHelperUtils tests', () => {
       const headers = {
         zelidauth: {
           zelid: '1NH9BP155Rp3HSf5ef6NpUbE8JcyLRruAM',
+          loginPhrase: '1623904359736pja76q7y68deb4264olbml6o8gyhot2yvj5oevgv9k2',
           signature: 'N4lWS4PcrR1tMo8RCLzeYYrd042tsJC9PteIKZvn091ZAYE4K9ydfri8M1KKWe905NHdS4LPPsClqvA4nY/G+II=',
         },
       };
@@ -395,6 +413,7 @@ describe('verificationHelperUtils tests', () => {
       const headers = {
         zelidauth: {
           zelid: '1NH9BP1z5Rp3HSf5ef6NpUbE8JcyLRruAM',
+          loginPhrase: '1623904359736pja76q7y68deb4264olbml6o8gyhot2yvj5oevgv9k2',
           signature: 'H4lWS4PcrR1tMo8RCLzeYYrd042tsJC9PteIKZvn091ZAYE4K9ydfri8M1KKWe905NHdS4LPPsClqvA4nY/G+II=',
         },
       };
@@ -408,6 +427,7 @@ describe('verificationHelperUtils tests', () => {
       const headers = {
         zelidauth: {
           zelid: '',
+          loginPhrase: '',
           signature: '',
         },
       };
@@ -421,6 +441,7 @@ describe('verificationHelperUtils tests', () => {
       const headers = {
         zelidauth: {
           zelid: true,
+          loginPhrase: true,
           signature: true,
         },
       };
@@ -474,7 +495,8 @@ describe('verificationHelperUtils tests', () => {
     it('should return true when requested by the app owner', async () => {
       const headers = {
         zelidauth: {
-          zelid: '1LZe3AUYQC4aT5YWLhgEcH1nLLdoKNBi9t',
+          zelid: '1KPKzyp9VyB9ouAA4spZ48x8g32sxLVK6W',
+          loginPhrase: '1644935889016mtmbo4uah32tvvwrmzg4j8qzv04ba8g8n56cevn6b',
           signature: 'H4bL1HhNXiYiHywCnUeptHtLQY/YiGmLt14N+BBNXRIKd6BkP+kFr9CvaGLELQxN1A31OXoy3SMBoHj2/OqiK6c=',
         },
       };
@@ -488,6 +510,7 @@ describe('verificationHelperUtils tests', () => {
       const headers = {
         zelidauth: {
           zelid: '1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC',
+          loginPhrase: '16125160820394ddsh5skgwv0ipodku92y0jbwvpyj17bh68lzrjlxq9',
           signature: 'IH9d68fk/dYQtuMlNN7ioc52MJ6ryRT0IYss6h/KCwVWGcbVNFoI8Jh6hIklRq+w2itV/6vs/xzCWp4TUdSWDBc=',
         },
       };
@@ -500,7 +523,8 @@ describe('verificationHelperUtils tests', () => {
     it('should return false when requested by the owner with a wrong signature', async () => {
       const headers = {
         zelidauth: {
-          zelid: '1LZe3AUYQC4aT5YWLhgEcH1nLLdoKNBi9t',
+          zelid: '1KPKzyp9VyB9ouAA4spZ48x8g32sxLVK6W',
+          loginPhrase: '1644935889016mtmbo4uah32tvvwrmzg4j8qzv04ba8g8n56cevn6b',
           signature: 'IH9d68fk/dYQtuMlNN7ioc52MJ6ryRT0IYss6h/KCwVWGcbVNFoI8Jh6hIklRq+w2itV/6vs/xzCWp4TUdSWDBc=',
         },
       };
@@ -514,6 +538,7 @@ describe('verificationHelperUtils tests', () => {
       const headers = {
         zelidauth: {
           zelid: '',
+          loginPhrase: '',
           signature: '',
         },
       };
@@ -535,7 +560,8 @@ describe('verificationHelperUtils tests', () => {
     it('should return true when requested with an empty app name', async () => {
       const headers = {
         zelidauth: {
-          zelid: '1LZe3AUYQC4aT5YWLhgEcH1nLLdoKNBi9t',
+          zelid: '1KPKzyp9VyB9ouAA4spZ48x8g32sxLVK6W',
+          loginPhrase: '1644935889016mtmbo4uah32tvvwrmzg4j8qzv04ba8g8n56cevn6b',
           signature: 'H4bL1HhNXiYiHywCnUeptHtLQY/YiGmLt14N+BBNXRIKd6BkP+kFr9CvaGLELQxN1A31OXoy3SMBoHj2/OqiK6c=',
         },
       };
@@ -575,7 +601,8 @@ describe('verificationHelperUtils tests', () => {
     it('should return true when requested by the app owner', async () => {
       const headers = {
         zelidauth: {
-          zelid: '1LZe3AUYQC4aT5YWLhgEcH1nLLdoKNBi9t',
+          zelid: '1KPKzyp9VyB9ouAA4spZ48x8g32sxLVK6W',
+          loginPhrase: '1644935889016mtmbo4uah32tvvwrmzg4j8qzv04ba8g8n56cevn6b',
           signature: 'H4bL1HhNXiYiHywCnUeptHtLQY/YiGmLt14N+BBNXRIKd6BkP+kFr9CvaGLELQxN1A31OXoy3SMBoHj2/OqiK6c=',
         },
       };
@@ -589,6 +616,7 @@ describe('verificationHelperUtils tests', () => {
       const headers = {
         zelidauth: {
           zelid: '1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC',
+          loginPhrase: '16125160820394ddsh5skgwv0ipodku92y0jbwvpyj17bh68lzrjlxq9',
           signature: 'IH9d68fk/dYQtuMlNN7ioc52MJ6ryRT0IYss6h/KCwVWGcbVNFoI8Jh6hIklRq+w2itV/6vs/xzCWp4TUdSWDBc=',
         },
       };
@@ -602,6 +630,7 @@ describe('verificationHelperUtils tests', () => {
       const headers = {
         zelidauth: {
           zelid: '1NH9BP155Rp3HSf5ef6NpUbE8JcyLRruAM',
+          loginPhrase: '1623904359736pja76q7y68deb4264olbml6o8gyhot2yvj5oevgv9k2',
           signature: 'H4lWS4PcrR1tMo8RCLzeYYrd042tsJC9PteIKZvn091ZAYE4K9ydfri8M1KKWe905NHdS4LPPsClqvA4nY/G+II=',
         },
       };
@@ -614,8 +643,9 @@ describe('verificationHelperUtils tests', () => {
     it('should return false when requested by a regular user', async () => {
       const headers = {
         zelidauth: {
-          zelid: '1hjy4bCYBJr4mny4zCE85J94RXa8W6q37',
-          signature: 'H9oD/ZA7mEVQMWYWNIGDF7T2J++R/EG8tYPfB+fQ+XvQIbOXIcBEhxZwPYmh0HRj531oMc/HfcXPAYjWlN9wCn4=',
+          zelid: '1E1NSwDHtvCziYP4CtgiDMcgvgZL64PhkR',
+          loginPhrase: '162797868130153vt9r89dzjjjfg6kf34ntf1d8aa5zqlk04j3zy8z40ni',
+          signature: 'IIwyGekXKejWRCnBKMb5Zn2ufi5ylnl3r/wmonoTDm7QCUoe5vZL0SXIwqxO7F8U3Q+kUJapRS2xlUe53KNmC9k=',
         },
       };
       const appName = 'PolkadotNode';
@@ -627,7 +657,8 @@ describe('verificationHelperUtils tests', () => {
     it('should return false when requested by the owner with a wrong signature', async () => {
       const headers = {
         zelidauth: {
-          zelid: '1LZe3AUYQC4aT5YWLhgEcH1nLLdoKNBi9t',
+          zelid: '1KPKzyp9VyB9ouAA4spZ48x8g32sxLVK6W',
+          loginPhrase: '1644935889016mtmbo4uah32tvvwrmzg4j8qzv04ba8g8n56cevn6b',
           signature: 'IH9d68fk/dYQtuMlNN7ioc52MJ6ryRT0IYss6h/KCwVWGcbVNFoI8Jh6hIklRq+w2itV/6vs/xzCWp4TUdSWDBc=',
         },
       };
@@ -641,6 +672,7 @@ describe('verificationHelperUtils tests', () => {
       const headers = {
         zelidauth: {
           zelid: '',
+          loginPhrase: '',
           signature: '',
         },
       };
@@ -662,7 +694,8 @@ describe('verificationHelperUtils tests', () => {
     it('should return true when requested with an empty app name', async () => {
       const headers = {
         zelidauth: {
-          zelid: '1LZe3AUYQC4aT5YWLhgEcH1nLLdoKNBi9t',
+          zelid: '1KPKzyp9VyB9ouAA4spZ48x8g32sxLVK6W',
+          loginPhrase: '1644935889016mtmbo4uah32tvvwrmzg4j8qzv04ba8g8n56cevn6b',
           signature: 'H4bL1HhNXiYiHywCnUeptHtLQY/YiGmLt14N+BBNXRIKd6BkP+kFr9CvaGLELQxN1A31OXoy3SMBoHj2/OqiK6c=',
         },
       };


### PR DESCRIPTION
Adjust authentication system:
Goal is to prevent expiring of sessions while load balancer switches backend nodes. Switch of backend node causes invalidation of authentication as new node does not know of previous signed messages. New scheme allows using any signed message of Flux sign scheme that was recently signed.

- Login phrase signature is no longer stored
- Instead search for loginPhrase with zelid is used
- auth header must contain all loginPhrase, zelid and signature
- Logins now expire after 14 days
- Logins for certain permissions of user, app owner are portable from one node to another for recently valid signatures
