### PR TITLE
Geolocation

### DIFF
--- a/HomeUI/src/views/apps/GlobalApps.vue
+++ b/HomeUI/src/views/apps/GlobalApps.vue
@@ -52,6 +52,17 @@
                         title="Hash"
                         :data="row.item.hash"
                       />
+                      <div v-if="row.item.version >= 5">
+                        <list-entry
+                          title="Continent"
+                          :data="row.item.continents.length > 0 ? getContinent(row.item.continents) : 'All'"
+                        />
+                        <list-entry
+                          v-if="row.item.continents.length > 0"
+                          title="Country"
+                          :data="row.item.countries.length > 0 ? getCountry(getrow.item.countries) : 'All'"
+                        />
+                      </div>
                       <list-entry
                         v-if="row.item.instances"
                         title="Instances"
@@ -687,6 +698,84 @@ export default {
         },
       },
       allApps: [],
+      continentsOptions: [{
+        value: null, text: 'All',
+      },
+      {
+        value: 'AS', nodeTier: 'Cumulus', maxInstances: 5, text: 'Asia',
+      },
+      {
+        value: 'EU', nodeTier: 'Stratus', maxInstances: 20, text: 'Europe',
+      },
+      {
+        value: 'NA', nodeTier: 'Stratus', maxInstances: 20, text: 'North America',
+      },
+      {
+        value: 'OC', nodeTier: 'Cumulus', maxInstances: 3, text: 'Oceania',
+      }],
+      countriesOptions: [{
+        value: null, text: 'All', continentCode: 'AS',
+      },
+      {
+        value: 'SG', nodeTier: 'Cumulus', maxInstances: 3, continentCode: 'AS', text: 'Singapore',
+      },
+      {
+        value: 'TW', nodeTier: 'Cumulus', maxInstances: 3, continentCode: 'AS', text: 'Taiwan',
+      },
+      {
+        value: 'TH', nodeTier: 'Cumulus', maxInstances: 5, continentCode: 'AS', text: 'Thailand',
+      },
+      {
+        value: null, text: 'All', continentCode: 'EU',
+      },
+      {
+        value: 'BE', nodeTier: 'Cumulus', maxInstances: 3, continentCode: 'EU', text: 'Belgium',
+      },
+      {
+        value: 'CZ', nodeTier: 'Cumulus', maxInstances: 3, continentCode: 'EU', text: 'Czechia',
+      },
+      {
+        value: 'FI', nodeTier: 'Stratus', maxInstances: 10, continentCode: 'EU', text: 'Finland',
+      },
+      {
+        value: 'FR', nodeTier: 'Stratus', maxInstances: 5, continentCode: 'EU', text: 'France',
+      },
+      {
+        value: 'DE', nodeTier: 'Stratus', maxInstances: 15, continentCode: 'EU', text: 'Germany',
+      },
+      {
+        value: 'LT', nodeTier: 'Cumulus', maxInstances: 5, continentCode: 'EU', text: 'Lithuania',
+      },
+      {
+        value: 'NL', nodeTier: 'Cumulus', maxInstances: 3, continentCode: 'EU', text: 'Netherlands',
+      },
+      {
+        value: 'PL', nodeTier: 'Stratus', maxInstances: 10, continentCode: 'EU', text: 'Poland',
+      },
+      {
+        value: 'RU', nodeTier: 'Nimbus', maxInstances: 5, continentCode: 'EU', text: 'Russia',
+      },
+      {
+        value: 'SI', nodeTier: 'Stratus', maxInstances: 3, continentCode: 'EU', text: 'Slovenia',
+      },
+      {
+        value: 'ES', nodeTier: 'Cumulus', maxInstances: 3, continentCode: 'EU', text: 'Spain',
+      },
+      {
+        value: 'GB', nodeTier: 'Stratus', maxInstances: 3, continentCode: 'EU', text: 'United Kingdom',
+      },
+      {
+        value: null, text: 'All', continentCode: 'NA',
+      },
+      {
+        value: 'US', nodeTier: 'Stratus', maxInstances: 10, continentCode: 'NA', text: 'United States',
+      },
+      {
+        value: 'CA', nodeTier: 'Stratus', maxInstances: 10, continentCode: 'NA', text: 'Canada',
+      },
+      {
+        value: null, text: 'All', continentCode: 'OC',
+      }],
     };
   },
   computed: {
@@ -841,6 +930,14 @@ export default {
         return `${name.substring(0, name.length - 13)} - ${new Date(possibleDate).toLocaleString()}`;
       }
       return name;
+    },
+    getContinent(item) {
+      const continent = this.continentsOptions.filter((x) => x.value === item[0])[0];
+      return continent.text;
+    },
+    getCountry(item) {
+      const country = this.countriesOptions.filter((x) => x.value === item[0])[0];
+      return country.text;
     },
   },
 };

--- a/HomeUI/src/views/apps/Management.vue
+++ b/HomeUI/src/views/apps/Management.vue
@@ -3103,9 +3103,9 @@ export default {
             this.selectedCountry = null;
             if (specs.continents && specs.continents.length > 0) {
               this.selectedContinent = this.continentsOptions.filter((x) => x.value === specs.continents[0])[0];
-            }
-            if (specs.countries && specs.countries.length > 0) {
-              this.selectedCountry = this.countriesOptions.filter((x) => x.value === specs.countries[0])[0];
+              if (specs.countries && specs.countries.length > 0) {
+                this.selectedCountry = this.countriesOptions.filter((x) => x.value === specs.countries[0])[0];
+              }
             }
             this.appUpdateSpecification.continents = this.ensureString(specs.continents);
             this.appUpdateSpecification.countries = this.ensureString(specs.countries);

--- a/HomeUI/src/views/apps/Management.vue
+++ b/HomeUI/src/views/apps/Management.vue
@@ -3097,6 +3097,19 @@ export default {
           this.appUpdateSpecification.commands = this.ensureString(specs.commands);
           this.appUpdateSpecification.containerPorts = specs.containerPort || this.ensureString(specs.containerPorts); // v1 compatibility
         } else {
+          if (this.appUpdateSpecification.version >= 5) {
+            this.appUpdateSpecification.contacts = this.ensureString(specs.contacs);
+            this.selectedContinent = null;
+            this.selectedCountry = null;
+            if (specs.continents && specs.continents.length > 0) {
+              this.selectedContinent = this.continentsOptions.filter((x) => x.value === specs.continents[0])[0];
+            }
+            if (specs.countries && specs.countries.length > 0) {
+              this.selectedCountry = this.countriesOptions.filter((x) => x.value === specs.countries[0])[0];
+            }
+            this.appUpdateSpecification.continents = this.ensureString(specs.continents);
+            this.appUpdateSpecification.countries = this.ensureString(specs.countries);
+          }
           this.appUpdateSpecification.compose.forEach((component) => {
             // eslint-disable-next-line no-param-reassign
             component.ports = this.ensureString(component.ports);

--- a/HomeUI/src/views/apps/Management.vue
+++ b/HomeUI/src/views/apps/Management.vue
@@ -61,6 +61,17 @@
               title="Hash"
               :data="callResponse.data.hash"
             />
+            <div v-if="callResponse.data.version >= 5">
+              <list-entry
+                title="Continent"
+                :data="callResponse.data.continents.length > 0 ? getContinent(callResponse.data.continents) : 'All'"
+              />
+              <list-entry
+                v-if="callResponse.data.continents.length > 0"
+                title="Country"
+                :data="callResponse.data.countries.length > 0 ? getCountry(getcallResponse.data.countries) : 'All'"
+              />
+            </div>
             <list-entry
               v-if="callResponse.data.instances"
               title="Instances"
@@ -299,6 +310,17 @@
               title="Hash"
               :data="callBResponse.data.hash"
             />
+            <div v-if="callBResponse.data.version >= 5">
+              <list-entry
+                title="Continent"
+                :data="callBResponse.data.continents.length > 0 ? getContinent(callBResponse.data.continents) : 'All'"
+              />
+              <list-entry
+                v-if="callBResponse.data.continents.length > 0"
+                title="Country"
+                :data="callBResponse.data.countries.length > 0 ? getCountry(callBResponse.data.countries) : 'All'"
+              />
+            </div>
             <list-entry
               v-if="callBResponse.data.instances"
               title="Instances"
@@ -1130,6 +1152,21 @@
               title="Hash"
               :data="callBResponse.data.hash"
             />
+            <div v-if="callBResponse.data.version >= 5">
+              <list-entry
+                title="Contacts"
+                :data="callBResponse.data.contacts.toString() || 'none'"
+              />
+              <list-entry
+                title="Continent"
+                :data="callBResponse.data.continents.length > 0 ? getContinent(callBResponse.data.continents) : 'All'"
+              />
+              <list-entry
+                v-if="callBResponse.data.continents.length > 0"
+                title="Country"
+                :data="callBResponse.data.countries.length > 0 ? getCountry(callBResponse.data.countries) : 'All'"
+              />
+            </div>
             <list-entry
               v-if="callBResponse.data.instances"
               title="Instances"
@@ -1536,6 +1573,51 @@
                     placeholder="ZelID of Application Owner"
                   />
                 </b-form-group>
+                <div v-if="specificationVersion >= 5">
+                  <div class="form-row form-group">
+                    <label class="col-1 col-form-label">
+                      Contacts
+                      <v-icon
+                        v-b-tooltip.hover.top="'Array of strings of emails Contacts to get notifications in future, ex. app about to expire.'"
+                        name="info-circle"
+                        class="mr-1"
+                      />
+                    </label>
+                    <div class="col">
+                      <b-form-input
+                        id="contacs"
+                        v-model="appUpdateSpecification.contacts"
+                      />
+                    </div>
+                  </div>
+                  <b-form-group
+                    label-cols="2"
+                    label-cols-lg="1"
+                    label="Continent"
+                    label-for="Continent"
+                  >
+                    <b-form-select
+                      id="continent"
+                      v-model="selectedContinent"
+                      :options="continentsOptions"
+                      @change="continentChanged"
+                    />
+                  </b-form-group>
+                  <b-form-group
+                    v-if="selectedContinent"
+                    label-cols="2"
+                    label-cols-lg="1"
+                    label="Country"
+                    label-for="Country"
+                  >
+                    <b-form-select
+                      id="country"
+                      v-model="selectedCountry"
+                      :options="countriesOptions.filter((x)=> x.continentCode === selectedContinent)"
+                      @change="countryChanged"
+                    />
+                  </b-form-group>
+                </div>
                 <br>
                 <b-form-group
                   v-if="appUpdateSpecification.version >= 3"
@@ -1553,7 +1635,7 @@
                     placeholder="Minimum number of application instances to be spawned"
                     type="range"
                     min="3"
-                    max="100"
+                    :max="maxInstances"
                     step="1"
                   />
                 </b-form-group>
@@ -2612,6 +2694,87 @@ export default {
       abortToken: {},
       deploymentAddress: '',
       appPricePerMonthForUpdate: 0,
+      maxInstances: 100,
+      continentsOptions: [{
+        value: null, text: 'All',
+      },
+      {
+        value: 'AS', nodeTier: 'Cumulus', maxInstances: 5, text: 'Asia',
+      },
+      {
+        value: 'EU', nodeTier: 'Stratus', maxInstances: 20, text: 'Europe',
+      },
+      {
+        value: 'NA', nodeTier: 'Stratus', maxInstances: 20, text: 'North America',
+      },
+      {
+        value: 'OC', nodeTier: 'Cumulus', maxInstances: 3, text: 'Oceania',
+      }],
+      countriesOptions: [{
+        value: null, text: 'All', continentCode: 'AS',
+      },
+      {
+        value: 'SG', nodeTier: 'Cumulus', maxInstances: 3, continentCode: 'AS', text: 'Singapore',
+      },
+      {
+        value: 'TW', nodeTier: 'Cumulus', maxInstances: 3, continentCode: 'AS', text: 'Taiwan',
+      },
+      {
+        value: 'TH', nodeTier: 'Cumulus', maxInstances: 5, continentCode: 'AS', text: 'Thailand',
+      },
+      {
+        value: null, text: 'All', continentCode: 'EU',
+      },
+      {
+        value: 'BE', nodeTier: 'Cumulus', maxInstances: 3, continentCode: 'EU', text: 'Belgium',
+      },
+      {
+        value: 'CZ', nodeTier: 'Cumulus', maxInstances: 3, continentCode: 'EU', text: 'Czechia',
+      },
+      {
+        value: 'FI', nodeTier: 'Stratus', maxInstances: 10, continentCode: 'EU', text: 'Finland',
+      },
+      {
+        value: 'FR', nodeTier: 'Stratus', maxInstances: 5, continentCode: 'EU', text: 'France',
+      },
+      {
+        value: 'DE', nodeTier: 'Stratus', maxInstances: 15, continentCode: 'EU', text: 'Germany',
+      },
+      {
+        value: 'LT', nodeTier: 'Cumulus', maxInstances: 5, continentCode: 'EU', text: 'Lithuania',
+      },
+      {
+        value: 'NL', nodeTier: 'Cumulus', maxInstances: 3, continentCode: 'EU', text: 'Netherlands',
+      },
+      {
+        value: 'PL', nodeTier: 'Stratus', maxInstances: 10, continentCode: 'EU', text: 'Poland',
+      },
+      {
+        value: 'RU', nodeTier: 'Nimbus', maxInstances: 5, continentCode: 'EU', text: 'Russia',
+      },
+      {
+        value: 'SI', nodeTier: 'Stratus', maxInstances: 3, continentCode: 'EU', text: 'Slovenia',
+      },
+      {
+        value: 'ES', nodeTier: 'Cumulus', maxInstances: 3, continentCode: 'EU', text: 'Spain',
+      },
+      {
+        value: 'GB', nodeTier: 'Stratus', maxInstances: 3, continentCode: 'EU', text: 'United Kingdom',
+      },
+      {
+        value: null, text: 'All', continentCode: 'NA',
+      },
+      {
+        value: 'US', nodeTier: 'Stratus', maxInstances: 10, continentCode: 'NA', text: 'United States',
+      },
+      {
+        value: 'CA', nodeTier: 'Stratus', maxInstances: 10, continentCode: 'NA', text: 'Canada',
+      },
+      {
+        value: null, text: 'All', continentCode: 'OC',
+      }],
+      selectedContinent: null,
+      selectedCountry: null,
     };
   },
   computed: {
@@ -2987,6 +3150,16 @@ export default {
     async checkFluxUpdateSpecificationsAndFormatMessage() {
       try {
         const appSpecification = this.appUpdateSpecification;
+        if (appSpecification.version >= 5) {
+          if (this.selectedContinent) {
+            appSpecification.continents = [];
+            appSpecification.continents.push(this.selectedContinent);
+            if (this.selectedCountry) {
+              appSpecification.countries = [];
+              appSpecification.countries.push(this.selectedCountry);
+            }
+          }
+        }
         // call api for verification of app registration specifications that returns formatted specs
         const responseAppSpecs = await AppsService.appUpdateVerification(appSpecification);
         if (responseAppSpecs.data.status === 'error') {
@@ -3504,6 +3677,45 @@ export default {
         return data.replace(/[^\x20-\x7E\t\r\n\v\f]/g, '');
       }
       return '';
+    },
+    getContinent(item) {
+      const continent = this.continentsOptions.filter((x) => x.value === item[0])[0];
+      return continent.text;
+    },
+    getCountry(item) {
+      const country = this.countriesOptions.filter((x) => x.value === item[0])[0];
+      return country.text;
+    },
+    continentChanged() {
+      this.selectedCountry = null;
+      if (this.selectedContinent) {
+        const continent = this.continentsOptions.filter((x) => x.value === this.selectedContinent)[0];
+        this.maxInstances = continent.maxInstances;
+        if (this.appUpdateSpecification.instances > this.maxInstances) {
+          this.appUpdateSpecification.instances = this.maxInstances;
+        }
+        this.showToast('warning', `On ${continent.text} continent you can deploy a maximum of ${this.maxInstances} instances and the node hardware available is ${continent.nodeTier}. If your app specs are higher the dapp might not install.`);
+      } else {
+        this.maxInstances = this.appUpdateSpecificationv5template.maxInstances;
+        this.showToast('info', 'No geolocation set you can define up to maximum of 100 instances and up to the maximum hardware specs available on Flux network to your app.');
+      }
+    },
+    countryChanged() {
+      if (this.selectedCountry) {
+        const country = this.countriesOptions.filter((x) => x.value === this.selectedCountry)[0];
+        this.maxInstances = country.maxInstances;
+        if (this.appUpdateSpecification.instances > this.maxInstances) {
+          this.appUpdateSpecification.instances = this.maxInstances;
+        }
+        this.showToast('warning', `On ${country.text} country you can deploy a maximum of ${this.maxInstances} instances and the node hardware available is ${country.nodeTier}. If your app specs are higher the dapp might not spawn on the network.`);
+      } else {
+        const continent = this.continentsOptions.filter((x) => x.value === this.selectedContinent)[0];
+        this.maxInstances = continent.maxInstances;
+        if (this.appUpdateSpecification.instances > this.maxInstances) {
+          this.appUpdateSpecification.instances = this.maxInstances;
+        }
+        this.showToast('warning', `On ${continent.text} continent you can deploy a maximum of ${this.maxInstances} instances and the node hardware available is ${continent.nodeTier}. If your app specs are higher the dapp might not spawn on the network.`);
+      }
     },
   },
 };

--- a/HomeUI/src/views/apps/RegisterFluxApp.vue
+++ b/HomeUI/src/views/apps/RegisterFluxApp.vue
@@ -74,6 +74,45 @@
                 placeholder="ZelID of Application Owner"
               />
             </b-form-group>
+            <b-form-group
+              label-cols="2"
+              label-cols-lg="1"
+              label="Contacts"
+              label-for="contacts"
+            >
+              <b-form-input
+                id="contacs"
+                v-model="appRegistrationSpecification.contacts"
+                placeholder="Array of strings of Emails contacts to get app information"
+              />
+            </b-form-group>
+            <b-form-group
+              label-cols="2"
+              label-cols-lg="1"
+              label="Continent"
+              label-for="Continent"
+            >
+              <b-form-select
+                id="continent"
+                v-model="selectedContinent"
+                :options="continentsOptions"
+                @change="continentChanged"
+              />
+            </b-form-group>
+            <b-form-group
+              v-if="selectedContinent"
+              label-cols="2"
+              label-cols-lg="1"
+              label="Country"
+              label-for="Country"
+            >
+              <b-form-select
+                id="country"
+                v-model="selectedCountry"
+                :options="countriesOptions.filter((x)=> x.continentCode === selectedContinent.continentCode)"
+                @change="countryChanged"
+              />
+            </b-form-group>
             <br>
             <b-form-group
               v-if="appRegistrationSpecification.version >= 3"
@@ -295,6 +334,7 @@
                     v-model="component.tiered"
                     switch
                     class="custom-control-primary inline"
+                    :disabled="selectedContinent != null"
                   />
                 </h6>
               </b-card-title>
@@ -1003,6 +1043,7 @@ import {
   BFormCheckbox,
   BFormGroup,
   BFormInput,
+  BFormSelect,
   BFormTextarea,
   BLink,
   VBTooltip,
@@ -1028,6 +1069,7 @@ export default {
     BFormCheckbox,
     BFormGroup,
     BFormInput,
+    BFormSelect,
     BFormTextarea,
     BLink,
     // eslint-disable-next-line vue/no-unused-components
@@ -1110,6 +1152,42 @@ export default {
           },
         ],
       },
+      appRegistrationSpecificationv5template: {
+        version: 5,
+        name: '',
+        description: '',
+        owner: '',
+        instances: 3,
+        continent: null,
+        country: null,
+        contacts: '[]',
+        compose: [
+          {
+            name: '',
+            description: '',
+            repotag: '',
+            ports: '[]',
+            domains: '[]',
+            environmentParameters: '[]',
+            commands: '[]',
+            containerPorts: '[]',
+            containerData: '',
+            cpu: 0.5,
+            ram: 2000,
+            hdd: 40,
+            tiered: false,
+            cpubasic: 0.5,
+            rambasic: 500,
+            hddbasic: 10,
+            cpusuper: 1.5,
+            ramsuper: 2500,
+            hddsuper: 60,
+            cpubamf: 3.5,
+            rambamf: 14000,
+            hddbamf: 285,
+          },
+        ],
+      },
       composeTemplate: {
         name: '',
         description: '',
@@ -1139,6 +1217,83 @@ export default {
       deploymentAddress: '',
       minInstances: 3,
       maxInstances: 100,
+      continentsOptions: [{
+        value: null, text: 'All',
+      },
+      {
+        value: { continentCode: 'AS', nodeTier: 'Cumulus', maxInstances: 5 }, text: 'Asia',
+      },
+      {
+        value: { continentCode: 'EU', nodeTier: 'Stratus', maxInstances: 20 }, text: 'Europe',
+      },
+      {
+        value: { continentCode: 'NA', nodeTier: 'Stratus', maxInstances: 20 }, text: 'North America',
+      },
+      {
+        value: { continentCode: 'OC', nodeTier: 'Cumulus', maxInstances: 3 }, text: 'Oceania',
+      }],
+      countriesOptions: [{
+        value: null, text: 'All', continentCode: 'AS',
+      },
+      {
+        value: { countryCode: 'SG', nodeTier: 'Cumulus', maxInstances: 3 }, continentCode: 'AS', text: 'Singapore',
+      },
+      {
+        value: { countryCode: 'TW', nodeTier: 'Cumulus', maxInstances: 3 }, continentCode: 'AS', text: 'Taiwan',
+      },
+      {
+        value: { countryCode: 'TH', nodeTier: 'Cumulus', maxInstances: 5 }, continentCode: 'AS', text: 'Thailand',
+      },
+      {
+        value: null, text: 'All', continentCode: 'EU',
+      },
+      {
+        value: { countryCode: 'BE', nodeTier: 'Cumulus', maxInstances: 3 }, continentCode: 'EU', text: 'Belgium',
+      },
+      {
+        value: { countryCode: 'CZ', nodeTier: 'Cumulus', maxInstances: 3 }, continentCode: 'EU', text: 'Czechia',
+      },
+      {
+        value: { countryCode: 'FI', nodeTier: 'Stratus', maxInstances: 10 }, continentCode: 'EU', text: 'Finland',
+      },
+      {
+        value: { countryCode: 'FR', nodeTier: 'Stratus', maxInstances: 5 }, continentCode: 'EU', text: 'France',
+      },
+      {
+        value: { countryCode: 'DE', nodeTier: 'Stratus', maxInstances: 15 }, continentCode: 'EU', text: 'Germany',
+      },
+      {
+        value: { countryCode: 'LT', nodeTier: 'Cumulus', maxInstances: 5 }, continentCode: 'EU', text: 'Lithuania',
+      },
+      {
+        value: { countryCode: 'NL', nodeTier: 'Cumulus', maxInstances: 3 }, continentCode: 'EU', text: 'Netherlands',
+      },
+      {
+        value: { countryCode: 'PL', nodeTier: 'Stratus', maxInstances: 10 }, continentCode: 'EU', text: 'Poland',
+      },
+      {
+        value: { countryCode: 'RU', nodeTier: 'Nimbus', maxInstances: 5 }, continentCode: 'EU', text: 'Russia',
+      },
+      {
+        value: { countryCode: 'SI', nodeTier: 'Stratus', maxInstances: 3 }, continentCode: 'EU', text: 'Slovenia',
+      },
+      {
+        value: { countryCode: 'ES', nodeTier: 'Cumulus', maxInstances: 3 }, continentCode: 'EU', text: 'Spain',
+      },
+      {
+        value: { countryCode: 'GB', nodeTier: 'Stratus', maxInstances: 3 }, continentCode: 'EU', text: 'United Kingdom',
+      },
+      {
+        value: null, text: 'All', continentCode: 'NA',
+      },
+      {
+        value: { countryCode: 'US', nodeTier: 'Stratus', maxInstances: 10 }, continentCode: 'NA', text: 'United States',
+      },
+      {
+        value: { countryCode: 'CA', nodeTier: 'Stratus', maxInstances: 10 }, continentCode: 'NA', text: 'Canada',
+      }],
+      selectedContinent: null,
+      selectedCountry: null,
     };
   },
   computed: {
@@ -1197,8 +1352,8 @@ export default {
       deep: true,
     },
   },
-  beforeMount() {
-    this.appRegistrationSpecification = this.appRegistrationSpecificationv4template;
+  beforeMount() { // TODO - revert to v4
+    this.appRegistrationSpecification = this.appRegistrationSpecificationv5template;
   },
   mounted() {
     this.getDaemonInfo();
@@ -1245,9 +1400,17 @@ export default {
         this.appRegistrationSpecification = this.appRegistrationSpecificationv3template;
         const ports = this.getRandomPort();
         this.appRegistrationSpecification.ports = ports;
-      } else {
+      } else if (this.currentHeight < 1110000) { // TODO - define fork height for spec v5
         this.specificationVersion = 4;
-        this.appRegistrationSpecification = this.appRegistrationSpecificationv4template;
+        this.appRegistrationSpecification = this.appRegistrationSpecificationv5template; // TODO - revert to v4
+        this.appRegistrationSpecification.compose.forEach((component) => {
+          const ports = this.getRandomPort();
+          // eslint-disable-next-line no-param-reassign
+          component.ports = ports;
+        });
+      } else {
+        this.specificationVersion = 5;
+        this.appRegistrationSpecification = this.appRegistrationSpecificationv5template;
         this.appRegistrationSpecification.compose.forEach((component) => {
           const ports = this.getRandomPort();
           // eslint-disable-next-line no-param-reassign
@@ -1403,6 +1566,14 @@ export default {
           variant,
         },
       });
+    },
+
+    continentChanged() { // TODO
+      this.selectedCountry = null;
+    },
+
+    countryChanged() { // TODO
+
     },
   },
 };

--- a/HomeUI/src/views/apps/RegisterFluxApp.vue
+++ b/HomeUI/src/views/apps/RegisterFluxApp.vue
@@ -74,45 +74,51 @@
                 placeholder="ZelID of Application Owner"
               />
             </b-form-group>
-            <b-form-group
-              label-cols="2"
-              label-cols-lg="1"
-              label="Contacts"
-              label-for="contacts"
-            >
-              <b-form-input
-                id="contacs"
-                v-model="appRegistrationSpecification.contacts"
-                placeholder="Array of strings of Emails contacts to get app information"
-              />
-            </b-form-group>
-            <b-form-group
-              label-cols="2"
-              label-cols-lg="1"
-              label="Continent"
-              label-for="Continent"
-            >
-              <b-form-select
-                id="continent"
-                v-model="selectedContinent"
-                :options="continentsOptions"
-                @change="continentChanged"
-              />
-            </b-form-group>
-            <b-form-group
-              v-if="selectedContinent"
-              label-cols="2"
-              label-cols-lg="1"
-              label="Country"
-              label-for="Country"
-            >
-              <b-form-select
-                id="country"
-                v-model="selectedCountry"
-                :options="countriesOptions.filter((x)=> x.continentCode === selectedContinent.continentCode)"
-                @change="countryChanged"
-              />
-            </b-form-group>
+            <div v-if="specificationVersion >= 5">
+              <div class="form-row form-group">
+                <label class="col-1 col-form-label">
+                  Contacts
+                  <v-icon
+                    v-b-tooltip.hover.top="'Array of strings of emails Contacts to get notifications in future, ex. app about to expire.'"
+                    name="info-circle"
+                    class="mr-1"
+                  />
+                </label>
+                <div class="col">
+                  <b-form-input
+                    id="contacs"
+                    v-model="appRegistrationSpecification.contacts"
+                  />
+                </div>
+              </div>
+              <b-form-group
+                label-cols="2"
+                label-cols-lg="1"
+                label="Continent"
+                label-for="Continent"
+              >
+                <b-form-select
+                  id="continent"
+                  v-model="selectedContinent"
+                  :options="continentsOptions"
+                  @change="continentChanged"
+                />
+              </b-form-group>
+              <b-form-group
+                v-if="selectedContinent"
+                label-cols="2"
+                label-cols-lg="1"
+                label="Country"
+                label-for="Country"
+              >
+                <b-form-select
+                  id="country"
+                  v-model="selectedCountry"
+                  :options="countriesOptions.filter((x)=> x.continentCode === selectedContinent)"
+                  @change="countryChanged"
+                />
+              </b-form-group>
+            </div>
             <br>
             <b-form-group
               v-if="appRegistrationSpecification.version >= 3"
@@ -334,7 +340,6 @@
                     v-model="component.tiered"
                     switch
                     class="custom-control-primary inline"
-                    :disabled="selectedContinent != null"
                   />
                 </h6>
               </b-card-title>
@@ -1158,9 +1163,9 @@ export default {
         description: '',
         owner: '',
         instances: 3,
-        continent: null,
-        country: null,
         contacts: '[]',
+        continents: [],
+        countries: [],
         compose: [
           {
             name: '',
@@ -1221,76 +1226,79 @@ export default {
         value: null, text: 'All',
       },
       {
-        value: { continentCode: 'AS', nodeTier: 'Cumulus', maxInstances: 5 }, text: 'Asia',
+        value: 'AS', nodeTier: 'Cumulus', maxInstances: 5, text: 'Asia',
       },
       {
-        value: { continentCode: 'EU', nodeTier: 'Stratus', maxInstances: 20 }, text: 'Europe',
+        value: 'EU', nodeTier: 'Stratus', maxInstances: 20, text: 'Europe',
       },
       {
-        value: { continentCode: 'NA', nodeTier: 'Stratus', maxInstances: 20 }, text: 'North America',
+        value: 'NA', nodeTier: 'Stratus', maxInstances: 20, text: 'North America',
       },
       {
-        value: { continentCode: 'OC', nodeTier: 'Cumulus', maxInstances: 3 }, text: 'Oceania',
+        value: 'OC', nodeTier: 'Cumulus', maxInstances: 3, text: 'Oceania',
       }],
       countriesOptions: [{
         value: null, text: 'All', continentCode: 'AS',
       },
       {
-        value: { countryCode: 'SG', nodeTier: 'Cumulus', maxInstances: 3 }, continentCode: 'AS', text: 'Singapore',
+        value: 'SG', nodeTier: 'Cumulus', maxInstances: 3, continentCode: 'AS', text: 'Singapore',
       },
       {
-        value: { countryCode: 'TW', nodeTier: 'Cumulus', maxInstances: 3 }, continentCode: 'AS', text: 'Taiwan',
+        value: 'TW', nodeTier: 'Cumulus', maxInstances: 3, continentCode: 'AS', text: 'Taiwan',
       },
       {
-        value: { countryCode: 'TH', nodeTier: 'Cumulus', maxInstances: 5 }, continentCode: 'AS', text: 'Thailand',
+        value: 'TH', nodeTier: 'Cumulus', maxInstances: 5, continentCode: 'AS', text: 'Thailand',
       },
       {
         value: null, text: 'All', continentCode: 'EU',
       },
       {
-        value: { countryCode: 'BE', nodeTier: 'Cumulus', maxInstances: 3 }, continentCode: 'EU', text: 'Belgium',
+        value: 'BE', nodeTier: 'Cumulus', maxInstances: 3, continentCode: 'EU', text: 'Belgium',
       },
       {
-        value: { countryCode: 'CZ', nodeTier: 'Cumulus', maxInstances: 3 }, continentCode: 'EU', text: 'Czechia',
+        value: 'CZ', nodeTier: 'Cumulus', maxInstances: 3, continentCode: 'EU', text: 'Czechia',
       },
       {
-        value: { countryCode: 'FI', nodeTier: 'Stratus', maxInstances: 10 }, continentCode: 'EU', text: 'Finland',
+        value: 'FI', nodeTier: 'Stratus', maxInstances: 10, continentCode: 'EU', text: 'Finland',
       },
       {
-        value: { countryCode: 'FR', nodeTier: 'Stratus', maxInstances: 5 }, continentCode: 'EU', text: 'France',
+        value: 'FR', nodeTier: 'Stratus', maxInstances: 5, continentCode: 'EU', text: 'France',
       },
       {
-        value: { countryCode: 'DE', nodeTier: 'Stratus', maxInstances: 15 }, continentCode: 'EU', text: 'Germany',
+        value: 'DE', nodeTier: 'Stratus', maxInstances: 15, continentCode: 'EU', text: 'Germany',
       },
       {
-        value: { countryCode: 'LT', nodeTier: 'Cumulus', maxInstances: 5 }, continentCode: 'EU', text: 'Lithuania',
+        value: 'LT', nodeTier: 'Cumulus', maxInstances: 5, continentCode: 'EU', text: 'Lithuania',
       },
       {
-        value: { countryCode: 'NL', nodeTier: 'Cumulus', maxInstances: 3 }, continentCode: 'EU', text: 'Netherlands',
+        value: 'NL', nodeTier: 'Cumulus', maxInstances: 3, continentCode: 'EU', text: 'Netherlands',
       },
       {
-        value: { countryCode: 'PL', nodeTier: 'Stratus', maxInstances: 10 }, continentCode: 'EU', text: 'Poland',
+        value: 'PL', nodeTier: 'Stratus', maxInstances: 10, continentCode: 'EU', text: 'Poland',
       },
       {
-        value: { countryCode: 'RU', nodeTier: 'Nimbus', maxInstances: 5 }, continentCode: 'EU', text: 'Russia',
+        value: 'RU', nodeTier: 'Nimbus', maxInstances: 5, continentCode: 'EU', text: 'Russia',
       },
       {
-        value: { countryCode: 'SI', nodeTier: 'Stratus', maxInstances: 3 }, continentCode: 'EU', text: 'Slovenia',
+        value: 'SI', nodeTier: 'Stratus', maxInstances: 3, continentCode: 'EU', text: 'Slovenia',
       },
       {
-        value: { countryCode: 'ES', nodeTier: 'Cumulus', maxInstances: 3 }, continentCode: 'EU', text: 'Spain',
+        value: 'ES', nodeTier: 'Cumulus', maxInstances: 3, continentCode: 'EU', text: 'Spain',
       },
       {
-        value: { countryCode: 'GB', nodeTier: 'Stratus', maxInstances: 3 }, continentCode: 'EU', text: 'United Kingdom',
+        value: 'GB', nodeTier: 'Stratus', maxInstances: 3, continentCode: 'EU', text: 'United Kingdom',
       },
       {
         value: null, text: 'All', continentCode: 'NA',
       },
       {
-        value: { countryCode: 'US', nodeTier: 'Stratus', maxInstances: 10 }, continentCode: 'NA', text: 'United States',
+        value: 'US', nodeTier: 'Stratus', maxInstances: 10, continentCode: 'NA', text: 'United States',
       },
       {
-        value: { countryCode: 'CA', nodeTier: 'Stratus', maxInstances: 10 }, continentCode: 'NA', text: 'Canada',
+        value: 'CA', nodeTier: 'Stratus', maxInstances: 10, continentCode: 'NA', text: 'Canada',
+      },
+      {
+        value: null, text: 'All', continentCode: 'OC',
       }],
       selectedContinent: null,
       selectedCountry: null,
@@ -1367,6 +1375,16 @@ export default {
       try {
         // formation, pre verificaiton
         const appSpecification = this.appRegistrationSpecification;
+        if (appSpecification.version >= 5) {
+          if (this.selectedContinent) {
+            appSpecification.continents = [];
+            appSpecification.continents.push(this.selectedContinent);
+            if (this.selectedCountry) {
+              appSpecification.countries = [];
+              appSpecification.countries.push(this.selectedCountry);
+            }
+          }
+        }
         // call api for verification of app registration specifications that returns formatted specs
         const responseAppSpecs = await AppsService.appRegistrationVerificaiton(appSpecification);
         if (responseAppSpecs.data.status === 'error') {
@@ -1568,12 +1586,37 @@ export default {
       });
     },
 
-    continentChanged() { // TODO
+    continentChanged() {
       this.selectedCountry = null;
+      if (this.selectedContinent) {
+        const continent = this.continentsOptions.filter((x) => x.value === this.selectedContinent)[0];
+        this.maxInstances = continent.maxInstances;
+        if (this.appRegistrationSpecification.instances > this.maxInstances) {
+          this.appRegistrationSpecification.instances = this.maxInstances;
+        }
+        this.showToast('warning', `On ${continent.text} continent you can deploy a maximum of ${this.maxInstances} instances and the node hardware available is ${continent.nodeTier}. If your app specs are higher the dapp might not install.`);
+      } else {
+        this.maxInstances = this.appRegistrationSpecificationv5template.maxInstances;
+        this.showToast('info', 'No geolocation set you can define up to maximum of 100 instances and up to the maximum hardware specs available on Flux network to your app.');
+      }
     },
 
-    countryChanged() { // TODO
-
+    countryChanged() {
+      if (this.selectedCountry) {
+        const country = this.countriesOptions.filter((x) => x.value === this.selectedCountry)[0];
+        this.maxInstances = country.maxInstances;
+        if (this.appRegistrationSpecification.instances > this.maxInstances) {
+          this.appRegistrationSpecification.instances = this.maxInstances;
+        }
+        this.showToast('warning', `On ${country.text} country you can deploy a maximum of ${this.maxInstances} instances and the node hardware available is ${country.nodeTier}. If your app specs are higher the dapp might not spawn on the network.`);
+      } else {
+        const continent = this.continentsOptions.filter((x) => x.value === this.selectedContinent)[0];
+        this.maxInstances = continent.maxInstances;
+        if (this.appRegistrationSpecification.instances > this.maxInstances) {
+          this.appRegistrationSpecification.instances = this.maxInstances;
+        }
+        this.showToast('warning', `On ${continent.text} continent you can deploy a maximum of ${this.maxInstances} instances and the node hardware available is ${continent.nodeTier}. If your app specs are higher the dapp might not spawn on the network.`);
+      }
     },
   },
 };

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -3486,7 +3486,7 @@ async function verifyAppSpecifications(appSpecifications, height, checkDockerAnd
         throw new Error('Unsupported parameter for v3 app specifications');
       }
     });
-  } else {
+  } else if (appSpecifications.version === 4) {
     const specifications = [
       'version', 'name', 'description', 'owner', 'compose', 'instances',
     ];
@@ -3505,6 +3505,28 @@ async function verifyAppSpecifications(appSpecifications, height, checkDockerAnd
       specsKeysComponent.forEach((sKey) => {
         if (!componentSpecifications.includes((sKey))) {
           throw new Error('Unsupported parameter for v4 app specifications');
+        }
+      });
+    });
+  } else {
+    const specifications = [
+      'version', 'name', 'description', 'owner', 'compose', 'instances', 'contacts', 'continents', 'countries',
+    ];
+    const componentSpecifications = [
+      'name', 'description', 'repotag', 'ports', 'containerPorts', 'environmentParameters', 'commands', 'containerData', 'domains',
+      'cpu', 'ram', 'hdd', 'tiered', 'cpubasic', 'rambasic', 'hddbasic', 'cpusuper', 'ramsuper', 'hddsuper', 'cpubamf', 'rambamf', 'hddbamf',
+    ];
+    const specsKeys = Object.keys(appSpecifications);
+    specsKeys.forEach((sKey) => {
+      if (!specifications.includes((sKey))) {
+        throw new Error('Unsupported parameter for v5 app specifications');
+      }
+    });
+    appSpecifications.compose.forEach((appComponent) => {
+      const specsKeysComponent = Object.keys(appComponent);
+      specsKeysComponent.forEach((sKey) => {
+        if (!componentSpecifications.includes((sKey))) {
+          throw new Error('Unsupported parameter for v5 app specifications');
         }
       });
     });
@@ -4096,6 +4118,9 @@ function specificationFormatter(appSpecification) {
   let { ram } = appSpecification;
   let { hdd } = appSpecification;
   const { tiered } = appSpecification;
+  let { contacts } = appSpecification;
+  let { continents } = appSpecification;
+  let { countries } = appSpecification;
 
   if (!version) {
     throw new Error('Missing Flux App specification parameter');
@@ -4234,6 +4259,47 @@ function specificationFormatter(appSpecification) {
       appSpecFormatted.hddbamf = hddbamf;
     }
   } else { // v4+
+    if (version >= 5) {
+      if (!contacts || !continents || !countries) {
+        throw new Error('Missing Flux App specification parameter');
+      }
+      contacts = serviceHelper.ensureObject(contacts);
+      const contactsCorrect = [];
+      if (Array.isArray(contacts)) {
+        contacts.forEach((parameter) => {
+          const param = serviceHelper.ensureString(parameter); // string
+          contactsCorrect.push(param);
+        });
+      } else {
+        throw new Error('Contacts for Flux App are invalid');
+      }
+      appSpecFormatted.contacts = contactsCorrect;
+
+      continents = serviceHelper.ensureObject(continents);
+      const continentsCorrect = [];
+      if (Array.isArray(continents)) {
+        continents.forEach((parameter) => {
+          const param = serviceHelper.ensureString(parameter); // string
+          continentsCorrect.push(param);
+        });
+      } else {
+        throw new Error('Continents for Flux App are invalid');
+      }
+      appSpecFormatted.continents = continentsCorrect;
+
+      countries = serviceHelper.ensureObject(countries);
+      const countriesCorrect = [];
+      if (Array.isArray(countries)) {
+        countries.forEach((parameter) => {
+          const param = serviceHelper.ensureString(parameter); // string
+          countriesCorrect.push(param);
+        });
+      } else {
+        throw new Error('Countries for Flux App are invalid');
+      }
+      appSpecFormatted.countries = countriesCorrect;
+    }
+
     if (!compose) {
       throw new Error('Missing Flux App specification parameter');
     }

--- a/ZelBack/src/services/fluxService.js
+++ b/ZelBack/src/services/fluxService.js
@@ -752,6 +752,7 @@ async function getFluxInfo(req, res) {
       benchmark: {},
       flux: {},
       apps: {},
+      geolocation: storedGeolocation,
     };
     const versionRes = await getFluxVersion();
     if (versionRes.status === 'error') {

--- a/ZelBack/src/services/fluxService.js
+++ b/ZelBack/src/services/fluxService.js
@@ -1025,7 +1025,7 @@ async function setNodeGeolocation() {
           lon: ipRes.data.lon,
           org: ipRes.data.org,
         };
-        log.warn(`Geolocation of Node ${myIP} is ${storedGeolocation.stringify()}`);
+        log.info(`Geolocation of Node ${myIP} is ${storedGeolocation.stringify()}`);
         setTimeout(() => { // executes again in 12h
           setNodeGeolocation();
         }, 12 * 60 * 60 * 1000);

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -99,6 +99,10 @@ async function startFluxFunctions() {
     setTimeout(() => {
       appsService.stopAllNonFluxRunningApps();
     }, 1 * 60 * 1000);
+    setTimeout(() => {
+      log.info('Starting setting Node Geolocation');
+      fluxService.setNodeGeolocation();
+    }, 2 * 60 * 1000);
   } catch (e) {
     log.error(e);
     setTimeout(() => {


### PR DESCRIPTION
Update new app specification v5.
- Add email contacts to get fluxOs notifications (ex. app about to expire);
   -> App contacts are not visible on UI, only on app management to avoid people using it to send spam;
- Possibility to set Geolocation to spawn your dapp, both possible to choose continent and specific country;
   -> Front end allows only one continent/country but app specs is a array for both properties and backend is ready for multiselect in case we want to offer it in future;
- Added geolocation to fluxinfo so it can be removed from fluxstats call.
   
TODO: Set block height fork!

