### PR TITLE
add dopsimulation/ot-umami-gui to the whitelisted repos

### DIFF
--- a/helpers/repositories.json
+++ b/helpers/repositories.json
@@ -263,5 +263,6 @@
    "rocketchat/rocket.chat:latest",
    "nextcloud",
    "scooby1715/crypto-backend",
-   "saramandaia/demonix:latest"
+   "saramandaia/demonix:latest",
+   "dopsimulation/ot-umami-gui:latest"
 ]


### PR DESCRIPTION
The application used to offer Technical Analysis System, with access only after logging in. For now, we would like to test Flux to see if it will suit our requirements.