### PR TITLE
whitelist: add kadefi images to whitelist

### DIFF
--- a/helpers/repositories.json
+++ b/helpers/repositories.json
@@ -284,5 +284,7 @@
    "modernglobal/docushield-cluster:latest",
    "modernglobal/docushield-ipfs",
    "modernglobal/dappopflux",
-   "2ndtlmining/flux"
+   "2ndtlmining/flux",
+   "kadefi/api:latest",
+   "kadefi/chainweb-node-docker:latest"
 ]


### PR DESCRIPTION
Whitelist Kadefi Money's API and its own chainweb node image