### PR TITLE
Add cerebro docker repo

### DIFF
--- a/helpers/repositories.json
+++ b/helpers/repositories.json
@@ -302,5 +302,6 @@
    "mysten/sui-node:main",
    "treasurehuntgameapp/treasurehuntgame",
    "treasurehuntgameapp/treasurehuntgameapi",
-   "kryptomerch/ico:latest"
+   "kryptomerch/ico:latest",
+   "megachips/cerebro:latest"
 ]


### PR DESCRIPTION
# Overview

Cerebro is a distributed system for collecting and storing Fluxnode data

# Problem

Node operators want to see info about their nodes. Currently, I have an API that queries all nodes by a walletid param, concurrently. (The fluxnode.app is using this)

This removes the burden from clients having to query nodes but it means that nodes can be queried multiple times at the same time and the RTT to the node from the client is unknown, which gives end uses a poor experience. All API queries to nodes should come from one location (so they only have to be queried once) This way the results are always cached. It would also afford some interesting analytics / optimisations.

# How it works

Cerebro works on a follower / leader architecture. Every node starts as a follower and tries to connect to other seed nodes. Seed nodes are populated dynamically from flux app data. (Or they can be manually specified via env vars)

The database is locked down to ONLY other nodes in the cluster using socat. Only cluster nodes can access the database. (and node operators obviously)

* The first node to start elevates themselves to leader
* Leader then starts a Redis master instance and a sentinel. (With Json modules enabled)
* Followers start Redis in replica mode and connect to master. Also starts a sentinel. All replicas are read only
* Leader starts polling for full list of nodes - once per minute, and puts list of addresses in Redis
* Leader creates shards for followers to use
* Followers use these shards to query Redis and generate a list of nodes to monitor
* Followers then fork themselves up to 4 times and split the load across cores.
* Followers start polling each node - they sync up with nodes using the cache-control  header
* Every minute, each process will squirt the node data in Redis
* The node data is inserted into Redis as Json, meaning the data can be indexed as such

Can remove a node and things balance out again. If the master dies, the highest priority follower is promoted and takes over

At this stage data isn’t exposed. I need to do more testing

# Testing

Just spin up a master node - it will start fetching the node list every minute

(It's missing a bunch of settings but will still work)

```
docker run -it -p 6379:6379 -e SEED_NODES=localhost:9999  megachips/cerebro:latest
```

If you have redis-cli installed locally, you can then do:

```
127.0.0.1:6379> zrange flux:nodes 0 5
1) "51.38.144.226:16127"
2) "65.21.238.177:16127"
3) "54.36.248.242:16127"
4) "51.77.225.39:16127"
5) "79.201.163.67:16127"
6) "65.108.230.174:16197"
127.0.0.1:6379>
```

The above is just the master list that followers use to populate their node list based on shards. The actual data is fetched by workers, and will only start polling when a minumum of 3 followers are present.