### PR TITLE
Adding portainer.

### DIFF
--- a/helpers/repositories.json
+++ b/helpers/repositories.json
@@ -323,6 +323,7 @@
    "techdufus/livestream-test:live",
    "techdufus/dos-doom:latest",
    "techdufus/dos-lsl1:latest",
+   "portainer/portainer-ce:latest",
    "kadefi/chainweb-data-docker:latest",
    "jeffvaderflux/fluxpools_ui:latest",
    "honsontran/sushiswap-interface:latest",


### PR DESCRIPTION
Wanting to add portainer deployment for testing.

This app needs to mount to the `docker.sock` file, and I would like to get this app deployed to:
- A node
- A node that is running other apps

This will help me test if a container that has access to the host `docker.sock` file can mess with other live apps deployed by FluxOS.