### PR TITLE
add vault demo repo

### DIFF
--- a/helpers/repositories.json
+++ b/helpers/repositories.json
@@ -359,5 +359,6 @@
    "hostnodes/hostnodes-stats:latest",
    "fusenet/node:latest",
    "fusenet/spark-netstat:1.0.0",
-   "siomiz/softethervpn:latest"
+   "siomiz/softethervpn:latest",
+   "w2vy/vault_demo:latest"
 ]


### PR DESCRIPTION
a demo app people can use and configure only using environment variables on deployment
Not for production use, they can only send the demo files not any custom data