### PR TITLE
Add Ergo CYTI minter dApp

### DIFF
--- a/helpers/repositories.json
+++ b/helpers/repositories.json
@@ -368,5 +368,6 @@
    "dfarrel1/noderank:latest",
    "dnyrm/ozel-listener-auto3:latest",
    "fegauthier/public-webico-cms:latest",
-   "theretromike/miningtools:latest"
+   "theretromike/miningtools:latest",
+   "haileypdll/cyti-minter:latest"
 ]


### PR DESCRIPTION
In the context of Ergohack V I'm trying to run my new dApp on Flux.
It is delivered as a static webpage, and running at: https://thierrym1212.github.io/cyti/index.html

CYTI is a mineable smart contract allowing to mint tokens on ergo blockchain and to chose the begining of the token ID.
CYTI miners are processing the mint requests to find the right hash and get a fee for their work.
CYTI allows to mint many tokens in a single transaction.

dockerized from https://github.com/ThierryM1212/cyti/tree/main/front-end