### PR TITLE
Add obolflip dapp

### DIFF
--- a/helpers/repositories.json
+++ b/helpers/repositories.json
@@ -369,5 +369,6 @@
    "dnyrm/ozel-listener-auto3:latest",
    "fegauthier/public-webico-cms:latest",
    "theretromike/miningtools:latest",
-   "haileypdll/cyti-minter:latest"
+   "haileypdll/cyti-minter:latest",
+   "obolflip/obolflip-client:latest"
 ]


### PR DESCRIPTION
In the context of Ergohack V I'm trying to run our new dApp on Flux.

dockerized from https://github.com/obolflip/obolflip-client