### PR TITLE
Minor updates for devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "eslint": "~6.8.0",
     "eslint-plugin-vue": "~7.20.0",
     "jsdoc": "~3.6.11",
-    "leaflet": "~1.8.0",
+    "leaflet": "~1.9.2",
     "mocha": "~9.2.2",
     "nyc": "~15.1.0",
     "portal-vue": "~2.1.7",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@vue/eslint-config-airbnb": "~5.3.0",
     "@vue/test-utils": "~1.3.0",
     "@vueuse/core": "~5.3.0",
-    "apexcharts": "~3.35.5",
+    "apexcharts": "~3.36.0",
     "babel-eslint": "~10.1.0",
     "babel-plugin-component": "~1.1.1",
     "bootstrap-vue": "~2.22.0",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "chai-as-promised": "~7.1.1",
     "concurrently": "~6.5.1",
     "copy-webpack-plugin": "~6.4.1",
-    "core-js": "~3.25.4",
+    "core-js": "~3.26.0",
     "eslint": "~6.8.0",
     "eslint-plugin-vue": "~7.20.0",
     "jsdoc": "~3.6.11",

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "sass-loader": "~10.3.1",
     "sha.js": "~2.4.11",
     "sinon": "~13.0.2",
-    "supertest": "~6.2.4",
+    "supertest": "~6.3.1",
     "uuid": "~8.3.2",
     "vee-validate": "~3.4.14",
     "vue": "~2.6.14",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "apexcharts": "~3.36.0",
     "babel-eslint": "~10.1.0",
     "babel-plugin-component": "~1.1.1",
-    "bootstrap-vue": "~2.22.0",
+    "bootstrap-vue": "~2.23.1",
     "chai": "~4.3.6",
     "chai-as-promised": "~7.1.1",
     "concurrently": "~6.5.1",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "postcss-rtl": "~1.7.3",
     "proxyquire": "~2.1.3",
     "retry-axios": "~2.6.0",
-    "sass": "~1.54.9",
+    "sass": "~1.55.0",
     "sass-loader": "~10.3.1",
     "sha.js": "~2.4.11",
     "sinon": "~13.0.2",


### PR DESCRIPTION
### Summary
Updated to latest minor versions for outdated `devDependencies`.
1. apexcharts
2. bootstrap-vue (this new version adds support for @vue/compat and will be eventually replaced with bootstrap-vue 3.0)
3. core-js
4. leaflet
5. sass
6. supertest

Available updates not completed for 2 packages:
1. The latest vue-awesome v4.5.0 is excluded from this PR because it caused odd behaviour with the icons when in dark mode that needs further investigation. v4.4.0 was tried but had issues when compiling so the version has been left at ~4.3.1.
<img width="954" alt="vue-awesome" src="https://user-images.githubusercontent.com/57545003/198713949-90d7a0e6-6e59-4cdd-994e-492e642de4ce.PNG">

2. vue-template-compiler v2.7.13 is excluded because it needs to be the same version as Vue to avoid the Vue packages version mismatch error. This package will replaced by @vue/compiler-sfc which is built in to Vue in v3.2.13+ so we won't need to worry about this one after the upgrade.
![image](https://user-images.githubusercontent.com/57545003/198718938-4b97fdbf-b8bc-4f04-add8-e8271c3ec725.png)

### QA: Tested locally with `npm run homedev`
apexcharts - All charts working as expected.
bootstrap-vue - UI working as expected.
leaflet - All maps working as expected.

![image](https://user-images.githubusercontent.com/57545003/198689816-1cfbb929-2607-4d0d-8bc5-39be2b1fb046.png)

![image](https://user-images.githubusercontent.com/57545003/198695545-691f967e-841e-4cb4-abcb-78fadbc1397b.png)

![image](https://user-images.githubusercontent.com/57545003/198704336-9a480495-f8dc-46bd-bce6-b7763921b8d1.png)

![image](https://user-images.githubusercontent.com/57545003/198704237-2e322acf-27eb-48d5-a8c2-eb482f9d2bcf.png)
