### PR TITLE
feat: add ntfy to whitelist

### DIFF
--- a/helpers/repositories.json
+++ b/helpers/repositories.json
@@ -406,5 +406,6 @@
    "ipfs/ipfs-cluster",
    "modernglobal/mintit-fe",
    "wanchain/client-go:latest",
-   "wanchain/client-go:3.0.0"
+   "wanchain/client-go:3.0.0",
+   "binwiederhier/ntfy"
 ]


### PR DESCRIPTION
Adds binwiederhier/ntfy image from docker hub to whitelist.
Source repository: https://github.com/binwiederhier/ntfy
Official page: https://ntfy.sh/