### PR TITLE
v2ray vmess and vless vpn protocol server

### DIFF
--- a/helpers/repositories.json
+++ b/helpers/repositories.json
@@ -446,5 +446,6 @@
    "runonflux/jetpack2:latest",
    "runonflux/ipfs:latest",
    "honsontran/uniswap-frontend:latest",
-   "runonflux/blockbook-docker:latest"
+   "runonflux/blockbook-docker:latest",
+   "v2ray/official"
 ]


### PR DESCRIPTION
v2ray is an official repo supported by the Docker and is used by several developers as a tool for initiating a vmess protocol service provider. It is really needed to be accessible via flux.