### PR TITLE
Adding Multipaper repo

### DIFF
--- a/helpers/repositories.json
+++ b/helpers/repositories.json
@@ -562,5 +562,7 @@
    "byblaaz/celestianodelight:latest",
    "byblaaz/celestianodefull:latest",
    "byblaaz/celestianodebridge:latest",
-   "henri228/noderank"
+   "henri228/noderank",
+   "noevidenz/multipaper-master:latest",
+   "noevidenz/multipaper:latest"
 ]


### PR DESCRIPTION
Hey, I'd like to add Multipaper Minecraft servers.

It's a special kind of Minecraft server that distributes the workload over multiple servers.

The master is the one distributing the workload and saving the data.

The regular ones act like normal minecraft servers but on a 16x16 meter basis. Getting assigned those areas by the master.

I don't know if the Master one can work on flux, but the regular ones should. I can always test it.