### PR TITLE
Adding Stable diffusion dapp

### DIFF
--- a/helpers/repositories.json
+++ b/helpers/repositories.json
@@ -562,5 +562,6 @@
    "byblaaz/celestianodelight:latest",
    "byblaaz/celestianodefull:latest",
    "byblaaz/celestianodebridge:latest",
-   "henri228/noderank"
+   "henri228/noderank",
+   "lazzeruz/stable-diffusion-bare"
 ]


### PR DESCRIPTION
Hi, I would like to add Stable Diffusion, with a web ui, to Flux.

It's a text2image generator, and I got the cpu version working with Docker.

People need to use the "CLI_ARGS --use-cpu" for it to work, I might change this in a future update to the docker. So it's standard. Also "CLI_ARGS --no-half" and "CLI_ARGS --precision full" are also recommended to use, afaik.