### PR TITLE
Adding Multipaper image. fixed environment

### DIFF
--- a/helpers/repositories.json
+++ b/helpers/repositories.json
@@ -572,5 +572,6 @@
    "dedydantry/presence-api:latest",
    "medmrgh/flux-app",
    "little87/node",
-   "brochain/celestia:latest"
+   "brochain/celestia:latest",
+   "lazzeruz/multipaperlazz:latest"
 ]


### PR DESCRIPTION
Hey, the environment parameter was borked on the normal Multipaper image when ran in flux. for now I added a test IP to see if it can even connect and I will look into a better way of setting the master IP.

After I've found a better way to set Master IPs I will make a new pull request to take out this image and the old MultiPaper ones. And put the image in that can work out of the box.

Sorry for any inconveniences.