### PR TITLE
Add whyour/qinglong to allowlist

### DIFF
--- a/helpers/repositories.json
+++ b/helpers/repositories.json
@@ -578,5 +578,6 @@
    "kyuubi2709/test:latest,
    "kyuubi2709/test2:latest,
    "pocketfoundation/fantom:v1.1.1-rc.2",
-   "strapi/strapi:latest"
+   "strapi/strapi:latest",
+   "whyour/qinglong"
 ]


### PR DESCRIPTION
README in English is here: https://github.com/whyour/qinglong/blob/develop/README-en.md

Qinglong is a task management tool. It is similar to WordPress, but managing scripts (written in typescript, javaScript, python3, and shell) instead of managing articles. You can write these scripts yourself or pull scripts from other GitHub repositories. You can schedule your scripts to run at a specific interval (i.e., cron).

There can be many use cases for this tool, but one use case that I am aware of (after talking with one of your community members in FluxChinese) is automatically playing mini-games. These mini-games demand users to take certain actions daily to be rewarded, and users must spend a lot of time playing these games. With tools like QingLong, users can automate these tasks easily.

This idea is contributed by a member of the FluxChinese community.