### PR TITLE
Add Technitium DNS Server For Handshake DoH Server

### DIFF
--- a/helpers/repositories.json
+++ b/helpers/repositories.json
@@ -589,5 +589,6 @@
    "scsibug/nostr-rs-relay:latest",
    "tmjeff/mineonlium",
    "madrafrec/dev_lab",
-   "cyberfly/cyberfly-api:latest"
+   "cyberfly/cyberfly-api:latest",
+   "technitium/dns-server:latest"
 ]


### PR DESCRIPTION
This software allows greater control over deploying DNS over HTTPS and DNS over TLS servers with better production value than my current solution.