### PR TITLE
Add Caddy Reverse Proxy For Handshake Domain Names

### DIFF
--- a/helpers/repositories.json
+++ b/helpers/repositories.json
@@ -590,5 +590,6 @@
    "tmjeff/mineonlium",
    "madrafrec/dev_lab",
    "cyberfly/cyberfly-api:latest",
-   "technitium/dns-server:latest"
+   "technitium/dns-server:latest",
+   "wirewrex/caddy-hns:latest"
 ]


### PR DESCRIPTION
Experimental.

Docs: https://hub.docker.com/r/wirewrex/caddy-hns