### PR TITLE
Disable creating conflict files

### DIFF
--- a/ZelBack/src/services/syncthingService.js
+++ b/ZelBack/src/services/syncthingService.js
@@ -1968,6 +1968,7 @@ async function startSyncthing() {
         sendOwnership: true,
         syncXattrs: true,
         sendXattrs: true,
+        maxConflicts: 0,
       };
       if (currentConfigOptions.status === 'success') {
         if (currentConfigOptions.data.globalAnnounceEnabled !== newConfig.globalAnnounceEnabled


### PR DESCRIPTION
Syncthing creates multiple duplicate conflict files when multiple nodes launch an app at the same time, this config disables that.