### PR TITLE
v3.32.1

### DIFF
--- a/ZelBack/src/services/upnpService.js
+++ b/ZelBack/src/services/upnpService.js
@@ -45,7 +45,7 @@ async function verifyUPNPsupport(apiport = config.apiport) {
     await client.createMapping({
       public: +apiport + 1,
       private: +apiport + 1,
-      ttl: 2 * 60 * 60, // 2 hours
+      ttl: 0, // 2 hours
       description: 'Flux_OS_reserved_port',
     });
   } catch (error) {
@@ -87,19 +87,19 @@ async function setupUPNP(apiport = config.apiport) {
     await client.createMapping({
       public: +apiport,
       private: +apiport,
-      ttl: 2 * 60 * 60, // 2 hours. Some routers force low ttl if 0, indefinite is used. Flux refreshes this every 6 blocks ~ 12 minutes
+      ttl: 0, // 2 hours. Some routers force low ttl if 0, indefinite is used. Flux refreshes this every 6 blocks ~ 12 minutes
       description: 'Flux_Backend_API',
     });
     await client.createMapping({
       public: +apiport - 1,
       private: +apiport - 1,
-      ttl: 2 * 60 * 60, // 2 hours
+      ttl: 0, // 2 hours
       description: 'Flux_Home_UI',
     });
     await client.createMapping({
       public: +apiport + 2,
       private: +apiport + 2,
-      ttl: 2 * 60 * 60, // 2 hours
+      ttl: 0, // 2 hours
       description: 'Flux_Syncthing',
     });
     return true;
@@ -120,14 +120,14 @@ async function mapUpnpPort(port, description) {
     await client.createMapping({
       public: port,
       private: port,
-      ttl: 2 * 60 * 60, // 2 hours
+      ttl: 0, // 2 hours
       protocol: 'TCP',
       description,
     });
     await client.createMapping({
       public: port,
       private: port,
-      ttl: 2 * 60 * 60, // 2 hours
+      ttl: 0, // 2 hours
       protocol: 'UDP',
       description,
     });
@@ -178,14 +178,14 @@ async function mapPortApi(req, res) {
       await client.createMapping({
         public: port,
         private: port,
-        ttl: 2 * 60 * 60, // 2 hours
+        ttl: 0, // 2 hours
         protocol: 'TCP',
         description: 'Flux_manual_entry',
       });
       await client.createMapping({
         public: port,
         private: port,
-        ttl: 2 * 60 * 60, // 2 hours
+        ttl: 0, // 2 hours
         protocol: 'UDP',
         description: 'Flux_manual_entry',
       });

--- a/ZelBack/src/services/upnpService.js
+++ b/ZelBack/src/services/upnpService.js
@@ -45,7 +45,7 @@ async function verifyUPNPsupport(apiport = config.apiport) {
     await client.createMapping({
       public: +apiport + 1,
       private: +apiport + 1,
-      ttl: 0, // 2 hours
+      ttl: 1 * 60 * 60, // 1 hour
       description: 'Flux_OS_reserved_port',
     });
   } catch (error) {
@@ -87,19 +87,19 @@ async function setupUPNP(apiport = config.apiport) {
     await client.createMapping({
       public: +apiport,
       private: +apiport,
-      ttl: 0, // 2 hours. Some routers force low ttl if 0, indefinite is used. Flux refreshes this every 6 blocks ~ 12 minutes
+      ttl: 1 * 60 * 60, // 1 hour. Some routers force low ttl if 0, indefinite is used. Flux refreshes this every 6 blocks ~ 12 minutes
       description: 'Flux_Backend_API',
     });
     await client.createMapping({
       public: +apiport - 1,
       private: +apiport - 1,
-      ttl: 0, // 2 hours
+      ttl: 1 * 60 * 60, // 1 hour
       description: 'Flux_Home_UI',
     });
     await client.createMapping({
       public: +apiport + 2,
       private: +apiport + 2,
-      ttl: 0, // 2 hours
+      ttl: 1 * 60 * 60, // 1 hour
       description: 'Flux_Syncthing',
     });
     return true;
@@ -120,14 +120,14 @@ async function mapUpnpPort(port, description) {
     await client.createMapping({
       public: port,
       private: port,
-      ttl: 0, // 2 hours
+      ttl: 1 * 60 * 60, // 1 hour
       protocol: 'TCP',
       description,
     });
     await client.createMapping({
       public: port,
       private: port,
-      ttl: 0, // 2 hours
+      ttl: 1 * 60 * 60, // 1 hour
       protocol: 'UDP',
       description,
     });
@@ -178,14 +178,14 @@ async function mapPortApi(req, res) {
       await client.createMapping({
         public: port,
         private: port,
-        ttl: 0, // 2 hours
+        ttl: 1 * 60 * 60, // 1 hour
         protocol: 'TCP',
         description: 'Flux_manual_entry',
       });
       await client.createMapping({
         public: port,
         private: port,
-        ttl: 0, // 2 hours
+        ttl: 1 * 60 * 60, // 1 hour
         protocol: 'UDP',
         description: 'Flux_manual_entry',
       });

--- a/ZelBack/src/services/upnpService.js
+++ b/ZelBack/src/services/upnpService.js
@@ -45,7 +45,7 @@ async function verifyUPNPsupport(apiport = config.apiport) {
     await client.createMapping({
       public: +apiport + 1,
       private: +apiport + 1,
-      ttl: 1 * 60 * 60, // 1 hour
+      ttl: 0, // 1 hour
       description: 'Flux_OS_reserved_port',
     });
   } catch (error) {
@@ -87,19 +87,19 @@ async function setupUPNP(apiport = config.apiport) {
     await client.createMapping({
       public: +apiport,
       private: +apiport,
-      ttl: 1 * 60 * 60, // 1 hour. Some routers force low ttl if 0, indefinite is used. Flux refreshes this every 6 blocks ~ 12 minutes
+      ttl: 0, // 1 hour. Some routers force low ttl if 0, indefinite is used. Flux refreshes this every 6 blocks ~ 12 minutes
       description: 'Flux_Backend_API',
     });
     await client.createMapping({
       public: +apiport - 1,
       private: +apiport - 1,
-      ttl: 1 * 60 * 60, // 1 hour
+      ttl: 0, // 1 hour
       description: 'Flux_Home_UI',
     });
     await client.createMapping({
       public: +apiport + 2,
       private: +apiport + 2,
-      ttl: 1 * 60 * 60, // 1 hour
+      ttl: 0, // 1 hour
       description: 'Flux_Syncthing',
     });
     return true;
@@ -120,14 +120,14 @@ async function mapUpnpPort(port, description) {
     await client.createMapping({
       public: port,
       private: port,
-      ttl: 1 * 60 * 60, // 1 hour
+      ttl: 0, // 1 hour
       protocol: 'TCP',
       description,
     });
     await client.createMapping({
       public: port,
       private: port,
-      ttl: 1 * 60 * 60, // 1 hour
+      ttl: 0, // 1 hour
       protocol: 'UDP',
       description,
     });
@@ -178,14 +178,14 @@ async function mapPortApi(req, res) {
       await client.createMapping({
         public: port,
         private: port,
-        ttl: 1 * 60 * 60, // 1 hour
+        ttl: 0, // 1 hour
         protocol: 'TCP',
         description: 'Flux_manual_entry',
       });
       await client.createMapping({
         public: port,
         private: port,
-        ttl: 1 * 60 * 60, // 1 hour
+        ttl: 0, // 1 hour
         protocol: 'UDP',
         description: 'Flux_manual_entry',
       });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flux",
-  "version": "3.32.0",
+  "version": "3.32.1",
   "description": "Flux, Your Gateway to a Decentralized World",
   "repository": {
     "type": "git",

--- a/tests/unit/upnpService.test.js
+++ b/tests/unit/upnpService.test.js
@@ -145,13 +145,13 @@ describe('upnpService tests', () => {
       sinon.assert.notCalled(logSpy);
       sinon.assert.calledThrice(createMappingSpy);
       sinon.assert.calledWithExactly(createMappingSpy, {
-        public: 123, private: 123, ttl: 7200, description: 'Flux_Backend_API',
+        public: 123, private: 123, ttl: 3600, description: 'Flux_Backend_API',
       });
       sinon.assert.calledWithExactly(createMappingSpy, {
-        public: 122, private: 122, ttl: 7200, description: 'Flux_Home_UI',
+        public: 122, private: 122, ttl: 3600, description: 'Flux_Home_UI',
       });
       sinon.assert.calledWithExactly(createMappingSpy, {
-        public: 125, private: 125, ttl: 7200, description: 'Flux_Syncthing',
+        public: 125, private: 125, ttl: 3600, description: 'Flux_Syncthing',
       });
     });
 
@@ -164,13 +164,13 @@ describe('upnpService tests', () => {
       sinon.assert.notCalled(logSpy);
       sinon.assert.calledThrice(createMappingSpy);
       sinon.assert.calledWithExactly(createMappingSpy, {
-        public: 5550, private: 5550, ttl: 7200, description: 'Flux_Backend_API',
+        public: 5550, private: 5550, ttl: 3600, description: 'Flux_Backend_API',
       });
       sinon.assert.calledWithExactly(createMappingSpy, {
-        public: 5549, private: 5549, ttl: 7200, description: 'Flux_Home_UI',
+        public: 5549, private: 5549, ttl: 3600, description: 'Flux_Home_UI',
       });
       sinon.assert.calledWithExactly(createMappingSpy, {
-        public: 5552, private: 5552, ttl: 7200, description: 'Flux_Syncthing',
+        public: 5552, private: 5552, ttl: 3600, description: 'Flux_Syncthing',
       });
     });
 
@@ -208,14 +208,14 @@ describe('upnpService tests', () => {
       sinon.assert.calledWithExactly(createMappingSpy, {
         public: 123,
         private: 123,
-        ttl: 2 * 60 * 60,
+        ttl: 1 * 60 * 60,
         protocol: 'TCP',
         description: 'some description',
       });
       sinon.assert.calledWithExactly(createMappingSpy, {
         public: 123,
         private: 123,
-        ttl: 2 * 60 * 60,
+        ttl: 1 * 60 * 60,
         protocol: 'UDP',
         description: 'some description',
       });
@@ -360,14 +360,14 @@ describe('upnpService tests', () => {
       sinon.assert.calledWithExactly(createMappingSpy, {
         public: 1234,
         private: 1234,
-        ttl: 2 * 60 * 60,
+        ttl: 1 * 60 * 60,
         protocol: 'TCP',
         description: 'Flux_manual_entry',
       });
       sinon.assert.calledWithExactly(createMappingSpy, {
         public: 1234,
         private: 1234,
-        ttl: 2 * 60 * 60,
+        ttl: 1 * 60 * 60,
         protocol: 'UDP',
         description: 'Flux_manual_entry',
       });
@@ -393,14 +393,14 @@ describe('upnpService tests', () => {
       sinon.assert.calledWithExactly(createMappingSpy, {
         public: 1234,
         private: 1234,
-        ttl: 2 * 60 * 60,
+        ttl: 1 * 60 * 60,
         protocol: 'TCP',
         description: 'Flux_manual_entry',
       });
       sinon.assert.calledWithExactly(createMappingSpy, {
         public: 1234,
         private: 1234,
-        ttl: 2 * 60 * 60,
+        ttl: 1 * 60 * 60,
         protocol: 'UDP',
         description: 'Flux_manual_entry',
       });


### PR DESCRIPTION
- TTL on UPNP mapping is set back to 0
On development mode we will set the TTL to 1 hour and test with more community routers.