### PR TITLE
Add a ChatGPT Bot to your Discord Server

### DIFF
--- a/helpers/repositories.json
+++ b/helpers/repositories.json
@@ -264,5 +264,6 @@
    "astridnet",
    "radiantcommunity",
    "staketechnologies",
-   "piwnik"
+   "piwnik",
+   "wirewrex/chatgpt-discord-bot:latest"
 ]


### PR DESCRIPTION
This image allows you to deploy your own single or multi-response ChatGPT Discord bot into your preferred Discord Server/Channel.

Deploy this image on traditional hosting to get one reply to each prompt within Discord. 

Run this image on Flux to get multiple replies to each prompt in discord. 

The multi-response capabilities enable you to consume multiple perspectives from just one query. While also giving you a streamlined learning experience.