### PR TITLE
v3.33.1

### DIFF
--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -8934,6 +8934,8 @@ async function checkMyAppsAvailability() {
       });
       if (resMyAppAvailability && resMyAppAvailability.data.status === 'error') {
         log.error(`Running application ${app.name} is not reachable from outside!`);
+        log.error(JSON.stringify(data));
+        log.error(`${askingIP}:${askingIpPort}`);
         currentDos += 1;
         dosState += 1;
       }

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -675,7 +675,7 @@ async function checkMyFluxAvailability(retryNumber = 0) {
       if (connectionInfo.status === 'error') {
         dosState += 0.13; // slow increment, DOS after ~75 minutes. 0.13 per minute. This check depends on other nodes being able to connect to my node
         if (dosState > 10) {
-          setDosMessage(connectionInfo.message || 'Flux does not have sufficient peers');
+          setDosMessage(connectionInfo.data.message || 'Flux does not have sufficient peers');
           log.error(dosMessage);
           return false;
         }

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -663,7 +663,13 @@ async function checkMyFluxAvailability(retryNumber = 0) {
   const measuredUptime = fluxUptime();
   if (measuredUptime.status === 'success' && measuredUptime.data > config.fluxapps.minUpTime) { // node has been running for 30 minutes. Upon starting a node, there can be dos that needs resetting
     const nodeList = await fluxCommunicationUtils.deterministicFluxList();
-    if (nodeList.length > config.fluxapps.minIncoming + config.fluxapps.minOutgoing) {
+    // nodeList must include our fluxnode ip myIP
+    let myCorrectIp = `${myIP}:${apiPort}`;
+    if (apiPort === 16127 || apiPort === '16127') {
+      myCorrectIp = myCorrectIp.split(':')[0];
+    }
+    const myNodeExists = nodeList.find((node) => node.ip === myCorrectIp);
+    if (nodeList.length > config.fluxapps.minIncoming + config.fluxapps.minOutgoing && myNodeExists) { // our node MUST be in confirmed list in order to have some peers
       // check sufficient connections
       const connectionInfo = isCommunicationEstablished();
       if (connectionInfo.status === 'error') {

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -561,9 +561,9 @@ function fluxUptime(req, res) {
 function isCommunicationEstablished(req, res) {
   let message;
   if (outgoingPeers.length < config.fluxapps.minOutgoing) { // easier to establish
-    message = messageHelper.createErrorMessage('Not enough outgoing connections established to Flux network');
+    message = messageHelper.createErrorMessage(`Not enough outgoing connections established to Flux network. Minimum required ${config.fluxapps.minOutgoing} found ${outgoingPeers.length}`);
   } else if (incomingPeers.length < config.fluxapps.minIncoming) { // depends on other nodes successfully connecting to my node, todo enforcement
-    message = messageHelper.createErrorMessage('Not enough incoming connections from Flux network');
+    message = messageHelper.createErrorMessage(`Not enough incoming connections from Flux network. Minimum required ${config.fluxapps.minIncoming} found ${incomingPeers.length}`);
   } else {
     message = messageHelper.createSuccessMessage('Communication to Flux network is properly established');
   }
@@ -675,7 +675,7 @@ async function checkMyFluxAvailability(retryNumber = 0) {
       if (connectionInfo.status === 'error') {
         dosState += 0.13; // slow increment, DOS after ~75 minutes. 0.13 per minute. This check depends on other nodes being able to connect to my node
         if (dosState > 10) {
-          setDosMessage(dosMessage || 'Flux does not have sufficient peers');
+          setDosMessage(connectionInfo.message || 'Flux does not have sufficient peers');
           log.error(dosMessage);
           return false;
         }

--- a/ZelBack/src/services/idService.js
+++ b/ZelBack/src/services/idService.js
@@ -135,8 +135,9 @@ async function loginPhrase(req, res) {
       // nodeHardwareSpecsGood is not part of response yet
       if (dosAppsState.data.dosState > 10 || dosAppsState.data.dosMessage !== null) {
         const errMessage = messageHelper.createErrorMessage(dosAppsState.data.dosMessage, 'DOS', dosAppsState.data.dosState);
-        res.json(errMessage);
-        return;
+        log.error(errMessage);
+        // res.json(errMessage);
+        // return;
       }
     }
 

--- a/ZelBack/src/services/idService.js
+++ b/ZelBack/src/services/idService.js
@@ -135,10 +135,8 @@ async function loginPhrase(req, res) {
       // nodeHardwareSpecsGood is not part of response yet
       if (dosAppsState.data.dosState > 10 || dosAppsState.data.dosMessage !== null) {
         const errMessage = messageHelper.createErrorMessage(dosAppsState.data.dosMessage, 'DOS', dosAppsState.data.dosState);
-        log.error(errMessage);
-        // TODO enable v3.32.1
-        // res.json(errMessage);
-        // return;
+        res.json(errMessage);
+        return;
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flux",
-  "version": "3.34.0",
+  "version": "3.33.1",
   "description": "Flux, Your Gateway to a Decentralized World",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flux",
-  "version": "3.33.1",
+  "version": "3.34.0",
   "description": "Flux, Your Gateway to a Decentralized World",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flux",
-  "version": "3.33.0",
+  "version": "3.33.1",
   "description": "Flux, Your Gateway to a Decentralized World",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Fixes missing opening of port before asking if receiver applications port is available
- Fixes 'Flux does not have sufficient peers' error happening on nodes that are not yet confirmed on the network. FluxOS can't have peers if it is not confirmed on Flux network first.
- Better logging