### PR TITLE
Updated "cybergate" to "pgerringer"

### DIFF
--- a/helpers/repositories.json
+++ b/helpers/repositories.json
@@ -272,7 +272,7 @@
    "coolbuster999",
    "realityofmadness",
    "teammakdi",
-   "cybergate",
+   "pgerringer",
    "drupal",
    "bleaker",
    "sigp",


### PR DESCRIPTION
Originally put the wrong repo name to whitelist.