### PR TITLE
Add fluxdapp Docker Repo

### DIFF
--- a/helpers/repositories.json
+++ b/helpers/repositories.json
@@ -280,5 +280,6 @@
    "xk4milx",
    "quoka1",
    "holdroot",
-   "pgerringer"
+   "pgerringer",
+   "fluxdapp"
 ]


### PR DESCRIPTION
# Application whitelist

- Whitelist is in a place acting as a first defence against malicious people that want to misuse Flux in order to for example mine cryptocurrencies or distribute illegal or copyrighted material. 
- To whitelist an application for Flux, please adjust helpers/repositories.json file by adding your desired whitelist for a specific docker hub organisation (recommended), docker hub image or target a specific tag of an image:
- Valid Examples: runonflux, runonflux/website, runonflux/website:latest

# What do you want to Run On Flux?

I don't have a particular application in mind per se. I am interested in experimenting with the capabilities of hosting containers on Flux. I have experience with running containers on Azure, AWS and GCP professionally and want some hands on experience with what Flux offers.

My initial thought process would simply be an app that has some form of benchmarking and I can monitor on several months of hosting for uptime, availability and performance.

# Is your desired application running somewhere already?

I do not currently have the application running.

# Is your application open source?

Not currently available as I have yet to 100% decide what exactly I will run.

# Checklist:

- [* ] Whitelist of application is only modifying repositories.json file
- [* ] repositories.json is still a valid JSON file
- [* ] Only whitelists single docker hub username (one whitelist at a time, more whitelists, more PRs)
- [ *] No other whitelist has been deleted
- [* ] I agree with ToS https://cdn.runonflux.io/Flux_Terms_of_Service.pdf
- [* ] Application follows ToS - Application is not malicious. Application is not a scam. Application does what is meant to do and does not mislead in any way. Application does not do anything illegal. Application is not a mining application (not even bandwidth mining).
- [ *] In case application receives multiple reports, behaves maliciously, it will be blacklisted and removed from the network.
