### PR TITLE
WhiteListing Isoko.xyz by Updating repositories.json

### DIFF
--- a/helpers/repositories.json
+++ b/helpers/repositories.json
@@ -296,5 +296,6 @@
    "sylvain71",
    "russb123",
    "velodrome",
-   "pvilalta"
+   "pvilalta",
+   "isokoxyz"
 ]


### PR DESCRIPTION
Whitelisting Isokoxyz for flux

# Application whitelist

- Whitelist is in a place acting as a first defence against malicious people that want to misuse Flux in order to for example mine cryptocurrencies or distribute illegal or copyrighted material. 
- To whitelist an application for Flux, please adjust helpers/repositories.json file by adding your desired whitelist for a specific docker hub organisation (recommended), docker hub image or target a specific tag of an image:
- Valid Examples: runonflux, runonflux/website, runonflux/website:latest

# What do you want to Run On Flux?

Isoko is an NFT Marketplace and Launchpad on Kadena

*Please describe what application(s) do you plan to run.*

# Is your desired application running somewhere already?

No

*Please provide a POC link to application if it is already running somewhere. (optional)*

# Is your application open source?

No

*Please provide a source code (optional)*

# Checklist:

- [ x] Whitelist of application is only modifying repositories.json file
- [ x] repositories.json is still a valid JSON file
- [ x] Only whitelists single docker hub username (one whitelist at a time, more whitelists, more PRs)
- [x ] No other whitelist has been deleted
- [ x] I agree with ToS https://cdn.runonflux.io/Flux_Terms_of_Service.pdf
- [ x] Application follows ToS - Application is not malicious. Application is not a scam. Application does what is meant to do and does not mislead in any way. Application does not do anything illegal. Application is not a mining application (not even bandwidth mining).
- [ x] In case application receives multiple reports, behaves maliciously, it will be blacklisted and removed from the network. :c
