### PR TITLE
Update syncthingService.js & dockerService.js

### DIFF
--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -781,8 +781,8 @@ async function createFluxAppDockerNetwork(appname, number) {
     Name: `fluxDockerNetwork_${appname}`,
     IPAM: {
       Config: [{
-        Subnet: `172.${number}.0.0/16`,
-        Gateway: `172.${number}.0.1`,
+        Subnet: `172.23.${number}.0/16`,
+        Gateway: `172.23.${number}.1`,
       }],
     },
   };

--- a/ZelBack/src/services/syncthingService.js
+++ b/ZelBack/src/services/syncthingService.js
@@ -1974,7 +1974,7 @@ async function startSyncthing() {
       await serviceHelper.delay(10 * 1000);
       await cmdAsync(execKill).catch((error) => log.error(error));
       await cmdAsync(execKillB).catch((error) => log.error(error));
-      const exec = 'sudo syncthing --allow-newer-config --no-browser --home=$HOME/.config/syncthing & disown';
+      const exec = 'sudo syncthing --allow-newer-config --no-browser --home=$HOME/.config/syncthing & nohup';
       log.info('Spawning Syncthing instance...');
       let errored = false;
       nodecmd.get(exec, async (err) => {


### PR DESCRIPTION
1. Remove disown from the syncthing command on line 1977 and replaced with nohup

2. Update Docker Network creation to allocate RFC complaint private IP addresses.

# Application whitelist

- Whitelist is in a place acting as a first defence against malicious people that want to misuse Flux in order to for example mine cryptocurrencies or distribute illegal or copyrighted material. 
- To whitelist an application for Flux, please adjust helpers/repositories.json file by adding your desired whitelist for a specific docker image organisation (recommended), docker image or target a specific tag of an image:
- Valid Examples: runonflux, runonflux/website, runonflux/website:latest, public.ecr.aws/docker/library/hello-world:linux, ghcr.io/handshake-org/hsd

# What do you want to Run On Flux?

*Please describe what application(s) do you plan to run.*

# Is your desired application running somewhere already?

*Please provide a POC link to application if it is already running somewhere. (optional)*

# Is your application open source?

*Please provide a source code (optional)*

# Checklist:

- [ ] Whitelist of application is only modifying repositories.json file
- [ ] repositories.json is still a valid JSON file
- [ ] Only whitelists single docker image organisation (one whitelist at a time, more whitelists, more PRs)
- [ ] No other whitelist has been deleted
- [ ] I agree with ToS https://cdn.runonflux.io/Flux_Terms_of_Service.pdf
- [ ] Application follows ToS - Application is not malicious. Application is not a scam. Application does what is meant to do and does not mislead in any way. Application does not do anything illegal. Application is not a mining application (not even bandwidth mining).
- [ ] In case application receives multiple reports, behaves maliciously, it will be blacklisted and removed from the network.
