### PR TITLE
Fixing repositories.json [#1028]

### DIFF
--- a/helpers/repositories.json
+++ b/helpers/repositories.json
@@ -311,6 +311,6 @@
    "download.lootlink.xyz/wirewrex",
    "beastob",
    "ngcheewee/gpt4summarizer:latest",
-   "hughparry,
+   "hughparry",
    "woodpeckerci"
 ]


### PR DESCRIPTION
There is a missing double quote in the helpers/repositories.json at line 314 caused by someone. 

Fixes #1028