### PR TITLE
[Improve] Improve passing initial benchmark with halting Block Explorer process

### DIFF
--- a/ZelBack/src/services/explorerService.js
+++ b/ZelBack/src/services/explorerService.js
@@ -28,6 +28,8 @@ let operationBlocked = false;
 let initBPfromNoBlockTimeout;
 let initBPfromErrorTimeout;
 
+const MINUTE_IN_MS = 60 * 1000;
+
 // cache for nodes
 const LRUoptions = {
   max: 20000, // store 20k of nodes value forever, no ttl
@@ -644,7 +646,15 @@ async function processBlock(blockHeight, isInsightExplorer) {
     if (!syncStatus.data.synced) {
       setTimeout(() => {
         processBlock(blockHeight, isInsightExplorer);
-      }, 2 * 60 * 1000);
+      }, 2 * MINUTE_IN_MS);
+      return;
+    }
+    const benchmarkBenchRes = await benchmarkService.getStatus();
+    if(benchmarkBenchRes.status !== 'success') {
+      log.info(`Processing Explorer halted at Height: ${blockDataVerbose.height}, reason Benchmark running or failed`);
+      setTimeout(() => {
+        processBlock(blockHeight, isInsightExplorer);
+      }, 2 * MINUTE_IN_MS);
       return;
     }
     someBlockIsProcessing = true;

--- a/ZelBack/src/services/explorerService.js
+++ b/ZelBack/src/services/explorerService.js
@@ -29,6 +29,7 @@ let initBPfromNoBlockTimeout;
 let initBPfromErrorTimeout;
 
 const MINUTE_IN_MS = 60 * 1000;
+const BENCHMARK_STATUS_CACHE = {validUntil: 0, status: 'none'};
 
 // cache for nodes
 const LRUoptions = {
@@ -649,8 +650,13 @@ async function processBlock(blockHeight, isInsightExplorer) {
       }, 2 * MINUTE_IN_MS);
       return;
     }
-    const benchmarkBenchRes = await benchmarkService.getStatus();
-    if(benchmarkBenchRes.status !== 'success') {
+
+    if(BENCHMARK_STATUS_CACHE.validUntil < Date.now() ){
+      BENCHMARK_STATUS_CACHE.status = await benchmarkService.getStatus();
+      BENCHMARK_STATUS_CACHE.validUntil = Date.now() + MINUTE_IN_MS;
+    }
+    
+    if(BENCHMARK_STATUS_CACHE.status !== 'success') {
       log.info(`Processing Explorer halted at Height: ${blockDataVerbose.height}, reason Benchmark running or failed`);
       setTimeout(() => {
         processBlock(blockHeight, isInsightExplorer);


### PR DESCRIPTION
**Reason:**
- Populating Block Explorer database is both CPU and Disk heavy operation, which can cause that Benchmark stuck in a failing/restarting loop until the Block Explorer process finish.

**Solution:**
- Only process block once benchmark in `success` status, and halt while running, failed, restarting.