### PR TITLE
add mysterium node

### DIFF
--- a/helpers/repositories.json
+++ b/helpers/repositories.json
@@ -339,5 +339,6 @@
    "jackxhxm",
    "hatchkins",
    "xecosystem",
-   "theraw/s3"
+   "theraw/s3",
+   "mysteriumnetwork/myst"
 ]


### PR DESCRIPTION
mysterium node are the node of a blockchain vpn service.


Description:
the application acts as a vpn service node allowing connection via wireguard or openvpn using blockchain technologies.


https://www.mysteriumvpn.com/