### PR TITLE
v4.9.1

### DIFF
--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -39,10 +39,10 @@ async function startFluxFunctions() {
       }
     } else {
       upnpService.setupUPNP(apiPort);
-      setInterval(() => {
-        upnpService.adjustFirewallForUPNP();
-      }, 2 * 60 * 60 * 1000); // every 2 hours
     }
+    setInterval(() => {
+      upnpService.adjustFirewallForUPNP();
+    }, 2 * 60 * 60 * 1000); // every 2 hours
     log.info('Initiating MongoDB connection');
     await dbHelper.initiateDB(); // either true or throws error
     log.info('DB connected');

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -27,7 +27,8 @@ async function startFluxFunctions() {
       process.exit();
     }
     const verifyUpnp = await upnpService.verifyUPNPsupport(apiPort);
-    if (userconfig.initial.apiport && userconfig.initial.apiport !== config.server.apiport) {
+    if (userconfig.initial.apiport && (userconfig.initial.apiport !== config.server.apiport || userconfig.initial.routerIP)) {
+      log.info('FluxOS is configured to run under UPNP');
       if (verifyUpnp !== true) {
         log.error(`Flux port ${userconfig.initial.apiport} specified but UPnP failed to verify support. Shutting down.`);
         process.exit();

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -38,12 +38,12 @@ async function startFluxFunctions() {
         log.error(`Flux port ${userconfig.initial.apiport} specified but UPnP failed to map to api or home port. Shutting down.`);
         process.exit();
       }
+      setInterval(() => {
+        upnpService.adjustFirewallForUPNP();
+      }, 2 * 60 * 60 * 1000); // every 2 hours
     } else {
       upnpService.setupUPNP(apiPort);
     }
-    setInterval(() => {
-      upnpService.adjustFirewallForUPNP();
-    }, 2 * 60 * 60 * 1000); // every 2 hours
     log.info('Initiating MongoDB connection');
     await dbHelper.initiateDB(); // either true or throws error
     log.info('DB connected');

--- a/ZelBack/src/services/upnpService.js
+++ b/ZelBack/src/services/upnpService.js
@@ -100,7 +100,7 @@ async function verifyUPNPsupport(apiport = config.server.apiport) {
       public: +apiport + 1,
       private: +apiport + 1,
       ttl: 0,
-      description: 'Flux_OS_reserved_port',
+      description: 'Flux_Backend_API_SSL',
     });
   } catch (error) {
     log.error(error);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flux",
-  "version": "4.9.0",
+  "version": "4.9.1",
   "description": "Flux, Your Gateway to a Decentralized World",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Patch version to fix verify UPNP support in some routers that fail to create a mapping on table when the local ip/port is already there but with a different description.
This was the error showing on FLuxOs:
VerifyUPNPsupport - Failed Create Mapping
Flux port 161x7 specified but UPnP failed to verify support. Shutting down.