### PR TITLE
Add private repo

### DIFF
--- a/helpers/repositories.json
+++ b/helpers/repositories.json
@@ -353,5 +353,6 @@
    "browserless",
    "gocd",
    "ruimarinho",
-   "lncm"
+   "lncm",
+   "europe-west2-docker.pkg.dev/chode-400710/mugawump"
 ]


### PR DESCRIPTION
Hey,

It's Method from discord. Just adding this private repo of mine from Google Artifact registry. The image is just a junk test image to actually test the end to end process. (I'm building automation tools)

Of note, the namespace is `chode-400710/mugawump` I only have one image in here `cv:latest`

Also - let me know if you would like a PR to fix up the image check for the registry images. Currently the auth endpoint (i.e. /token) is hardcoded as the same as the repo name. This isn't technically correct and is subject to change.

 I have just gone through all this as I have built a tool that validates repos, except it uses the www-authenticate header to parse the realm/service/scope. An obvious example of this is the actual dockerhub registry itself - if you use the www-authenticate header, you don't need to hardcode it.

It's kind of already broken as it is for the following repo:

public.ecr.aws/docker/library/hello-world:linux

This only works because axios is following redirects automatically.

E.g.:

```
> curl -s https://public.ecr.aws/token
<a href="/token/">Moved Permanently</a>.
```

Currently "/token" is hardcoded for the auth endpoint, but if you look at the response from aws, it's actually "/token/" 

Here is the auth header:

```
www-authenticate: Bearer realm="https://public.ecr.aws/token/",service="public.ecr.aws",scope="aws"
```

A better way is to either call the naked /v2 endpoint first and check the return header or to just call the specific endpoint you are after and parse the www-authenticate header for the realm/service/scope. (The latter is the better option)

Let me know if you'd like a PR, thanks - David.
