### PR TITLE
fix typo

### DIFF
--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -321,7 +321,7 @@ async function dockerContainerExec(container, cmd, env, res, callback) {
         callback(err);
       }
       mystream.on('data', (data) => {
-        resulttString = serviceHelper.dockerBufferToString(data);
+        resultString = serviceHelper.dockerBufferToString(data);
         res.write(resultString);
       });
       mystream.on('end', () => callback(null));


### PR DESCRIPTION
- typo in dockerContainerExec prevent correct output
