### PR TITLE
add: notrustverify entity

### DIFF
--- a/helpers/repositories.json
+++ b/helpers/repositories.json
@@ -357,5 +357,6 @@
    "lncm",
    "europe-west2-docker.pkg.dev/chode-400710/mugawump",
    "hydr0gen5",
-   "anonym100"
+   "anonym100",
+   "notrustverify"
 ]


### PR DESCRIPTION
# Application whitelist

- Whitelist is in a place acting as a first defence against malicious people that want to misuse Flux in order to for example mine cryptocurrencies or distribute illegal or copyrighted material. 
- To whitelist an application for Flux, please adjust helpers/repositories.json file by adding your desired whitelist for a specific docker image organisation (recommended), docker image or target a specific tag of an image:
- Valid Examples: runonflux, runonflux/website, runonflux/website:latest, public.ecr.aws/docker/library/hello-world:linux, ghcr.io/handshake-org/hsd

# What do you want to Run On Flux?

A decentralized application application running on Alephium

# Is your desired application running somewhere already?

https://walph.io

# Is your application open source?

https://github.com/notrustverify/walph-frontend

# Checklist:

- [X] Whitelist of application is only modifying repositories.json file
- [X] repositories.json is still a valid JSON file
- [X] Only whitelists single docker image organisation (one whitelist at a time, more whitelists, more PRs)
- [X] No other whitelist has been deleted
- [X] I agree with ToS https://cdn.runonflux.io/Flux_Terms_of_Service.pdf
- [X] Application follows ToS - Application is not malicious. Application is not a scam. Application does what is meant to do and does not mislead in any way. Application does not do anything illegal. Application is not a mining application (not even bandwidth mining).
- [X] In case application receives multiple reports, behaves maliciously, it will be blacklisted and removed from the network.
