### PR TITLE
V4.25.1

### DIFF
--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -10245,6 +10245,15 @@ async function syncthingApps() {
             await cmdAsync(execDIRst);
             // eslint-disable-next-line no-await-in-loop
             const locations = await appLocation(installedApp.name);
+            locations.sort((a, b) => {
+              if (a.ip < b.ip) {
+                return -1;
+              }
+              if (a.ip > b.ip) {
+                return 1;
+              }
+              return 0;
+            });
             // eslint-disable-next-line no-restricted-syntax
             for (const appInstance of locations) {
               const ip = appInstance.ip.split(':')[0];
@@ -10407,6 +10416,15 @@ async function syncthingApps() {
               await cmdAsync(execDIRst);
               // eslint-disable-next-line no-await-in-loop
               const locations = await appLocation(installedApp.name);
+              locations.sort((a, b) => {
+                if (a.ip < b.ip) {
+                  return -1;
+                }
+                if (a.ip > b.ip) {
+                  return 1;
+                }
+                return 0;
+              });
               // eslint-disable-next-line no-restricted-syntax
               for (const appInstance of locations) {
                 const ip = appInstance.ip.split(':')[0];

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -10381,7 +10381,7 @@ async function syncthingApps() {
             foldersConfiguration.push(syncthingFolder);
             if (!syncFolder) {
               newFoldersConfiguration.push(syncthingFolder);
-            } else if (syncFolder && (syncFolder.paused || syncFolder.type !== syncthingFolder.type)) {
+            } else if (syncFolder && (syncFolder.paused || syncFolder.type !== syncthingFolder.type || syncFolder.devices !== syncthingFolder.devices)) {
               newFoldersConfiguration.push(syncthingFolder);
             }
           }

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -10381,7 +10381,7 @@ async function syncthingApps() {
             foldersConfiguration.push(syncthingFolder);
             if (!syncFolder) {
               newFoldersConfiguration.push(syncthingFolder);
-            } else if (syncFolder && (syncFolder.paused || syncFolder.type !== syncthingFolder.type || syncFolder.devices !== syncthingFolder.devices)) {
+            } else if (syncFolder && (syncFolder.paused || syncFolder.type !== syncthingFolder.type || JSON.stringify(syncFolder.devices) !== JSON.stringify(syncthingFolder.devices))) {
               newFoldersConfiguration.push(syncthingFolder);
             }
           }
@@ -10546,7 +10546,7 @@ async function syncthingApps() {
               foldersConfiguration.push(syncthingFolder);
               if (!syncFolder) {
                 newFoldersConfiguration.push(syncthingFolder);
-              } else if (syncFolder && (syncFolder.paused || syncFolder.type !== syncthingFolder.type || syncFolder.devices !== syncthingFolder.devices)) {
+              } else if (syncFolder && (syncFolder.paused || syncFolder.type !== syncthingFolder.type || JSON.stringify(syncFolder.devices) !== JSON.stringify(syncthingFolder.devices))) {
                 newFoldersConfiguration.push(syncthingFolder);
               }
             }

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -10546,7 +10546,7 @@ async function syncthingApps() {
               foldersConfiguration.push(syncthingFolder);
               if (!syncFolder) {
                 newFoldersConfiguration.push(syncthingFolder);
-              } else if (syncFolder && (syncFolder.paused || syncFolder.type !== syncthingFolder.type)) {
+              } else if (syncFolder && (syncFolder.paused || syncFolder.type !== syncthingFolder.type || syncFolder.devices !== syncthingFolder.devices)) {
                 newFoldersConfiguration.push(syncthingFolder);
               }
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flux",
-  "version": "4.25.0",
+  "version": "4.25.1",
   "description": "Flux, Your Gateway to a Decentralized World",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Fix syncthing where folders were not being updated if they were already present on syncthing, the problem is that the devices where that folder are supposed to connect are in the folders configuration, so if devices change, the folder would stop to sync with the new devices and so stop to sync if all devices from the first time the folder was created no longer are running the app or have a new device ID.

This version is the one that will be enforced instead of 4.25.0 and enforcement will happen on january 26th.
It's very important that node operators update as soon as possible to this new version.