### PR TITLE
Add nodejsversion to api

### DIFF
--- a/ZelBack/src/routes.js
+++ b/ZelBack/src/routes.js
@@ -232,8 +232,8 @@ module.exports = (app, expressWs) => {
   app.get('/flux/version', cache('30 seconds'), (req, res) => {
     fluxService.getFluxVersion(req, res);
   });
-  app.get('/flux/nodejsversion', cache('30 seconds'), (req, res) => {
-    fluxService.getNodeJsVersion(req, res);
+  app.get('/flux/nodejsversions', cache('30 seconds'), (req, res) => {
+    fluxService.getNodeJsVersions(req, res);
   });
   app.get('/flux/ip', cache('30 seconds'), (req, res) => {
     fluxService.getFluxIP(req, res);

--- a/ZelBack/src/routes.js
+++ b/ZelBack/src/routes.js
@@ -232,6 +232,9 @@ module.exports = (app, expressWs) => {
   app.get('/flux/version', cache('30 seconds'), (req, res) => {
     fluxService.getFluxVersion(req, res);
   });
+  app.get('/flux/nodejsversion', cache('30 seconds'), (req, res) => {
+    fluxService.getNodeJsVersion(req, res);
+  });
   app.get('/flux/ip', cache('30 seconds'), (req, res) => {
     fluxService.getFluxIP(req, res);
   });

--- a/ZelBack/src/services/fluxService.js
+++ b/ZelBack/src/services/fluxService.js
@@ -926,7 +926,7 @@ async function getFluxInfo(req, res) {
     if (nodeJsVersionsRes.status === 'error') {
       throw nodeJsVersionsRes.data;
     }
-    info.flux.nodeJsVersions = nodeJsVersionsRes.data;
+    info.flux.nodeJsVersion = nodeJsVersionsRes.data.node;
     const ipRes = await getFluxIP();
     if (ipRes.status === 'error') {
       throw ipRes.data;

--- a/ZelBack/src/services/fluxService.js
+++ b/ZelBack/src/services/fluxService.js
@@ -425,9 +425,9 @@ function getFluxVersion(req, res) {
  * @param {object} res Response.
  * @returns {object} Message.
  */
-function getNodeJsVersion(req, res) {
-  const version = process.versions.node;
-  const message = messageHelper.createDataMessage(version);
+function getNodeJsVersions(req, res) {
+  const { versions } = process;
+  const message = messageHelper.createDataMessage(versions);
   return res ? res.json(message) : message;
 }
 
@@ -922,11 +922,11 @@ async function getFluxInfo(req, res) {
       throw versionRes.data;
     }
     info.flux.version = versionRes.data;
-    const nodeJsVersionRes = await getNodeJsVersion();
-    if (nodeJsVersionRes.status === 'error') {
-      throw nodeJsVersionRes.data;
+    const nodeJsVersionsRes = await getNodeJsVersions();
+    if (nodeJsVersionsRes.status === 'error') {
+      throw nodeJsVersionsRes.data;
     }
-    info.flux.nodeJsVersion = nodeJsVersionRes.data;
+    info.flux.nodeJsVersions = nodeJsVersionsRes.data;
     const ipRes = await getFluxIP();
     if (ipRes.status === 'error') {
       throw ipRes.data;
@@ -1473,7 +1473,7 @@ module.exports = {
   restartDaemon,
   reindexDaemon,
   getFluxVersion,
-  getNodeJsVersion,
+  getNodeJsVersions,
   getFluxIP,
   getFluxZelID,
   getFluxPGPidentity,

--- a/ZelBack/src/services/fluxService.js
+++ b/ZelBack/src/services/fluxService.js
@@ -420,6 +420,18 @@ function getFluxVersion(req, res) {
 }
 
 /**
+ * To show NodeJS version.
+ * @param {object} req Request.
+ * @param {object} res Response.
+ * @returns {object} Message.
+ */
+function getNodeJsVersion(req, res) {
+  const version = process.versions.node;
+  const message = messageHelper.createDataMessage(version);
+  return res ? res.json(message) : message;
+}
+
+/**
  * To show FluxOS IP address.
  * @param {object} req Request.
  * @param {object} res Response.
@@ -910,6 +922,11 @@ async function getFluxInfo(req, res) {
       throw versionRes.data;
     }
     info.flux.version = versionRes.data;
+    const nodeJsVersionRes = await getNodeJsVersion();
+    if (nodeJsVersionRes.status === 'error') {
+      throw nodeJsVersionRes.data;
+    }
+    info.flux.nodeJsVersion = nodeJsVersionRes.data;
     const ipRes = await getFluxIP();
     if (ipRes.status === 'error') {
       throw ipRes.data;
@@ -941,26 +958,22 @@ async function getFluxInfo(req, res) {
       throw dosResult.data;
     }
     info.flux.dos = dosResult.data;
-
     const dosAppsResult = await appsService.getAppsDOSState();
     if (dosResult.status === 'error') {
       throw dosAppsResult.data;
     }
     info.flux.appsDos = dosAppsResult.data;
     info.flux.development = userconfig.initial.development || false;
-
     const daemonInfoRes = await daemonServiceControlRpcs.getInfo();
     if (daemonInfoRes.status === 'error') {
       throw daemonInfoRes.data;
     }
     info.daemon.info = daemonInfoRes.data;
-
     const daemonNodeStatusRes = await daemonServiceFluxnodeRpcs.getFluxNodeStatus();
     if (daemonNodeStatusRes.status === 'error') {
       throw daemonNodeStatusRes.data;
     }
     info.node.status = daemonNodeStatusRes.data;
-
     const benchmarkInfoRes = await benchmarkService.getInfo();
     if (benchmarkInfoRes.status === 'error') {
       throw benchmarkInfoRes.data;
@@ -1460,6 +1473,7 @@ module.exports = {
   restartDaemon,
   reindexDaemon,
   getFluxVersion,
+  getNodeJsVersion,
   getFluxIP,
   getFluxZelID,
   getFluxPGPidentity,


### PR DESCRIPTION
Small pull just to add NodeJS version to the Flux api. If this is already available (or crazy), please let me know and close this PR. Also tidied up some inconsistency around whitespace in `fluxService.js`

The benefits outweigh any security risks with exposing the nodeJS version. Security through obfusication is not security. Good version hygiene will ensure node operators are maintaining their nodes. Maybe in the future NodeJS minimum versioning could be enforced alongside fluxOS versions?

The reason I want this is so I can profile nodes to see what node versions people are running - so I can make sure I'm targeting apropriate node versions for a TS package I'm writing.

Also be interesting to see what is out there in the wild.

Testing and working on one of my nodes.

new endpoint `/flux/nodejsversion`

```
davew@salad:~$ curl -s http://localhost:16197/flux/nodejsversion | jq .
{
  "status": "success",
  "data": "20.9.0"
}
```

**Snippet from /flux/info:**
```
    },
    "flux": {
      "version": "4.25.1",
      "nodeJsVersion": "20.9.0",
```

Cheers! 