### PR TITLE
Update repositories.json

### DIFF
--- a/helpers/repositories.json
+++ b/helpers/repositories.json
@@ -386,7 +386,7 @@
    "edouardl",
    "opentensor",
    "clachx/clabe",
-   "omniadevs/ic-http-request-executor",
+   "omniadevs/ic-http-proxy-client",
    "ghcr.io/akash-network/cosmos-omnibus",
    "steemfans",
    "hackmdio",


### PR DESCRIPTION
Related to https://github.com/RunOnFlux/flux/pull/1168.

The image name has simply changed and the new image url is [omniadevs/ic-http-proxy-client](https://hub.docker.com/r/omniadevs/ic-http-proxy-client).