### PR TITLE
[WIP] Feature: pgp flux app signer

### DIFF
--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -9,6 +9,7 @@ module.exports = {
   server: {
     allowedPorts: [16127, 16137, 16147, 16157, 16167, 16177, 16187, 16197],
     apiport: 16127, // homeport is -1, ssl port is +1
+    appVerificationAddress: "169.254.42.42",
   },
   database: {
     url: '127.0.0.1',

--- a/ZelBack/src/services/appVerificationService.js
+++ b/ZelBack/src/services/appVerificationService.js
@@ -16,7 +16,8 @@ const dockerService = require('./dockerService');
 const serviceHelper = require('./serviceHelper');
 const pgpSerivce = require('./pgpService');
 const messageHelper = require('./messageHelper');
-const daemonServiceUtils = require('./daemonService/daemonServiceUtils')
+const daemonServiceUtils = require('./daemonService/daemonServiceUtils');
+const generalService = require('./generalService');
 
 const { randomBytes } = require('node:crypto');
 const express = require('express');

--- a/ZelBack/src/services/appVerificationService.js
+++ b/ZelBack/src/services/appVerificationService.js
@@ -1,0 +1,170 @@
+/**
+ * GetNodeIdentity | NodeBApp -> NodeB (so other end can get public pgp key)
+ * NodeIdentitySent | NodeBApp -> NodeAApp
+ * ChallengeRequest | NodeAApp -> NodeA (contains target ip, apiport via identity)
+ * ChallengeCreated | NodeA (Gets pgp pubkey from ip apiport)
+ * ChallengeSent | NodeAApp -> NodeBApp
+ * ChallengeDecryptRequest | NodeBApp -> NodeB
+ * ChallengeDecrypted | NodeB
+ * DecryptedSent | NodeBApp -> NodeAApp
+ * Verified | NodeAApp has now verified NodeBApp
+ */
+
+const config = require('config');
+const dockerService = require('./dockerService');
+const serviceHelper = require('./serviceHelper');
+const pgpSerivce = require('./pgpService');
+const messageHelper = require('./messageHelper');
+const daemonServiceUtils = require('./daemonService/daemonServiceUtils')
+
+const { randomBytes } = require('node:crypto');
+const express = require('express');
+
+let server = null;
+
+async function generateChallengeMessage(req, res) {
+  const parsedBody = serviceHelper.ensureObject(req.body);
+  const { identity } = parsedBody;
+
+  if (!identity) {
+    res.statusMessage = "Authenticating node identity is required";
+    res.status(422).end();
+    return;
+  }
+
+  const app = await dockerService.getAppNameByContainerIp(req.socket.remoteAddress);
+  if (!app) {
+    res.statusMessage = "You are not authorized for this endpoint";
+    res.status(403).end();
+    return;
+  }
+
+  const fluxnode = daemonServiceUtils.executeCall("listfluxnodes", [identity.txhash]);
+
+  if (!fluxnode) {
+    res.statusMessage = 'Unable to find node identity in deterministicfluxnodelist'
+    res.status(422).end();
+    return;
+  }
+
+  // this is ridiculous having to do this all the time. The node identity should always include the port
+  const [ip, apiport] = fluxnode.ip.includes(":") ? fluxnode.ip.split(":") : [fluxnode.ip, "16127"]
+
+  const message = randomBytes(16).toString('hex');
+  const toEncrypt = JSON.stringify({ app, message })
+
+  // https://1-2-3-4-16127.node.api.runonflux.io/flux/pgp
+  const hyphenEncodedHostname = `${ip.split(".").join("-")}-${apiport}`
+  const pgpEndpoint = `http://${hyphenEncodedHostname}.node.api.runonflux.io/flux/pgp`
+
+  const { data: pgpPubKeyRes } = await serviceHelper.axiosGet(pgpEndpoint, { timeout: 2000 })
+
+  if (!pgpPubKeyRes?.status === "success") {
+    res.statusMessage = "Unable to retrieve pgp key for target"
+    res.status(422).end();
+  }
+
+  const encrypted = await pgpSerivce.encryptMessage(toEncrypt, [pgpPubKeyRes.data])
+
+  const dataMessage = messageHelper.createDataMessage({ message, encrypted });
+  return res ? res.json(dataMessage) : dataMessage;
+}
+
+async function getNodeIdentity(req, res) {
+  const app = await dockerService.getAppNameByContainerIp(req.socket.remoteAddress);
+  if (!app) {
+    res.statusMessage = "You are not authorized for this endpoint";
+    res.status(403).end();
+    return;
+  }
+
+  let outPoint = null;
+  try {
+    // this is reliant on fluxd running
+    const res = await generalService.obtainNodeCollateralInformation();
+    outPoint = { txhash: res.txhash, outidx: res.txindex };
+  } catch {
+    log.error('Error getting collateral info from daemon.');
+  }
+
+  if (!outPoint) {
+    res.statusMessage = 'Unable to get node identity.. try again later'
+    res.status(503).end();
+    return;
+  }
+
+  const message = messageHelper.createDataMessage(outPoint);
+
+  return res ? res.json(message) : message;
+}
+
+async function decryptChallengeMessage(req, res) {
+  const app = await dockerService.getAppNameByContainerIp(req.socket.remoteAddress);
+  if (!app) {
+    res.statusMessage = "You are not authorized for this endpoint";
+    res.status(403).end();
+    return;
+  }
+
+  const parsedBody = serviceHelper.ensureObject(req.body);
+  const { encrypted } = parsedBody;
+
+  if (!encrypted) {
+    res.statusMessage = "Encrypted message not provided";
+    res.status(422).end();
+    return;
+  }
+
+  const pgpPrivateKey = userconfig.initial.pgpPrivateKey;
+
+  if (!pgpPrivateKey) {
+    res.statusMessage = "Pgp key not set"
+    res.status(500).end();
+    return;
+  }
+
+  const decrypted = await pgpSerivce.decryptMessage(encrypted, pgpPrivateKey)
+
+  if (!decrypted) {
+    res.statusMessage = "Unable to decrypt message";
+    res.status(500).end();
+  }
+
+  const challenge = JSON.parse(decrypted);
+
+  if (challenge.app !== app) {
+    res.status(403).end();
+    return;
+  }
+
+  const dataMessage = messageHelper.createDataMessage(challenge.message);
+  return res ? res.json(dataMessage) : dataMessage;
+}
+
+function start() {
+  if (server) return;
+
+  const app = express();
+  app.use(express.json());
+  app.post("/createchallenge", generateChallengeMessage)
+  app.post("/decryptchallenge", decryptChallengeMessage)
+  app.get("/nodeindentity", getNodeIdentity)
+  app.all('*', (_, res) => res.status(404).end());
+
+  const bindAddress = config.server.appVerificationAddress;
+  server = app.listen(80, bindAddress, () => {
+    console.log(`Server listening on port: 80 address: ${bindAddress}`)
+  });
+}
+
+function stop() {
+  if (server) {
+    server.close();
+    server = null;
+  }
+}
+
+module.exports = {
+  start,
+  stop,
+};

--- a/ZelBack/src/services/appVerificationService.js
+++ b/ZelBack/src/services/appVerificationService.js
@@ -11,6 +11,7 @@
  */
 
 const config = require('config');
+const log = require('../lib/log');
 const dockerService = require('./dockerService');
 const serviceHelper = require('./serviceHelper');
 const pgpSerivce = require('./pgpService');
@@ -153,7 +154,7 @@ function start() {
 
   const bindAddress = config.server.appVerificationAddress;
   server = app.listen(80, bindAddress, () => {
-    console.log(`Server listening on port: 80 address: ${bindAddress}`)
+    log.info(`Server listening on port: 80 address: ${bindAddress}`)
   });
 }
 

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -3383,6 +3383,7 @@ async function registerAppLocally(appSpecs, componentSpecs, res) {
       if (!fluxNet) {
         throw new Error(`Flux App network of ${appName} failed to initiate. Range already assigned to different application.`);
       }
+      await fluxNetworkHelper.allowDockerNetworksToAppVerification(fluxNet.IPAM.Config[0].Subnet);
       log.info(serviceHelper.ensureString(fluxNet));
       const fluxNetResponse = {
         status: `Docker network of ${appName} initiated.`,

--- a/ZelBack/src/services/daemonService/daemonServiceUtils.js
+++ b/ZelBack/src/services/daemonService/daemonServiceUtils.js
@@ -37,7 +37,7 @@ let daemonCallRunning = false;
  * To execute a remote procedure call (RPC).
  * @param {string} rpc Remote procedure call.
  * @param {string[]} params RPC parameters.
- * @returns {object} Message.
+ * @returns {Promise<object>} Message.
  */
 async function executeCall(rpc, params) {
   const rpcparameters = params || [];

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -164,6 +164,52 @@ async function getDockerContainerByIdOrName(idOrName) {
   const dockerContainer = docker.getContainer(myContainer.Id);
   return dockerContainer;
 }
+
+/**
+ *
+ * @returns {Promise<string[]>}
+ */
+async function getFluxDockerNetworkSubnets() {
+  const fluxNetworks = await docker.listNetworks({
+    filters: JSON.stringify({
+      name: ['fluxDockerNetwork'],
+    })
+  })
+
+  const subnets = fluxNetworks.map((network) => network.IPAM.Config[0].Subnet);
+
+  return subnets;
+}
+
+async function getAppNameByContainerIp(ip) {
+  const fluxNetworks = await docker.listNetworks({
+    filters: JSON.stringify({
+      name: ['fluxDockerNetwork'],
+    })
+  })
+
+  const fluxNetworkNames = fluxNetworks.map(n => n.Name)
+
+  const networkPromises = []
+  fluxNetworkNames.forEach((networkName) => {
+    const dockerNetwork = docker.getNetwork(networkName)
+    networkPromises.push(dockerNetwork.inspect());
+  })
+
+  const fluxNetworkData = await Promise.all(networkPromises);
+
+  let appName = null;
+  for (const fluxNetwork of fluxNetworkData) {
+    const subnet = fluxNetwork.IPAM.Config[0].Subnet
+    if (serviceHelper.ipInSubnet(ip, subnet)) {
+      appName = fluxNetwork.Name.split("_")[1];
+      break;
+    }
+  }
+
+  return appName;
+}
+
 /**
  * Returns low-level information about a container.
  *
@@ -972,6 +1018,8 @@ module.exports = {
   createFluxDockerNetwork,
   getDockerContainerOnly,
   getDockerContainerByIdOrName,
+  getFluxDockerNetworkSubnets,
+  getAppNameByContainerIp,
   createFluxAppDockerNetwork,
   removeFluxAppDockerNetwork,
   pruneNetworks,

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -633,6 +633,7 @@ async function appDockerCreate(appSpecifications, appName, isComponent, fullAppS
           'max-size': '20m',
         },
       },
+      ExtraHosts: [`app.identity.service:${config.server.appVerificationAddress}`]
     },
   };
 

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -1274,17 +1274,18 @@ async function allowOnlyDockerNetworksToAppVerification() {
 
   if (!firewallActive) return;
 
+  const fluxAppDockerNetworks = '172.23.0.0/16';
   const appVerificationAddress = config.server.appVerificationAddress;
-  const allowDockerNetworks = `LANG="en_US.UTF-8" && sudo ufw allow from 172.23.0.0/16 proto tcp to ${appVerificationAddress}/32 port 80`;
+  const allowDockerNetworks = `LANG="en_US.UTF-8" && sudo ufw allow from ${fluxAppDockerNetworks} proto tcp to ${appVerificationAddress}/32 port 80`;
   // have to use iptables here as ufw won't filter loopback
-  const denyAllElse = `LANG="en_US.UTF-8" && sudo iptables -I INPUT -i lo ! -s 172.23.0.0/16 -d ${appVerificationAddress}/32 -J DROP`;
+  const denyAllElse = `LANG="en_US.UTF-8" && sudo iptables -I INPUT -i lo ! -s ${fluxAppDockerNetworks} -d ${appVerificationAddress}/32 -J DROP`;
   const cmdAsync = util.promisify(nodecmd.get);
   try {
     const cmdResA = await cmdAsync(allowDockerNetworks);
     if (serviceHelper.ensureString(cmdResA).includes('updated') || serviceHelper.ensureString(cmdResA).includes('existing') || serviceHelper.ensureString(cmdResA).includes('added')) {
-      log.info(`Firewall adjusted for network: ${network} to address: ${appVerificationAddress}/32`);
+      log.info(`Firewall adjusted for network: ${fluxAppDockerNetworks} to address: ${appVerificationAddress}/32`);
     } else {
-      log.warn(`Failed to adjust Firewall for network: ${network} to address: ${appVerificationAddress}/32`);
+      log.warn(`Failed to adjust Firewall for network: ${fluxAppDockerNetworks} to address: ${appVerificationAddress}/32`);
     }
     const cmdResB = await cmdAsync(denyAllElse);
     if (serviceHelper.ensureString(cmdResB).includes('updated') || serviceHelper.ensureString(cmdResB).includes('existing') || serviceHelper.ensureString(cmdResB).includes('added')) {

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -1499,7 +1499,7 @@ async function addAppVerificationIpToLoopback() {
     await cmdAsync(addIp);
     ok = true;
   } catch (err) {
-    if (serviceHelper.ensureString(err).includes('File exists')) {
+    if (err.message.includes('File exists')) {
       ok = true;
     } else {
       log.error(err);

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -1278,7 +1278,7 @@ async function allowOnlyDockerNetworksToAppVerification() {
   const appVerificationAddress = config.server.appVerificationAddress;
   const allowDockerNetworks = `LANG="en_US.UTF-8" && sudo ufw allow from ${fluxAppDockerNetworks} proto tcp to ${appVerificationAddress}/32 port 80`;
   // have to use iptables here as ufw won't filter loopback
-  const denyAllElse = `LANG="en_US.UTF-8" && sudo iptables -I INPUT -i lo ! -s ${fluxAppDockerNetworks} -d ${appVerificationAddress}/32 -J DROP`;
+  const denyAllElse = `LANG="en_US.UTF-8" && sudo iptables -I INPUT -i lo ! -s ${fluxAppDockerNetworks} -d ${appVerificationAddress}/32 -j DROP`;
   const cmdAsync = util.promisify(nodecmd.get);
   try {
     const cmdResA = await cmdAsync(allowDockerNetworks);

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -1278,17 +1278,23 @@ async function allowOnlyDockerNetworksToAppVerification() {
   const allowDockerNetworks = `LANG="en_US.UTF-8" && sudo ufw allow from 172.23.0.0/16 proto tcp to ${appVerificationAddress}/32 port 80`;
   // have to use iptables here as ufw won't filter loopback
   const denyAllElse = `LANG="en_US.UTF-8" && sudo iptables -I INPUT -i lo ! -s 172.23.0.0/16 -d ${appVerificationAddress}/32 -J DROP`;
-  const cmdResA = await cmdAsync(allowDockerNetworks);
-  if (serviceHelper.ensureString(cmdResA).includes('updated') || serviceHelper.ensureString(cmdResA).includes('existing') || serviceHelper.ensureString(cmdResA).includes('added')) {
-    log.info(`Firewall adjusted for network: ${network} to address: ${appVerificationAddress}/32`);
-  } else {
-    log.warn(`Failed to adjust Firewall for network: ${network} to address: ${appVerificationAddress}/32`);
+  const cmdAsync = util.promisify(nodecmd.get);
+  try {
+    const cmdResA = await cmdAsync(allowDockerNetworks);
+    if (serviceHelper.ensureString(cmdResA).includes('updated') || serviceHelper.ensureString(cmdResA).includes('existing') || serviceHelper.ensureString(cmdResA).includes('added')) {
+      log.info(`Firewall adjusted for network: ${network} to address: ${appVerificationAddress}/32`);
+    } else {
+      log.warn(`Failed to adjust Firewall for network: ${network} to address: ${appVerificationAddress}/32`);
+    }
+    const cmdResB = await cmdAsync(denyAllElse);
+    if (serviceHelper.ensureString(cmdResB).includes('updated') || serviceHelper.ensureString(cmdResB).includes('existing') || serviceHelper.ensureString(cmdResB).includes('added')) {
+      log.info(`Firewall adjusted to deny access to: ${appVerificationAddress}/32`);
+    } else {
+      log.warn(`Failed to adjust Firewall access to: ${appVerificationAddress}/32`);
+    }
   }
-  const cmdResB = await cmdAsync(denyAllElse);
-  if (serviceHelper.ensureString(cmdResB).includes('updated') || serviceHelper.ensureString(cmdResB).includes('existing') || serviceHelper.ensureString(cmdResB).includes('added')) {
-    log.info(`Firewall adjusted to deny access to: ${appVerificationAddress}/32`);
-  } else {
-    log.warn(`Failed to adjust Firewall access to: ${appVerificationAddress}/32`);
+  catch (err) {
+    log.error(err)
   }
 }
 

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -1287,12 +1287,9 @@ async function allowOnlyDockerNetworksToAppVerification() {
     } else {
       log.warn(`Failed to adjust Firewall for network: ${fluxAppDockerNetworks} to address: ${appVerificationAddress}/32`);
     }
-    const cmdResB = await cmdAsync(denyAllElse);
-    if (serviceHelper.ensureString(cmdResB).includes('updated') || serviceHelper.ensureString(cmdResB).includes('existing') || serviceHelper.ensureString(cmdResB).includes('added')) {
-      log.info(`Firewall adjusted to deny access to: ${appVerificationAddress}/32`);
-    } else {
-      log.warn(`Failed to adjust Firewall access to: ${appVerificationAddress}/32`);
-    }
+    // this doesn't give any output
+    await cmdAsync(denyAllElse);
+    log.info(`Firewall adjusted to deny access to: ${appVerificationAddress}/32`);
   }
   catch (err) {
     log.error(err)

--- a/ZelBack/src/services/pgpService.js
+++ b/ZelBack/src/services/pgpService.js
@@ -101,7 +101,7 @@ async function generateIdentity() {
  * To encrypt a message with an array of encryption public keys
  * @param {string} message Message to encrypt
  * @param {array} encryptionKeys Armored version of array of public key
- * @returns {string} Return armored version of encrypted message
+ * @returns {Promise<string>} Return armored version of encrypted message
  */
 async function encryptMessage(message, encryptionKeys) {
   try {
@@ -124,7 +124,7 @@ async function encryptMessage(message, encryptionKeys) {
  * To decrypt a message with an armored private key
  * @param {string} encryptedMessage Message to encrypt
  * @param {string} decryptionKey Armored version of private key
- * @returns {string} Return plain text message
+ * @returns {Promise<string>} Return plain text message
  */
 async function decryptMessage(encryptedMessage, decryptionKey = userconfig.initial.pgpPrivateKey) {
   try {

--- a/ZelBack/src/services/serviceHelper.js
+++ b/ZelBack/src/services/serviceHelper.js
@@ -145,10 +145,10 @@ function isDecimalLimit(value, decimals = 8) {
  * To handle timeouts on axios connection.
  * @param {string} url URL.
  * @param {object} options Options object.
- * @returns {object} Response.
+ * @returns {Promise<object>} Response.
  */
 // helper function for timeout on axios connection
-const axiosGet = (url, options = {}) => {
+const axiosGet = async (url, options = {}) => {
   if (!options.timeout) {
     // eslint-disable-next-line no-param-reassign
     options.timeout = 20000;
@@ -200,6 +200,25 @@ function commandStringToArray(command) {
   return splitargs(command);
 }
 
+/**
+ * To confirm if ip is in subnet
+ * @param {string} ip
+ * @param {string} subnet
+ * @returns {Boolean}
+ */
+function ipInSubnet(ip, subnet) {
+  let [network, mask] = subnet.split("/");
+
+  ip = Number(ip.split('.').reduce(
+    (ipInt, octet) => (ipInt << 8) + parseInt(octet || 0, 10), 0)
+  );
+  network = Number(network.split('.').reduce(
+    (ipInt, octet) => (ipInt << 8) + parseInt(octet || 0, 10), 0)
+  );
+  mask = parseInt('1'.repeat(mask) + '0'.repeat(32 - mask), 2);
+  return (ip & mask) == (network & mask);
+}
+
 module.exports = {
   ensureBoolean,
   ensureNumber,
@@ -212,4 +231,5 @@ module.exports = {
   isDecimalLimit,
   dockerBufferToString,
   commandStringToArray,
+  ipInSubnet,
 };

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -14,6 +14,7 @@ const geolocationService = require('./geolocationService');
 const upnpService = require('./upnpService');
 const syncthingService = require('./syncthingService');
 const pgpService = require('./pgpService');
+const appVerificationService = require('./appVerificationService')
 
 const apiPort = userconfig.initial.apiport || config.server.apiport;
 const development = userconfig.initial.development || false;
@@ -34,6 +35,10 @@ async function startFluxFunctions() {
         upnpService.adjustFirewallForUPNP();
       }, 1 * 60 * 60 * 1000); // every 1 hours
     }
+
+    fluxNetworkHelper.addAppVerificationIpToLoopback();
+    fluxNetworkHelper.allowOnlyDockerNetworksToAppVerification();
+    appVerificationService.start();
 
     fluxNetworkHelper.installNetcat();
     log.info('Initiating MongoDB connection');


### PR DESCRIPTION
This ones a pretty big deal in my opinon. Mostly done - just need a bit more real world testing and some unittests. (and check the networking)

Allows Flux apps to validate each other. So you can be sure that the inbound / outbound sockets are authenticated between apps. 

**Background:**

Flux has an issue whereby you want to inject private data into running apps, like databases, secrets etc. This in the past has been done by FluxVault. When the app starts up, FluxVault connects to it and gives it some config. This is reliant on the public ip address, and more importantly, there is secure way for a node to reach out to the vault and identify itself.

Now you can!

It means you can seed a FluxApp once - and then nodes can go to other nodes to get their config / secrets!

**What this pull does:**

Adds a service that is available to flux docker networks on the hostname `http://app.identity.service:80` where applications can request a message signed by the node.

The cleartext message and encrypted message are returned to the flux application. The encrypted message contains the appname (based off container source IP by inspecting docker networks) so it is authentication on a per app basis per fluxnode.

There is also an endpoint to decrypt a message - the other end would use this, then send the cleartext message back to prove that they are part of the "app group"

This app signer service has 3 endpoints:

* getnodeidentity (gets the nodes confirmation txid)
* createchallenge - returns the challenge message in cleartext and an encrypted version to be sent
* decryptchallenge - decrypts the message and returns the cleartext if the container ip matches the network for the message.

Suggested mesage flow for an app:

 * GetNodeIdentity | NodeBApp -> NodeB (so other end can get public pgp key)
 * NodeIdentitySent | NodeBApp -> NodeAApp
 * ChallengeRequest | NodeAApp -> NodeA (contains target ip, apiport via identity)
 * ChallengeCreated | NodeA (Gets pgp pubkey from ip apiport)
 * ChallengeSent | NodeAApp -> NodeBApp
 * ChallengeDecryptRequest | NodeBApp -> NodeB
 * ChallengeDecrypted | NodeB
 * DecryptedSent | NodeBApp -> NodeAApp
 * Verified | NodeAApp has now verified NodeBApp

I will edit this writeup and expand a bit... just want to get this pull in.

* Adds an Automatic Private IP Addressing (APIPA) to the loopback adaptor (169.254.42.42)
* Allows connections from flux docker networks to this endpoint
* Denies all other traffic (security in layers) so the host can't access this unless they source their traffic from 172.23.x.x
* Spins up an http server on this loopback address on port 80 (app signer service) (name tbd)

