### PR TITLE
[BUGFIX] fix iptables rules to make them idempotent

### DIFF
--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -3772,6 +3772,14 @@ async function softRegisterAppLocally(appSpecs, componentSpecs, res) {
         throw new Error(`Flux App network of ${appName} failed to initiate. Range already assigned to different application`);
       }
       log.info(serviceHelper.ensureString(fluxNet));
+      const fluxNetworkInterfaces = await dockerService.getFluxDockerNetworkPhysicalInterfaceNames();
+      const accessRemoved = await fluxNetworkHelper.removeDockerContainerAccessToNonRoutable(fluxNetworkInterfaces);
+      const accessRemovedRes = {
+        status: accessRemoved ? `Private network access removed for ${appName}` : `Error removing private network access for ${appName}`,
+      };
+      if (res) {
+        res.write(serviceHelper.ensureString(accessRemovedRes));
+      }
       const fluxNetResponse = {
         status: `Docker network of ${appName} initiated.`,
       };

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -3391,7 +3391,8 @@ async function registerAppLocally(appSpecs, componentSpecs, res) {
         throw new Error(`Flux App network of ${appName} failed to initiate. Range already assigned to different application.`);
       }
       log.info(serviceHelper.ensureString(fluxNet));
-      const accessRemoved = await fluxNetworkHelper.removeDockerContainerAccessToNonRoutable();
+      const fluxNetworkInterfaces = await dockerService.getFluxDockerNetworkPhysicalInterfaceNames();
+      const accessRemoved = await fluxNetworkHelper.removeDockerContainerAccessToNonRoutable(fluxNetworkInterfaces);
       const accessRemovedRes = {
         status: accessRemoved ? `Private network access removed for ${appName}` : `Error removing private network access for ${appName}`,
       };

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -3391,6 +3391,13 @@ async function registerAppLocally(appSpecs, componentSpecs, res) {
         throw new Error(`Flux App network of ${appName} failed to initiate. Range already assigned to different application.`);
       }
       log.info(serviceHelper.ensureString(fluxNet));
+      const accessRemoved = await fluxNetworkHelper.removeDockerContainerAccessToNonRoutable();
+      const accessRemovedRes = {
+        status: accessRemoved ? `Private network access removed for ${appName}` : `Error removing private network access for ${appName}`,
+      };
+      if (res) {
+        res.write(serviceHelper.ensureString(accessRemovedRes));
+      }
       const fluxNetResponse = {
         status: `Docker network of ${appName} initiated.`,
       };

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -822,6 +822,46 @@ async function createFluxDockerNetwork() {
 }
 
 /**
+ *
+ * @returns {Promise<Docker.NetworkInspectInfo[]>}
+ */
+async function getFluxDockerNetworks() {
+  const fluxNetworks = await docker.listNetworks({
+    filters: JSON.stringify({
+      name: ['fluxDockerNetwork'],
+    }),
+  });
+
+  return fluxNetworks;
+}
+
+/**
+ *
+ * @returns {Promise<string[]>}
+ */
+async function getFluxDockerNetworkPhysicalInterfaceNames() {
+  const fluxNetworks = await getFluxDockerNetworks();
+
+  const interfaceNames = fluxNetworks.map((network) => {
+    // the physical interface name is br-<first 12 chars of Id>
+    const intName = `br-${network.Id.slice(0, 12)}`;
+    return intName;
+  });
+
+  return interfaceNames;
+}
+
+/**
+ *
+ * @returns {Promise<string[]>}
+ */
+async function getFluxDockerNetworkSubnets() {
+  const fluxNetworks = await getFluxDockerNetworks();
+  const subnets = fluxNetworks.map((network) => network.IPAM.Config[0].Subnet);
+  return subnets;
+}
+
+/**
  * Creates flux application docker network if doesn't exist
  *
  * @returns {object} response
@@ -973,6 +1013,8 @@ module.exports = {
   createFluxDockerNetwork,
   getDockerContainerOnly,
   getDockerContainerByIdOrName,
+  getFluxDockerNetworkPhysicalInterfaceNames,
+  getFluxDockerNetworkSubnets,
   createFluxAppDockerNetwork,
   removeFluxAppDockerNetwork,
   pruneNetworks,

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -1387,7 +1387,10 @@ async function removeDockerContainerAccessToNonRoutable(fluxNetworkInterfaces) {
   const cmdAsync = util.promisify(nodecmd.get);
 
   const checkIptables = 'sudo iptables --version';
-  const iptablesInstalled = await cmdAsync(checkIptables).catch(() => false);
+  const iptablesInstalled = await cmdAsync(checkIptables).catch(() => {
+    log.error('Unable to find iptables binary');
+    return false
+  });
 
   if (!iptablesInstalled) return false;
 

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -1358,7 +1358,9 @@ async function purgeUFW() {
  * As can be seen in this example:
  *
  * Originally, was using the FLUX chain, but you can see docker inserted the br-72d1725e481c network ahead, as well as the JUMP to DOCKER-USER,
- * which invalidates any rules in the FLUX chain, as there is basically an accept any.
+ * which invalidates any rules in the FLUX chain, as there is basically an accept any:
+ *
+ * FORWARD -i br-72d1725e481c ! -o br-72d1725e481c -j ACCEPT
  *
  * ```bash
  * -A INPUT -j ufw-track-input

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -1430,8 +1430,8 @@ async function removeDockerContainerAccessToNonRoutable() {
   const appendAction = '-A';
 
   const baseDropCmd = `sudo iptables ### DOCKER-USER -s ${fluxSrc} -d @@@ -j DROP`;
-  const baseAllowEstablishedCmd = `sudo iptables ### DOCKER-USER -s ${fluxSrc} -d @@@ -m state --state ESTABLISHED,RELATED -j ACCEPT`;
-  const baseAllowDnsCmd = `sudo iptables ### DOCKER-USER -s ${fluxSrc} -p udp -d @@@ --dport 53 -j ACCEPT`;
+  const baseAllowEstablishedCmd = `sudo iptables ### DOCKER-USER -s ${fluxSrc} -d @@@ -m state --state RELATED,ESTABLISHED -j ACCEPT`;
+  const baseAllowDnsCmd = `sudo iptables ### DOCKER-USER -s ${fluxSrc} -d @@@ -p udp --dport 53 -j ACCEPT`;
 
   const baseCheckDropAccess = baseDropCmd.replace('###', checkAction);
   const baseCheckHostAccess = baseAllowEstablishedCmd.replace('###', checkAction);

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -1382,7 +1382,7 @@ async function removeDockerContainerAccessToHost() {
   const cmdAsync = util.promisify(nodecmd.get);
 
   // check if rules have been created, as iptables is NOT idempotent.
-  const checkDockerUserChain = 'sudo iptables -L DOCKER-USER ';
+  const checkDockerUserChain = 'sudo iptables -L DOCKER-USER';
   const checkJumpChain = 'sudo iptables -C FORWARD -j DOCKER-USER';
 
   let unrecoverable = false;
@@ -1431,39 +1431,35 @@ async function removeDockerContainerAccessToHost() {
   try {
     routes = JSON.parse(rawRoutes);
   } catch (err) {
-    log.error("Error parsing JSON for routes... skipping");
+    log.error('Error parsing JSON for routes... skipping');
     return;
   }
 
-  const defaultRoute = routes.find((route) => route.dst === "default");
+  const defaultRoute = routes.find((route) => route.dst === 'default');
 
   if (!defaultRoute) {
-    log.error("Unable to find default gateway... skipping");
+    log.error('Unable to find default gateway... skipping');
     return;
   }
 
   const localSubnet = routes.find((route) => serviceHelper.ipInSubnet(defaultRoute.gateway, route.dst));
 
   if (!localSubnet) {
-    log.error("Unable to find local subnet... skipping");
+    log.error('Unable to find local subnet... skipping');
   }
 
-  // console.log(defaultRoute)
-  // console.log(localSubnet)
-
-  const fluxSrc = '172.23.0.0/16'
+  const fluxSrc = '172.23.0.0/16';
   const checkAction = '-C';
-  const insertAction = "-I";
-  const appendAction = "-A";
+  const insertAction = '-I';
+  const appendAction = '-A';
 
-  const baseDropCmd = `sudo iptables ### DOCKER-USER -s ${fluxSrc} -d ${localSubnet.dst} -j DROP`
-  const baseAllowEstablishedCmd = `sudo iptables ### DOCKER-USER -s ${fluxSrc} -d ${localSubnet.dst} -m state --state ESTABLISHED,RELATED -j ACCEPT`
-  const baseAllowDnsCmd = `sudo iptables ### DOCKER-USER -s ${fluxSrc} -p udp -d ${localSubnet.dst} --dport 53 -j ACCEPT`
+  const baseDropCmd = `sudo iptables ### DOCKER-USER -s ${fluxSrc} -d ${localSubnet.dst} -j DROP`;
+  const baseAllowEstablishedCmd = `sudo iptables ### DOCKER-USER -s ${fluxSrc} -d ${localSubnet.dst} -m state --state ESTABLISHED,RELATED -j ACCEPT`;
+  const baseAllowDnsCmd = `sudo iptables ### DOCKER-USER -s ${fluxSrc} -p udp -d ${localSubnet.dst} --dport 53 -j ACCEPT`;
 
   const checkDropAccess = baseDropCmd.replace('###', checkAction);
   const checkHostAccess = baseAllowEstablishedCmd.replace('###', checkAction);
   const checkContainerDnsAccess = baseAllowDnsCmd.replace('###', checkAction);
-
 
   if (checkJumpToDockerChain) log.info('jump to DOCKER-USER chain already enabled in iptables');
 

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -1429,7 +1429,7 @@ async function removeDockerContainerAccessToNonRoutable() {
   const fluxSrc = '172.23.0.0/16';
 
   const baseDropCmd = `sudo iptables -A DOCKER-USER -s ${fluxSrc} -d #DST -j DROP`;
-  const baseAllowToFluxNetworksCmd = `sudo iptables -I DOCKER-USER -i #INT -o #INT -j ACCEPT`;
+  const baseAllowToFluxNetworksCmd = 'sudo iptables -I DOCKER-USER -i #INT -o #INT -j ACCEPT';
   const baseAllowEstablishedCmd = `sudo iptables -I DOCKER-USER -s ${fluxSrc} -d #DST -m state --state RELATED,ESTABLISHED -j ACCEPT`;
   const baseAllowDnsCmd = `sudo iptables -I DOCKER-USER -s ${fluxSrc} -d #DST -p udp --dport 53 -j ACCEPT`;
 
@@ -1438,7 +1438,7 @@ async function removeDockerContainerAccessToNonRoutable() {
 
   try {
     await cmdAsync(flushDockerUserCmd);
-    log.info(`IPTABLES: DOCKER-USER table flushed`);
+    log.info('IPTABLES: DOCKER-USER table flushed');
   } catch (err) {
     log.error(`IPTABLES: Error flushing DOCKER-USER table. ${err}`);
     return false;
@@ -1448,9 +1448,10 @@ async function removeDockerContainerAccessToNonRoutable() {
   // add for legacy apps
   fluxNetworkInterfaces.push('docker0');
 
+  // eslint-disable-next-line no-restricted-syntax
   for (const int of fluxNetworkInterfaces) {
     // if this errors, we need to bail, as if the deny succeedes, we may cut off access
-    const giveFluxNetworkAccess = baseAllowToFluxNetworksCmd.replace(/#INT/g, int)
+    const giveFluxNetworkAccess = baseAllowToFluxNetworksCmd.replace(/#INT/g, int);
     try {
       // eslint-disable-next-line no-await-in-loop
       await cmdAsync(giveFluxNetworkAccess);
@@ -1499,7 +1500,7 @@ async function removeDockerContainerAccessToNonRoutable() {
 
   try {
     await cmdAsync(addReturnCmd);
-    log.info(`IPTABLES: DOCKER-USER explicit return to FORWARD chain added`);
+    log.info('IPTABLES: DOCKER-USER explicit return to FORWARD chain added');
   } catch (err) {
     log.error(`IPTABLES: Error adding explicit return to Forward chain. ${err}`);
     return false;

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -20,7 +20,6 @@ const daemonServiceWalletRpcs = require('./daemonService/daemonServiceWalletRpcs
 const benchmarkService = require('./benchmarkService');
 const verificationHelper = require('./verificationHelper');
 const fluxCommunicationUtils = require('./fluxCommunicationUtils');
-const dockerService = require('./dockerService');
 const {
   outgoingConnections, outgoingPeers, incomingPeers, incomingConnections,
 } = require('./utils/establishedConnections');
@@ -1379,9 +1378,9 @@ async function purgeUFW() {
  *```
  * This means if a user or someone was to delete a single rule, we are able to recover correctly from it.
  *
- * The other option - is just to Flush all rules on every run, and reset them all.
+ * The other option - is just to Flush all rules on every run, and reset them all. This is what we are doing now.
  */
-async function removeDockerContainerAccessToNonRoutable() {
+async function removeDockerContainerAccessToNonRoutable(fluxNetworkInterfaces) {
   const cmdAsync = util.promisify(nodecmd.get);
 
   // check if rules have been created, as iptables is NOT idempotent.
@@ -1444,7 +1443,6 @@ async function removeDockerContainerAccessToNonRoutable() {
     return false;
   }
 
-  const fluxNetworkInterfaces = await dockerService.getFluxDockerNetworkPhysicalInterfaceNames();
   // add for legacy apps
   fluxNetworkInterfaces.push('docker0');
 

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -80,11 +80,6 @@ class TokenBucket {
 }
 
 /**
- * no operation function
- */
-function noop() { }
-
-/**
  * Check if semantic version is bigger or equal to minimum version
  * @param {string} version Version to check
  * @param {string} minimumVersion minimum version that version must meet
@@ -1374,8 +1369,7 @@ async function removeDockerContainerAccessToHost() {
   const fluxChainExists = await cmdAsync(checkFluxChain).catch(async () => {
     try {
       await cmdAsync('sudo iptables -N FLUX');
-      // catch this silently so we are only testing one statement with try
-      log.info('Flux iptables chain created').catch(noop);
+      log.info('Flux iptables chain created');
     } catch (err) {
       log.error('Error adding FLUX chain to iptables');
       // if we can't add chain, we can't proceed
@@ -1392,7 +1386,7 @@ async function removeDockerContainerAccessToHost() {
       const jumpToFluxChain = 'sudo iptables -I FORWARD -j FLUX';
       try {
         await cmdAsync(jumpToFluxChain);
-        log.info('New FORWARDED inserted to jump to FLUX chain in iptables').catch(noop);
+        log.info('New FORWARDED inserted to jump to FLUX chain in iptables');
       } catch (err) {
         log.error('Error inserting FORWARD jump to FLUX chain');
         // if we can't jump, we need to bail out
@@ -1415,7 +1409,7 @@ async function removeDockerContainerAccessToHost() {
       const dropAccessToHostNetwork = "sudo iptables -A FLUX -i docker0 -d $(ip route | grep \"src $(ip addr show dev $(ip route | awk '/default/ {print $5}') | grep \"inet\" | awk 'NR==1{print $2}' | cut -d'/' -f 1)\" | awk '{print $1}') -j DROP";
       try {
         await cmdAsync(dropAccessToHostNetwork);
-        log.info('Access to host from containers removed').catch(noop);
+        log.info('Access to host from containers removed');
       } catch (err) { log.error(`Error executing dropAccessToHostNetwork command:${err}`); }
     } else {
       log.error(checkErr);
@@ -1429,7 +1423,7 @@ async function removeDockerContainerAccessToHost() {
       const giveHostAccessToDockerNetwork = "sudo iptables -I FLUX -i docker0 -d $(ip route | grep \"src $(ip addr show dev $(ip route | awk '/default/ {print $5}') | grep \"inet\" | awk 'NR==1{print $2}' | cut -d'/' -f 1)\" | awk '{print $1}') -m state --state ESTABLISHED,RELATED -j ACCEPT";
       try {
         await cmdAsync(giveHostAccessToDockerNetwork);
-        log.info('Access to containers from host accepted').catch(noop);
+        log.info('Access to containers from host accepted');
       } catch (err) { log.error(`Error executing giveHostAccessToDockerNetwork command:${err}`); }
     } else {
       log.error(checkErr);
@@ -1443,7 +1437,7 @@ async function removeDockerContainerAccessToHost() {
       const giveContainerAccessToDNS = "sudo iptables -I FLUX -i docker0 -p udp -d $(ip route | grep \"src $(ip addr show dev $(ip route | awk '/default/ {print $5}') | grep \"inet\" | awk 'NR==1{print $2}' | cut -d'/' -f 1)\" | awk '{print $1}') --dport 53 -j ACCEPT";
       try {
         await cmdAsync(giveContainerAccessToDNS);
-        log.info('Access to host DNS from containers accepted').catch(noop);
+        log.info('Access to host DNS from containers accepted');
       } catch (err) { log.error(`Error executing giveContainerAccessToDNS command:${err}`); }
     } else {
       log.error(checkErr);

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -1478,8 +1478,6 @@ async function removeDockerContainerAccessToHost() {
   if (containerDns) log.info('Access to host DNS from containers already accepted');
 }
 
-removeDockerContainerAccessToHost();
-
 const lruRateOptions = {
   max: 500,
   ttl: 1000 * 15, // 15 seconds

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -80,6 +80,11 @@ class TokenBucket {
 }
 
 /**
+ * no operation function
+ */
+function noop() { }
+
+/**
  * Check if semantic version is bigger or equal to minimum version
  * @param {string} version Version to check
  * @param {string} minimumVersion minimum version that version must meet
@@ -1369,7 +1374,8 @@ async function removeDockerContainerAccessToHost() {
   const fluxChainExists = await cmdAsync(checkFluxChain).catch(async () => {
     try {
       await cmdAsync('sudo iptables -N FLUX');
-      log.info('Flux iptables chain created');
+      // catch this silently so we are only testing one statement with try
+      log.info('Flux iptables chain created').catch(noop);
     } catch (err) {
       log.error('Error adding FLUX chain to iptables');
       // if we can't add chain, we can't proceed
@@ -1386,14 +1392,16 @@ async function removeDockerContainerAccessToHost() {
       const jumpToFluxChain = 'sudo iptables -I FORWARD -j FLUX';
       try {
         await cmdAsync(jumpToFluxChain);
-        log.info('New FORWARDED inserted to jump to FLUX chain in iptables');
+        log.info('New FORWARDED inserted to jump to FLUX chain in iptables').catch(noop);
       } catch (err) {
         log.error('Error inserting FORWARD jump to FLUX chain');
         // if we can't jump, we need to bail out
-        unrecoverable = true;;
+        unrecoverable = true;
       }
     } else {
+      // if we can't check if the chain jump is ok, we should bail out
       log.error(checkErr);
+      unrecoverable = true;;
     }
   });
 
@@ -1407,7 +1415,7 @@ async function removeDockerContainerAccessToHost() {
       const dropAccessToHostNetwork = "sudo iptables -A FLUX -i docker0 -d $(ip route | grep \"src $(ip addr show dev $(ip route | awk '/default/ {print $5}') | grep \"inet\" | awk 'NR==1{print $2}' | cut -d'/' -f 1)\" | awk '{print $1}') -j DROP";
       try {
         await cmdAsync(dropAccessToHostNetwork);
-        log.info('Access to host from containers removed');
+        log.info('Access to host from containers removed').catch(noop);
       } catch (err) { log.error(`Error executing dropAccessToHostNetwork command:${err}`); }
     } else {
       log.error(checkErr);
@@ -1421,7 +1429,7 @@ async function removeDockerContainerAccessToHost() {
       const giveHostAccessToDockerNetwork = "sudo iptables -I FLUX -i docker0 -d $(ip route | grep \"src $(ip addr show dev $(ip route | awk '/default/ {print $5}') | grep \"inet\" | awk 'NR==1{print $2}' | cut -d'/' -f 1)\" | awk '{print $1}') -m state --state ESTABLISHED,RELATED -j ACCEPT";
       try {
         await cmdAsync(giveHostAccessToDockerNetwork);
-        log.info('Access to containers from host accepted');
+        log.info('Access to containers from host accepted').catch(noop);
       } catch (err) { log.error(`Error executing giveHostAccessToDockerNetwork command:${err}`); }
     } else {
       log.error(checkErr);
@@ -1435,7 +1443,7 @@ async function removeDockerContainerAccessToHost() {
       const giveContainerAccessToDNS = "sudo iptables -I FLUX -i docker0 -p udp -d $(ip route | grep \"src $(ip addr show dev $(ip route | awk '/default/ {print $5}') | grep \"inet\" | awk 'NR==1{print $2}' | cut -d'/' -f 1)\" | awk '{print $1}') --dport 53 -j ACCEPT";
       try {
         await cmdAsync(giveContainerAccessToDNS);
-        log.info('Access to host DNS from containers accepted');
+        log.info('Access to host DNS from containers accepted').catch(noop);
       } catch (err) { log.error(`Error executing giveContainerAccessToDNS command:${err}`); }
     } else {
       log.error(checkErr);

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -1371,6 +1371,7 @@ async function removeDockerContainerAccessToHost() {
     } catch (err) {
       log.error('Error adding FLUX chain to iptables');
       // if we can't add chain, we can't proceed
+      return;
     }
   });
 
@@ -1385,6 +1386,7 @@ async function removeDockerContainerAccessToHost() {
       } catch (err) {
         log.error('Error inserting FORWARD jump to FLUX chain');
         // if we can't jump, we need to bail out
+        return;
       }
     } else {
       log.error(checkErr);

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -1381,7 +1381,7 @@ async function purgeUFW() {
  * The other option - is just to Flush all rules on every run, and reset them all. This is what we are doing now.
  *
  * @param {string[]} fluxNetworkInterfaces The network interfaces, br-<12 character string>
- * @returns  {Boolean}
+ * @returns  {Promise<Boolean>}
  */
 async function removeDockerContainerAccessToNonRoutable(fluxNetworkInterfaces) {
   const cmdAsync = util.promisify(nodecmd.get);

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -1379,6 +1379,9 @@ async function purgeUFW() {
  * This means if a user or someone was to delete a single rule, we are able to recover correctly from it.
  *
  * The other option - is just to Flush all rules on every run, and reset them all. This is what we are doing now.
+ *
+ * @param {string[]} fluxNetworkInterfaces The network interfaces, br-<12 character string>
+ * @returns  {Boolean}
  */
 async function removeDockerContainerAccessToNonRoutable(fluxNetworkInterfaces) {
   const cmdAsync = util.promisify(nodecmd.get);

--- a/ZelBack/src/services/serviceHelper.js
+++ b/ZelBack/src/services/serviceHelper.js
@@ -200,6 +200,42 @@ function commandStringToArray(command) {
   return splitargs(command);
 }
 
+/**
+ *
+ * @param {*} ip ip address to check
+ * @returns {Boolean}
+ */
+function validIpv4Address(ip) {
+  // first octet must start with 1-9, then next 3 can be 0.
+  const ipv4Regex = /^[1-9]\d{0,2}\.(\d{0,3}\.){2}\d{0,3}$/;
+
+  if (!ipv4Regex.test(ip)) return false;
+
+  const octets = ip.split('.');
+  const isValid = octets.every((octet) => parseInt(octet, 10) < 256);
+  return isValid;
+}
+
+/**
+ * To confirm if ip is in subnet
+ * @param {string} ip
+ * @param {string} subnet
+ * @returns {Boolean}
+ */
+function ipInSubnet(ip, subnet) {
+  const [network, mask] = subnet.split('/');
+
+  if (!validIpv4Address(ip) || !validIpv4Address(network)) return false;
+
+  // eslint-disable-next-line no-bitwise
+  const ipAsInt = Number(ip.split('.').reduce((ipInt, octet) => (ipInt << 8) + parseInt(octet || 0, 10), 0));
+  // eslint-disable-next-line no-bitwise
+  const networkAsInt = Number(network.split('.').reduce((ipInt, octet) => (ipInt << 8) + parseInt(octet || 0, 10), 0));
+  const maskAsInt = parseInt('1'.repeat(mask) + '0'.repeat(32 - mask), 2);
+  // eslint-disable-next-line no-bitwise
+  return (ipAsInt & maskAsInt) === (networkAsInt & maskAsInt);
+}
+
 module.exports = {
   ensureBoolean,
   ensureNumber,
@@ -212,4 +248,6 @@ module.exports = {
   isDecimalLimit,
   dockerBufferToString,
   commandStringToArray,
+  validIpv4Address,
+  ipInSubnet,
 };

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -14,6 +14,7 @@ const geolocationService = require('./geolocationService');
 const upnpService = require('./upnpService');
 const syncthingService = require('./syncthingService');
 const pgpService = require('./pgpService');
+const dockerService = require('./dockerService');
 
 const apiPort = userconfig.initial.apiport || config.server.apiport;
 const development = userconfig.initial.development || false;

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -91,10 +91,11 @@ async function startFluxFunctions() {
     setTimeout(() => {
       fluxCommunicationUtils.constantlyUpdateDeterministicFluxList(); // updates deterministic flux list for communication every 2 minutes, so we always trigger cache and have up to date value
     }, 15 * 1000);
-    setTimeout(() => {
+    setTimeout(async () => {
       log.info('Rechecking firewall app rules');
       fluxNetworkHelper.purgeUFW();
-      fluxNetworkHelper.removeDockerContainerAccessToNonRoutable();
+      const fluxNetworkInterfaces = await dockerService.getFluxDockerNetworkPhysicalInterfaceNames();
+      fluxNetworkHelper.removeDockerContainerAccessToNonRoutable(fluxNetworkInterfaces);
       appsService.testAppMount(); // test if our node can mount a volume
     }, 30 * 1000);
     setTimeout(() => {

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -94,7 +94,7 @@ async function startFluxFunctions() {
     setTimeout(() => {
       log.info('Rechecking firewall app rules');
       fluxNetworkHelper.purgeUFW();
-      fluxNetworkHelper.removeDockerContainerAccessToHost();
+      fluxNetworkHelper.removeDockerContainerAccessToNonRoutable();
       appsService.testAppMount(); // test if our node can mount a volume
     }, 30 * 1000);
     setTimeout(() => {

--- a/tests/unit/fluxNetworkHelper.test.js
+++ b/tests/unit/fluxNetworkHelper.test.js
@@ -5,6 +5,7 @@ const sinon = require('sinon');
 const WebSocket = require('ws');
 const path = require('path');
 const chaiAsPromised = require('chai-as-promised');
+const proxyquire = require('proxyquire');
 const fs = require('fs').promises;
 const util = require('util');
 const log = require('../../ZelBack/src/lib/log');
@@ -17,7 +18,6 @@ const daemonServiceFluxnodeRpcs = require('../../ZelBack/src/services/daemonServ
 const fluxCommunicationUtils = require('../../ZelBack/src/services/fluxCommunicationUtils');
 const benchmarkService = require('../../ZelBack/src/services/benchmarkService');
 const verificationHelper = require('../../ZelBack/src/services/verificationHelper');
-const dockerService = require('../../ZelBack/src/services/dockerService');
 
 const {
   outgoingConnections, outgoingPeers, incomingPeers, incomingConnections,
@@ -2044,7 +2044,7 @@ describe('fluxNetworkHelper tests', () => {
       });
       utilStub.returns(funcStub);
 
-      const result = await fluxNetworkHelper.removeDockerContainerAccessToNonRoutable();
+      const result = await fluxNetworkHelper.removeDockerContainerAccessToNonRoutable([]);
       expect(result).to.eql(true);
 
       sinon.assert.calledWith(funcStub, 'sudo iptables -L DOCKER-USER');
@@ -2063,7 +2063,7 @@ describe('fluxNetworkHelper tests', () => {
       });
       utilStub.returns(funcStub);
 
-      const result = await fluxNetworkHelper.removeDockerContainerAccessToNonRoutable();
+      const result = await fluxNetworkHelper.removeDockerContainerAccessToNonRoutable([]);
 
       expect(result).to.eql(true);
       sinon.assert.calledWith(funcStub, 'sudo iptables -L DOCKER-USER');
@@ -2079,7 +2079,7 @@ describe('fluxNetworkHelper tests', () => {
       });
       utilStub.returns(funcStub);
 
-      const result = await fluxNetworkHelper.removeDockerContainerAccessToNonRoutable();
+      const result = await fluxNetworkHelper.removeDockerContainerAccessToNonRoutable([]);
 
       expect(result).to.eql(false);
       sinon.assert.calledWith(funcStub, 'sudo iptables -L DOCKER-USER');
@@ -2102,7 +2102,7 @@ describe('fluxNetworkHelper tests', () => {
       });
       utilStub.returns(funcStub);
 
-      const result = await fluxNetworkHelper.removeDockerContainerAccessToNonRoutable();
+      const result = await fluxNetworkHelper.removeDockerContainerAccessToNonRoutable([]);
 
       expect(result).to.eql(true);
       sinon.assert.calledWith(funcStub, 'sudo iptables -C FORWARD -j DOCKER-USER');
@@ -2122,7 +2122,7 @@ describe('fluxNetworkHelper tests', () => {
       });
       utilStub.returns(funcStub);
 
-      const result = await fluxNetworkHelper.removeDockerContainerAccessToNonRoutable();
+      const result = await fluxNetworkHelper.removeDockerContainerAccessToNonRoutable([]);
 
       expect(result).to.eql(true);
       sinon.assert.neverCalledWith(funcStub, 'sudo iptables -I FORWARD -j DOCKER-USER');
@@ -2144,7 +2144,7 @@ describe('fluxNetworkHelper tests', () => {
       });
       utilStub.returns(funcStub);
 
-      const result = await fluxNetworkHelper.removeDockerContainerAccessToNonRoutable();
+      const result = await fluxNetworkHelper.removeDockerContainerAccessToNonRoutable([]);
 
       expect(result).to.eql(false);
       sinon.assert.calledWith(funcStub, 'sudo iptables -C FORWARD -j DOCKER-USER');
@@ -2165,7 +2165,7 @@ describe('fluxNetworkHelper tests', () => {
       });
       utilStub.returns(funcStub);
 
-      const result = await fluxNetworkHelper.removeDockerContainerAccessToNonRoutable();
+      const result = await fluxNetworkHelper.removeDockerContainerAccessToNonRoutable([]);
 
       expect(result).to.eql(true);
       sinon.assert.calledWith(funcStub, 'sudo iptables -F DOCKER-USER');
@@ -2184,7 +2184,7 @@ describe('fluxNetworkHelper tests', () => {
       });
       utilStub.returns(funcStub);
 
-      const result = await fluxNetworkHelper.removeDockerContainerAccessToNonRoutable();
+      const result = await fluxNetworkHelper.removeDockerContainerAccessToNonRoutable([]);
 
       expect(result).to.eql(false);
       sinon.assert.calledWith(funcStub, 'sudo iptables -F DOCKER-USER');
@@ -2204,7 +2204,7 @@ describe('fluxNetworkHelper tests', () => {
       });
       utilStub.returns(funcStub);
 
-      const result = await fluxNetworkHelper.removeDockerContainerAccessToNonRoutable();
+      const result = await fluxNetworkHelper.removeDockerContainerAccessToNonRoutable([]);
 
       expect(result).to.eql(true);
 
@@ -2222,7 +2222,6 @@ describe('fluxNetworkHelper tests', () => {
 
     it('should add an allow for intra-network traffic per docker network', async () => {
       const interfaces = ['br-aaf87aa57b20', 'br-098bac43a7f1'];
-      const dockerStub = sinon.stub(dockerService, 'getFluxDockerNetworkPhysicalInterfaceNames').resolves(interfaces);
 
       funcStub = sinon.fake(async (cmd) => {
         if (cmd.includes('sudo iptables -L DOCKER-USER')) {
@@ -2233,7 +2232,7 @@ describe('fluxNetworkHelper tests', () => {
       });
       utilStub.returns(funcStub);
 
-      const result = await fluxNetworkHelper.removeDockerContainerAccessToNonRoutable();
+      const result = await fluxNetworkHelper.removeDockerContainerAccessToNonRoutable(interfaces);
 
       expect(result).to.eql(true);
 
@@ -2245,7 +2244,6 @@ describe('fluxNetworkHelper tests', () => {
 
       // 1 for the CHAIN rules, 1 FLUSH, 1 docker0 allow 2 interface allows, 9 for the adds and 1 for the RETURN
       expect(infoLogSpy.callCount).to.eql(15);
-      expect(dockerStub.callCount).to.eql(1);
       sinon.assert.notCalled(errorLogSpy);
     });
 
@@ -2266,7 +2264,7 @@ describe('fluxNetworkHelper tests', () => {
       });
       utilStub.returns(funcStub);
 
-      const result = await fluxNetworkHelper.removeDockerContainerAccessToNonRoutable();
+      const result = await fluxNetworkHelper.removeDockerContainerAccessToNonRoutable([]);
 
       expect(result).to.eql(false);
       expect(funcStub.callCount).to.eql(4);

--- a/tests/unit/fluxNetworkHelper.test.js
+++ b/tests/unit/fluxNetworkHelper.test.js
@@ -2026,6 +2026,8 @@ describe('fluxNetworkHelper tests', () => {
     let infoLogSpy;
     let errorLogSpy;
     beforeEach(() => {
+      // hide console output from logs, but still get logging spy
+      sinon.stub(console, 'log');
       utilStub = sinon.stub(util, 'promisify');
       infoLogSpy = sinon.spy(log, 'info');
       errorLogSpy = sinon.spy(log, 'error');


### PR DESCRIPTION
Not sure what your workflow is, usually I would branch off master for a bugfix and merge back into master (and rebase or merge on development) but have branched off develop here as I believe you will merge this into next release.

Fixes #1213 

Regarding the existing extra rules, I think they're okay to leave, they will get removed by attrition over time as nodes reboot etc (iptables rules get flushed on reboot). It's non trival to remove them manually as there are rules inbetween. It only adds a new rule if the FluxOS services is restarted - I only notice as I'm doing testing on one of my nodes for some other work, and have restarted many times.

I've update this function to include a check for each iptables command using the `-C` option

```
       -C, --check chain rule-specification
              Check whether a rule matching the specification does exist in the selected chain. This command uses the same  logic  as  -D  to
              find  a  matching  entry,  but does not alter the existing iptables configuration and uses its exit code to indicate success or
              failure.
```

There was also a problem where if someone deletes one rule - it was impossible to know where to insert new rules, as you can't have the DROP rule first.

Have implemented a FLUX chain and jump to this immediately from the FORWARD chain. This way, can INSERT the ACCEPT rules, and APPEND the DROP rule. Of note, once the end of the FLUX chain is reached, there is an implicit RETURN back to the FORWARD chain, and rule evaulation continues if no match found.

I've only done quick testing on this (I'm pretty sure it's good) by running the function on one of my nodes. I have to pop out for a couple of hours and will deploy it properly on a node when I get back.
