### PR TITLE
Feature: add hostname to container

### DIFF
--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -555,6 +555,7 @@ async function appDockerCreate(appSpecifications, appName, isComponent, fullAppS
   const options = {
     Image: appSpecifications.repotag,
     name: getAppIdentifier(identifier),
+    Hostname: appSpecifications.name,
     AttachStdin: true,
     AttachStdout: true,
     AttachStderr: true,


### PR DESCRIPTION
This one is a real quick win.

I've always found it tedious / frustrating trying to communicate between containers, as you have to use the full `flux<container_name>_<appname>` and I would always make mistakes.

Now you can just ping  / comms via container name (hostname) - and it mainitains the existing dns names so won't break any existing apps.

```
davew@chud:~/zelflux$ docker ps
CONTAINER ID   IMAGE                   COMMAND                  CREATED         STATUS                PORTS                                                                                                            NAMES
2f49a664b947   megachips/ipshow:web    "python3 app.py"         2 minutes ago   Up 2 minutes          36794/tcp, 36794/udp, 0.0.0.0:36794->3000/tcp, 0.0.0.0:36794->3000/udp, :::36794->3000/tcp, :::36794->3000/udp   fluxweb2_newapp123
f07aa39a7c21   megachips/ipshow:web    "python3 app.py"         2 minutes ago   Up 2 minutes          35114/tcp, 35114/udp, 0.0.0.0:35114->3000/tcp, 0.0.0.0:35114->3000/udp, :::35114->3000/tcp, :::35114->3000/udp   fluxweb1_newapp123
b38ff429f5c3   containrrr/watchtower   "/watchtower --clean…"   2 months ago    Up 2 days (healthy)   8080/tcp                                                                                                         flux_watchtower

davew@chud:~/zelflux$ docker exec -it 2f49a664b947 /bin/sh

/app # ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
924: eth0@if925: <BROADCAST,MULTICAST,UP,LOWER_UP,M-DOWN> mtu 1500 qdisc noqueue state UP
    link/ether 02:42:ac:17:b1:03 brd ff:ff:ff:ff:ff:ff
    inet 172.23.177.3/24 brd 172.23.177.255 scope global eth0
       valid_lft forever preferred_lft forever

/app # ping web1
PING web1 (172.23.177.2): 56 data bytes
64 bytes from 172.23.177.2: seq=0 ttl=64 time=0.107 ms
64 bytes from 172.23.177.2: seq=1 ttl=64 time=0.106 ms
^C
--- web1 ping statistics ---
2 packets transmitted, 2 packets received, 0% packet loss
round-trip min/avg/max = 0.106/0.106/0.107 ms

/app # ping fluxweb1_newapp123
PING fluxweb1_newapp123 (172.23.177.2): 56 data bytes
64 bytes from 172.23.177.2: seq=0 ttl=64 time=0.252 ms
64 bytes from 172.23.177.2: seq=1 ttl=64 time=0.104 ms
^C
--- fluxweb1_newapp123 ping statistics ---
2 packets transmitted, 2 packets received, 0% packet loss
round-trip min/avg/max = 0.104/0.178/0.252 ms
```