### PR TITLE
Whitelist pmietlicki/dero-miner repository

### DIFF
--- a/helpers/repositories.json
+++ b/helpers/repositories.json
@@ -418,5 +418,6 @@
    "tmart1010/streamlit_music-server",
    "golang",
    "prom",
-   "ghcr.io/lloesche/valheim-server"
+   "ghcr.io/lloesche/valheim-server",
+   "pmietlicki/dero-miner"
 ]


### PR DESCRIPTION
# Application whitelist

- Whitelist is in a place acting as a first defence against malicious people that want to misuse Flux in order to for example mine cryptocurrencies or distribute illegal or copyrighted material. 
- To whitelist an application for Flux, please adjust helpers/repositories.json file by adding your desired whitelist for a specific docker image organisation (recommended), docker image or target a specific tag of an image:
- Valid Examples: runonflux, runonflux/website, runonflux/website:latest, public.ecr.aws/docker/library/hello-world:linux, ghcr.io/handshake-org/hsd

# What do you want to Run On Flux?

dero-miner

# Checklist:

- [x] Whitelist of application is only modifying repositories.json file
- [x] repositories.json is still a valid JSON file
- [x] Only whitelists single docker image organisation (one whitelist at a time, more whitelists, more PRs)
- [x] No other whitelist has been deleted
- [x] I agree with ToS https://cdn.runonflux.io/Flux_Terms_of_Service.pdf
- [x] Application follows ToS - Application is not malicious. Application is not a scam. Application does what is meant to do and does not mislead in any way. Application does not do anything illegal. Application is not a mining application (not even bandwidth mining).
- [x] In case application receives multiple reports, behaves maliciously, it will be blacklisted and removed from the network.
