### PR TITLE
[BUGFIX] Stop syncthing restarting every time FluxOS does

### DIFF
--- a/ZelBack/src/services/syncthingService.js
+++ b/ZelBack/src/services/syncthingService.js
@@ -2230,7 +2230,9 @@ async function startSyncthing() {
           await cmdAsync(execKillC).catch((error) => log.error(error));
         }
       }
-      const exec = 'sudo nohup syncthing -logfile $HOME/.config/syncthing/syncthing.log --logflags=3 --log-max-old-files=2 --log-max-size=26214400 --allow-newer-config --no-browser --home=$HOME/.config/syncthing &';
+      const exec = 'sudo nohup syncthing -logfile $HOME/.config/syncthing/syncthing.log --logflags=3 '
+        + '--log-max-old-files=2 --log-max-size=26214400 --allow-newer-config --no-browser '
+        + '--home=$HOME/.config/syncthing >/dev/null 2>&1 </dev/null &';
       log.info('Spawning Syncthing instance...');
       nodecmd.get(exec, async (err) => {
         if (err) {

--- a/tests/unit/fluxNetworkHelper.test.js
+++ b/tests/unit/fluxNetworkHelper.test.js
@@ -2050,18 +2050,18 @@ describe('fluxNetworkHelper tests', () => {
       expect(result).to.eql(false);
       sinon.assert.calledOnceWithExactly(funcStub, 'sudo iptables --version');
       sinon.assert.calledWith(errorLogSpy, 'Unable to find iptables binary');
-
-    })
+    });
 
     it('should add the DOCKER-USER chain to iptables if it is missing', async () => {
       funcStub = sinon.fake(async (cmd) => {
         if (cmd.includes('sudo iptables --version')) {
-          return 'iptables v1.8.7 (nf_tables)'
+          return 'iptables v1.8.7 (nf_tables)';
         }
-        else if (cmd.includes('-L')) {
+        if (cmd.includes('-L')) {
           // chain doesn't exists
           throw new Error();
         }
+        return null;
       });
       utilStub.returns(funcStub);
 
@@ -2077,9 +2077,9 @@ describe('fluxNetworkHelper tests', () => {
     it('should skip addding the DOCKER-USER chain to iptables if it already exists', async () => {
       funcStub = sinon.fake(async (cmd) => {
         if (cmd.includes('sudo iptables --version')) {
-          return 'iptables v1.8.7 (nf_tables)'
+          return 'iptables v1.8.7 (nf_tables)';
         }
-        else if (cmd.includes('-L')) {
+        if (cmd.includes('-L')) {
           return `Chain DOCKER-USER (0 references)
           target     prot opt source               destination`;
         }
@@ -2099,11 +2099,10 @@ describe('fluxNetworkHelper tests', () => {
     it('should bail out if there is an error addding the DOCKER-USER chain to iptables', async () => {
       funcStub = sinon.fake(async (cmd) => {
         if (cmd.includes('sudo iptables --version')) {
-          return 'iptables v1.8.7 (nf_tables)'
-        } else {
-          // throw for both -L and -N (throwing on -L is normal)
-          throw new Error();
+          return 'iptables v1.8.7 (nf_tables)';
         }
+        // throw for both -L and -N (throwing on -L is normal)
+        throw new Error();
       });
       utilStub.returns(funcStub);
 
@@ -2119,12 +2118,12 @@ describe('fluxNetworkHelper tests', () => {
     it('should add the jump to DOCKER-USER chain from FORWARD chain to iptables if it is missing', async () => {
       funcStub = sinon.fake(async (cmd) => {
         if (cmd.includes('sudo iptables --version')) {
-          return 'iptables v1.8.7 (nf_tables)'
-        } else if (cmd.includes('sudo iptables -L DOCKER-USER')) {
+          return 'iptables v1.8.7 (nf_tables)';
+        } if (cmd.includes('sudo iptables -L DOCKER-USER')) {
           // chain doesn't exists
           return `Chain DOCKER-USER (0 references)
           target     prot opt source               destination`;
-        } else if (cmd.includes('sudo iptables -C FORWARD -j DOCKER-USER && echo true')) {
+        } if (cmd.includes('sudo iptables -C FORWARD -j DOCKER-USER && echo true')) {
           throw new Error('iptables: Bad rule (does a matching rule exist in that chain?).');
         } else {
           return 'DOCKER-USER  all opt -- in * out *  0.0.0.0/0  -> 0.0.0.0/0';
@@ -2145,8 +2144,8 @@ describe('fluxNetworkHelper tests', () => {
     it('should skip adding the jump to DOCKER-USER chain from FORWARD chain to iptables if it already exists', async () => {
       funcStub = sinon.fake(async (cmd) => {
         if (cmd.includes('sudo iptables --version')) {
-          return 'iptables v1.8.7 (nf_tables)'
-        } else if (cmd.includes('sudo iptables -L DOCKER-USER')) {
+          return 'iptables v1.8.7 (nf_tables)';
+        } if (cmd.includes('sudo iptables -L DOCKER-USER')) {
           return `Chain DOCKER-USER (0 references)
           target     prot opt source               destination`;
         }
@@ -2166,11 +2165,11 @@ describe('fluxNetworkHelper tests', () => {
     it('should bail out if there is an error addding the DOCKER-USER chain to iptables', async () => {
       funcStub = sinon.fake(async (cmd) => {
         if (cmd.includes('sudo iptables --version')) {
-          return 'iptables v1.8.7 (nf_tables)'
-        } else if (cmd.includes('sudo iptables -L DOCKER-USER')) {
+          return 'iptables v1.8.7 (nf_tables)';
+        } if (cmd.includes('sudo iptables -L DOCKER-USER')) {
           return `Chain DOCKER-USER (0 references)
           target     prot opt source               destination`;
-        } else if (cmd.includes('sudo iptables -C FORWARD -j DOCKER-USER')) {
+        } if (cmd.includes('sudo iptables -C FORWARD -j DOCKER-USER')) {
           throw new Error('iptables: Bad rule (does a matching rule exist in that chain?).');
         } else {
           throw new Error();
@@ -2192,8 +2191,8 @@ describe('fluxNetworkHelper tests', () => {
     it('should flush the DOCKER-USER chain', async () => {
       funcStub = sinon.fake(async (cmd) => {
         if (cmd.includes('sudo iptables --version')) {
-          return 'iptables v1.8.7 (nf_tables)'
-        } else if (cmd.includes('sudo iptables -L DOCKER-USER')) {
+          return 'iptables v1.8.7 (nf_tables)';
+        } if (cmd.includes('sudo iptables -L DOCKER-USER')) {
           return `Chain DOCKER-USER (0 references)
           target     prot opt source               destination`;
         }
@@ -2211,11 +2210,11 @@ describe('fluxNetworkHelper tests', () => {
     it('should bail out if there is an error flushing the DOCKER-USER chain', async () => {
       funcStub = sinon.fake(async (cmd) => {
         if (cmd.includes('sudo iptables --version')) {
-          return 'iptables v1.8.7 (nf_tables)'
-        } else if (cmd.includes('sudo iptables -L DOCKER-USER')) {
+          return 'iptables v1.8.7 (nf_tables)';
+        } if (cmd.includes('sudo iptables -L DOCKER-USER')) {
           return `Chain DOCKER-USER (0 references)
           target     prot opt source               destination`;
-        } else if (cmd.includes('sudo iptables -C FORWARD -j DOCKER-USER && echo true')) {
+        } if (cmd.includes('sudo iptables -C FORWARD -j DOCKER-USER && echo true')) {
           return 'DOCKER-USER  all opt -- in * out *  0.0.0.0/0  -> 0.0.0.0/0';
         }
         throw new Error();
@@ -2235,8 +2234,8 @@ describe('fluxNetworkHelper tests', () => {
 
       funcStub = sinon.fake(async (cmd) => {
         if (cmd.includes('sudo iptables --version')) {
-          return 'iptables v1.8.7 (nf_tables)'
-        } else if (cmd.includes('sudo iptables -L DOCKER-USER')) {
+          return 'iptables v1.8.7 (nf_tables)';
+        } if (cmd.includes('sudo iptables -L DOCKER-USER')) {
           return `Chain DOCKER-USER (0 references)
           target     prot opt source               destination`;
         }
@@ -2265,8 +2264,8 @@ describe('fluxNetworkHelper tests', () => {
 
       funcStub = sinon.fake(async (cmd) => {
         if (cmd.includes('sudo iptables --version')) {
-          return 'iptables v1.8.7 (nf_tables)'
-        } else if (cmd.includes('sudo iptables -L DOCKER-USER')) {
+          return 'iptables v1.8.7 (nf_tables)';
+        } if (cmd.includes('sudo iptables -L DOCKER-USER')) {
           return `Chain DOCKER-USER (0 references)
           target     prot opt source               destination`;
         }
@@ -2292,8 +2291,8 @@ describe('fluxNetworkHelper tests', () => {
     it('should bail out as soon as a rule errors out', async () => {
       funcStub = sinon.fake(async (cmd) => {
         if (cmd.includes('sudo iptables --version')) {
-          return 'iptables v1.8.7 (nf_tables)'
-        } else if (cmd.includes('sudo iptables -L DOCKER-USER')) {
+          return 'iptables v1.8.7 (nf_tables)';
+        } if (cmd.includes('sudo iptables -L DOCKER-USER')) {
           return `Chain DOCKER-USER (0 references)
           target     prot opt source               destination`;
         } if (cmd.includes('sudo iptables -C FORWARD -j DOCKER-USER')) {

--- a/tests/unit/repositories.test.js
+++ b/tests/unit/repositories.test.js
@@ -4,7 +4,7 @@ const path = require('path');
 
 describe('Repositories', () => {
   const repositoriesPath = path.join(__dirname, '../../helpers/repositories.json');
-  
+
   it('should load repositories from JSON file', () => {
     // Read the repositories.json file
     const repositoriesJson = fs.readFileSync(repositoriesPath, 'utf8');


### PR DESCRIPTION
This one has bugged me for a while. To be honest, I still don't fully understand why / how it is happening.

Ran the linter, picked up a few things. 

Currently, every time Flux is restarted, the `syncthing` process is terminated, and a new process is started. I'm sure this isn't a good time for apps running on the node that are syncing data with syncthing when this happens.

We should be aiming to keep seperation between the control plane (FluxOS) and the data plane (Syncthing, docker etc) so in the event of a control plane outage, the data plane is still operational.

IMO, syncthing should not even be controlled via FluxOS, it should be installed and managed the same as `Fluxd`. I.e. managed by `systemd`

Anyway, debugging with `strace` I was able to at least see syncthing was being closed with a `SIGPIPE` which is kinda weird, meaning that syncthing was on the producer / receiver end of a pipe that was closed? and then something tries to write / read from that pipe, causing the process to terminate.

So that led me to redirecting stderr/stdin/stdout to /dev/null to stop this from happening - which, has stopped syncthing being restarted every time flux is.

In order for the fix to be applied, Flux needs to be restarted. (This will kill the syncthing processes) Then the next time flux is restarted, syncthing will work as expected.

Here is the old behavior:

FluxOS restarted at 10:45:11

```bash
2024-02-28T10:45:11.327Z          Initiating MongoDB connection
2024-02-28T10:45:11.335Z          Flux https listening on port 16158!
2024-02-28T10:45:11.335Z          Flux Home running on port 16156!
2024-02-28T10:45:11.339Z          DB connected
2024-02-28T10:45:11.340Z          Preparing local database...
2024-02-28T10:45:11.571Z          Local database prepared
2024-02-28T10:45:11.571Z          Preparing temporary database...
2024-02-28T10:45:11.573Z          Temporary database prepared
```

Syncthing killed and restarted at 10:46:23

```
davew@crab:~$ tail -f .config/syncthing/syncthing.log
[PJXLB] 2024/02/28 10:34:42 INFO: Listen (BEP/tcp): TLS handshake: EOF
[PJXLB] 2024/02/28 10:35:43 INFO: Listen (BEP/tcp): TLS handshake: EOF
[PJXLB] 2024/02/28 10:36:44 INFO: Listen (BEP/tcp): TLS handshake: EOF
[PJXLB] 2024/02/28 10:37:45 INFO: Listen (BEP/tcp): TLS handshake: EOF
[PJXLB] 2024/02/28 10:38:45 INFO: Listen (BEP/tcp): TLS handshake: EOF
[PJXLB] 2024/02/28 10:39:45 INFO: Listen (BEP/tcp): TLS handshake: EOF
[PJXLB] 2024/02/28 10:40:46 INFO: Listen (BEP/tcp): TLS handshake: EOF
[PJXLB] 2024/02/28 10:41:47 INFO: Listen (BEP/tcp): TLS handshake: EOF
[PJXLB] 2024/02/28 10:42:47 INFO: Listen (BEP/tcp): TLS handshake: EOF
[PJXLB] 2024/02/28 10:43:47 INFO: Listen (BEP/tcp): TLS handshake: EOF
[PJXLB] 2024/02/28 10:44:48 INFO: Listen (BEP/tcp): TLS handshake: EOF
[start] 2024/02/28 10:46:23 INFO: syncthing v1.26.1 "Gold Grasshopper" (go1.21.4 linux-amd64) debian@github.syncthing.net 2023-11-15 09:54:03 UTC [noupgrade]
[PJXLB] 2024/02/28 10:46:23 INFO: My ID: PJXLBUZ-3Q2GTWQ-LN7TVSU-KSQJ3RP-JACFFWL-PMPJDAX-WRIOCEK-DOSFVQW
[PJXLB] 2024/02/28 10:46:24 INFO: Single thread SHA256 performance is 2243 MB/s using crypto/sha256 (2237 MB/s using minio/sha256-simd).
[PJXLB] 2024/02/28 10:46:25 INFO: Hashing performance is 1395.79 MB/s
[PJXLB] 2024/02/28 10:46:25 INFO: Overall send rate is unlimited, receive rate is unlimited
```


here is the new behavior:

FluxOS debug log - you can see I restarted at 10:38:37
```
2024-02-28T10:38:37.233Z          Preparing local database...
2024-02-28T10:38:37.429Z          Local database prepared
2024-02-28T10:38:37.429Z          Preparing temporary database...
2024-02-28T10:38:37.431Z          Temporary database prepared
2024-02-28T10:38:37.431Z          Preparing Flux Apps locations
2024-02-28T10:38:37.494Z          Flux Apps locations prepared
2024-02-28T10:38:37.496Z          Firewalls checked
2024-02-28T10:38:37.497Z          Node allowed to bind privileged ports
2024-02-28T10:38:37.498Z          Connections polling prepared
2024-02-28T10:38:37.499Z          Flux Daemon Info Service Started
2024-02-28T10:38:37.500Z          Flux checks operational
```

syncthing log - you can see where I restarted syncthing at 10:38:01 (prior to this test). Flux was restarted at 10:38:37 - and it didn't restart syncthing. Yay.

```bash
[GBWGA] 2024/02/28 10:38:01 INFO: My name is "chloe"
[GBWGA] 2024/02/28 10:38:01 WARNING: Syncthing should not run as a privileged or system user. Please consider using a normal user account.
[GBWGA] 2024/02/28 10:38:38 INFO: Listen (BEP/tcp): TLS handshake: EOF
[GBWGA] 2024/02/28 10:39:39 INFO: Listen (BEP/tcp): TLS handshake: EOF
[GBWGA] 2024/02/28 10:40:39 INFO: Listen (BEP/tcp): TLS handshake: EOF
[GBWGA] 2024/02/28 10:41:39 INFO: Listen (BEP/tcp): TLS handshake: EOF
```

Here is a command you can use to watch in realtime when you restart Flux, before this change, these processes would get terminated? (not sure exactly how) and restarted.

` watch 'ps axufww | grep syncthing | grep -v grep'`

```bash
Every 2.0s: ps axufww | grep syncthing | grep -v grep                 chud: Wed Feb 28 10:27:38 2024

root      289556  0.0  0.0  11500  5540 ?        S    09:55   0:00 sudo nohup syncthing -logfile /ho
me/davew/.config/syncthing/syncthing.log --logflags=3 --log-max-old-files=2 --log-max-size=26214400
--allow-newer-config --no-browser --home=/home/davew/.config/syncthing
root      289558  0.0  0.0 1249336 16616 ?       Sl   09:55   0:00  \_ syncthing -logfile /home/dave
w/.config/syncthing/syncthing.log --logflags=3 --log-max-old-files=2 --log-max-size=26214400 --allow
-newer-config --no-browser --home=/home/davew/.config/syncthing
root      289566  1.4  0.0 1251768 25660 ?       SNl  09:55   0:02      \_ /usr/bin/syncthing -logfi
le /home/davew/.config/syncthing/syncthing.log --logflags=3 --log-max-old-files=2 --log-max-size=262
14400 --allow-newer-config --no-browser --home=/home/davew/.config/syncthing
```

