### PR TITLE
The shell command abstraction pull

### DIFF
--- a/ZelBack/src/lib/log.js
+++ b/ZelBack/src/lib/log.js
@@ -39,6 +39,9 @@ function ensureString(parameter) {
 }
 
 function writeToFile(filepath, args) {
+  // this function was raising if args are undefined, i.e. no message propery
+  if (!args) return;
+
   const size = getFilesizeInBytes(filepath);
   let flag = 'a+';
   if (size > 25 * 1024 * 1024) {

--- a/ZelBack/src/services/serviceHelper.js
+++ b/ZelBack/src/services/serviceHelper.js
@@ -254,7 +254,9 @@ function ipInSubnet(ip, subnet) {
  */
 async function runCommand(userCmd, options = {}) {
   const res = { error: null, stdout: null, stderr: null };
-  const { runAsRoot, logError, exclusive, ...execOptions } = options;
+  const {
+    runAsRoot, logError, exclusive, ...execOptions
+  } = options;
 
   const params = options.params || [];
   delete execOptions.params;
@@ -293,7 +295,10 @@ async function runCommand(userCmd, options = {}) {
   const { stdout, stderr } = await execFile(cmd, params, execOptions).catch((err) => {
     // do this so we can standardize the return value for errors vs non errors
     const { stdout: errStdout, stderr: errStderr } = err;
+
+    // eslint-disable-next-line no-param-reassign
     delete err.stdout;
+    // eslint-disable-next-line no-param-reassign
     delete err.stderr;
 
     res.error = err;

--- a/ZelBack/src/services/serviceHelper.js
+++ b/ZelBack/src/services/serviceHelper.js
@@ -1,3 +1,6 @@
+const util = require('node:util');
+const execFile = util.promisify(require('node:child_process').execFile);
+
 const axios = require('axios');
 const config = require('config');
 const splitargs = require('splitargs');

--- a/ZelBack/src/services/utils/asyncLock.js
+++ b/ZelBack/src/services/utils/asyncLock.js
@@ -1,0 +1,28 @@
+class AsyncLock {
+  ready = Promise.resolve();
+
+  locked = false;
+
+  constructor() {
+    this.disable = () => { };
+  }
+
+  async enable() {
+    if (this.locked) await this.ready;
+    this.ready = new Promise((resolve) => {
+      this.locked = true;
+      this.disable = () => {
+        this.reset();
+        resolve();
+      };
+    });
+  }
+
+  reset() {
+    this.disable = () => { };
+    this.ready = Promise.resolve();
+    this.locked = false;
+  }
+}
+
+module.exports = { AsyncLock }

--- a/ZelBack/src/services/utils/asyncLock.js
+++ b/ZelBack/src/services/utils/asyncLock.js
@@ -25,4 +25,4 @@ class AsyncLock {
   }
 }
 
-module.exports = { AsyncLock }
+module.exports = { AsyncLock };

--- a/ZelBack/src/services/utils/fluxController.js
+++ b/ZelBack/src/services/utils/fluxController.js
@@ -2,8 +2,10 @@ const { AsyncLock } = require('./asyncLock');
 
 class FluxController {
   #timeoutId = 0;
+
   #timeouts = new Map();
-  #abortController = new AbortController()
+
+  #abortController = new AbortController();
 
   lock = new AsyncLock();
 
@@ -22,7 +24,8 @@ class FluxController {
    * @returns {Promise<void>}
    */
   sleep(ms) {
-    const id = ++this.#timeoutId;
+    this.#timeoutId += 1;
+    const id = this.#timeoutId;
     return new Promise((resolve, reject) => {
       this.#timeouts.set(id, [reject, setTimeout(() => {
         this.#timeouts.delete(id);

--- a/ZelBack/src/services/utils/fluxController.js
+++ b/ZelBack/src/services/utils/fluxController.js
@@ -1,0 +1,52 @@
+const { AsyncLock } = require('./asyncLock');
+
+class FluxController {
+  #timeoutId = 0;
+  #timeouts = new Map();
+  #abortController = new AbortController()
+
+  lock = new AsyncLock();
+
+  get ['aborted']() {
+    return this.#abortController.signal.aborted;
+  }
+
+  get ['locked']() {
+    return this.lock.locked;
+  }
+
+  /**
+   * An interruptable sleep. If you call abort() on the controller,
+   * The promise will reject immediately with { name: 'AbortError' }.
+   * @param {number} ms How many milliseconds to sleep for
+   * @returns {Promise<void>}
+   */
+  sleep(ms) {
+    const id = ++this.#timeoutId;
+    return new Promise((resolve, reject) => {
+      this.#timeouts.set(id, [reject, setTimeout(() => {
+        this.#timeouts.delete(id);
+        resolve();
+      }, ms)]);
+    });
+  }
+
+  /**
+   * Sets AbortController signal, Interrupts any sleeps that are running,
+   * awaits the lock and creates a new AbortController
+   */
+  async abort() {
+    this.#abortController.abort();
+    // eslint-disable-next-line no-restricted-syntax
+    for (const [reject, timeout] of this.#timeouts.values()) {
+      clearTimeout(timeout);
+      reject(new Error('AbortError'));
+    }
+    this.#timeouts.clear();
+    this.#timeoutId = 0;
+    await this.lock.ready;
+    this.#abortController = new AbortController();
+  }
+}
+
+module.exports = { FluxController };

--- a/tests/unit/asyncLock.test.js
+++ b/tests/unit/asyncLock.test.js
@@ -8,13 +8,13 @@ describe('asyncLock tests', () => {
 
   afterEach(() => {
     sinon.restore();
-  })
+  });
 
   it('should instantiate and not be locked', () => {
     const asyncLock = new AsyncLock();
 
     expect(asyncLock.locked).to.be.false;
-  })
+  });
 
   it('should set locked when enabled', async () => {
     const asyncLock = new AsyncLock();
@@ -22,11 +22,11 @@ describe('asyncLock tests', () => {
     await asyncLock.enable();
 
     expect(asyncLock.locked).to.be.true;
-  })
+  });
 
   it('should resolve immediately when ready awaited and not locked', async () => {
     const asyncLock = new AsyncLock();
-    await asyncLock.ready
+    await asyncLock.ready;
   });
 
   it('should resolve eventually when ready awaited and locked', async () => {
@@ -38,7 +38,7 @@ describe('asyncLock tests', () => {
     const tester = async () => {
       await asyncLock.ready;
       testVar = true;
-    }
+    };
 
     await asyncLock.enable();
     setTimeout(asyncLock.disable, 5000);
@@ -59,7 +59,7 @@ describe('asyncLock tests', () => {
     const tester = async () => {
       await asyncLock.enable();
       testVar = true;
-    }
+    };
 
     await asyncLock.enable();
     setTimeout(asyncLock.disable, 5000);
@@ -78,5 +78,5 @@ describe('asyncLock tests', () => {
 
     expect(asyncLock.locked).to.be.false;
     await asyncLock.ready;
-  })
+  });
 });

--- a/tests/unit/asyncLock.test.js
+++ b/tests/unit/asyncLock.test.js
@@ -1,0 +1,82 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+
+const { AsyncLock } = require('../../ZelBack/src/services/utils/asyncLock');
+
+describe('asyncLock tests', () => {
+  beforeEach(async () => { });
+
+  afterEach(() => {
+    sinon.restore();
+  })
+
+  it('should instantiate and not be locked', () => {
+    const asyncLock = new AsyncLock();
+
+    expect(asyncLock.locked).to.be.false;
+  })
+
+  it('should set locked when enabled', async () => {
+    const asyncLock = new AsyncLock();
+
+    await asyncLock.enable();
+
+    expect(asyncLock.locked).to.be.true;
+  })
+
+  it('should resolve immediately when ready awaited and not locked', async () => {
+    const asyncLock = new AsyncLock();
+    await asyncLock.ready
+  });
+
+  it('should resolve eventually when ready awaited and locked', async () => {
+    const clock = sinon.useFakeTimers();
+
+    const asyncLock = new AsyncLock();
+    let testVar = false;
+
+    const tester = async () => {
+      await asyncLock.ready;
+      testVar = true;
+    }
+
+    await asyncLock.enable();
+    setTimeout(asyncLock.disable, 5000);
+    tester();
+    expect(testVar).to.be.false;
+    await clock.tickAsync(4000);
+    expect(testVar).to.be.false;
+    await clock.tickAsync(1000);
+    expect(testVar).to.be.true;
+  });
+
+  it('should wait if enable called and already locked', async () => {
+    const clock = sinon.useFakeTimers();
+
+    const asyncLock = new AsyncLock();
+    let testVar = false;
+
+    const tester = async () => {
+      await asyncLock.enable();
+      testVar = true;
+    }
+
+    await asyncLock.enable();
+    setTimeout(asyncLock.disable, 5000);
+    tester();
+    expect(testVar).to.be.false;
+    await clock.tickAsync(4000);
+    expect(testVar).to.be.false;
+    await clock.tickAsync(1000);
+    expect(testVar).to.be.true;
+  });
+
+  it('should set unlocked and resolve immediately if lock disabled', async () => {
+    const asyncLock = new AsyncLock();
+    await asyncLock.enable();
+    asyncLock.disable();
+
+    expect(asyncLock.locked).to.be.false;
+    await asyncLock.ready;
+  })
+});

--- a/tests/unit/fluxController.test.js
+++ b/tests/unit/fluxController.test.js
@@ -12,14 +12,14 @@ describe('fluxController tests', () => {
 
   afterEach(() => {
     sinon.restore();
-  })
+  });
 
   it('should instantiate and not be aborted or locked', () => {
     const fc = new FluxController();
 
     expect(fc.locked).to.be.false;
     expect(fc.aborted).to.be.false;
-  })
+  });
 
   it('should interrupt any sleeps that are being awaited if abort called', async () => {
     const clock = sinon.useFakeTimers();
@@ -30,7 +30,7 @@ describe('fluxController tests', () => {
     const tester = async () => {
       await fc.sleep(5000);
       testVar = true;
-    }
+    };
 
     const promise = tester();
 
@@ -40,7 +40,7 @@ describe('fluxController tests', () => {
     expect(testVar).to.be.false;
     await expect(promise).to.be.rejectedWith(Error);
     expect(testVar).to.be.false;
-  })
+  });
 
   it('should wait for any actions to be completed when aborted', async () => {
     const clock = sinon.useFakeTimers();
@@ -51,15 +51,15 @@ describe('fluxController tests', () => {
 
     const dummy = async () => {
       await fc.lock.enable();
-      await new Promise((r) => setTimeout(r, 5000));
+      await new Promise((r) => { setTimeout(r, 5000); });
       dummyVar = true;
       fc.lock.disable();
-    }
+    };
 
     const waiter = async () => {
       await fc.abort();
       waiterVar = true;
-    }
+    };
 
     const testPromise = dummy();
     expect(dummyVar).to.be.false;
@@ -84,7 +84,6 @@ describe('fluxController tests', () => {
     expect(fc.locked).to.be.false;
     expect(waiterVar).to.be.true;
 
-
     // these should both resolve immediately
     await abortPromise;
     await testPromise;
@@ -92,20 +91,18 @@ describe('fluxController tests', () => {
     expect(dummyVar).to.be.true;
     expect(fc.locked).to.be.false;
     expect(waiterVar).to.be.true;
-  })
+  });
 
   it('should reset the abort controller on abort', async () => {
     const fc = new FluxController();
-    const aborted = null;
 
     const tester = async () => {
       try {
         await fc.sleep(5000);
-      }
-      catch {
+      } catch {
         expect(fc.aborted).to.be.true;
       }
-    }
+    };
 
     const promise = tester();
 
@@ -113,5 +110,5 @@ describe('fluxController tests', () => {
     await fc.abort();
     await promise;
     expect(fc.aborted).to.be.false;
-  })
+  });
 });

--- a/tests/unit/fluxController.test.js
+++ b/tests/unit/fluxController.test.js
@@ -1,0 +1,117 @@
+const chai = require('chai');
+chai.use(require('chai-as-promised'));
+
+const { expect } = chai;
+
+const sinon = require('sinon');
+
+const { FluxController } = require('../../ZelBack/src/services/utils/fluxController');
+
+describe('fluxController tests', () => {
+  beforeEach(async () => { });
+
+  afterEach(() => {
+    sinon.restore();
+  })
+
+  it('should instantiate and not be aborted or locked', () => {
+    const fc = new FluxController();
+
+    expect(fc.locked).to.be.false;
+    expect(fc.aborted).to.be.false;
+  })
+
+  it('should interrupt any sleeps that are being awaited if abort called', async () => {
+    const clock = sinon.useFakeTimers();
+    let testVar = false;
+
+    const fc = new FluxController();
+
+    const tester = async () => {
+      await fc.sleep(5000);
+      testVar = true;
+    }
+
+    const promise = tester();
+
+    await clock.tickAsync(3000);
+    expect(testVar).to.be.false;
+    await fc.abort();
+    expect(testVar).to.be.false;
+    await expect(promise).to.be.rejectedWith(Error);
+    expect(testVar).to.be.false;
+  })
+
+  it('should wait for any actions to be completed when aborted', async () => {
+    const clock = sinon.useFakeTimers();
+    let dummyVar = false;
+    let waiterVar = false;
+
+    const fc = new FluxController();
+
+    const dummy = async () => {
+      await fc.lock.enable();
+      await new Promise((r) => setTimeout(r, 5000));
+      dummyVar = true;
+      fc.lock.disable();
+    }
+
+    const waiter = async () => {
+      await fc.abort();
+      waiterVar = true;
+    }
+
+    const testPromise = dummy();
+    expect(dummyVar).to.be.false;
+    expect(fc.locked).to.be.true;
+
+    await clock.tickAsync(3000);
+    expect(dummyVar).to.be.false;
+    expect(fc.locked).to.be.true;
+
+    const abortPromise = waiter();
+
+    // test function still sleeping
+    // watier still waiting on abort
+    await clock.tickAsync(1000);
+    expect(dummyVar).to.be.false;
+    expect(fc.locked).to.be.true;
+    expect(waiterVar).to.be.false;
+
+    // both test function and waiter have resolved
+    await clock.tickAsync(1000);
+    expect(dummyVar).to.be.true;
+    expect(fc.locked).to.be.false;
+    expect(waiterVar).to.be.true;
+
+
+    // these should both resolve immediately
+    await abortPromise;
+    await testPromise;
+
+    expect(dummyVar).to.be.true;
+    expect(fc.locked).to.be.false;
+    expect(waiterVar).to.be.true;
+  })
+
+  it('should reset the abort controller on abort', async () => {
+    const fc = new FluxController();
+    const aborted = null;
+
+    const tester = async () => {
+      try {
+        await fc.sleep(5000);
+      }
+      catch {
+        expect(fc.aborted).to.be.true;
+      }
+    }
+
+    const promise = tester();
+
+    expect(fc.aborted).to.be.false;
+    await fc.abort();
+    await promise;
+    expect(fc.aborted).to.be.false;
+  })
+});

--- a/tests/unit/serviceHelper.test.js
+++ b/tests/unit/serviceHelper.test.js
@@ -8,7 +8,6 @@ const proxyquire = require('proxyquire');
 const { expect } = chai;
 
 const log = require('../../ZelBack/src/lib/log');
-const asyncLock = require('../../ZelBack/src/services/utils/asyncLock');
 const dbHelper = require('../../ZelBack/src/services/dbHelper');
 
 const adminConfig = {

--- a/tests/unit/serviceHelper.test.js
+++ b/tests/unit/serviceHelper.test.js
@@ -547,9 +547,6 @@ describe('serviceHelper tests', () => {
         stderr: null,
       };
 
-      const error = new Error('Test Error');
-      error.stdout = '';
-      error.stderr = '';
       runCmdStub.resolves(expected);
 
       const response = await serviceHelper.runCommand('testCmd', { cwd: '/home/testuser' });

--- a/tests/unit/serviceHelper.test.js
+++ b/tests/unit/serviceHelper.test.js
@@ -18,7 +18,7 @@ const adminConfig = {
   },
 };
 
-let runCmdStub = sinon.stub();
+const runCmdStub = sinon.stub();
 const utilFake = { promisify: () => runCmdStub };
 
 const serviceHelper = proxyquire(
@@ -382,7 +382,7 @@ describe('serviceHelper tests', () => {
       debugSpy = sinon.spy(log, 'debug');
       infoSpy = sinon.spy(log, 'info');
       errorSpy = sinon.spy(log, 'error');
-    })
+    });
 
     afterEach(() => {
       sinon.restore();
@@ -406,7 +406,7 @@ describe('serviceHelper tests', () => {
     it('should return error if params are not an Array', async () => {
       const expected = {
         error: new Error(
-          'Invalid params for command, must be an Array of strings'
+          'Invalid params for command, must be an Array of strings',
         ),
         stdout: null,
         stderr: null,
@@ -420,7 +420,7 @@ describe('serviceHelper tests', () => {
     it('should return error if param elements are not of correct type', async () => {
       const expected = {
         error: new Error(
-          'Invalid params for command, must be an Array of strings'
+          'Invalid params for command, must be an Array of strings',
         ),
         stdout: null,
         stderr: null,
@@ -434,11 +434,11 @@ describe('serviceHelper tests', () => {
     it('should run command as sudo if runAsRoot options passed', async () => {
       const expected = {
         error: null,
-        stdout: "test output",
+        stdout: 'test output',
         stderr: null,
       };
 
-      runCmdStub.resolves({ stdout: 'test output', stderr: null, error: null })
+      runCmdStub.resolves({ stdout: 'test output', stderr: null, error: null });
 
       const response = await serviceHelper.runCommand('testCmd', { runAsRoot: true });
 
@@ -450,14 +450,14 @@ describe('serviceHelper tests', () => {
     it('should set async lock if command is run exclusively', async () => {
       const expected = {
         error: null,
-        stdout: "test output",
+        stdout: 'test output',
         stderr: null,
       };
 
       const clock = sinon.useFakeTimers();
 
       // a dummy command that takes 5 seconds
-      const timeout = () => new Promise(r => setTimeout(() => r(expected), 5000));
+      const timeout = () => new Promise((r) => { setTimeout(() => r(expected), 5000); });
 
       runCmdStub.callsFake(timeout);
 
@@ -491,11 +491,11 @@ describe('serviceHelper tests', () => {
     it('should return stdout and stderr', async () => {
       const expected = {
         error: null,
-        stdout: "test output",
-        stderr: "test stderr message",
+        stdout: 'test output',
+        stderr: 'test stderr message',
       };
 
-      runCmdStub.resolves({ stdout: 'test output', stderr: "test stderr message", error: null });
+      runCmdStub.resolves({ stdout: 'test output', stderr: 'test stderr message', error: null });
 
       const response = await serviceHelper.runCommand('testCmd');
 
@@ -506,12 +506,12 @@ describe('serviceHelper tests', () => {
 
     it('should return error and log it if command causes an error', async () => {
       const expected = {
-        error: new Error("Test Error"),
+        error: new Error('Test Error'),
         stdout: '',
         stderr: '',
       };
 
-      const error = new Error("Test Error")
+      const error = new Error('Test Error');
       error.stdout = '';
       error.stderr = '';
       runCmdStub.rejects(error);
@@ -520,16 +520,16 @@ describe('serviceHelper tests', () => {
 
       expect(response).to.be.deep.equal(expected);
       sinon.assert.calledOnceWithExactly(runCmdStub, 'testCmd', [], {});
-      sinon.assert.calledOnceWithExactly(errorSpy, error)
+      sinon.assert.calledOnceWithExactly(errorSpy, error);
     });
     it('should return error and not log it if command causes an error and logError is false', async () => {
       const expected = {
-        error: new Error("Test Error"),
+        error: new Error('Test Error'),
         stdout: '',
         stderr: '',
       };
 
-      const error = new Error("Test Error")
+      const error = new Error('Test Error');
       error.stdout = '';
       error.stderr = '';
       runCmdStub.rejects(error);
@@ -547,7 +547,7 @@ describe('serviceHelper tests', () => {
         stderr: null,
       };
 
-      const error = new Error("Test Error")
+      const error = new Error('Test Error');
       error.stdout = '';
       error.stderr = '';
       runCmdStub.resolves(expected);

--- a/tests/unit/serviceHelper.test.js
+++ b/tests/unit/serviceHelper.test.js
@@ -1,12 +1,14 @@
 /* eslint-disable no-restricted-syntax */
 const chai = require('chai');
+const sinon = require('sinon');
 const config = require('config');
 const { ObjectId } = require('mongodb');
 const proxyquire = require('proxyquire');
 
 const { expect } = chai;
 
-let serviceHelper = require('../../ZelBack/src/services/serviceHelper');
+const log = require('../../ZelBack/src/lib/log');
+const asyncLock = require('../../ZelBack/src/services/utils/asyncLock');
 const dbHelper = require('../../ZelBack/src/services/dbHelper');
 
 const adminConfig = {
@@ -16,9 +18,13 @@ const adminConfig = {
     testnet: true,
   },
 };
-serviceHelper = proxyquire(
+
+let runCmdStub = sinon.stub();
+const utilFake = { promisify: () => runCmdStub };
+
+const serviceHelper = proxyquire(
   '../../ZelBack/src/services/serviceHelper',
-  { '../../../config/userconfig': adminConfig },
+  { '../../../config/userconfig': adminConfig, 'node:util': utilFake },
 );
 
 describe('serviceHelper tests', () => {
@@ -313,8 +319,8 @@ describe('serviceHelper tests', () => {
   });
 
   describe('commandStringToArray tests', () => {
-    beforeEach(() => {});
-    afterEach(() => {});
+    beforeEach(() => { });
+    afterEach(() => { });
 
     it('should split double quoted string', () => {
       const i = " I  said 'I am sorry.', and he said \"it doesn't matter.\" ";
@@ -366,6 +372,192 @@ describe('serviceHelper tests', () => {
       expect(o[4]).to.equal('he');
       expect(o[5]).to.equal('said');
       expect(o[6]).to.equal("it doesn't matter.");
+    });
+  });
+  describe('runCommand tests', () => {
+    let debugSpy;
+    let infoSpy;
+    let errorSpy;
+
+    beforeEach(() => {
+      debugSpy = sinon.spy(log, 'debug');
+      infoSpy = sinon.spy(log, 'info');
+      errorSpy = sinon.spy(log, 'error');
+    })
+
+    afterEach(() => {
+      sinon.restore();
+      // this must be called as sinon.restore() doesn't work when the stub is
+      // passed into proxy
+      runCmdStub.reset();
+    });
+
+    it('should return error if no command is passed', async () => {
+      const expected = {
+        error: new Error('Command must be present'),
+        stdout: null,
+        stderr: null,
+      };
+
+      const response = await serviceHelper.runCommand();
+
+      expect(response).to.be.deep.equal(expected);
+    });
+
+    it('should return error if params are not an Array', async () => {
+      const expected = {
+        error: new Error(
+          'Invalid params for command, must be an Array of strings'
+        ),
+        stdout: null,
+        stderr: null,
+      };
+
+      const response = await serviceHelper.runCommand('testCmd', { params: {} });
+
+      expect(response).to.be.deep.equal(expected);
+    });
+
+    it('should return error if param elements are not of correct type', async () => {
+      const expected = {
+        error: new Error(
+          'Invalid params for command, must be an Array of strings'
+        ),
+        stdout: null,
+        stderr: null,
+      };
+
+      const response = await serviceHelper.runCommand('testCmd', { params: ['test', {}] });
+
+      expect(response).to.be.deep.equal(expected);
+    });
+
+    it('should run command as sudo if runAsRoot options passed', async () => {
+      const expected = {
+        error: null,
+        stdout: "test output",
+        stderr: null,
+      };
+
+      runCmdStub.resolves({ stdout: 'test output', stderr: null, error: null })
+
+      const response = await serviceHelper.runCommand('testCmd', { runAsRoot: true });
+
+      expect(response).to.be.deep.equal(expected);
+      sinon.assert.calledOnceWithExactly(runCmdStub, 'sudo', ['testCmd'], {});
+      sinon.assert.calledOnceWithExactly(debugSpy, 'Run Cmd: sudo testCmd');
+    });
+
+    it('should set async lock if command is run exclusively', async () => {
+      const expected = {
+        error: null,
+        stdout: "test output",
+        stderr: null,
+      };
+
+      const clock = sinon.useFakeTimers();
+
+      // a dummy command that takes 5 seconds
+      const timeout = () => new Promise(r => setTimeout(() => r(expected), 5000));
+
+      runCmdStub.callsFake(timeout);
+
+      const promises = [];
+
+      promises.push(serviceHelper.runCommand('testCmd', { exclusive: true }));
+      promises.push(serviceHelper.runCommand('testCmd', { exclusive: true }));
+
+      // the runCmdStub waits 5 seconds, since the commands run one after the other,
+      // we would expect at this point for the stub to only have been called once.
+      await clock.tickAsync(3000);
+      sinon.assert.calledOnce(runCmdStub);
+      // advance to 6 seconds, should have been called again
+      await clock.tickAsync(3000);
+      sinon.assert.calledTwice(runCmdStub);
+      // run out the rest of the clock
+      await clock.tickAsync(4000);
+
+      const responses = await Promise.all(promises);
+
+      expect(responses[0]).to.be.deep.equal(expected);
+      expect(responses[1]).to.be.deep.equal(expected);
+
+      // check log order too
+      expect(infoSpy.getCall(0).calledWithExactly('Exclusive lock enabled for command: testCmd'));
+      expect(infoSpy.getCall(1).calledWithExactly('Exclusive lock disabled for command: testCmd'));
+      expect(infoSpy.getCall(2).calledWithExactly('Exclusive lock enabled for command: testCmd'));
+      expect(infoSpy.getCall(3).calledWithExactly('Exclusive lock disabled for command: testCmd'));
+    });
+
+    it('should return stdout and stderr', async () => {
+      const expected = {
+        error: null,
+        stdout: "test output",
+        stderr: "test stderr message",
+      };
+
+      runCmdStub.resolves({ stdout: 'test output', stderr: "test stderr message", error: null });
+
+      const response = await serviceHelper.runCommand('testCmd');
+
+      expect(response).to.be.deep.equal(expected);
+      sinon.assert.calledOnceWithExactly(runCmdStub, 'testCmd', [], {});
+      sinon.assert.calledOnceWithExactly(debugSpy, 'Run Cmd: testCmd ');
+    });
+
+    it('should return error and log it if command causes an error', async () => {
+      const expected = {
+        error: new Error("Test Error"),
+        stdout: '',
+        stderr: '',
+      };
+
+      const error = new Error("Test Error")
+      error.stdout = '';
+      error.stderr = '';
+      runCmdStub.rejects(error);
+
+      const response = await serviceHelper.runCommand('testCmd');
+
+      expect(response).to.be.deep.equal(expected);
+      sinon.assert.calledOnceWithExactly(runCmdStub, 'testCmd', [], {});
+      sinon.assert.calledOnceWithExactly(errorSpy, error)
+    });
+    it('should return error and not log it if command causes an error and logError is false', async () => {
+      const expected = {
+        error: new Error("Test Error"),
+        stdout: '',
+        stderr: '',
+      };
+
+      const error = new Error("Test Error")
+      error.stdout = '';
+      error.stderr = '';
+      runCmdStub.rejects(error);
+
+      const response = await serviceHelper.runCommand('testCmd', { logError: false });
+
+      expect(response).to.be.deep.equal(expected);
+      sinon.assert.calledOnceWithExactly(runCmdStub, 'testCmd', [], {});
+      sinon.assert.notCalled(errorSpy);
+    });
+    it('should pass along any exec options to execFile', async () => {
+      const expected = {
+        error: null,
+        stdout: 'Test output',
+        stderr: null,
+      };
+
+      const error = new Error("Test Error")
+      error.stdout = '';
+      error.stderr = '';
+      runCmdStub.resolves(expected);
+
+      const response = await serviceHelper.runCommand('testCmd', { cwd: '/home/testuser' });
+
+      expect(response).to.be.deep.equal(expected);
+      sinon.assert.calledOnceWithExactly(runCmdStub, 'testCmd', [], { cwd: '/home/testuser' });
+      sinon.assert.notCalled(errorSpy);
     });
   });
 });


### PR DESCRIPTION
In terms of modifying current FluxOS functionality - this pull does nothing at all.

**Background**

IMO, running shell commands from FluxOS is a hack, and it should be a FluxOS aspiration to remove them eventually. (Obviously, this isn't possible right now, due to other issues around users and root) Shell commands exist outside FluxOS control and their output / side effects can be unknown.

Currently, shell comands are hardcoded everywhere in FluxOS, many of which are OS dependent, meaning that FluxOS is forced to run on Debian, (eg use of `apt`), or make other assumptions about the underlying OS. Since these commands are hardcoded, there is no ability to run different commands on different OSes.

Another obstacle Flux faces, the assumption has been made that FluxOS never stops, I.e., there is no provision to stop any of the "Flux Functions". There are many unreachable timers / intervals and it is impossible to shutdown gracefully. FluxOS should be able to shut down gracefully and manage this itself. This is where the FluxController (mentioned below) will come into effect in later pulls.

Use of Nodemon - Nodemon is a development tool, it shouldn't be used in production, it's a bit of a crutch. There are many tools available for FluxOS to manage itself - this issue is in conjunction with the above, as Flux can't close gracefully and reload, something like Nodemon has to be used.

**What this pull does**

* Fixes a bug in the logging module where if you logged undefined, it would raise an error.
* Implements the `AsyncLock`.
* Implements the `FluxController` .
* Implements a `runCommand` function in the `serviceHelper` module.
* Adds tests to `serviceHelper` for the runCommand function
* Adds a new test file for the `AsyncLock`
* Adds a new test file for the `FluxController`

***AsyncLock***

 This is useful as you can just wait for a lock to become available, instead of checking a variable every x seconds, and sleeping in a loop.

 ***FluxController***

Incorporates an asyncLock, and an abortController. Introduces the concept of an interruptable sleep. This allows for modules to instantiate the FluxController class, and make use of the abort controller and sleep methods, which can be controlled from outside the module.  This makes stopping complex operations simple.

***runCommand***

```javacscript
const { stdout, stderr, error } = await serviceHelper.runCommand('rm', {
  runAsRoot: true,
  params: ['-rf', rootOwnedDir],
});
```


This is the abstraction layer where all commands are run through. It adds some structure around how a command is run. E.g you can pass in an option `runAsRoot` to run the command as root.

It handles error logging and catch errors etc. Error logging is on by default, but can be disabled with the `logError` option.

All commands are executed WITHOUT A SHELL. This offers performance improvements, as 99% of commands don't actually need a shell. Majority of the commands that are using pipes etc (that require a shell) can simply be rewritten to not use pipes and do the work in FluxOS itself. (I have done this already).

If necessary, you can pass `shell` option and it will run the command in a shell

This will make things orders of magnitude easier in the future, as we can just swap out the command executor for whatever.

**Next steps**

I have already rewritten EVERY shell command in FluxOS to use the runCommand function, as well as updated ALL tests to reflect this. They are in another pull, which has become unwieldly, so will slice them out and merge them seperately.

Of note, I've started writing tests for syncthing, as I have changed quite a bit of logic here around how it's started and managed, installed etc. Will probably do this as the next pull.
