### PR TITLE
Feature/syncthing version check

### DIFF
--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -77,6 +77,7 @@ module.exports = {
   },
   minimumFluxBenchAllowedVersion: '4.0.0',
   minimumFluxOSAllowedVersion: '5.0.0',
+  minimumSyncthingAllowedVersion: '1.27.6',
   fluxTeamZelId: '1hjy4bCYBJr4mny4zCE85J94RXa8W6q37',
   deterministicNodesStart: 558000,
   syncthingVersionCheckStart: 1630040, // block where we will start looking at a min. syncthing version installed. block expected on 26th of April 2024

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -782,7 +782,7 @@ async function checkMyFluxAvailability(retryNumber = 0) {
   if (daemonInfoRes.status === 'error') {
     syncthingVersionAllowed = false;
   } else {
-    let { blocks } = daemonInfoRes.data;
+    const { blocks } = daemonInfoRes.data;
     if (blocks >= config.syncthingVersionCheckStart) {
       syncthingVersionAllowed = await checkSyncthingVersionAllowed();
     }

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -88,6 +88,9 @@ class TokenBucket {
  * @returns {boolean} True if version is equal or higher to minimum version otherwise false.
  */
 function minVersionSatisfy(version, minimumVersion) {
+  // remove any leading character that is not a digit i.e. v1.2.6 -> 1.2.6
+  const version = targetVersion.replace(/[^\d.]/g, '')
+
   const splittedVersion = version.split('.');
   const major = Number(splittedVersion[0]);
   const minor = Number(splittedVersion[1]);
@@ -658,6 +661,7 @@ async function checkFluxbenchVersionAllowed() {
  */
 async function checkSyncthingVersionAllowed() {
   if (storedSyncthingVersion) {
+    // config version may have changed
     const versionOK = minVersionSatisfy(storedSyncthingVersion, config.minimumSyncthingAllowedVersion);
     if (versionOK) return versionOK;
   }

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -1,4 +1,3 @@
-
 /* global userconfig */
 /* eslint-disable no-underscore-dangle */
 const config = require('config');

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -83,11 +83,11 @@ class TokenBucket {
 
 /**
  * Check if semantic version is bigger or equal to minimum version
- * @param {string} version Version to check
+ * @param {string} targetVersion Version to check
  * @param {string} minimumVersion minimum version that version must meet
  * @returns {boolean} True if version is equal or higher to minimum version otherwise false.
  */
-function minVersionSatisfy(version, minimumVersion) {
+function minVersionSatisfy(targetVersion, minimumVersion) {
   // remove any leading character that is not a digit i.e. v1.2.6 -> 1.2.6
   const version = targetVersion.replace(/[^\d.]/g, '')
 

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -13,6 +13,7 @@ const log = require('../lib/log');
 const serviceHelper = require('./serviceHelper');
 const messageHelper = require('./messageHelper');
 const daemonServiceMiscRpcs = require('./daemonService/daemonServiceMiscRpcs');
+const daemonServiceControlRpcs = require('./daemonService/daemonServiceControlRpcs');
 const daemonServiceUtils = require('./daemonService/daemonServiceUtils');
 const daemonServiceFluxnodeRpcs = require('./daemonService/daemonServiceFluxnodeRpcs');
 const daemonServiceBenchmarkRpcs = require('./daemonService/daemonServiceBenchmarkRpcs');
@@ -89,7 +90,7 @@ class TokenBucket {
  */
 function minVersionSatisfy(targetVersion, minimumVersion) {
   // remove any leading character that is not a digit i.e. v1.2.6 -> 1.2.6
-  const version = targetVersion.replace(/[^\d.]/g, '')
+  const version = targetVersion.replace(/[^\d.]/g, '');
 
   const splittedVersion = version.split('.');
   const major = Number(splittedVersion[0]);

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -80,40 +80,6 @@ class TokenBucket {
 }
 
 /**
- * Check if semantic version is bigger or equal to minimum version
- * @param {string} version Version to check
- * @param {string} minimumVersion minimum version that version must meet
- * @returns {boolean} True if version is equal or higher to minimum version otherwise false.
- */
-function minVersionSatisfy(version, minimumVersion) {
-  const splittedVersion = version.split('.');
-  const major = Number(splittedVersion[0]);
-  const minor = Number(splittedVersion[1]);
-  const patch = Number(splittedVersion[2]);
-
-  const splittedVersionMinimum = minimumVersion.split('.');
-  const majorMinimum = Number(splittedVersionMinimum[0]);
-  const minorMinimum = Number(splittedVersionMinimum[1]);
-  const patchMinimum = Number(splittedVersionMinimum[2]);
-  if (major < majorMinimum) {
-    return false;
-  }
-  if (major > majorMinimum) {
-    return true;
-  }
-  if (minor < minorMinimum) {
-    return false;
-  }
-  if (minor > minorMinimum) {
-    return true;
-  }
-  if (patch < patchMinimum) {
-    return false;
-  }
-  return true;
-}
-
-/**
  * To get if port belongs to enterprise range
  * @returns {boolean} Returns true if enterprise
  */
@@ -234,7 +200,7 @@ async function isFluxAvailable(ip, port = config.server.apiport) {
     if (fluxResponse.data.status !== 'success') return false;
 
     const fluxVersion = fluxResponse.data.data;
-    const versionMinOK = minVersionSatisfy(fluxVersion, config.minimumFluxOSAllowedVersion);
+    const versionMinOK = serviceHelper.minVersionSatisfy(fluxVersion, config.minimumFluxOSAllowedVersion);
     if (!versionMinOK) return false;
 
     const homePort = +port - 1;
@@ -599,7 +565,7 @@ function getStoredFluxBenchAllowed() {
  */
 async function checkFluxbenchVersionAllowed() {
   if (storedFluxBenchAllowed) {
-    const versionOK = minVersionSatisfy(storedFluxBenchAllowed, config.minimumFluxBenchAllowedVersion);
+    const versionOK = serviceHelper.minVersionSatisfy(storedFluxBenchAllowed, config.minimumFluxBenchAllowedVersion);
     return versionOK;
   }
   try {
@@ -608,7 +574,7 @@ async function checkFluxbenchVersionAllowed() {
       log.info(benchmarkInfoResponse);
       const benchmarkVersion = benchmarkInfoResponse.data.version;
       setStoredFluxBenchAllowed(benchmarkVersion);
-      const versionOK = minVersionSatisfy(benchmarkVersion, config.minimumFluxBenchAllowedVersion);
+      const versionOK = serviceHelper.minVersionSatisfy(benchmarkVersion, config.minimumFluxBenchAllowedVersion);
       if (versionOK) {
         return true;
       }
@@ -1599,7 +1565,6 @@ async function installNetcat() {
 }
 
 module.exports = {
-  minVersionSatisfy,
   isFluxAvailable,
   checkFluxAvailability,
   getMyFluxIPandPort,

--- a/ZelBack/src/services/fluxService.js
+++ b/ZelBack/src/services/fluxService.js
@@ -1110,10 +1110,6 @@ async function getFluxInfo(req, res) {
       throw daemonInfoRes.data;
     }
     info.daemon.info = daemonInfoRes.data;
-    if (info.daemon.info.blocks >= config.syncthingVersionCheckStart) {
-      const versionMinOK = fluxNetworkHelper.minVersionSatisfy(info.flux.syncthingVersion.replace(/[^\d.]/g, ''), '1.27.6');
-      if (!versionMinOK) throw new Error('Syncthing version bellow minimum version allowed 1.27.6, update your machine.');
-    }
     const daemonNodeStatusRes = await daemonServiceFluxnodeRpcs.getFluxNodeStatus();
     if (daemonNodeStatusRes.status === 'error') {
       throw daemonNodeStatusRes.data;

--- a/ZelBack/src/services/serviceHelper.js
+++ b/ZelBack/src/services/serviceHelper.js
@@ -318,7 +318,7 @@ async function runCommand(userCmd, options = {}) {
 }
 
 /**
- *
+ * Parses a raw version string from dpkg-query into an object
  * @param {string} rawVersion version string from dpkg-query. Eg:
  * 0.36.1-4ubuntu0.1 (ufw)
  * @returns {{version, major, minor, patch} | null} The parsed version
@@ -338,6 +338,7 @@ function parseVersion(rawVersion) {
       version, major, minor, patch,
     };
   }
+  return null;
 }
 
 /**

--- a/ZelBack/src/services/serviceHelper.js
+++ b/ZelBack/src/services/serviceHelper.js
@@ -317,19 +317,75 @@ async function runCommand(userCmd, options = {}) {
   return res;
 }
 
+/**
+ *
+ * @param {string} rawVersion version string from dpkg-query. Eg:
+ * 0.36.1-4ubuntu0.1 (ufw)
+ * @returns {{version, major, minor, patch} | null} The parsed version
+ */
+function parseVersion(rawVersion) {
+  const semver = /^[^\d]?(?<version>(?<major>0|[1-9][0-9]*)\.(?<minor>0|[1-9][0-9]*)\.(?<patch>0|[1-9][0-9]*))(-(0|[1-9A-Za-z-][0-9A-Za-z-]*)(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/
+
+  const match = semver.exec(rawVersion)
+
+  if (match) {
+    const { groups: { version, major, minor, patch } } = match
+    return { version, major, minor, patch }
+  }
+}
+
+/**
+ * Check if semantic version is bigger or equal to minimum version
+ * @param {string} targetVersion Version to check
+ * @param {string} minimumVersion minimum version that version must meet
+ * @returns {boolean} True if version is equal or higher to minimum version otherwise false.
+ */
+function minVersionSatisfy(targetVersion, minimumVersion) {
+  // remove any leading character that is not a digit i.e. v1.2.6 -> 1.2.6
+  const version = targetVersion.replace(/[^\d.]/g, '');
+
+  const splittedVersion = version.split('.');
+  const major = Number(splittedVersion[0]);
+  const minor = Number(splittedVersion[1]);
+  const patch = Number(splittedVersion[2]);
+
+  const splittedVersionMinimum = minimumVersion.split('.');
+  const majorMinimum = Number(splittedVersionMinimum[0]);
+  const minorMinimum = Number(splittedVersionMinimum[1]);
+  const patchMinimum = Number(splittedVersionMinimum[2]);
+  if (major < majorMinimum) {
+    return false;
+  }
+  if (major > majorMinimum) {
+    return true;
+  }
+  if (minor < minorMinimum) {
+    return false;
+  }
+  if (minor > minorMinimum) {
+    return true;
+  }
+  if (patch < patchMinimum) {
+    return false;
+  }
+  return true;
+}
+
 module.exports = {
+  axiosGet,
+  commandStringToArray,
+  delay,
+  deleteLoginPhrase,
+  dockerBufferToString,
   ensureBoolean,
   ensureNumber,
   ensureObject,
   ensureString,
-  axiosGet,
-  delay,
   getApplicationOwner,
-  deleteLoginPhrase,
-  isDecimalLimit,
-  dockerBufferToString,
-  commandStringToArray,
-  validIpv4Address,
   ipInSubnet,
+  isDecimalLimit,
+  minVersionSatisfy,
+  parseVersion,
   runCommand,
+  validIpv4Address,
 };

--- a/ZelBack/src/services/serviceHelper.js
+++ b/ZelBack/src/services/serviceHelper.js
@@ -324,13 +324,19 @@ async function runCommand(userCmd, options = {}) {
  * @returns {{version, major, minor, patch} | null} The parsed version
  */
 function parseVersion(rawVersion) {
-  const semver = /^[^\d]?(?<version>(?<major>0|[1-9][0-9]*)\.(?<minor>0|[1-9][0-9]*)\.(?<patch>0|[1-9][0-9]*))(-(0|[1-9A-Za-z-][0-9A-Za-z-]*)(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/
+  const semver = /^[^\d]?(?<version>(?<major>0|[1-9][0-9]*)\.(?<minor>0|[1-9][0-9]*)\.(?<patch>0|[1-9][0-9]*))(-(0|[1-9A-Za-z-][0-9A-Za-z-]*)(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/;
 
-  const match = semver.exec(rawVersion)
+  const match = semver.exec(rawVersion);
 
   if (match) {
-    const { groups: { version, major, minor, patch } } = match
-    return { version, major, minor, patch }
+    const {
+      groups: {
+        version, major, minor, patch,
+      },
+    } = match;
+    return {
+      version, major, minor, patch,
+    };
   }
 }
 

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -16,6 +16,7 @@ const syncthingService = require('./syncthingService');
 const pgpService = require('./pgpService');
 const dockerService = require('./dockerService');
 const backupRestoreService = require('./backupRestoreService');
+const systemService = require('./systemService');
 
 const apiPort = userconfig.initial.apiport || config.server.apiport;
 const development = userconfig.initial.development || false;
@@ -91,6 +92,9 @@ async function startFluxFunctions() {
     log.info('Syncthing service started');
     await pgpService.generateIdentity();
     log.info('PGP service initiated');
+    await systemService.monitorSyncthingPackage();
+    log.info('System service initiated');
+
     setTimeout(() => {
       fluxCommunicationUtils.constantlyUpdateDeterministicFluxList(); // updates deterministic flux list for communication every 2 minutes, so we always trigger cache and have up to date value
     }, 15 * 1000);

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -92,7 +92,7 @@ async function startFluxFunctions() {
     log.info('Syncthing service started');
     await pgpService.generateIdentity();
     log.info('PGP service initiated');
-    await systemService.monitorSyncthingPackage();
+    await systemService.monitorSystem();
     log.info('System service initiated');
 
     setTimeout(() => {

--- a/ZelBack/src/services/systemService.js
+++ b/ZelBack/src/services/systemService.js
@@ -66,7 +66,13 @@ async function getPackageVersion(package) {
 
   if (error) return '';
 
-  return stdout.replace(/'/g, '');
+  const parsed = serviceHelper.parseVersion(stdout.replace(/'/g, ''))
+
+  if (parsed) {
+    return parsed.version;
+  }
+
+  return '';
 }
 
 /**
@@ -83,42 +89,11 @@ async function upgradePackage(package) {
 }
 
 /**
- * Check if semantic version is bigger or equal to minimum version
- * @param {string} targetVersion Version to check
- * @param {string} minimumVersion minimum version that version must meet
- * @returns {boolean} True if version is equal or higher to minimum version otherwise false.
+ *  Makes sure the package version is above the minimum version provided
+ * @param {string} package The package version to check
+ * @param {string} version The minimum acceptable version
+ * @returns {Promise<void>}
  */
-function minVersionSatisfy(targetVersion, minimumVersion) {
-  // remove any leading character that is not a digit i.e. v1.2.6 -> 1.2.6
-  const version = targetVersion.replace(/[^\d.]/g, '');
-
-  const splittedVersion = version.split('.');
-  const major = Number(splittedVersion[0]);
-  const minor = Number(splittedVersion[1]);
-  const patch = Number(splittedVersion[2]);
-
-  const splittedVersionMinimum = minimumVersion.split('.');
-  const majorMinimum = Number(splittedVersionMinimum[0]);
-  const minorMinimum = Number(splittedVersionMinimum[1]);
-  const patchMinimum = Number(splittedVersionMinimum[2]);
-  if (major < majorMinimum) {
-    return false;
-  }
-  if (major > majorMinimum) {
-    return true;
-  }
-  if (minor < minorMinimum) {
-    return false;
-  }
-  if (minor > minorMinimum) {
-    return true;
-  }
-  if (patch < patchMinimum) {
-    return false;
-  }
-  return true;
-}
-
 async function ensurePackageVersion(package, version) {
   const currentVersion = getPackageVersion(package);
 
@@ -127,7 +102,7 @@ async function ensurePackageVersion(package, version) {
     return;
   }
 
-  const versionOk = minVersionSatisfy(currentVersion, version)
+  const versionOk = serviceHelper.minVersionSatisfy(currentVersion, version)
 
   if (versionOk) return;
 

--- a/ZelBack/src/services/systemService.js
+++ b/ZelBack/src/services/systemService.js
@@ -98,7 +98,7 @@ async function ensurePackageVersion(systemPackage, version) {
   const currentVersion = getPackageVersion(systemPackage);
 
   if (!currentVersion) {
-    await upgradePackage();
+    await upgradePackage(systemPackage);
     return;
   }
 

--- a/ZelBack/src/services/systemService.js
+++ b/ZelBack/src/services/systemService.js
@@ -124,7 +124,10 @@ async function monitorSyncthingPackage() {
   if (syncthingTimer) return;
 
   let syncthingVersion = config.minimumSyncthingAllowedVersion;
-  let response = await axios.get('https://stats.runonflux.io/getmodulesminimumversions').catch((error) => log.error(error));
+  const axiosConfig = {
+    timeout: 10000,
+  };
+  let response = await axios.get('https://stats.runonflux.io/getmodulesminimumversions', axiosConfig).catch((error) => log.error(error));
   if (response && response.data && response.data.status === 'success') {
     syncthingVersion = response.data.data.syncthing || config.minimumSyncthingAllowedVersion;
   }
@@ -133,7 +136,7 @@ async function monitorSyncthingPackage() {
 
   syncthingTimer = setInterval(async () => {
     syncthingVersion = config.minimumSyncthingAllowedVersion;
-    response = await axios.get('https://stats.runonflux.io/getmodulesminimumversions').catch((error) => log.error(error));
+    response = await axios.get('https://stats.runonflux.io/getmodulesminimumversions', axiosConfig).catch((error) => log.error(error));
     if (response && response.data && response.data.status === 'success') {
       syncthingVersion = response.data.data.syncthing || config.minimumSyncthingAllowedVersion;
     }

--- a/ZelBack/src/services/systemService.js
+++ b/ZelBack/src/services/systemService.js
@@ -1,0 +1,87 @@
+const fs = require('node:fs/promises');
+
+const serviceHelper = require('./serviceHelper');
+
+/**
+ * The running interval to check when syncthing was updated
+ */
+let timer = null;
+
+/**
+ *  Gets the last time the cache was updated. This is a JS port
+ * of how Ansible (python) does it, except this falls back to 0
+ * if neither file found
+ * @returns {Promise<number>}
+ */
+async function cacheUpdateTime() {
+  const stampPath = '/var/lib/apt/periodic/update-success-stamp';
+  const listsPath = '/var/lib/apt/lists';
+
+  const stampStat = await fs.stat(stampPath).catch(() => null);
+
+  if (!stampStat) {
+    const listsStat = await fs.stat(listsPath).catch(() => ({ mtimeMs: 0 }));
+    return listsStat.mtimeMs;
+  }
+
+  return stampStat.mtimeMs;
+}
+
+/**
+ * Updates the apt cache, will only update if it hasn't
+ * been updated within 24 hours
+ * @returns {Promise<Boolean>} If there was an error
+ */
+async function updateAptCache() {
+  const oneDay = 86400;
+  const lastUpdate = await cacheUpdateTime();
+
+  if (lastUpdate + oneDay < Date.now()) {
+    const { error } = await serviceHelper.runCommand('apt-get', { runAsRoot: true, params: ['update'] });
+
+    return Boolean(error);
+  }
+
+  return false;
+}
+
+/**
+ * Updates the apt cache and installs latest version of syncthing
+ * @returns {Promise<Boolean>} If there was an error
+ */
+async function upgradeSyncthing() {
+  const updateError = await updateAptCache();
+  if (updateError) return false;
+
+  const { error } = await serviceHelper.runCommand('apt-get', { runAsRoot: true, params: ['install', 'syncthing'] });
+  return Boolean(error);
+}
+
+/**
+ * Checks daily if syncthing is updated (and updates apt cache)
+ * If it hasn't been updated in the last 30 days, will install
+ * latest version
+ * @returns {Promise<void>}
+ */
+async function monitorSyncthingPackage() {
+  if (timer) return;
+
+  const oneDay = 86400 * 1000;
+  let lastUpdate = 0;
+
+  timer = setInterval(async () => {
+    const now = Date.now();
+    if (lastUpdate + 30 * oneDay < now) {
+      const upgradeError = await upgradeSyncthing();
+      if (!upgradeError) lastUpdate = now;
+    }
+  }, oneDay);
+}
+
+if (require.main === module) {
+  upgradeSyncthing().then((res) => console.log('Error:', res));
+}
+
+module.exports = {
+  monitorSyncthingPackage,
+};

--- a/ZelBack/src/services/systemService.js
+++ b/ZelBack/src/services/systemService.js
@@ -1,5 +1,6 @@
 const fs = require('node:fs/promises');
 
+const log = require('../lib/log');
 const serviceHelper = require('./serviceHelper');
 
 /**
@@ -38,7 +39,7 @@ async function updateAptCache() {
 
   if (lastUpdate + oneDay < Date.now()) {
     const { error } = await serviceHelper.runCommand('apt-get', { runAsRoot: true, params: ['update'] });
-
+    if (!error) log.info('Apt Cache updated');
     return Boolean(error);
   }
 
@@ -73,7 +74,10 @@ async function monitorSyncthingPackage() {
     const now = Date.now();
     if (lastUpdate + 30 * oneDay < now) {
       const upgradeError = await upgradeSyncthing();
-      if (!upgradeError) lastUpdate = now;
+      if (!upgradeError) {
+        lastUpdate = now;
+        log.info('Syncthing is on the latest version');
+      }
     }
   }, oneDay);
 }

--- a/ZelBack/src/services/systemService.js
+++ b/ZelBack/src/services/systemService.js
@@ -58,11 +58,11 @@ async function updateAptCache() {
 
 /**
  * Gets an installed packages version
- * @param package the target package to check
+ * @param systemPackage the target package to check
  * @returns {Promise<string>}
  */
-async function getPackageVersion(package) {
-  const { stdout, error } = await serviceHelper.runCommand('dpkg-query', { runAsRoot: true, logError: false, params: ["--showformat='${Version}'", '--show', package] });
+async function getPackageVersion(systemPackage) {
+  const { stdout, error } = await serviceHelper.runCommand('dpkg-query', { runAsRoot: true, logError: false, params: ["--showformat='${Version}'", '--show', systemPackage] });
 
   if (error) return '';
 

--- a/ZelBack/src/services/systemService.js
+++ b/ZelBack/src/services/systemService.js
@@ -97,7 +97,7 @@ async function upgradePackage(systemPackage) {
  * @returns {Promise<void>}
  */
 async function ensurePackageVersion(systemPackage, version) {
-  const currentVersion = getPackageVersion(systemPackage);
+  const currentVersion = await getPackageVersion(systemPackage);
 
   if (!currentVersion) {
     await upgradePackage(systemPackage);

--- a/ZelBack/src/services/systemService.js
+++ b/ZelBack/src/services/systemService.js
@@ -45,7 +45,7 @@ async function cacheUpdateTime() {
  * @returns {Promise<Boolean>} If there was an error
  */
 async function updateAptCache() {
-  const oneDay = 86400;
+  const oneDay = 86400 * 1000;
   const lastUpdate = await cacheUpdateTime();
 
   if (lastUpdate + oneDay < Date.now()) {

--- a/ZelBack/src/services/systemService.js
+++ b/ZelBack/src/services/systemService.js
@@ -90,12 +90,12 @@ async function upgradePackage(package) {
 
 /**
  *  Makes sure the package version is above the minimum version provided
- * @param {string} package The package version to check
+ * @param {string} systemPackage The package version to check
  * @param {string} version The minimum acceptable version
  * @returns {Promise<void>}
  */
-async function ensurePackageVersion(package, version) {
-  const currentVersion = getPackageVersion(package);
+async function ensurePackageVersion(systemPackage, version) {
+  const currentVersion = getPackageVersion(systemPackage);
 
   if (!currentVersion) {
     await upgradePackage();
@@ -106,9 +106,9 @@ async function ensurePackageVersion(package, version) {
 
   if (versionOk) return;
 
-  const upgradeError = await upgradePackage(package);
+  const upgradeError = await upgradePackage(systemPackage);
   if (!upgradeError) {
-    log.info(`${package} is on the latest version`);
+    log.info(`${systemPackage} is on the latest version`);
   }
 }
 

--- a/ZelBack/src/services/systemService.js
+++ b/ZelBack/src/services/systemService.js
@@ -80,11 +80,11 @@ async function getPackageVersion(systemPackage) {
  * @param {string} package The package to update
  * @returns {Promise<Boolean>} If there was an error
  */
-async function upgradePackage(package) {
+async function upgradePackage(systemPackage) {
   const updateError = await updateAptCache();
   if (updateError) return true;
 
-  const { error } = await serviceHelper.runCommand('apt-get', { runAsRoot: true, params: ['install', package] });
+  const { error } = await serviceHelper.runCommand('apt-get', { runAsRoot: true, params: ['install', systemPackage] });
   return Boolean(error);
 }
 

--- a/ZelBack/src/services/systemService.js
+++ b/ZelBack/src/services/systemService.js
@@ -146,13 +146,22 @@ async function ensurePackageVersion(package, version) {
 async function monitorSyncthingPackage() {
   if (syncthingTimer) return;
 
-  const oneDay = 86400 * 1000;
+  let minimumSyncthingAllowedVersion = config.minimumSyncthingAllowedVersion;
+  const response = await axios.get('https://stats.runonflux.io/getmodulesminimumversions', axiosConfig).catch((error) => log.error(error));
+  if (response && response.data && response.data.status === 'success') {
+    minimumSyncthingAllowedVersion = response.data.data.syncthing || config.minimumSyncthingAllowedVersion;
+  }
 
-  await ensurePackageVersion('syncthing', config.minimumSyncthingAllowedVersion);
+  await ensurePackageVersion('syncthing', minimumSyncthingAllowedVersion);
 
-  syncthingTimer = setInterval(() => {
-    ensurePackageVersion('syncthing');
-  }, oneDay);
+  syncthingTimer = setInterval(async () => {
+    let minimumSyncthingAllowedVersion = config.minimumSyncthingAllowedVersion;
+    const response = await axios.get('https://stats.runonflux.io/getmodulesminimumversions', axiosConfig).catch((error) => log.error(error));
+    if (response && response.data && response.data.status === 'success') {
+      minimumSyncthingAllowedVersion = response.data.data.syncthing || config.minimumSyncthingAllowedVersion;
+    }
+    ensurePackageVersion('syncthing', minimumSyncthingAllowedVersion);
+  }, 1000 * 60 * 60 * 24); // 24 hours
 };
 
 /**

--- a/tests/unit/fluxNetworkHelper.test.js
+++ b/tests/unit/fluxNetworkHelper.test.js
@@ -243,52 +243,6 @@ describe('fluxNetworkHelper tests', () => {
     });
   });
 
-  describe('minVersionSatisfy tests', () => {
-    const minimalVersion = '3.4.12';
-
-    it('should return true if major version is higher than minimalVersion', async () => {
-      const versionAllowed = await fluxNetworkHelper.minVersionSatisfy('4.0.0', minimalVersion);
-
-      expect(versionAllowed).to.equal(true);
-    });
-
-    it('should return true if minor version is higher than minimalVersion', async () => {
-      const versionAllowed = await fluxNetworkHelper.minVersionSatisfy('3.6.0', minimalVersion);
-
-      expect(versionAllowed).to.equal(true);
-    });
-
-    it('should return true if patch version is higher than minimalVersion', async () => {
-      const versionAllowed = await fluxNetworkHelper.minVersionSatisfy('3.4.13', minimalVersion);
-
-      expect(versionAllowed).to.equal(true);
-    });
-
-    it('should return true if patch version is equal to minimalVersion', async () => {
-      const versionAllowed = await fluxNetworkHelper.minVersionSatisfy('3.4.12', minimalVersion);
-
-      expect(versionAllowed).to.equal(true);
-    });
-
-    it('should return false if patch version is below to minimalVersion', async () => {
-      const versionAllowed = await fluxNetworkHelper.minVersionSatisfy('3.4.11', minimalVersion);
-
-      expect(versionAllowed).to.equal(false);
-    });
-
-    it('should return false if minor version is below to minimalVersion', async () => {
-      const versionAllowed = await fluxNetworkHelper.minVersionSatisfy('3.3.11', minimalVersion);
-
-      expect(versionAllowed).to.equal(false);
-    });
-
-    it('should return false if major version is below to minimalVersion', async () => {
-      const versionAllowed = await fluxNetworkHelper.minVersionSatisfy('2.3.11', minimalVersion);
-
-      expect(versionAllowed).to.equal(false);
-    });
-  });
-
   describe('isFluxAvailable tests', () => {
     let stub;
     const ip = '127.0.0.1';
@@ -329,7 +283,7 @@ describe('fluxNetworkHelper tests', () => {
       const mockResponse = {
         data: {
           status: 'success',
-          data: '4.20.2',
+          data: '5.0.0',
         },
       };
       Object.setPrototypeOf(mockResponse.data, { // axios on home expects string

--- a/tests/unit/fluxNetworkHelper.test.js
+++ b/tests/unit/fluxNetworkHelper.test.js
@@ -16,7 +16,6 @@ const daemonServiceWalletRpcs = require('../../ZelBack/src/services/daemonServic
 const daemonServiceFluxnodeRpcs = require('../../ZelBack/src/services/daemonService/daemonServiceFluxnodeRpcs');
 const fluxCommunicationUtils = require('../../ZelBack/src/services/fluxCommunicationUtils');
 const benchmarkService = require('../../ZelBack/src/services/benchmarkService');
-const syncthingService = require('../../ZelBack/src/services/syncthingService');
 const verificationHelper = require('../../ZelBack/src/services/verificationHelper');
 
 const {
@@ -1113,116 +1112,6 @@ describe('fluxNetworkHelper tests', () => {
 
       expect(isFluxbenchVersionAllowed).to.equal(false);
       expect(fluxNetworkHelper.getStoredFluxBenchAllowed()).to.equal(null);
-    });
-  });
-
-  describe('checkSyncthingVersionAllowed tests', () => {
-    // Minimum version is: 1.27.6
-    let syncthingVersionStub;
-
-    beforeEach(() => {
-      syncthingVersionStub = sinon.stub(syncthingService, 'systemVersion');
-      fluxNetworkHelper.setStoredSyncthingVersion(null);
-    });
-
-    afterEach(() => {
-      sinon.restore();
-    });
-
-    it('should return true if syncthing version is higher than minimal and stored in cache', async () => {
-      fluxNetworkHelper.setStoredSyncthingVersion('66.5.0');
-
-      const isSyncthingVersionAllowed = await fluxNetworkHelper.checkSyncthingVersionAllowed();
-
-      sinon.assert.notCalled(syncthingVersionStub);
-      expect(isSyncthingVersionAllowed).to.equal(true);
-    });
-
-    it('should return true if syncthing version is equal to minimal and stored in cache', async () => {
-      fluxNetworkHelper.setStoredSyncthingVersion('1.27.6');
-
-      const isSyncthingVersionAllowed = await fluxNetworkHelper.checkSyncthingVersionAllowed();
-
-      sinon.assert.notCalled(syncthingVersionStub);
-      expect(isSyncthingVersionAllowed).to.equal(true);
-    });
-
-    it('should return false if bench version is lower than minimal and is stored in cache', async () => {
-      fluxNetworkHelper.setStoredSyncthingVersion('1.2.3');
-
-      const isSyncthingVersionAllowed = await fluxNetworkHelper.checkSyncthingVersionAllowed();
-
-      sinon.assert.calledOnce(syncthingVersionStub);
-      expect(isSyncthingVersionAllowed).to.equal(false);
-    });
-
-    it('should return true if the version is higher than minimal and is not set in cache', async () => {
-      const versionResponse = {
-        status: 'success',
-        data: {
-          version: '66.5.4',
-        },
-      };
-      syncthingVersionStub.resolves(versionResponse);
-
-      const isSyncthingVersionAllowed = await fluxNetworkHelper.checkSyncthingVersionAllowed();
-
-      expect(isSyncthingVersionAllowed).to.equal(true);
-      expect(fluxNetworkHelper.getStoredSyncthingVersion()).to.equal('66.5.4');
-    });
-
-    it('should return true if the version is equal to minimal and is not set in cache', async () => {
-      const syncthingVersionResponse = {
-        status: 'success',
-        data: {
-          version: '1.27.6',
-        },
-      };
-      syncthingVersionStub.returns(syncthingVersionResponse);
-
-      const isSyncthingVersionAllowed = await fluxNetworkHelper.checkSyncthingVersionAllowed();
-
-      expect(isSyncthingVersionAllowed).to.equal(true);
-      expect(fluxNetworkHelper.getStoredSyncthingVersion()).to.equal('1.27.6');
-    });
-
-    it('should return false if the version is lower than minimal and is not set in cache', async () => {
-      const syncthingVersionResponse = {
-        status: 'success',
-        data: {
-          version: '1.2.0',
-        },
-      };
-      syncthingVersionStub.returns(syncthingVersionResponse);
-
-      const isSyncthingVersionAllowed = await fluxNetworkHelper.checkSyncthingVersionAllowed();
-
-      expect(isSyncthingVersionAllowed).to.equal(false);
-      expect(fluxNetworkHelper.getStoredSyncthingVersion()).to.equal('1.2.0');
-    });
-
-    it('should return false if the version is unattainable from benchmarkInfo', async () => {
-      const syncthingVersionResponse = {
-        status: 'error',
-        data: {
-          test: 'test',
-        },
-      };
-      syncthingVersionStub.returns(syncthingVersionResponse);
-
-      const isSyncthingVersionAllowed = await fluxNetworkHelper.checkSyncthingVersionAllowed();
-
-      expect(isSyncthingVersionAllowed).to.equal(false);
-      expect(fluxNetworkHelper.getStoredSyncthingVersion()).to.equal(null);
-    });
-
-    it('should return false if benchmarkInfo throws error', async () => {
-      syncthingVersionStub.throws();
-
-      const isSyncthingVersionAllowed = await fluxNetworkHelper.checkSyncthingVersionAllowed();
-
-      expect(isSyncthingVersionAllowed).to.equal(false);
-      expect(fluxNetworkHelper.getStoredSyncthingVersion()).to.equal(null);
     });
   });
 

--- a/tests/unit/fluxService.test.js
+++ b/tests/unit/fluxService.test.js
@@ -4,6 +4,7 @@ const path = require('node:path');
 
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
+
 chai.use(chaiAsPromised);
 const { expect } = chai;
 

--- a/tests/unit/globalconfig/default.js
+++ b/tests/unit/globalconfig/default.js
@@ -73,6 +73,7 @@ module.exports = {
   },
   minimumFluxBenchAllowedVersion: '4.0.0',
   minimumFluxOSAllowedVersion: '5.0.0',
+  minimumSyncthingAllowedVersion: '1.27.6',
   fluxTeamZelId: '1NH9BP155Rp3HSf5ef6NpUbE8JcyLRruAM',
   deterministicNodesStart: 558000,
   syncthingVersionCheckStart: 1630040, // block where we will start looking at a min. syncthing version installed. block expected on 26th of April 2024

--- a/tests/unit/serviceHelper.test.js
+++ b/tests/unit/serviceHelper.test.js
@@ -556,4 +556,50 @@ describe('serviceHelper tests', () => {
       sinon.assert.notCalled(errorSpy);
     });
   });
+
+  describe('minVersionSatisfy tests', () => {
+    const minimalVersion = '3.4.12';
+
+    it('should return true if major version is higher than minimalVersion', async () => {
+      const versionAllowed = await serviceHelper.minVersionSatisfy('4.0.0', minimalVersion);
+
+      expect(versionAllowed).to.equal(true);
+    });
+
+    it('should return true if minor version is higher than minimalVersion', async () => {
+      const versionAllowed = await serviceHelper.minVersionSatisfy('3.6.0', minimalVersion);
+
+      expect(versionAllowed).to.equal(true);
+    });
+
+    it('should return true if patch version is higher than minimalVersion', async () => {
+      const versionAllowed = await serviceHelper.minVersionSatisfy('3.4.13', minimalVersion);
+
+      expect(versionAllowed).to.equal(true);
+    });
+
+    it('should return true if patch version is equal to minimalVersion', async () => {
+      const versionAllowed = await serviceHelper.minVersionSatisfy('3.4.12', minimalVersion);
+
+      expect(versionAllowed).to.equal(true);
+    });
+
+    it('should return false if patch version is below to minimalVersion', async () => {
+      const versionAllowed = await serviceHelper.minVersionSatisfy('3.4.11', minimalVersion);
+
+      expect(versionAllowed).to.equal(false);
+    });
+
+    it('should return false if minor version is below to minimalVersion', async () => {
+      const versionAllowed = await serviceHelper.minVersionSatisfy('3.3.11', minimalVersion);
+
+      expect(versionAllowed).to.equal(false);
+    });
+
+    it('should return false if major version is below to minimalVersion', async () => {
+      const versionAllowed = await serviceHelper.minVersionSatisfy('2.3.11', minimalVersion);
+
+      expect(versionAllowed).to.equal(false);
+    });
+  });
 });

--- a/tests/unit/systemService.test.js
+++ b/tests/unit/systemService.test.js
@@ -209,31 +209,5 @@ describe('system Services tests', () => {
       await systemService.monitorSyncthingPackage();
       sinon.assert.notCalled(logSpy);
     });
-
-    it('should call upgradeSyncthing every month', async () => {
-      const now = 1713858779721;
-      const oneDay = 86400 * 1000;
-
-      runCmdStub.resolves({ error: null, stdout: '1.27.3' });
-
-      // don't update
-      statStub.resolves({ mtimeMs: now });
-
-      const clock = sinon.useFakeTimers({
-        now,
-      });
-
-      await systemService.monitorSyncthingPackage();
-      sinon.assert.calledOnceWithExactly(logSpy, 'syncthing is on the latest version');
-
-      // go forward 30 days
-      await clock.tickAsync(30 * oneDay + oneDay);
-
-      const filteredCalls = logSpy.getCalls().filter(
-        (call) => call.args[0] === 'syncthing is on the latest version',
-      );
-
-      expect(filteredCalls.length).to.equal(2);
-    });
   });
 });

--- a/tests/unit/systemService.test.js
+++ b/tests/unit/systemService.test.js
@@ -1,0 +1,226 @@
+const chai = require('chai');
+const sinon = require('sinon');
+
+const { expect } = chai;
+
+const fs = require('node:fs/promises');
+
+const log = require('../../ZelBack/src/lib/log');
+const systemService = require('../../ZelBack/src/services/systemService');
+const serviceHelper = require('../../ZelBack/src/services/serviceHelper');
+
+describe('system Services tests', () => {
+  describe('get last cache time update tests', () => {
+    let statStub;
+    let stubFake;
+
+    beforeEach(() => {
+      statStub = sinon.stub(fs, 'stat');
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('should return 0 if neither cache path exists', async () => {
+      statStub.rejects(new Error('No file'));
+
+      const res = await systemService.cacheUpdateTime();
+
+      expect(res).to.equal(0);
+    });
+
+    it('should return mtime of update-success-stamp if it exists', async () => {
+      const testTime = 1713858779721.123;
+
+      stubFake = sinon.fake(async (path) => {
+        if (path === '/var/lib/apt/periodic/update-success-stamp') {
+          return { mtimeMs: testTime };
+        }
+        throw new Error('Test Error here');
+      });
+      statStub.callsFake(stubFake);
+
+      const res = await systemService.cacheUpdateTime();
+
+      expect(res).to.equal(testTime);
+    });
+
+    it('should return mtime of lists if stamp does not exist and lists does', async () => {
+      const testTime = 1713858779721.123;
+
+      stubFake = sinon.fake(async (path) => {
+        if (path === '/var/lib/apt/periodic/update-success-stamp') {
+          throw new Error('Test Error here');
+        }
+        return { mtimeMs: testTime };
+      });
+      statStub.callsFake(stubFake);
+
+      const res = await systemService.cacheUpdateTime();
+
+      expect(res).to.equal(testTime);
+    });
+  });
+
+  describe('updateAptCache tests', () => {
+    let statStub;
+    let runCmdStub;
+
+    beforeEach(() => {
+      statStub = sinon.stub(fs, 'stat');
+      runCmdStub = sinon.stub(serviceHelper, 'runCommand');
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('should skip updating if last update was within 24 hours', async () => {
+      const now = 1713858779721;
+
+      sinon.useFakeTimers({
+        now,
+      });
+
+      // 10 seconds ago
+      statStub.resolves({ mtimeMs: now - 10000 });
+
+      const cacheUpdateError = await systemService.updateAptCache();
+
+      expect(cacheUpdateError).to.equal(false);
+      sinon.assert.notCalled(runCmdStub);
+    });
+
+    it('should update cache if last update was over 24 hours ago', async () => {
+      const now = 1713858779721;
+      const oneDay = 86400 * 1000;
+
+      runCmdStub.resolves({ error: null });
+
+      sinon.useFakeTimers({
+        now,
+      });
+
+      // 2 days ago
+      statStub.resolves({ mtimeMs: now - oneDay * 2 });
+
+      const cacheUpdateError = await systemService.updateAptCache();
+
+      expect(cacheUpdateError).to.equal(false);
+      sinon.assert.calledOnceWithExactly(runCmdStub, 'apt-get', { runAsRoot: true, params: ['update'] });
+    });
+  });
+
+  describe('updateSyncthing tests', () => {
+    let statStub;
+    let runCmdStub;
+
+    beforeEach(() => {
+      statStub = sinon.stub(fs, 'stat');
+      runCmdStub = sinon.stub(serviceHelper, 'runCommand');
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('should not upgrade syncthing if there is an error with apt-get update', async () => {
+      const now = 1713858779721;
+      const oneDay = 86400 * 1000;
+
+      runCmdStub.resolves({ error: new Error('No update for apt cache') });
+
+      sinon.useFakeTimers({
+        now,
+      });
+
+      // 2 days ago
+      statStub.resolves({ mtimeMs: now - oneDay * 2 });
+
+      const error = await systemService.upgradeSyncthing();
+
+      expect(error).to.equal(true);
+      // if there was no error, this would be called twice
+      sinon.assert.calledOnceWithExactly(runCmdStub, 'apt-get', { runAsRoot: true, params: ['update'] });
+    });
+
+    it('should upgrade syncthing if there is no error with apt-get update', async () => {
+      const now = 1713858779721;
+      const oneDay = 86400 * 1000;
+
+      runCmdStub.resolves({ error: null });
+
+      sinon.useFakeTimers({
+        now,
+      });
+
+      // 2 days ago
+      statStub.resolves({ mtimeMs: now - oneDay * 2 });
+
+      const error = await systemService.upgradeSyncthing();
+
+      expect(error).to.equal(false);
+      sinon.assert.calledWithExactly(runCmdStub, 'apt-get', { runAsRoot: true, params: ['install', 'syncthing'] });
+    });
+  });
+
+  describe('monitorSyncthingPackage tests', () => {
+    let statStub;
+    let runCmdStub;
+    let logSpy;
+
+    beforeEach(() => {
+      systemService.resetTimer();
+      statStub = sinon.stub(fs, 'stat');
+      runCmdStub = sinon.stub(serviceHelper, 'runCommand');
+      logSpy = sinon.spy(log, 'info');
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('should call upgradeSyncthing immediately', async () => {
+      const now = 1713858779721;
+
+      runCmdStub.resolves({ error: null });
+
+      // don't update
+      statStub.resolves({ mtimeMs: now });
+
+      sinon.useFakeTimers({
+        now,
+      });
+
+      await systemService.monitorSyncthingPackage();
+      sinon.assert.calledOnceWithExactly(logSpy, 'Syncthing is on the latest version');
+    });
+
+    it('should call upgradeSyncthing every month', async () => {
+      const now = 1713858779721;
+      const oneDay = 86400 * 1000;
+
+      runCmdStub.resolves({ error: null });
+
+      // don't update
+      statStub.resolves({ mtimeMs: now });
+
+      const clock = sinon.useFakeTimers({
+        now,
+      });
+
+      await systemService.monitorSyncthingPackage();
+      sinon.assert.calledOnceWithExactly(logSpy, 'Syncthing is on the latest version');
+
+      // go forward 30 days
+      await clock.tickAsync(30 * oneDay + oneDay);
+
+      const filteredCalls = logSpy.getCalls().filter(
+        (call) => call.args[0] === 'Syncthing is on the latest version',
+      );
+
+      expect(filteredCalls.length).to.equal(2);
+    });
+  });
+});


### PR DESCRIPTION
* Adds syncthing version config variable;
* Add new system service module, with a loop to check syncthing version every 1 day. It will update the cache at max once per day.
* minimum version allowed is get from stats, in case stats is down or not available it gets directly from fluxOs config.