### PR TITLE
Make interaction with apt more robust

### DIFF
--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -1550,20 +1550,6 @@ async function allowNodeToBindPrivilegedPorts() {
   }
 }
 
-/**
- * Install Netcat from apt
- * Despite nc tool is by default present on both Debian and Ubuntu we install netcat for precaution
- */
-async function installNetcat() {
-  try {
-    const cmdAsync = util.promisify(nodecmd.get);
-    const exec = 'sudo apt install netcat-openbsd -y';
-    await cmdAsync(exec);
-  } catch (error) {
-    log.error(error);
-  }
-}
-
 module.exports = {
   isFluxAvailable,
   checkFluxAvailability,
@@ -1609,6 +1595,5 @@ module.exports = {
   isPortUPNPBanned,
   isPortUserBlocked,
   allowNodeToBindPrivilegedPorts,
-  installNetcat,
   removeDockerContainerAccessToNonRoutable,
 };

--- a/ZelBack/src/services/serviceHelper.js
+++ b/ZelBack/src/services/serviceHelper.js
@@ -11,6 +11,11 @@ const dbHelper = require('./dbHelper');
 const log = require('../lib/log');
 
 /**
+ * The max time a child process can run for (15 minutes)
+ */
+const MAX_CHILD_PROCESS_TIME = 15 * 60 * 1000;
+
+/**
  * Allows for exclusive locks when running child processes
  */
 const locks = new Map();
@@ -261,6 +266,9 @@ async function runCommand(userCmd, options = {}) {
   const params = options.params || [];
   delete execOptions.params;
 
+  // Default max of 15 minutes
+  if (!execOptions.hasOwnProperty('timeout')) execOptions['timeout'] = MAX_CHILD_PROCESS_TIME;
+
   if (!userCmd) {
     res.error = new Error('Command must be present');
     return res;
@@ -324,7 +332,14 @@ async function runCommand(userCmd, options = {}) {
  * @returns {{version, major, minor, patch} | null} The parsed version
  */
 function parseVersion(rawVersion) {
-  const semver = /^[^\d]?(?<version>(?<major>0|[1-9][0-9]*)\.(?<minor>0|[1-9][0-9]*)\.(?<patch>0|[1-9][0-9]*))(-(0|[1-9A-Za-z-][0-9A-Za-z-]*)(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/;
+  // Todo: tests
+
+  // modified this to allow for just major and minor. (and also ~ instead of - after version)
+  // I.e. dpkg-query --showformat='${Version}' --show netcat-openbsd
+  // 1.218-4ubuntu1
+
+  //const semver = /^[^\d]?(?<version>(?<major>0|[1-9][0-9]*)\.(?<minor>0|[1-9][0-9]*)\.(?<patch>0|[1-9][0-9]*))(-(0|[1-9A-Za-z-][0-9A-Za-z-]*)(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/;
+  const semver = /^[^\d]?(?<version>(?<major>0|[1-9][0-9]*)\.(?<minor>0|[1-9][0-9]*)(?:\.(?<patch>0|[1-9][0-9]*))?)([-~](0|[1-9A-Za-z-][0-9A-Za-z-]*)(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/
 
   const match = semver.exec(rawVersion);
 

--- a/ZelBack/src/services/serviceHelper.js
+++ b/ZelBack/src/services/serviceHelper.js
@@ -338,7 +338,6 @@ function parseVersion(rawVersion) {
   // I.e. dpkg-query --showformat='${Version}' --show netcat-openbsd
   // 1.218-4ubuntu1
 
-  //const semver = /^[^\d]?(?<version>(?<major>0|[1-9][0-9]*)\.(?<minor>0|[1-9][0-9]*)\.(?<patch>0|[1-9][0-9]*))(-(0|[1-9A-Za-z-][0-9A-Za-z-]*)(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/;
   const semver = /^[^\d]?(?<version>(?<major>0|[1-9][0-9]*)\.(?<minor>0|[1-9][0-9]*)(?:\.(?<patch>0|[1-9][0-9]*))?)([-~](0|[1-9A-Za-z-][0-9A-Za-z-]*)(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/
 
   const match = semver.exec(rawVersion);

--- a/ZelBack/src/services/serviceHelper.js
+++ b/ZelBack/src/services/serviceHelper.js
@@ -393,10 +393,6 @@ function minVersionSatisfy(targetVersion, minimumVersion) {
   return true;
 }
 
-if (require.main === module) {
-  console.log(parseVersion('20230311ubuntu0.22.04.1'));
-}
-
 module.exports = {
   axiosGet,
   commandStringToArray,

--- a/ZelBack/src/services/serviceHelper.js
+++ b/ZelBack/src/services/serviceHelper.js
@@ -267,7 +267,9 @@ async function runCommand(userCmd, options = {}) {
   delete execOptions.params;
 
   // Default max of 15 minutes
-  if (!execOptions.hasOwnProperty('timeout')) execOptions['timeout'] = MAX_CHILD_PROCESS_TIME;
+  if (!Object.prototype.hasOwnProperty.call(execOptions, 'timeout')) {
+    execOptions.timeout = MAX_CHILD_PROCESS_TIME;
+  }
 
   if (!userCmd) {
     res.error = new Error('Command must be present');
@@ -338,7 +340,7 @@ function parseVersion(rawVersion) {
   // I.e. dpkg-query --showformat='${Version}' --show netcat-openbsd
   // 1.218-4ubuntu1
 
-  const semver = /^[^\d]?(?<version>(?<major>0|[1-9][0-9]*)\.(?<minor>0|[1-9][0-9]*)(?:\.(?<patch>0|[1-9][0-9]*))?)([-~](0|[1-9A-Za-z-][0-9A-Za-z-]*)(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/
+  const semver = /^[^\d]?(?<version>(?<major>0|[1-9][0-9]*)\.(?<minor>0|[1-9][0-9]*)(?:\.(?<patch>0|[1-9][0-9]*))?)([-~](0|[1-9A-Za-z-][0-9A-Za-z-]*)(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/;
 
   const match = semver.exec(rawVersion);
 

--- a/ZelBack/src/services/serviceHelper.js
+++ b/ZelBack/src/services/serviceHelper.js
@@ -334,15 +334,14 @@ async function runCommand(userCmd, options = {}) {
  * @returns {{version, major, minor, patch} | null} The parsed version
  */
 function parseVersion(rawVersion) {
-  // Todo: tests
+  // modified this to allow for just major and minor or just major. (and also ~ instead of - after version)
+  // I.e:
+  //    dpkg-query --showformat='${Version}' --show netcat-openbsd    1.218-4ubuntu1
+  //    dpkg-query --showformat='${Version}' --show ca-certificates   20230311ubuntu0.22.04.1
 
-  // modified this to allow for just major and minor. (and also ~ instead of - after version)
-  // I.e. dpkg-query --showformat='${Version}' --show netcat-openbsd
-  // 1.218-4ubuntu1
+  const versionRegex = /^[^\d]?(?<version>(?<major>0|[1-9][0-9]*)(?:\.(?<minor>0|[1-9][0-9]*)(?:\.(?<patch>0|[1-9][0-9]*))?)?)([-~]?(0|[1-9A-Za-z-][0-9A-Za-z-]*)(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/;
 
-  const semver = /^[^\d]?(?<version>(?<major>0|[1-9][0-9]*)\.(?<minor>0|[1-9][0-9]*)(?:\.(?<patch>0|[1-9][0-9]*))?)([-~](0|[1-9A-Za-z-][0-9A-Za-z-]*)(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/;
-
-  const match = semver.exec(rawVersion);
+  const match = versionRegex.exec(rawVersion);
 
   if (match) {
     const {
@@ -392,6 +391,10 @@ function minVersionSatisfy(targetVersion, minimumVersion) {
     return false;
   }
   return true;
+}
+
+if (require.main === module) {
+  console.log(parseVersion('20230311ubuntu0.22.04.1'));
 }
 
 module.exports = {

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -39,7 +39,8 @@ async function startFluxFunctions() {
     }
     log.info('Checking docker log for corruption...');
     await dockerService.dockerLogsFix();
-    fluxNetworkHelper.installNetcat();
+    systemService.monitorSystem();
+    log.info('System service initiated');
     log.info('Initiating MongoDB connection');
     await dbHelper.initiateDB(); // either true or throws error
     log.info('DB connected');
@@ -92,8 +93,6 @@ async function startFluxFunctions() {
     log.info('Syncthing service started');
     await pgpService.generateIdentity();
     log.info('PGP service initiated');
-    systemService.monitorSystem();
-    log.info('System service initiated');
 
     setTimeout(() => {
       fluxCommunicationUtils.constantlyUpdateDeterministicFluxList(); // updates deterministic flux list for communication every 2 minutes, so we always trigger cache and have up to date value

--- a/ZelBack/src/services/syncthingService.js
+++ b/ZelBack/src/services/syncthingService.js
@@ -2090,6 +2090,7 @@ function isRunning() {
  * Check if Synchtng is installed and if not install it
  */
 let syncthingExecutable = false;
+// eslint-disable-next-line no-unused-vars
 async function installSyncthing() { // can throw
   // check if syncthing is installed or not
   log.info('Checking if Syncthing is installed...');
@@ -2199,12 +2200,14 @@ async function startSyncthing() {
     run += 1;
 
     while (!syncthingExecutable) {
+      // eslint-disable-next-line no-await-in-loop
       const { error } = await serviceHelper.runCommand('syncthing', { params: '--version' });
       if (!error) {
         syncthingExecutable = true;
         startSyncthing();
         return;
       }
+      log.warn('Unable to find syncthing excutable... trying again in 15s.');
       // eslint-disable-next-line no-await-in-loop
       await serviceHelper.delay(15 * 1000);
     }

--- a/ZelBack/src/services/syncthingService.js
+++ b/ZelBack/src/services/syncthingService.js
@@ -2201,7 +2201,7 @@ async function startSyncthing() {
 
     while (!syncthingExecutable) {
       // eslint-disable-next-line no-await-in-loop
-      const { error } = await serviceHelper.runCommand('syncthing', { params: '--version' });
+      const { error } = await serviceHelper.runCommand('syncthing', { params: ['--version'] });
       if (!error) {
         syncthingExecutable = true;
         startSyncthing();

--- a/ZelBack/src/services/syncthingService.js
+++ b/ZelBack/src/services/syncthingService.js
@@ -2201,7 +2201,7 @@ async function startSyncthing() {
 
     while (!syncthingExecutable) {
       // eslint-disable-next-line no-await-in-loop
-      const { error } = await serviceHelper.runCommand('syncthing', { params: ['--version'] });
+      const { error } = await serviceHelper.runCommand('syncthing', { logError: false, params: ['--version'] });
       if (!error) {
         syncthingExecutable = true;
         startSyncthing();

--- a/ZelBack/src/services/systemService.js
+++ b/ZelBack/src/services/systemService.js
@@ -165,9 +165,9 @@ async function updateAptCache(options = {}) {
  * @returns {Promise<string>}
  */
 async function getPackageVersion(systemPackage) {
-  // eslint-disable-next-line no-template-curly-in-string
   const { stdout, error } = await serviceHelper.runCommand('dpkg-query', {
     logError: false,
+    // eslint-disable-next-line no-template-curly-in-string
     params: ["--showformat='${Version}:${Status}'", '--show', systemPackage],
   });
 

--- a/ZelBack/src/services/systemService.js
+++ b/ZelBack/src/services/systemService.js
@@ -105,7 +105,7 @@ async function queueAptGetCommand(command, options = {}) {
   const commandOptions = { command, params, timeout: options.timeout }
   const workerOptions = { retries: options.retries }
 
-  return aptQueue.push(wait, { commandOptions, workerOptions })
+  return aptQueue.push({ commandOptions, workerOptions }, wait)
 }
 
 /**

--- a/ZelBack/src/services/systemService.js
+++ b/ZelBack/src/services/systemService.js
@@ -244,7 +244,7 @@ async function monitorAptCache(event) {
 
   // we don't care about apt-get update error, most likely
   // apt-get update was already running (this uses a different lock
-  // thab apt-get install)
+  // than apt-get install)
   if (options.command === 'update') {
     aptQueue.resume();
     return;

--- a/ZelBack/src/services/systemService.js
+++ b/ZelBack/src/services/systemService.js
@@ -1,4 +1,7 @@
 const fs = require('node:fs/promises');
+// we do this for node 14.18.1... it doesn't have constants on fs/promises
+const { constants: fsConstants } = require('node:fs');
+
 const os = require('node:os');
 const path = require('node:path');
 
@@ -220,7 +223,7 @@ async function addGpgKey(url, keyringName) {
   // this is a hack until we fork a small nodejs process with IPC as root for apt management / fs management (idea)
   // check /usr/share/keyrings is writeable
   // eslint-disable-next-line no-bitwise
-  const keyringAccessError = await fs.access(path.dirname(filePath), fs.constants.R_OK | fs.constants.W_OK).catch(async () => {
+  const keyringAccessError = await fs.access(path.dirname(filePath), fsConstants.R_OK | fsConstants.W_OK).catch(async () => {
     const user = os.userInfo().username;
     const { error } = await serviceHelper.runCommand('chown', { runAsRoot: true, params: [`${user}:${user}`, path.dirname(filePath)] });
     if (error) return true;
@@ -257,7 +260,7 @@ async function addAptSource(packageName, url, dist, components, options = {}) {
   // this is a hack until we fork a smaller nodejs process as root for apt management (idea)
   // check /etc/apt/sources.list.d is writeable
   // eslint-disable-next-line no-bitwise
-  const sourcesAccessError = await fs.access(path.dirname(filePath), fs.constants.R_OK | fs.constants.W_OK).catch(async () => {
+  const sourcesAccessError = await fs.access(path.dirname(filePath), fsConstants.R_OK | fsConstants.W_OK).catch(async () => {
     const user = os.userInfo().username;
     const { error } = await serviceHelper.runCommand('chown', { runAsRoot: true, params: [`${user}:${user}`, path.dirname(filePath)] });
     if (error) return true;

--- a/ZelBack/src/services/utils/fifoQueue.js
+++ b/ZelBack/src/services/utils/fifoQueue.js
@@ -10,7 +10,7 @@ class FifoQueue extends EventEmitter {
   // Class constants
   static get defaultRetries() { return 5; }
 
-  static get defaultRetryDelay() { return 10000; } // 10s
+  static get defaultRetryDelay() { return 60000; } // 1m
 
   static get defaultMaxSize() { return 10; }
 
@@ -169,7 +169,6 @@ class FifoQueue extends EventEmitter {
     // nullish coalescing to allow for zero
     let retriesRemaining = workerOptions.retries ?? this.retries;
     const retryDelay = workerOptions.retryDelay ?? this.retryDelay;
-
     // we add one for the initial attempt
     retriesRemaining += 1;
 

--- a/ZelBack/src/services/utils/fifoQueue.js
+++ b/ZelBack/src/services/utils/fifoQueue.js
@@ -1,0 +1,126 @@
+/**
+ * A reusable implementation of a First In First Out queue.
+ * You can pass in a worker, then whenever you pass in at item,
+ * it will be run by the worker. If there are already items running,
+ * they will queue up.
+ */
+class FifoQueue {
+  list = [];
+  working = false;
+
+  /**
+   *
+   * @param {{worker?: () => Promise<void>, retries?: number, retryDelay?: number}} options
+   */
+  constructor(options = {}) {
+    this.worker = options.worker || null;
+    this.retries = options.retries ?? 5;
+    this.retryDelay = options.retryDelay ?? 10 * 1000; // 10s
+  }
+
+  /**
+   * If there is work to be done
+   * @returns {Boolean}
+   */
+  get workAvailable() {
+    return Boolean(this.list.length);
+  }
+
+  /**
+   * Setter for worker
+   * @param {() => Promise<void>} worker
+   */
+  addWorker(worker) {
+    if (this.worker) return;
+
+    this.worker = worker;
+    if (this.workAvailable) this.work();
+  }
+
+  /**
+   * @param {Boolean} wait If we should wait for the work to be finished
+   * @param {Object} payload The properties to pass to the worker
+   * @return {Promise<Any>}
+   */
+  async push(wait, payload) {
+    return new Promise((resolve) => {
+      this.list.push([payload, resolve]);
+      if (this.worker) this.work();
+      if (!wait) resolve({ error: null });
+    })
+  }
+
+  /**
+   *  Same as Array shift
+   * @returns {Any}
+   */
+  shift() {
+    return this.list.length ? this.list.shift() : null;
+  }
+
+  /**
+   *  Same as Array pop
+   * @returns {Any}
+   */
+  pop() {
+    return this.list.length ? this.list.pop() : null;
+  }
+
+  /**
+   *
+   * @param {number} index The Array index to return
+   * @returns {Any}
+   */
+  at(index) {
+    return this.list.length > index ? this.list[index] : null;
+  }
+
+  /**
+   *
+   * @param {Object} props The items to pass to the worker
+   */
+  async runWorker(props) {
+    const [options, resolve] = props;
+
+    const { workerOptions, ...commandOptions } = options;
+
+    // nullish coalescing to allow for zero
+    let retriesRemaining = workerOptions.retries ?? this.retries;
+    const retryDelay = workerOptions.retryDelay ?? this.retryDelay;
+
+    // we add one for the initial attempt
+    retriesRemaining += 1;
+
+    while (retriesRemaining) {
+      retriesRemaining -= 1;
+      try {
+        const res = await this.worker(commandOptions);
+        resolve(res);
+        return;
+      } catch (error) {
+        if (!retriesRemaining) resolve({ error });
+        // wait default 10 seconds between retries
+        await new Promise(r => setTimeout(r, retryDelay));
+      }
+    }
+  }
+
+  async work() {
+    if (this.working) return;
+
+    try {
+      while (this.workAvailable) {
+        this.working = true;
+        const props = this.shift();
+
+        if (!Object.keys(props).length) return;
+
+        await this.runWorker(props)
+      }
+    } finally {
+      this.working = false;
+    }
+  }
+}
+
+module.exports = { FifoQueue }

--- a/tests/unit/fifoQueue.test.js
+++ b/tests/unit/fifoQueue.test.js
@@ -20,21 +20,21 @@ describe('FiFoQueue tests', () => {
       expect(queue.retries).to.equal(5);
       expect(queue.retryDelay).to.equal(10000);
       expect(queue.maxSize).to.equal(10);
-    })
+    });
     it('should add the worker if defined at instantiation', () => {
-      const worker = () => { }
+      const worker = () => { };
 
       const queue = new fifoQueue.FifoQueue({ worker });
       expect(queue.worker).to.equal(worker);
-    })
+    });
     it('should add the worker if added via addWorker', () => {
-      const worker = () => { }
+      const worker = () => { };
 
       const queue = new fifoQueue.FifoQueue();
       queue.addWorker(worker);
 
       expect(queue.worker).to.equal(worker);
-    })
+    });
     it('should not start work if work is avaiable but no worker present', () => {
       const queue = new fifoQueue.FifoQueue();
       queue.push('hi there');
@@ -43,20 +43,20 @@ describe('FiFoQueue tests', () => {
       expect(queue.working).to.equal(false);
       expect(queue.list.length).to.equal(1);
       expect(queue.halted).to.equal(false);
-    })
-  })
+    });
+  });
 
   describe('FifoQueue work tests', () => {
     beforeEach(() => {
 
-    })
+    });
     afterEach(() => {
       sinon.restore();
-    })
+    });
 
     it('should start work if worker present and task added to queue', async () => {
       let called = 0;
-      const worker = async () => { called += 1; }
+      const worker = async () => { called += 1; };
       const queue = new fifoQueue.FifoQueue({ worker });
 
       const promise = queue.push('hi there');
@@ -64,7 +64,7 @@ describe('FiFoQueue tests', () => {
       await promise;
       expect(queue.working).to.equal(false);
       expect(called).to.equal(1);
-    })
+    });
 
     it('should await work if worker present and task added to queue', async () => {
       const clock = sinon.useFakeTimers();
@@ -73,10 +73,10 @@ describe('FiFoQueue tests', () => {
       const wait = true;
 
       const worker = async () => {
-        await new Promise(r => setTimeout(r, 1000));
+        await new Promise((r) => { setTimeout(r, 1000); });
         called += 1;
-        return 42
-      }
+        return 42;
+      };
 
       const queue = new fifoQueue.FifoQueue({ worker });
 
@@ -90,7 +90,7 @@ describe('FiFoQueue tests', () => {
       expect(queue.working).to.equal(false);
       expect(called).to.equal(1);
       expect(res).to.equal(42);
-    })
+    });
 
     it('should retry task if task has an error', async () => {
       const clock = sinon.useFakeTimers();
@@ -104,12 +104,12 @@ describe('FiFoQueue tests', () => {
           throw new Error('Simulated task error');
         }
         called += 1;
-        return 42
-      }
+        return 42;
+      };
 
       const queue = new fifoQueue.FifoQueue({ retries: 1, worker });
 
-      queue.on('failed', () => { error += 1 });
+      queue.on('failed', () => { error += 1; });
 
       queue.push(['lets work!']);
       expect(called).to.equal(1);
@@ -119,23 +119,21 @@ describe('FiFoQueue tests', () => {
       expect(called).to.equal(2);
       expect(error).to.equal(0);
       expect(queue.working).to.equal(false);
-      await queue.empty
-    })
+      await queue.empty;
+    });
 
     it('should emit error if task is unrecoverable', async () => {
       const clock = sinon.useFakeTimers();
 
       let error = 0;
 
-      const wait = true;
-
       const worker = async () => {
         throw new Error('Simulated task error');
-      }
+      };
 
       const queue = new fifoQueue.FifoQueue({ retries: 2, retryDelay: 500, worker });
 
-      queue.on('failed', () => error += 1);
+      queue.on('failed', () => { error += 1; });
 
       queue.push(['lets work!']);
 
@@ -143,8 +141,8 @@ describe('FiFoQueue tests', () => {
       await clock.tickAsync(1000);
 
       expect(error).to.equal(1);
-      await queue.empty
-    })
+      await queue.empty;
+    });
 
     it('should run tasks synchronously', async () => {
       const clock = sinon.useFakeTimers();
@@ -155,15 +153,15 @@ describe('FiFoQueue tests', () => {
       const wait = true;
 
       const worker = async (input) => {
-        await new Promise(r => setTimeout(r, 1000));
+        await new Promise((r) => { setTimeout(r, 1000); });
         count += 1;
-        return input
-      }
+        return input;
+      };
 
       const queue = new fifoQueue.FifoQueue({ worker });
 
-      const tasks = []
-      for (let i = 0; i < 5; i++) {
+      const tasks = [];
+      for (let i = 0; i < 5; i += 1) {
         tasks.push(queue.push(i, wait));
       }
 
@@ -171,7 +169,7 @@ describe('FiFoQueue tests', () => {
       await clock.tickAsync(2 * 1000);
       expect(count).to.equal(2);
 
-      for (let i = 5; i < 10; i++) {
+      for (let i = 5; i < 10; i += 1) {
         tasks.push(queue.push(i, wait));
       }
 
@@ -183,8 +181,8 @@ describe('FiFoQueue tests', () => {
       expect(count).to.equal(10);
       expect(results).to.deep.equal(expected);
 
-      await queue.empty
-    })
+      await queue.empty;
+    });
 
     it('should halt any further tasks if a task errors', async () => {
       const clock = sinon.useFakeTimers();
@@ -196,19 +194,19 @@ describe('FiFoQueue tests', () => {
       const wait = true;
 
       const worker = async (input) => {
-        await new Promise(r => setTimeout(r, 1000));
+        await new Promise((r) => { setTimeout(r, 1000); });
         if (count === 3) throw new Error('Simulated task error');
 
         count += 1;
 
-        return input
-      }
+        return input;
+      };
 
       const queue = new fifoQueue.FifoQueue({ worker });
-      queue.on('failed', () => error += 1);
+      queue.on('failed', () => { error += 1; });
 
-      const tasks = []
-      for (let i = 0; i < 10; i++) {
+      const tasks = [];
+      for (let i = 0; i < 10; i += 1) {
         tasks.push(queue.push(i, wait));
       }
 
@@ -226,11 +224,11 @@ describe('FiFoQueue tests', () => {
       expect(queue.halted).to.equal(true);
       expect(queue.workAvailable).to.equal(true);
       // task gets added back to start of queue
-      expect(queue.length).to.equal(7)
+      expect(queue.length).to.equal(7);
 
       expect(count).to.equal(3);
       expect(queue.list).to.deep.equal(expectedRemaining);
-    })
+    });
 
     it('should resume tasks if there was a previous error', async () => {
       const clock = sinon.useFakeTimers();
@@ -246,32 +244,32 @@ describe('FiFoQueue tests', () => {
         // so if it's the first item in the queue
         if (!input && count <= 6) throw new Error('Simulated task error');
 
-        return input
-      }
+        return input;
+      };
 
       const queue = new fifoQueue.FifoQueue({ worker });
-      queue.on('failed', () => error += 1);
+      queue.on('failed', () => { error += 1; });
 
-      const tasks = []
-      for (let i = 0; i < 10; i++) {
+      const tasks = [];
+      for (let i = 0; i < 10; i += 1) {
         tasks.push(queue.push(i, wait));
       }
 
       // run out the retry clock
-      await clock.tickAsync(50 * 1000)
+      await clock.tickAsync(50 * 1000);
 
       expect(error).to.equal(1);
       expect(queue.halted).to.equal(true);
 
       // run out the clock some more, if tasks were still running,
       // they would have finished a long time ago
-      await clock.tickAsync(50 * 1000)
+      await clock.tickAsync(50 * 1000);
       expect(queue.halted).to.equal(true);
       queue.resume();
-      await queue.empty
+      await queue.empty;
       // 7 for the first task, 1 normal attempt, 5 retries. Then another normal attempt
       // after the resume(), then 9 normal tasks = 16.
       expect(count).to.equal(16);
-    })
-  })
-})
+    });
+  });
+});

--- a/tests/unit/fifoQueue.test.js
+++ b/tests/unit/fifoQueue.test.js
@@ -273,9 +273,6 @@ describe('FiFoQueue tests', () => {
       // 7 for the first task, 1 normal attempt, 5 retries. Then another normal attempt
       // after the resume(), then 9 normal tasks = 16.
       expect(count).to.equal(16);
-
-
-
     })
   })
 })

--- a/tests/unit/fifoQueue.test.js
+++ b/tests/unit/fifoQueue.test.js
@@ -18,7 +18,7 @@ describe('FiFoQueue tests', () => {
       expect(queue.queueFull).to.equal(false);
       // defaults
       expect(queue.retries).to.equal(5);
-      expect(queue.retryDelay).to.equal(10000);
+      expect(queue.retryDelay).to.equal(60000);
       expect(queue.maxSize).to.equal(10);
     });
     it('should add the worker if defined at instantiation', () => {
@@ -114,7 +114,7 @@ describe('FiFoQueue tests', () => {
       queue.push(['lets work!']);
       expect(called).to.equal(1);
 
-      await clock.tickAsync(10 * 1000);
+      await clock.tickAsync(60 * 1000);
 
       expect(called).to.equal(2);
       expect(error).to.equal(0);
@@ -215,7 +215,7 @@ describe('FiFoQueue tests', () => {
       expect(count).to.equal(3);
 
       // allow 5 retries for faulty task (and 6000ms for tasks)
-      await clock.tickAsync(5 * 10000 + 6000);
+      await clock.tickAsync(5 * 60000 + 6000);
       expect(error).to.equal(1);
 
       // allow enough time that the tasks could run if the queue wasn't halted
@@ -256,7 +256,7 @@ describe('FiFoQueue tests', () => {
       }
 
       // run out the retry clock
-      await clock.tickAsync(50 * 1000);
+      await clock.tickAsync(300 * 1000);
 
       expect(error).to.equal(1);
       expect(queue.halted).to.equal(true);

--- a/tests/unit/fifoQueue.test.js
+++ b/tests/unit/fifoQueue.test.js
@@ -6,7 +6,6 @@ const { expect } = chai;
 
 const fifoQueue = require('../../ZelBack/src/services/utils/fifoQueue');
 
-
 describe('FiFoQueue tests', () => {
   describe('FiFoQueue initialization tests', () => {
     it('should instantiate with defaults, and be an instance of EventEmitter', async () => {

--- a/tests/unit/fifoQueue.test.js
+++ b/tests/unit/fifoQueue.test.js
@@ -1,0 +1,281 @@
+const chai = require('chai');
+const sinon = require('sinon');
+const EventEmitter = require('node:events');
+
+const { expect } = chai;
+
+const fifoQueue = require('../../ZelBack/src/services/utils/fifoQueue');
+
+
+describe('FiFoQueue tests', () => {
+  describe('FiFoQueue initialization tests', () => {
+    it('should instantiate with defaults, and be an instance of EventEmitter', async () => {
+      const queue = new fifoQueue.FifoQueue();
+
+      expect(queue instanceof EventEmitter === true).to.equal(true);
+      expect(queue.workAvailable).to.equal(false);
+      expect(queue.working).to.equal(false);
+      expect(queue.halted).to.equal(false);
+      expect(queue.queueFull).to.equal(false);
+      // defaults
+      expect(queue.retries).to.equal(5);
+      expect(queue.retryDelay).to.equal(10000);
+      expect(queue.maxSize).to.equal(10);
+    })
+    it('should add the worker if defined at instantiation', () => {
+      const worker = () => { }
+
+      const queue = new fifoQueue.FifoQueue({ worker });
+      expect(queue.worker).to.equal(worker);
+    })
+    it('should add the worker if added via addWorker', () => {
+      const worker = () => { }
+
+      const queue = new fifoQueue.FifoQueue();
+      queue.addWorker(worker);
+
+      expect(queue.worker).to.equal(worker);
+    })
+    it('should not start work if work is avaiable but no worker present', () => {
+      const queue = new fifoQueue.FifoQueue();
+      queue.push('hi there');
+
+      expect(queue.workAvailable).to.equal(true);
+      expect(queue.working).to.equal(false);
+      expect(queue.list.length).to.equal(1);
+      expect(queue.halted).to.equal(false);
+    })
+  })
+
+  describe('FifoQueue work tests', () => {
+    beforeEach(() => {
+
+    })
+    afterEach(() => {
+      sinon.restore();
+    })
+
+    it('should start work if worker present and task added to queue', async () => {
+      let called = 0;
+      const worker = async () => { called += 1; }
+      const queue = new fifoQueue.FifoQueue({ worker });
+
+      const promise = queue.push('hi there');
+      expect(queue.working).to.equal(true);
+      await promise;
+      expect(queue.working).to.equal(false);
+      expect(called).to.equal(1);
+    })
+
+    it('should await work if worker present and task added to queue', async () => {
+      const clock = sinon.useFakeTimers();
+
+      let called = 0;
+      const wait = true;
+
+      const worker = async () => {
+        await new Promise(r => setTimeout(r, 1000));
+        called += 1;
+        return 42
+      }
+
+      const queue = new fifoQueue.FifoQueue({ worker });
+
+      const promise = queue.push('hi there', wait);
+      expect(queue.working).to.equal(true);
+      expect(called).to.equal(0);
+
+      await clock.tickAsync(1000);
+
+      const res = await promise;
+      expect(queue.working).to.equal(false);
+      expect(called).to.equal(1);
+      expect(res).to.equal(42);
+    })
+
+    it('should retry task if task has an error', async () => {
+      const clock = sinon.useFakeTimers();
+
+      let called = 0;
+      let error = 0;
+
+      const worker = async () => {
+        if (!called) {
+          called += 1;
+          throw new Error('Simulated task error');
+        }
+        called += 1;
+        return 42
+      }
+
+      const queue = new fifoQueue.FifoQueue({ retries: 1, worker });
+
+      queue.on('failed', () => { error += 1 });
+
+      queue.push(['lets work!']);
+      expect(called).to.equal(1);
+
+      await clock.tickAsync(10 * 1000);
+
+      expect(called).to.equal(2);
+      expect(error).to.equal(0);
+      expect(queue.working).to.equal(false);
+      await queue.empty
+    })
+
+    it('should emit error if task is unrecoverable', async () => {
+      const clock = sinon.useFakeTimers();
+
+      let error = 0;
+
+      const wait = true;
+
+      const worker = async () => {
+        throw new Error('Simulated task error');
+      }
+
+      const queue = new fifoQueue.FifoQueue({ retries: 2, retryDelay: 500, worker });
+
+      queue.on('failed', () => error += 1);
+
+      queue.push(['lets work!']);
+
+      // 500ms per retry
+      await clock.tickAsync(1000);
+
+      expect(error).to.equal(1);
+      await queue.empty
+    })
+
+    it('should run tasks synchronously', async () => {
+      const clock = sinon.useFakeTimers();
+      const expected = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+      let count = 0;
+
+      const wait = true;
+
+      const worker = async (input) => {
+        await new Promise(r => setTimeout(r, 1000));
+        count += 1;
+        return input
+      }
+
+      const queue = new fifoQueue.FifoQueue({ worker });
+
+      const tasks = []
+      for (let i = 0; i < 5; i++) {
+        tasks.push(queue.push(i, wait));
+      }
+
+      // only 2 tasks would have run at this point
+      await clock.tickAsync(2 * 1000);
+      expect(count).to.equal(2);
+
+      for (let i = 5; i < 10; i++) {
+        tasks.push(queue.push(i, wait));
+      }
+
+      // run out the clock on the tasks
+      await clock.tickAsync(8 * 1000);
+
+      const results = await Promise.all(tasks);
+
+      expect(count).to.equal(10);
+      expect(results).to.deep.equal(expected);
+
+      await queue.empty
+    })
+
+    it('should halt any further tasks if a task errors', async () => {
+      const clock = sinon.useFakeTimers();
+      const expectedRemaining = [3, 4, 5, 6, 7, 8, 9];
+
+      let count = 0;
+      let error = 0;
+
+      const wait = true;
+
+      const worker = async (input) => {
+        await new Promise(r => setTimeout(r, 1000));
+        if (count === 3) throw new Error('Simulated task error');
+
+        count += 1;
+
+        return input
+      }
+
+      const queue = new fifoQueue.FifoQueue({ worker });
+      queue.on('failed', () => error += 1);
+
+      const tasks = []
+      for (let i = 0; i < 10; i++) {
+        tasks.push(queue.push(i, wait));
+      }
+
+      // let the first 3 tasks run successfully
+      await clock.tickAsync(3 * 1000);
+      expect(count).to.equal(3);
+
+      // allow 5 retries for faulty task (and 6000ms for tasks)
+      await clock.tickAsync(5 * 10000 + 6000);
+      expect(error).to.equal(1);
+
+      // allow enough time that the tasks could run if the queue wasn't halted
+      await clock.tickAsync(7 * 1000);
+
+      expect(queue.halted).to.equal(true);
+      expect(queue.workAvailable).to.equal(true);
+      // task gets added back to start of queue
+      expect(queue.length).to.equal(7)
+
+      expect(count).to.equal(3);
+      expect(queue.list).to.deep.equal(expectedRemaining);
+    })
+
+    it('should resume tasks if there was a previous error', async () => {
+      const clock = sinon.useFakeTimers();
+
+      let count = 0;
+      let error = 0;
+
+      const wait = true;
+
+      const worker = async (input) => {
+        count += 1;
+        // the 6 is the retries + the initial
+        // so if it's the first item in the queue
+        if (!input && count <= 6) throw new Error('Simulated task error');
+
+        return input
+      }
+
+      const queue = new fifoQueue.FifoQueue({ worker });
+      queue.on('failed', () => error += 1);
+
+      const tasks = []
+      for (let i = 0; i < 10; i++) {
+        tasks.push(queue.push(i, wait));
+      }
+
+      // run out the retry clock
+      await clock.tickAsync(50 * 1000)
+
+      expect(error).to.equal(1);
+      expect(queue.halted).to.equal(true);
+
+      // run out the clock some more, if tasks were still running,
+      // they would have finished a long time ago
+      await clock.tickAsync(50 * 1000)
+      expect(queue.halted).to.equal(true);
+      queue.resume();
+      await queue.empty
+      // 7 for the first task, 1 normal attempt, 5 retries. Then another normal attempt
+      // after the resume(), then 9 normal tasks = 16.
+      expect(count).to.equal(16);
+
+
+
+    })
+  })
+})

--- a/tests/unit/serviceHelper.test.js
+++ b/tests/unit/serviceHelper.test.js
@@ -561,6 +561,7 @@ describe('serviceHelper tests', () => {
   describe('minVersionSatisfy tests', () => {
     const minimalVersion = '3.4.12';
     const majorMinorOnly = '3.4';
+    const majorOnly = '20230311';
 
     it('should return true if major version is higher than minimalVersion', async () => {
       const versionAllowed = await serviceHelper.minVersionSatisfy('4.0.0', minimalVersion);
@@ -627,11 +628,24 @@ describe('serviceHelper tests', () => {
 
       expect(versionAllowed).to.equal(true);
     });
+
+    it('should return true if major version is higher than minimalVersion and no minor or patch', async () => {
+      const versionAllowed = await serviceHelper.minVersionSatisfy('20240507', majorOnly);
+
+      expect(versionAllowed).to.equal(true);
+    });
+
+    it('should return false if major version is lower than minimalVersion and no minor or patch', async () => {
+      const versionAllowed = await serviceHelper.minVersionSatisfy('20221023', majorOnly);
+
+      expect(versionAllowed).to.equal(false);
+    });
   });
 
   describe('parseVersion tests', () => {
     it('should parse all semantic versions and also dpkg versions', () => {
       const versions = [
+        ['20230311ubuntu0.22.04.1', '20230311'],
         ['1.2', '1.2'],
         ['5.7-prerelease', '5.7'],
         ['1.218-4ubuntu1', '1.218'],

--- a/tests/unit/serviceHelper.test.js
+++ b/tests/unit/serviceHelper.test.js
@@ -444,7 +444,7 @@ describe('serviceHelper tests', () => {
       const response = await serviceHelper.runCommand('testCmd', { runAsRoot: true });
 
       expect(response).to.be.deep.equal(expected);
-      sinon.assert.calledOnceWithExactly(runCmdStub, 'sudo', ['testCmd'], {});
+      sinon.assert.calledOnceWithExactly(runCmdStub, 'sudo', ['testCmd'], { timeout: 900000 });
       sinon.assert.calledOnceWithExactly(debugSpy, 'Run Cmd: sudo testCmd');
     });
 
@@ -501,7 +501,7 @@ describe('serviceHelper tests', () => {
       const response = await serviceHelper.runCommand('testCmd');
 
       expect(response).to.be.deep.equal(expected);
-      sinon.assert.calledOnceWithExactly(runCmdStub, 'testCmd', [], {});
+      sinon.assert.calledOnceWithExactly(runCmdStub, 'testCmd', [], { timeout: 900000 });
       sinon.assert.calledOnceWithExactly(debugSpy, 'Run Cmd: testCmd ');
     });
 
@@ -520,7 +520,7 @@ describe('serviceHelper tests', () => {
       const response = await serviceHelper.runCommand('testCmd');
 
       expect(response).to.be.deep.equal(expected);
-      sinon.assert.calledOnceWithExactly(runCmdStub, 'testCmd', [], {});
+      sinon.assert.calledOnceWithExactly(runCmdStub, 'testCmd', [], { timeout: 900000 });
       sinon.assert.calledOnceWithExactly(errorSpy, error);
     });
     it('should return error and not log it if command causes an error and logError is false', async () => {
@@ -538,7 +538,7 @@ describe('serviceHelper tests', () => {
       const response = await serviceHelper.runCommand('testCmd', { logError: false });
 
       expect(response).to.be.deep.equal(expected);
-      sinon.assert.calledOnceWithExactly(runCmdStub, 'testCmd', [], {});
+      sinon.assert.calledOnceWithExactly(runCmdStub, 'testCmd', [], { timeout: 900000 });
       sinon.assert.notCalled(errorSpy);
     });
     it('should pass along any exec options to execFile', async () => {
@@ -553,7 +553,7 @@ describe('serviceHelper tests', () => {
       const response = await serviceHelper.runCommand('testCmd', { cwd: '/home/testuser' });
 
       expect(response).to.be.deep.equal(expected);
-      sinon.assert.calledOnceWithExactly(runCmdStub, 'testCmd', [], { cwd: '/home/testuser' });
+      sinon.assert.calledOnceWithExactly(runCmdStub, 'testCmd', [], { cwd: '/home/testuser', timeout: 900000 });
       sinon.assert.notCalled(errorSpy);
     });
   });
@@ -657,8 +657,8 @@ describe('serviceHelper tests', () => {
       ];
 
       for (let index = 0; index < versions.length; index += 1) {
-        const { version } = serviceHelper.parseVersion(versions[index[0]]);
-        expect(version).to.equal(versions[index[1]]);
+        const { version } = serviceHelper.parseVersion(versions[index][0]);
+        expect(version).to.equal(versions[index][1]);
       }
     });
   });

--- a/tests/unit/serviceHelper.test.js
+++ b/tests/unit/serviceHelper.test.js
@@ -559,6 +559,7 @@ describe('serviceHelper tests', () => {
 
   describe('minVersionSatisfy tests', () => {
     const minimalVersion = '3.4.12';
+    const majorMinorOnly = '3.4'
 
     it('should return true if major version is higher than minimalVersion', async () => {
       const versionAllowed = await serviceHelper.minVersionSatisfy('4.0.0', minimalVersion);
@@ -600,6 +601,64 @@ describe('serviceHelper tests', () => {
       const versionAllowed = await serviceHelper.minVersionSatisfy('2.3.11', minimalVersion);
 
       expect(versionAllowed).to.equal(false);
+    });
+
+    it('should return false if minor version is below to minimalVersion and no patch', async () => {
+      const versionAllowed = await serviceHelper.minVersionSatisfy('3.3', majorMinorOnly);
+
+      expect(versionAllowed).to.equal(false);
+    });
+
+    it('should return false if major version is below to minimalVersion and no patch', async () => {
+      const versionAllowed = await serviceHelper.minVersionSatisfy('2.3', majorMinorOnly);
+
+      expect(versionAllowed).to.equal(false);
+    });
+
+    it('should return true if major version is higher than minimalVersion and no patch', async () => {
+      const versionAllowed = await serviceHelper.minVersionSatisfy('4.0', majorMinorOnly);
+
+      expect(versionAllowed).to.equal(true);
+    });
+
+    it('should return true if minor version is higher than minimalVersion and no patch', async () => {
+      const versionAllowed = await serviceHelper.minVersionSatisfy('3.6', majorMinorOnly);
+
+      expect(versionAllowed).to.equal(true);
+    });
+  });
+
+  describe("parseVersion tests", () => {
+    it('should parse all semantic versions and also dpkg versions', () => {
+      const versions = [
+        ['1.2', '1.2'],
+        ['5.7-prerelease', '5.7'],
+        ['1.218-4ubuntu1', '1.218'],
+        ['1.219~d12', '1.219'],
+        ['0.0.4', '0.0.4'],
+        ['1.2.3', '1.2.3'],
+        ['10.20.30', '10.20.30'],
+        ['1.1.2-prerelease+meta', '1.1.2'],
+        ['1.1.2+meta', '1.1.2'],
+        ['1.0.0-alpha', '1.0.0'],
+        ['1.0.0-alpha.beta', '1.0.0'],
+        ['1.0.0-alpha.1', '1.0.0'],
+        ['1.0.0-alpha.0valid', '1.0.0'],
+        ['1.0.0-rc.1+build.1', '1.0.0'],
+        ['1.2.3-beta', '1.2.3'],
+        ['10.2.3-DEV-SNAPSHOT', '10.2.3'],
+        ['1.2.3-SNAPSHOT-123', '1.2.3'],
+        ['1.0.0', '1.0.0'],
+        ['2.0.0+build.1848', '2.0.0'],
+        ['2.0.1-alpha.1227', '2.0.1'],
+        ['1.0.0-alpha+beta', '1.0.0'],
+        ['1.2.3----RC-SNAPSHOT.12.9.1--.12+788', '1.2.3'],
+      ]
+
+      for (let index = 0; index++; index < versions.length) {
+        const { version } = serviceHelper.parseVersion(versions[index[0]]);
+        expect(version).to.equal(versions[index[1]]);
+      }
     });
   });
 });

--- a/tests/unit/serviceHelper.test.js
+++ b/tests/unit/serviceHelper.test.js
@@ -78,6 +78,7 @@ describe('serviceHelper tests', () => {
 
       expect(ensureNumberOutput).to.be.NaN;
     });
+
     it('parameter {name: 1} of type object should return NaN', () => {
       const ensureNumberOutput = serviceHelper.ensureNumber({ name: 1 });
 

--- a/tests/unit/serviceHelper.test.js
+++ b/tests/unit/serviceHelper.test.js
@@ -560,7 +560,7 @@ describe('serviceHelper tests', () => {
 
   describe('minVersionSatisfy tests', () => {
     const minimalVersion = '3.4.12';
-    const majorMinorOnly = '3.4'
+    const majorMinorOnly = '3.4';
 
     it('should return true if major version is higher than minimalVersion', async () => {
       const versionAllowed = await serviceHelper.minVersionSatisfy('4.0.0', minimalVersion);
@@ -629,7 +629,7 @@ describe('serviceHelper tests', () => {
     });
   });
 
-  describe("parseVersion tests", () => {
+  describe('parseVersion tests', () => {
     it('should parse all semantic versions and also dpkg versions', () => {
       const versions = [
         ['1.2', '1.2'],
@@ -654,9 +654,9 @@ describe('serviceHelper tests', () => {
         ['2.0.1-alpha.1227', '2.0.1'],
         ['1.0.0-alpha+beta', '1.0.0'],
         ['1.2.3----RC-SNAPSHOT.12.9.1--.12+788', '1.2.3'],
-      ]
+      ];
 
-      for (let index = 0; index++; index < versions.length) {
+      for (let index = 0; index < versions.length; index += 1) {
         const { version } = serviceHelper.parseVersion(versions[index[0]]);
         expect(version).to.equal(versions[index[1]]);
       }

--- a/tests/unit/systemService.test.js
+++ b/tests/unit/systemService.test.js
@@ -1,13 +1,16 @@
 const chai = require('chai');
 const sinon = require('sinon');
-
 const { expect } = chai;
 
+const config = require('config');
+
 const fs = require('node:fs/promises');
+const axios = require('axios');
 
 const log = require('../../ZelBack/src/lib/log');
-const systemService = require('../../ZelBack/src/services/systemService');
 const serviceHelper = require('../../ZelBack/src/services/serviceHelper');
+
+const systemService = require('../../ZelBack/src/services/systemService');
 
 describe('system Services tests', () => {
   describe('get last cache time update tests', () => {
@@ -66,6 +69,7 @@ describe('system Services tests', () => {
   describe('updateAptCache tests', () => {
     let statStub;
     let runCmdStub;
+    systemService.getQueue().addWorker(systemService.aptRunner);
 
     beforeEach(() => {
       statStub = sinon.stub(fs, 'stat');
@@ -74,6 +78,7 @@ describe('system Services tests', () => {
 
     afterEach(() => {
       sinon.restore();
+      systemService.getQueue().clear();
     });
 
     it('should skip updating if last update was within 24 hours', async () => {
@@ -108,7 +113,7 @@ describe('system Services tests', () => {
       const cacheUpdateError = await systemService.updateAptCache();
 
       expect(cacheUpdateError).to.equal(false);
-      sinon.assert.calledOnceWithExactly(runCmdStub, 'apt-get', { runAsRoot: true, params: ['update'] });
+      sinon.assert.calledOnceWithExactly(runCmdStub, 'apt-get', { runAsRoot: true, params: ['-o', 'DPkg::Lock::Timeout=180', 'update'] });
     });
   });
 
@@ -123,29 +128,11 @@ describe('system Services tests', () => {
 
     afterEach(() => {
       sinon.restore();
+      systemService.getQueue().clear();
     });
 
-    it('should not upgrade syncthing if there is an error with apt-get update', async () => {
-      const now = 1713858779721;
-      const oneDay = 86400 * 1000;
-
-      runCmdStub.resolves({ error: new Error('No update for apt cache') });
-
-      sinon.useFakeTimers({
-        now,
-      });
-
-      // 2 days ago
-      statStub.resolves({ mtimeMs: now - oneDay * 2 });
-
-      const error = await systemService.upgradePackage('syncthing');
-
-      expect(error).to.equal(true);
-      // if there was no error, this would be called twice
-      sinon.assert.calledOnceWithExactly(runCmdStub, 'apt-get', { runAsRoot: true, params: ['update'] });
-    });
-
-    it('should upgrade syncthing if there is no error with apt-get update', async () => {
+    it('should upgrade syncthing', async () => {
+      // it checks for version first with dpkg, check that
       const now = 1713858779721;
       const oneDay = 86400 * 1000;
 
@@ -161,7 +148,7 @@ describe('system Services tests', () => {
       const error = await systemService.upgradePackage('syncthing');
 
       expect(error).to.equal(false);
-      sinon.assert.calledWithExactly(runCmdStub, 'apt-get', { runAsRoot: true, params: ['install', 'syncthing'] });
+      sinon.assert.calledWithExactly(runCmdStub, 'apt-get', { runAsRoot: true, params: ['-o', 'DPkg::Lock::Timeout=180', 'install', 'syncthing'] });
     });
   });
 
@@ -171,7 +158,7 @@ describe('system Services tests', () => {
     let logSpy;
 
     beforeEach(() => {
-      systemService.resetTimer();
+      systemService.resetTimers();
       statStub = sinon.stub(fs, 'stat');
       runCmdStub = sinon.stub(serviceHelper, 'runCommand');
       logSpy = sinon.spy(log, 'info');
@@ -181,25 +168,88 @@ describe('system Services tests', () => {
       sinon.restore();
     });
 
-    it('should call upgradeSyncthing immediately if on lower version', async () => {
-      const now = 1713858779721;
+    it('should use stats.runonflux.io over local minimum version', async () => {
+      const statsEndpoint = 'https://stats.runonflux.io/getmodulesminimumversions';
+      const statsVersion = '1.27.3';
 
-      runCmdStub.resolves({ error: null, stdout: 'v1.27.3' });
+      const axiosRes = { data: { status: 'success', data: { syncthing: statsVersion } } };
 
-      // don't update
-      statStub.resolves({ mtimeMs: now });
+      const axiosStub = sinon.stub(axios, 'get').resolves(axiosRes);
 
-      sinon.useFakeTimers({
-        now,
-      });
+      runCmdStub.resolves({ error: null, stdout: statsVersion });
+
+      await systemService.monitorSyncthingPackage();
+
+      sinon.assert.calledOnceWithExactly(axiosStub, statsEndpoint, { timeout: 10000 });
+      sinon.assert.calledWith(logSpy, `Checking package syncthing is updated to version ${statsVersion}`);
     })
 
-    it('should not call upgradeSyncthing if on correct version', async () => {
+    it('should fallback to local syncthing version if there is an axios error', async () => {
+      const statsEndpoint = 'https://stats.runonflux.io/getmodulesminimumversions';
+      const localVersion = '1.25.2';
+
+      config.minimumSyncthingAllowedVersion = localVersion
+
+      const axiosStub = sinon.stub(axios, 'get').rejects(new Error('Simulated Axios error'));
+
+      runCmdStub.resolves({ error: null, stdout: localVersion });
+
+      await systemService.monitorSyncthingPackage();
+
+      sinon.assert.calledOnceWithExactly(axiosStub, statsEndpoint, { timeout: 10000 });
+      sinon.assert.calledWith(logSpy, `Checking package syncthing is updated to version ${localVersion}`);
+    })
+
+    it('should fallback to local syncthing version if there is a fluxstats error', async () => {
+      const statsEndpoint = 'https://stats.runonflux.io/getmodulesminimumversions';
+      const localVersion = '1.25.2';
+
+      config.minimumSyncthingAllowedVersion = localVersion;
+
+      const axiosStub = sinon.stub(axios, 'get').resolves({ data: { status: 'error', data: { code: 123, error: 'Test error', 'message': 'Broken' } } });
+
+      runCmdStub.resolves({ error: null, stdout: localVersion });
+
+      await systemService.monitorSyncthingPackage();
+
+      sinon.assert.calledOnceWithExactly(axiosStub, statsEndpoint, { timeout: 10000 });
+      sinon.assert.calledWith(logSpy, `Checking package syncthing is updated to version ${localVersion}`);
+    })
+
+    it('should fallback to local syncthing version if fluxstats syncthing response is empty', async () => {
+      const statsEndpoint = 'https://stats.runonflux.io/getmodulesminimumversions';
+      const localVersion = '1.25.2';
+
+      config.minimumSyncthingAllowedVersion = localVersion;
+
+      const axiosStub = sinon.stub(axios, 'get').resolves({ data: { status: 'success', data: { syncthing: null } } });
+
+      runCmdStub.resolves({ error: null, stdout: localVersion });
+
+      await systemService.monitorSyncthingPackage();
+
+      sinon.assert.calledOnceWithExactly(axiosStub, statsEndpoint, { timeout: 10000 });
+      sinon.assert.calledWith(logSpy, `Checking package syncthing is updated to version ${localVersion}`);
+    })
+
+    it('should upgrade syncthing immediately if on lower version', async () => {
       const now = 1713858779721;
 
-      runCmdStub.resolves({ error: null, stdout: 'v1.27.6' });
+      const statsVersion = '2.2.2';
 
-      // don't update
+      const axiosRes = { data: { status: 'success', data: { syncthing: statsVersion } } }
+
+      sinon.stub(axios, 'get').resolves(axiosRes);
+
+      const cmdRunner = sinon.fake((cmd) => {
+        if (cmd === 'dpkg-query') return { error: null, stdout: '1.27.3' };
+        if (cmd === 'apt-get') return { error: null };
+        return null;
+      })
+
+      runCmdStub.callsFake(cmdRunner);
+
+      // don't update apt cache
       statStub.resolves({ mtimeMs: now });
 
       sinon.useFakeTimers({
@@ -207,7 +257,272 @@ describe('system Services tests', () => {
       });
 
       await systemService.monitorSyncthingPackage();
-      sinon.assert.notCalled(logSpy);
+
+      sinon.assert.calledWithExactly(runCmdStub, 'apt-get', { runAsRoot: true, params: ['-o', 'DPkg::Lock::Timeout=180', 'install', 'syncthing'] });
+    })
+
+    it('should not call upgradeSyncthing if on correct version', async () => {
+      const now = 1713858779721;
+
+      const statsVersion = '2.2.2';
+
+      const axiosRes = { data: { status: 'success', data: { syncthing: statsVersion } } }
+
+      sinon.stub(axios, 'get').resolves(axiosRes);
+
+      const cmdRunner = sinon.fake((cmd) => {
+        if (cmd === 'dpkg-query') return { error: null, stdout: statsVersion };
+        if (cmd === 'apt-get') return { error: null };
+        return null;
+      })
+
+      runCmdStub.callsFake(cmdRunner);
+
+      // don't update apt cache
+      statStub.resolves({ mtimeMs: now });
+
+      sinon.useFakeTimers({
+        now,
+      });
+
+      await systemService.monitorSyncthingPackage();
+      sinon.assert.calledOnceWithMatch(runCmdStub, 'dpkg-query');
+    });
+  });
+
+  describe('monitorAptCache tests', () => {
+    let runCmdStub;
+    let errorSpy;
+
+    beforeEach(() => {
+      systemService.resetTimers();
+      statStub = sinon.stub(fs, 'stat');
+      runCmdStub = sinon.stub(serviceHelper, 'runCommand');
+      errorSpy = sinon.spy(log, 'error');
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('should bail out if the apt cache is alredy being monitored', async () => {
+      const event = { options: { command: 'install', params: ['syncthing'] }, error: new Error('Non lock error') };
+
+      const cmdRunner = sinon.fake((cmd) => {
+        // dpkg --configure -a
+        if (cmd === 'dpkg') return '';
+        // apt-get check
+        if (cmd === 'apt-get') return { error: new Error('Still broken') };
+        return null;
+      })
+
+      runCmdStub.callsFake(cmdRunner);
+
+      await systemService.monitorAptCache(event);
+      // calls configure and check
+      sinon.assert.calledTwice(cmdRunner);
+      sinon.assert.calledOnceWithExactly(errorSpy, 'Unable to run apt-get command(s), all apt activities are halted, will resume in 12 hours.');
+
+      // should return immediately as timer is running
+      await systemService.monitorAptCache(event);
+      sinon.assert.calledTwice(cmdRunner);
+      sinon.assert.calledOnce(errorSpy);
+    });
+
+    it('should resume halted queue if the error was for apt-get update', async () => {
+      const event = { options: { command: 'update', params: [] }, error: new Error('Lock error') };
+
+      let count = 0;
+
+      const worker = () => { count += 1 };
+
+      const queue = systemService.getQueue();
+
+      queue.halted = true;
+      queue.worker = worker;
+      queue.push('42');
+
+      expect(count).to.equal(0);
+
+      await systemService.monitorAptCache(event);
+
+      expect(queue.halted).to.equal(false);
+      expect(count).to.equal(1);
+    });
+
+    it('should retry 3 times with a 10 minute wait between retries if unable to get a lock', async () => {
+      const clock = sinon.useFakeTimers();
+
+      let checkCount = 0;
+
+      const lockError = new Error('No lock: /var/lib/dpkg/lock-frontend');
+      const event = { options: { command: 'install', params: ['syncthing'] }, error: lockError };
+
+      const cmdRunner = sinon.fake((cmd) => {
+        // apt-get check
+        if (cmd === 'apt-get') {
+          checkCount += 1;
+          return { error: lockError };
+        }
+        return null;
+      })
+
+      runCmdStub.callsFake(cmdRunner);
+
+      const promise = systemService.monitorAptCache(event);
+
+      expect(checkCount).to.equal(0);
+      await clock.tickAsync(10 * 60 * 1000);
+      expect(checkCount).to.equal(1);
+      await clock.tickAsync(10 * 60 * 1000);
+      expect(checkCount).to.equal(2);
+      await clock.tickAsync(10 * 60 * 1000);
+      expect(checkCount).to.equal(3);
+
+      await promise
+      expect(checkCount).to.equal(3);
+      sinon.assert.calledOnceWithExactly(errorSpy, 'Unable to run apt-get command(s), all apt activities are halted, will resume in 12 hours.')
+    });
+
+    it('should resume if there is a lock error and it clears', async () => {
+      const clock = sinon.useFakeTimers();
+      let checkCount = 0;
+      let workCount = 0;
+
+      const worker = () => { workCount += 1 };
+
+      const queue = systemService.getQueue();
+
+      queue.halted = true;
+      queue.worker = worker;
+      queue.push('42');
+
+      expect(workCount).to.equal(0);
+
+      const lockError = new Error('No lock: /var/lib/dpkg/lock-frontend');
+      const event = { options: { command: 'install', params: ['syncthing'] }, error: lockError };
+
+      const cmdRunner = sinon.fake((cmd) => {
+        // apt-get check
+        if (cmd === 'apt-get') {
+          checkCount += 1;
+          if (checkCount === 1) return { error: lockError };
+          return { error: null }
+        }
+        return null;
+      })
+
+      runCmdStub.callsFake(cmdRunner);
+
+      const promise = systemService.monitorAptCache(event);
+
+      expect(checkCount).to.equal(0);
+      await clock.tickAsync(10 * 60 * 1000);
+      expect(checkCount).to.equal(1);
+      await clock.tickAsync(10 * 60 * 1000);
+      expect(checkCount).to.equal(2);
+
+      await promise
+      expect(checkCount).to.equal(2);
+      expect(workCount).to.equal(1);
+
+      sinon.assert.notCalled(errorSpy);
+    });
+
+    it('should run dpkg configure if there is a non Lock error after a lock error', async () => {
+      const clock = sinon.useFakeTimers();
+
+      let dpkgCount = 0;
+
+      const lockError = new Error('No lock: /var/lib/dpkg/lock-frontend');
+      const event = { options: { command: 'install', params: ['syncthing'] }, error: lockError };
+
+      const cmdRunner = sinon.fake((cmd) => {
+        // apt-get check
+        if (cmd === 'apt-get') return { error: new Error('Some other error') };
+        if (cmd === 'dpkg') {
+          dpkgCount += 1;
+          return { error: null };
+        }
+        return null;
+      })
+
+      runCmdStub.callsFake(cmdRunner);
+
+      const promise = systemService.monitorAptCache(event);
+      await clock.tickAsync(10 * 60 * 1000);
+      await promise;
+      expect(dpkgCount).to.equal(1);
+    });
+
+    it('should resume if there is a non lock error and it clears after running dpkg configure', async () => {
+      const clock = sinon.useFakeTimers();
+      let workCount = 0;
+
+      const worker = () => { workCount += 1 };
+
+      const queue = systemService.getQueue();
+
+      queue.halted = true;
+      queue.worker = worker;
+      queue.push('42');
+
+      expect(workCount).to.equal(0);
+
+      const nonLockError = new Error('Some other error');
+      const event = { options: { command: 'install', params: ['syncthing'] }, error: nonLockError };
+
+      const cmdRunner = sinon.fake((cmd) => {
+        // apt-get check
+        if (cmd === 'apt-get') return { error: null };
+        return null;
+      })
+
+      runCmdStub.callsFake(cmdRunner);
+
+      await systemService.monitorAptCache(event);
+
+      sinon.assert.notCalled(errorSpy);
+      expect(workCount).to.equal(1);
+    });
+
+    it('should resume queue activities in 12 hours if there is an unrecoverable error', async () => {
+      const clock = sinon.useFakeTimers();
+      let workCount = 0;
+
+      const worker = () => { workCount += 1 };
+
+      const queue = systemService.getQueue();
+
+      queue.halted = true;
+      queue.worker = worker;
+      queue.push('42');
+
+      expect(workCount).to.equal(0);
+
+      const nonLockError = new Error('Some other error');
+      const event = { options: { command: 'install', params: ['syncthing'] }, error: nonLockError };
+
+      const cmdRunner = sinon.fake((cmd) => {
+        // apt-get check
+        if (cmd === 'apt-get') return { error: nonLockError };
+        if (cmd === 'dpkg') return { error: null };
+        return null;
+      })
+
+      runCmdStub.callsFake(cmdRunner);
+
+      await systemService.monitorAptCache(event);
+
+      sinon.assert.calledOnceWithExactly(errorSpy, 'Unable to run apt-get command(s), all apt activities are halted, will resume in 12 hours.');
+      expect(workCount).to.equal(0)
+
+      // roll forward 11 hours
+      await clock.tickAsync(1000 * 3600 * 11);
+      expect(workCount).to.equal(0);
+      // another hour
+      await clock.tickAsync(1000 * 3600);
+      expect(workCount).to.equal(1);
     });
   });
 });

--- a/tests/unit/systemService.test.js
+++ b/tests/unit/systemService.test.js
@@ -1,5 +1,6 @@
 const chai = require('chai');
 const sinon = require('sinon');
+
 const { expect } = chai;
 
 const config = require('config');
@@ -182,13 +183,13 @@ describe('system Services tests', () => {
 
       sinon.assert.calledOnceWithExactly(axiosStub, statsEndpoint, { timeout: 10000 });
       sinon.assert.calledWith(logSpy, `Checking package syncthing is updated to version ${statsVersion}`);
-    })
+    });
 
     it('should fallback to local syncthing version if there is an axios error', async () => {
       const statsEndpoint = 'https://stats.runonflux.io/getmodulesminimumversions';
       const localVersion = '1.25.2';
 
-      config.minimumSyncthingAllowedVersion = localVersion
+      config.minimumSyncthingAllowedVersion = localVersion;
 
       const axiosStub = sinon.stub(axios, 'get').rejects(new Error('Simulated Axios error'));
 
@@ -198,7 +199,7 @@ describe('system Services tests', () => {
 
       sinon.assert.calledOnceWithExactly(axiosStub, statsEndpoint, { timeout: 10000 });
       sinon.assert.calledWith(logSpy, `Checking package syncthing is updated to version ${localVersion}`);
-    })
+    });
 
     it('should fallback to local syncthing version if there is a fluxstats error', async () => {
       const statsEndpoint = 'https://stats.runonflux.io/getmodulesminimumversions';
@@ -206,7 +207,7 @@ describe('system Services tests', () => {
 
       config.minimumSyncthingAllowedVersion = localVersion;
 
-      const axiosStub = sinon.stub(axios, 'get').resolves({ data: { status: 'error', data: { code: 123, error: 'Test error', 'message': 'Broken' } } });
+      const axiosStub = sinon.stub(axios, 'get').resolves({ data: { status: 'error', data: { code: 123, error: 'Test error', message: 'Broken' } } });
 
       runCmdStub.resolves({ error: null, stdout: localVersion });
 
@@ -214,7 +215,7 @@ describe('system Services tests', () => {
 
       sinon.assert.calledOnceWithExactly(axiosStub, statsEndpoint, { timeout: 10000 });
       sinon.assert.calledWith(logSpy, `Checking package syncthing is updated to version ${localVersion}`);
-    })
+    });
 
     it('should fallback to local syncthing version if fluxstats syncthing response is empty', async () => {
       const statsEndpoint = 'https://stats.runonflux.io/getmodulesminimumversions';
@@ -230,14 +231,14 @@ describe('system Services tests', () => {
 
       sinon.assert.calledOnceWithExactly(axiosStub, statsEndpoint, { timeout: 10000 });
       sinon.assert.calledWith(logSpy, `Checking package syncthing is updated to version ${localVersion}`);
-    })
+    });
 
     it('should upgrade syncthing immediately if on lower version', async () => {
       const now = 1713858779721;
 
       const statsVersion = '2.2.2';
 
-      const axiosRes = { data: { status: 'success', data: { syncthing: statsVersion } } }
+      const axiosRes = { data: { status: 'success', data: { syncthing: statsVersion } } };
 
       sinon.stub(axios, 'get').resolves(axiosRes);
 
@@ -245,7 +246,7 @@ describe('system Services tests', () => {
         if (cmd === 'dpkg-query') return { error: null, stdout: '1.27.3' };
         if (cmd === 'apt-get') return { error: null };
         return null;
-      })
+      });
 
       runCmdStub.callsFake(cmdRunner);
 
@@ -259,14 +260,14 @@ describe('system Services tests', () => {
       await systemService.monitorSyncthingPackage();
 
       sinon.assert.calledWithExactly(runCmdStub, 'apt-get', { runAsRoot: true, params: ['-o', 'DPkg::Lock::Timeout=180', 'install', 'syncthing'] });
-    })
+    });
 
     it('should not call upgradeSyncthing if on correct version', async () => {
       const now = 1713858779721;
 
       const statsVersion = '2.2.2';
 
-      const axiosRes = { data: { status: 'success', data: { syncthing: statsVersion } } }
+      const axiosRes = { data: { status: 'success', data: { syncthing: statsVersion } } };
 
       sinon.stub(axios, 'get').resolves(axiosRes);
 
@@ -274,7 +275,7 @@ describe('system Services tests', () => {
         if (cmd === 'dpkg-query') return { error: null, stdout: statsVersion };
         if (cmd === 'apt-get') return { error: null };
         return null;
-      })
+      });
 
       runCmdStub.callsFake(cmdRunner);
 
@@ -296,7 +297,6 @@ describe('system Services tests', () => {
 
     beforeEach(() => {
       systemService.resetTimers();
-      statStub = sinon.stub(fs, 'stat');
       runCmdStub = sinon.stub(serviceHelper, 'runCommand');
       errorSpy = sinon.spy(log, 'error');
     });
@@ -314,7 +314,7 @@ describe('system Services tests', () => {
         // apt-get check
         if (cmd === 'apt-get') return { error: new Error('Still broken') };
         return null;
-      })
+      });
 
       runCmdStub.callsFake(cmdRunner);
 
@@ -334,7 +334,7 @@ describe('system Services tests', () => {
 
       let count = 0;
 
-      const worker = () => { count += 1 };
+      const worker = () => { count += 1; };
 
       const queue = systemService.getQueue();
 
@@ -365,7 +365,7 @@ describe('system Services tests', () => {
           return { error: lockError };
         }
         return null;
-      })
+      });
 
       runCmdStub.callsFake(cmdRunner);
 
@@ -379,9 +379,9 @@ describe('system Services tests', () => {
       await clock.tickAsync(10 * 60 * 1000);
       expect(checkCount).to.equal(3);
 
-      await promise
+      await promise;
       expect(checkCount).to.equal(3);
-      sinon.assert.calledOnceWithExactly(errorSpy, 'Unable to run apt-get command(s), all apt activities are halted, will resume in 12 hours.')
+      sinon.assert.calledOnceWithExactly(errorSpy, 'Unable to run apt-get command(s), all apt activities are halted, will resume in 12 hours.');
     });
 
     it('should resume if there is a lock error and it clears', async () => {
@@ -389,7 +389,7 @@ describe('system Services tests', () => {
       let checkCount = 0;
       let workCount = 0;
 
-      const worker = () => { workCount += 1 };
+      const worker = () => { workCount += 1; };
 
       const queue = systemService.getQueue();
 
@@ -407,10 +407,10 @@ describe('system Services tests', () => {
         if (cmd === 'apt-get') {
           checkCount += 1;
           if (checkCount === 1) return { error: lockError };
-          return { error: null }
+          return { error: null };
         }
         return null;
-      })
+      });
 
       runCmdStub.callsFake(cmdRunner);
 
@@ -422,7 +422,7 @@ describe('system Services tests', () => {
       await clock.tickAsync(10 * 60 * 1000);
       expect(checkCount).to.equal(2);
 
-      await promise
+      await promise;
       expect(checkCount).to.equal(2);
       expect(workCount).to.equal(1);
 
@@ -445,7 +445,7 @@ describe('system Services tests', () => {
           return { error: null };
         }
         return null;
-      })
+      });
 
       runCmdStub.callsFake(cmdRunner);
 
@@ -456,10 +456,9 @@ describe('system Services tests', () => {
     });
 
     it('should resume if there is a non lock error and it clears after running dpkg configure', async () => {
-      const clock = sinon.useFakeTimers();
       let workCount = 0;
 
-      const worker = () => { workCount += 1 };
+      const worker = () => { workCount += 1; };
 
       const queue = systemService.getQueue();
 
@@ -476,7 +475,7 @@ describe('system Services tests', () => {
         // apt-get check
         if (cmd === 'apt-get') return { error: null };
         return null;
-      })
+      });
 
       runCmdStub.callsFake(cmdRunner);
 
@@ -490,7 +489,7 @@ describe('system Services tests', () => {
       const clock = sinon.useFakeTimers();
       let workCount = 0;
 
-      const worker = () => { workCount += 1 };
+      const worker = () => { workCount += 1; };
 
       const queue = systemService.getQueue();
 
@@ -508,14 +507,14 @@ describe('system Services tests', () => {
         if (cmd === 'apt-get') return { error: nonLockError };
         if (cmd === 'dpkg') return { error: null };
         return null;
-      })
+      });
 
       runCmdStub.callsFake(cmdRunner);
 
       await systemService.monitorAptCache(event);
 
       sinon.assert.calledOnceWithExactly(errorSpy, 'Unable to run apt-get command(s), all apt activities are halted, will resume in 12 hours.');
-      expect(workCount).to.equal(0)
+      expect(workCount).to.equal(0);
 
       // roll forward 11 hours
       await clock.tickAsync(1000 * 3600 * 11);

--- a/tests/unit/systemService.test.js
+++ b/tests/unit/systemService.test.js
@@ -177,6 +177,9 @@ describe('system Services tests', () => {
 
       const axiosStub = sinon.stub(axios, 'get').resolves(axiosRes);
 
+      // for aptSource
+      statStub.resolves(true);
+
       runCmdStub.resolves({ error: null, stdout: statsVersion });
 
       await systemService.monitorSyncthingPackage();
@@ -192,6 +195,9 @@ describe('system Services tests', () => {
       config.minimumSyncthingAllowedVersion = localVersion;
 
       const axiosStub = sinon.stub(axios, 'get').rejects(new Error('Simulated Axios error'));
+
+      // for aptSource
+      statStub.resolves(true);
 
       runCmdStub.resolves({ error: null, stdout: localVersion });
 
@@ -209,6 +215,9 @@ describe('system Services tests', () => {
 
       const axiosStub = sinon.stub(axios, 'get').resolves({ data: { status: 'error', data: { code: 123, error: 'Test error', message: 'Broken' } } });
 
+      // for aptSource
+      statStub.resolves(true);
+
       runCmdStub.resolves({ error: null, stdout: localVersion });
 
       await systemService.monitorSyncthingPackage();
@@ -224,6 +233,9 @@ describe('system Services tests', () => {
       config.minimumSyncthingAllowedVersion = localVersion;
 
       const axiosStub = sinon.stub(axios, 'get').resolves({ data: { status: 'success', data: { syncthing: null } } });
+
+      // for aptSource
+      statStub.resolves(true);
 
       runCmdStub.resolves({ error: null, stdout: localVersion });
 


### PR DESCRIPTION
**Version matrix**

| OS version     | apt           | netcat-openbsd | ca-certificates |
| --------------|----------|-----------------|----------------
| Ubuntu 18.04  | 1.6.17      | 1.187                  | 20230311          |
| Ubuntu 20.04 | 2.0.10      | 1.206                 | 20230311          |
| Ubuntu 22.04 | 2.4.11      | 1.218                  | 20230311         |
| Ubuntu 24.04 | 2.7.14      | 1.226                 | 20240203         |
| Debian 12       | 2.6.1        | 1.219                  | 20230311         |

***Apt***

Any version of apt before 1.9.11 does not have access to the `-o DPkg::Lock::Timeout=x` feature. This just means that instead of using apt to wait for the lock, we have to do it manually. We have a 1 minute retry cooldown between retries if an apt command fails, and we retry 5 times.

***Netcat***

We just target a minimum version of `1.187` which will satisify the above OSes.

**What this pull does:**

* Add a 15 minute timeout to any child_process command (This is able to be overridden per command)
* Update semver check to allow just major and minor, or just major. (So not semver) As some dpkg versions don’t have minor or patch (ca-certificates, netcat-openbsd)
* Move netcat install to part of system service.
* Stop using syncthing install shell script, and move to systemService.
* Install netcat from systemService
* Checks installed packages meet requirements. (uses dpkg-query) Also makes sure package is installed.
* Move systemService start to top of serviceManager.
* Add fifo queue for apt commands. This will do the following:
  * run them sequentially, i.e. fifo.
  * If you add more than what can run, the commands will queue up.
  * If a command errors, the queue is halted and error event emitted.
  * If a command errors, it is re-added at the start of the queue (configurable).
  * On error, apt-get monitoring starts. If the error clears, the queue resumes.
  * If the error doesn’t clear and it’s not a lock, dpkg configure is run as a last resort.
  * At no point do we try kill any other apt processes, or delete any locks.
  * Sets a max queue size of 10. If more commands get added, old commands drop off.
  * You can add tasks to the queue, and optionally await them, or, just await the queue being empty.

Tested on 18.04, 20.04, 22.04 Debian 12. The minimum version for netcat-openbsd is 1.187. That is the latest package available on 18.04.

We probably need to create an object that contains the supported systems, with minimum package versions. This shouldn’t be hard to do.

**ToDo**:

***Tests:***
- [x] semver
- [x] fifoqueue
- [x] systemservice

**Risks:**
We aren’t really able to run the apt commands as detached children, as we need to get the error info back.

So until nodemon is removed, there will always be a risk that we get a messed up dpkg database from an apt command being killed. However, this should be resolved by the monitorApt method, so pretty edge case I think.