### PR TITLE
Feature - Sort components by docker compose "depends_on"

### DIFF
--- a/HomeUI/src/services/Api.js
+++ b/HomeUI/src/services/Api.js
@@ -31,6 +31,5 @@ const sourceCancelToken = axios.CancelToken.source();
 export { sourceCancelToken };
 
 export default () => axios.create({
-
   baseURL: store.get('backendURL') || mybackend,
 });

--- a/HomeUI/src/utils/topologicalSort.js
+++ b/HomeUI/src/utils/topologicalSort.js
@@ -1,0 +1,161 @@
+/* eslint max-classes-per-file: 0 */
+
+class Node {
+  prev = null;
+
+  next = null;
+
+  constructor(value) {
+    this.value = value;
+  }
+}
+
+class Queue {
+  #dummyHead = new Node();
+
+  #dummyTail = new Node();
+
+  #length = 0;
+
+  constructor() {
+    this.#dummyHead.prev = this.#dummyTail;
+    this.#dummyTail.next = this.#dummyHead;
+  }
+
+  /**
+ * Determines if the queue is empty.
+ * @return {boolean} `true` if the queue has no items, `false` otherwise.
+ */
+  get isEmpty() {
+    return this.#length === 0;
+  }
+
+  /**
+   * Returns the item at the front of the queue without removing it from the queue.
+   * @return {*} The item at the front of the queue if it is not empty, `undefined` otherwise.
+   */
+  get front() {
+    if (this.isEmpty) {
+      return undefined;
+    }
+
+    return this.#dummyHead.prev.value;
+  }
+
+  /**
+   * Returns the item at the back of the queue without removing it from the queue it.
+   * @return {*} The item at the back of the queue if it is not empty, `undefined` otherwise.
+   */
+  get back() {
+    if (this.isEmpty) {
+      return undefined;
+    }
+
+    return this.#dummyTail.next.value;
+  }
+
+  /**
+   * Returns the number of items in the queue.
+   * @return {number} The number of items in the queue.
+   */
+  get length() {
+    return this.#length;
+  }
+
+  /**
+   * Adds an item to the back of the queue.
+   * @param {*} item The item to be pushed onto the queue.
+   * @return {number} The new length of the queue.
+   */
+  enqueue(item) {
+    const node = new Node(item);
+    const prevLast = this.#dummyTail.next;
+    prevLast.prev = node;
+
+    node.next = prevLast;
+    node.prev = this.#dummyTail;
+    this.#dummyTail.next = node;
+    this.#length += 1;
+    return this.#length;
+  }
+
+  /**
+   * Remove an item from the front of the queue.
+   * @return {*} The item at the front of the queue if it is not empty, `undefined` otherwise.
+   */
+  dequeue() {
+    if (this.isEmpty) {
+      return undefined;
+    }
+
+    const node = this.#dummyHead.prev;
+    const newFirst = node.prev;
+    this.#dummyHead.prev = newFirst;
+    newFirst.next = this.#dummyHead;
+    // Unlink the node to be dequeued.
+    node.prev = null;
+    node.next = null;
+    this.#length -= 1;
+    return node.value;
+  }
+}
+
+/**
+ * Sort a DAG topologically. Used for docker compose dependencies
+ * @param {Object} graph Node to array of neighboring nodes.
+ * @return {Array<string>} A topological traversal of nodes.
+ *
+ * Kahn's Algorithm:
+ *   - Initialize a queue and a list to store the sorted nodes.
+ *   - For each node in the graph, if it has no incoming edges, add it to the queue.
+ *   - While the queue is not empty:
+ *   - Dequeue a node from the front of the queue.
+ *   - Add this node to the list of sorted nodes.
+ *   - For each child of this node, decrease its in-degree (the number of incoming edges) by 1.
+ *   - If a child's in-degree becomes 0, add it to the queue.
+ *   - If the length of the sorted list is less than the number of nodes in the graph, this means
+ *     that there is a cycle in the graph, and no topological ordering is possible.
+ */
+function topologicalSort(graph) {
+  const nodes = new Map();
+  const queue = new Queue();
+  const order = [];
+
+  Object.keys(graph).forEach((node) => {
+    nodes.set(node, { in: 0, out: new Set(graph[node]) });
+  });
+
+  Object.keys(graph).forEach((node) => {
+    graph[node].forEach((neighbor) => {
+      if (nodes.has(neighbor)) nodes.get(neighbor).in += 1;
+    });
+  });
+
+  nodes.forEach((value, node) => {
+    if (value.in === 0) {
+      queue.enqueue(node);
+    }
+  });
+
+  while (queue.length) {
+    const node = queue.dequeue();
+
+    nodes.get(node).out.forEach((neighbor) => {
+      if (nodes.has(neighbor)) {
+        nodes.get(neighbor).in -= 1;
+        if (nodes.get(neighbor).in === 0) {
+          queue.enqueue(neighbor);
+        }
+      }
+    });
+
+    order.push(node);
+  }
+
+  // Return topological sorted array if it has the same length as
+  // the number of keys in the graph, otherwise there is a cycle
+  // and we return an empty array.
+  return order.length === Object.keys(graph).length ? order : [];
+}
+
+module.exports = topologicalSort;

--- a/HomeUI/src/views/apps/RegisterFluxApp.vue
+++ b/HomeUI/src/views/apps/RegisterFluxApp.vue
@@ -4054,8 +4054,8 @@ export default {
             let dependsOn = config.depends_on;
 
             // assume we have an object and use the keys
-            if (!(Array.isArray(config.depends_on))) {
-              dependsOn = Object.keys(config.depends_on);
+            if (!(Array.isArray(dependsOn))) {
+              dependsOn = Object.keys(dependsOn);
             }
 
             dependsOn.forEach((dependee) => {

--- a/HomeUI/src/views/apps/RegisterFluxApp.vue
+++ b/HomeUI/src/views/apps/RegisterFluxApp.vue
@@ -2115,6 +2115,7 @@ import { useClipboard } from '@vueuse/core';
 import { getUser } from '@/libs/firebase';
 import getPaymentGateways, { paymentBridge } from '@/libs/fiatGateways';
 
+import topologicalSort from '@/utils/topologicalSort';
 import yaml from 'js-yaml';
 
 const projectId = 'df787edc6839c7de49d527bba9199eaa';
@@ -4040,12 +4041,31 @@ export default {
         const range = (start, stop, step) => Array.from({ length: (stop - start) / step + 1 }, (_, i) => start + i * step);
 
         const fluxApp = { compose: [] };
+        const dependsOnDag = {};
 
         Object.entries(parsed.services).forEach((entry) => {
           const [componentName, config] = entry;
 
           const component = { name: componentName };
           fluxApp.compose.push(component);
+          if (!(componentName in dependsOnDag)) dependsOnDag[componentName] = new Set();
+
+          if (config.depends_on) {
+            let dependsOn = config.depends_on;
+
+            // assume we have an object and use the keys
+            if (!(Array.isArray(config.depends_on))) {
+              dependsOn = Object.keys(config.depends_on);
+            }
+
+            dependsOn.forEach((dependee) => {
+              if (!(dependee in dependsOnDag)) {
+                dependsOnDag[dependee] = new Set();
+              }
+
+              dependsOnDag[dependee].add(componentName);
+            });
+          }
 
           component.repotag = config.image || '';
 
@@ -4162,12 +4182,19 @@ export default {
           component.rambamf = 14000;
           component.hddbamf = 285;
         });
+
+        const order = topologicalSort(dependsOnDag);
+        if (order.length === fluxApp.compose.length) {
+          fluxApp.compose.sort((a, b) => order.indexOf(a.name) - order.indexOf(b.name));
+        }
+
         this.appRegistrationSpecification.compose = fluxApp.compose;
 
         if (this.$refs.components.length && !this.isElementInViewport(this.$refs.components[0])) {
           this.$refs.components[0].scrollIntoView({ behavior: 'smooth' });
         }
-      } catch {
+      } catch (err) {
+        console.log(err);
         this.showToast('Error', 'Unable to parse compose specifications.');
       }
     },

--- a/tests/unit/homeUiDagSort.test.js
+++ b/tests/unit/homeUiDagSort.test.js
@@ -1,0 +1,67 @@
+const chai = require('chai');
+
+const { expect } = chai;
+
+const topologicalSort = require('../../HomeUI/src/utils/topologicalSort');
+
+describe('topologicalSort tests', () => {
+  it('should return an empty array if the graph is empty', () => {
+    const graph = {};
+
+    const sorted = topologicalSort(graph);
+    expect(sorted).to.deep.equal([]);
+  });
+
+  it('should return an empty array if there is a cycle', () => {
+    const graph = { a: ['b'], b: ['a'] };
+
+    const sorted = topologicalSort(graph);
+    expect(sorted).to.deep.equal([]);
+  });
+
+  it('should ignore any dependency missing from the graph', () => {
+    const graph = { a: ['b'], b: ['c'], d: ['a'] };
+
+    const sorted = topologicalSort(graph);
+    expect(sorted).to.deep.equal(['d', 'a', 'b']);
+  });
+
+  it('should sort graphs based on dependencies', () => {
+    const expected = [
+      ['a', 'b', 'c', 'd', 'e', 'f'],
+      ['a', 'b', 'c', 'd', 'e', 'f'],
+      ['f', 'e', 'd', 'c', 'b', 'a'],
+    ];
+    const graphs = [
+      {
+        a: ['b', 'c'],
+        b: ['c', 'd', 'e'],
+        c: ['f'],
+        d: [],
+        e: ['f'],
+        f: [],
+      },
+      {
+        a: ['b', 'c'],
+        b: ['c', 'd'],
+        c: ['d'],
+        d: ['e'],
+        e: ['f'],
+        f: [],
+      },
+      {
+        a: [],
+        b: ['a'],
+        c: ['b'],
+        d: ['c'],
+        e: ['d'],
+        f: ['e'],
+      },
+    ];
+
+    graphs.forEach((graph, index) => {
+      const sorted = topologicalSort(graph);
+      expect(sorted).to.deep.equal(expected[index]);
+    });
+  });
+});

--- a/tests/unit/idService.test.js
+++ b/tests/unit/idService.test.js
@@ -269,6 +269,10 @@ describe('idService tests', () => {
     let collateralStub;
     let getDOSStateStub;
 
+    before(async () => {
+      await dbHelper.initiateDB();
+    })
+
     beforeEach(() => {
       osTotalmemStub = sinon.stub(os, 'totalmem');
       osCpusStub = sinon.stub(os, 'cpus');


### PR DESCRIPTION
**What this pull does**

* When importing a docker compose file, it takes into account the depends_on of the services.
* Sorts the components by depends_on. I.e. The containers that are "depended on" are first in the list, so they get installed first. I.e if `web` depends_on `mysql`, mysql will get installed first.
* Can specify both long form and short form `depends_on` however, only the keys are used for long_form. 
* Uses a DAG to resolve dependencies.
* Any cycles and the components are left in their original state. I.e. if you have `a depends_on b` and `b depends_on a`.
* Adds tests for topologicalSort.