### PR TITLE
Update system service (again)

### DIFF
--- a/ZelBack/src/services/serviceHelper.js
+++ b/ZelBack/src/services/serviceHelper.js
@@ -339,18 +339,18 @@ function parseVersion(rawVersion) {
   //    dpkg-query --showformat='${Version}' --show netcat-openbsd    1.218-4ubuntu1
   //    dpkg-query --showformat='${Version}' --show ca-certificates   20230311ubuntu0.22.04.1
 
-  const versionRegex = /^[^\d]?(?<version>(?<major>0|[1-9][0-9]*)(?:\.(?<minor>0|[1-9][0-9]*)(?:\.(?<patch>0|[1-9][0-9]*))?)?)([-~]?(0|[1-9A-Za-z-][0-9A-Za-z-]*)(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/;
+  const versionRegex = /^[^\d]?(?:(?<epoch>[0-9]+):)?(?<version>(?<major>0|[1-9][0-9]*)(?:\.(?<minor>0|[1-9][0-9]*)(?:\.(?<patch>0|[1-9][0-9]*))?)?)/;
 
   const match = versionRegex.exec(rawVersion);
 
   if (match) {
     const {
       groups: {
-        version, major, minor, patch,
+        epoch, version, major, minor, patch,
       },
     } = match;
     return {
-      version, major, minor, patch,
+      epoch, version, major, minor, patch,
     };
   }
   return null;

--- a/tests/unit/serviceHelper.test.js
+++ b/tests/unit/serviceHelper.test.js
@@ -669,6 +669,7 @@ describe('serviceHelper tests', () => {
         ['2.0.1-alpha.1227', '2.0.1'],
         ['1.0.0-alpha+beta', '1.0.0'],
         ['1.2.3----RC-SNAPSHOT.12.9.1--.12+788', '1.2.3'],
+        ['5:26.1.3-1~ubuntu.22.04~jammy', '26.1.3'],
       ];
 
       for (let index = 0; index < versions.length; index += 1) {


### PR DESCRIPTION
### What this pull does

**1/ Adds a command at the end of the apt monitor**

If the apt cache is broken, try and fix it by running:

`apt-get install --fix-broken`

**2/ Small fix to the dpkg version parser**

This is the format:

`[epoch:]upstream_version[-debian_revision]`

We now correctly parse this.

I.e. when running:

```
davew@chud:~$ dpkg-query --showformat='${Version}\n' --show docker-ce-cli
5:26.1.2-1~ubuntu.22.04~jammy

davew@chud:~$ docker --version
Docker version 26.1.2, build 211e74b
```

The version will get correctly parsed as: `26.1.2`

Note... when running the command `docker --version` that is just giving the version of the `docker-ce-cli` package. We need to be updating the following:

```
davew@chud:~$ apt list --installed | grep docker

docker-buildx-plugin/jammy,now 0.13.1-1~ubuntu.22.04~jammy amd64 [installed,upgradable to: 0.14.0-1~ubuntu.22.04~jammy]
docker-ce-cli/jammy,now 5:26.1.2-1~ubuntu.22.04~jammy amd64 [installed,upgradable to: 5:26.1.3-1~ubuntu.22.04~jammy]
docker-ce-rootless-extras/jammy,now 5:26.0.0-1~ubuntu.22.04~jammy amd64 [installed,upgradable to: 5:26.1.3-1~ubuntu.22.04~jammy]
docker-ce/jammy,now 5:26.1.3-1~ubuntu.22.04~jammy amd64 [installed]
docker-compose-plugin/jammy,now 2.25.0-1~ubuntu.22.04~jammy amd64 [installed,upgradable to: 2.27.0-1~ubuntu.22.04~jammy]

davew@chud:~$ apt list --installed | grep containerd

containerd.io/jammy,now 1.6.31-1 amd64 [installed]
```

However, it's not as simple as just updating these packages. 

If installed via snap... none of these packages exist.

```
davew@chloe:~$ apt list --installed | grep docker

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

davew@chloe:~$ which docker
/snap/bin/docker
```



