### PR TITLE
mongodGpgKeyVerify 

### DIFF
--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -40,6 +40,7 @@ async function startFluxFunctions() {
     }
     log.info('Checking docker log for corruption...');
     await dockerService.dockerLogsFix();
+    await systemService.mongodGpgKeyVeryfity();
     await systemService.mongoDBConfig();
     systemService.monitorSystem();
     log.info('System service initiated');

--- a/ZelBack/src/services/systemService.js
+++ b/ZelBack/src/services/systemService.js
@@ -227,7 +227,7 @@ async function addGpgKey(url, keyringName) {
   }
 
   if (!keyring) {
-    log.error('Unable to fetch syncthing gpg keyring');
+    log.error('Unable to fetch gpg keyring');
     return false;
   }
 
@@ -248,7 +248,7 @@ async function addGpgKey(url, keyringName) {
 
   let success = true;
   // as long as the directory exists, this shouldn't error
-  await fs.writeFile(filePath, keyring).catch((error) => {
+  await fs.writeFile(filePath, keyring, { flag: 'w' }).catch((error) => {
     log.error(error);
     success = false;
   });

--- a/ZelBack/src/services/systemService.js
+++ b/ZelBack/src/services/systemService.js
@@ -573,7 +573,7 @@ async function mongodGpgKeyVeryfity() {
   try {
     const { stdout, stderr, error } = await serviceHelper.runCommand('gpg', { runAsRoot: true, params: ['--show-keys', '/usr/share/keyrings/mongodb-archive-keyring.gpg'] });
     if (error) {
-      throw new Error(`Error executing gpg: ${error}`);
+      throw new Error(`Executing gpg: ${error}`);
     }
     if (stderr) {
       throw new Error(`gpg stderr: ${stderr}`);
@@ -594,16 +594,16 @@ async function mongodGpgKeyVeryfity() {
           logError: true,
         });
         if (error) {
-          throw new Error(`Error: ${error}`);
+          throw new Error(`Update command failed: ${error}`);
         }
         if (stderr) {
-          throw new Error(`Error: ${error}`);
+          throw new Error(`Update command failed: ${stderr}`);
         }
         log.info('The key was updated successfully.');
         return true;
       // eslint-disable-next-line no-else-return
       } else {
-        throw new Error('Error: MongoDB version not found.');
+        throw new Error('MongoDB version not found.');
       }
     // eslint-disable-next-line no-else-return
     } else {

--- a/ZelBack/src/services/systemService.js
+++ b/ZelBack/src/services/systemService.js
@@ -607,7 +607,7 @@ async function mongodGpgKeyVeryfity() {
       }
     // eslint-disable-next-line no-else-return
     } else {
-      log.info('MongoDB PGP key is still valid.');
+      log.info('MongoDB GPG key is still valid.');
       return true;
     }
   } catch (error) {

--- a/ZelBack/src/services/systemService.js
+++ b/ZelBack/src/services/systemService.js
@@ -248,7 +248,7 @@ async function addGpgKey(url, keyringName) {
 
   let success = true;
   // as long as the directory exists, this shouldn't error
-  await fs.writeFile(filePath, keyring, { flag: 'w' }).catch((error) => {
+  await fs.writeFile(filePath, keyring).catch((error) => {
     log.error(error);
     success = false;
   });

--- a/ZelBack/src/services/systemService.js
+++ b/ZelBack/src/services/systemService.js
@@ -587,7 +587,7 @@ async function mongodGpgKeyVeryfity() {
         log.info(`MongoDB version: ${versionMatch[1]}`);
         log.info(`GPG URL: https://pgp.mongodb.com/server-${versionMatch[1]}.asc`);
         log.info(`The key has expired on ${expiredMatch[1]}`);
-        const command = `curl -fsSL ${keyUrl} | sudo gpg -o ${filePath} --dearmor`;
+        const command = `curl -fsSL ${keyUrl} | sudo gpg --batch --yes -o ${filePath} --dearmor`;
         // eslint-disable-next-line no-shadow
         const { error, stderr } = await serviceHelper.runCommand(command, {
           shell: true,


### PR DESCRIPTION
The purpose of this function is to:

Verify the current GPG key used for MongoDB.
Check if the key has expired.
Update the GPG key if it has expired.
