### PR TITLE
Bugfix - Outbound connections

### DIFF
--- a/ZelBack/src/services/fluxCommunication.js
+++ b/ZelBack/src/services/fluxCommunication.js
@@ -854,7 +854,7 @@ async function fluxDiscovery() {
       const fixedIndex = fluxNodeIndex + i < sortedNodeList.length ? fluxNodeIndex + i : fluxNodeIndex + i - sortedNodeList.length;
       const { ip } = sortedNodeList[fixedIndex];
       const ipInc = ip.split(':')[0];
-      const portInc = ip.split(':')[1] || 16127;
+      const portInc = ip.split(':')[1] || '16127';
       // additional precaution
       const clientExists = outgoingConnections.find((client) => client.ip === ipInc && client.port === portInc);
       const clientIncomingExists = incomingConnections.find((client) => client.ip === ipInc && client.port === portInc);
@@ -870,7 +870,7 @@ async function fluxDiscovery() {
       const fixedIndex = fluxNodeIndex - i > 0 ? fluxNodeIndex - i : sortedNodeList.length - fluxNodeIndex - i;
       const { ip } = sortedNodeList[fixedIndex];
       const ipInc = ip.split(':')[0];
-      const portInc = ip.split(':')[1] || 16127;
+      const portInc = ip.split(':')[1] || '16127';
       // additional precaution
       const clientExists = outgoingConnections.find((client) => client.ip === ipInc && client.port === portInc);
       const clientIncomingExists = incomingConnections.find((client) => client.ip === ipInc && client.port === portInc);
@@ -892,7 +892,7 @@ async function fluxDiscovery() {
       const connection = await fluxNetworkHelper.getRandomConnection();
       if (connection) {
         const ipInc = connection.split(':')[0];
-        const portInc = connection.split(':')[1] || 16127;
+        const portInc = connection.split(':')[1] || '16127';
         // additional precaution
         const sameConnectedIp = currentIpsConnTried.find((connectedIP) => connectedIP === ipInc);
         const clientExists = outgoingConnections.find((client) => client.ip === ipInc && client.port === portInc);
@@ -913,7 +913,7 @@ async function fluxDiscovery() {
       const connection = await fluxNetworkHelper.getRandomConnection();
       if (connection) {
         const ipInc = connection.split(':')[0];
-        const portInc = connection.split(':')[1] || 16127;
+        const portInc = connection.split(':')[1] || '16127';
         // additional precaution
         const sameConnectedIp = currentIpsConnTried.find((connectedIP) => connectedIP === ipInc);
         const clientExists = outgoingConnections.find((client) => client.ip === ipInc && client.port === portInc);


### PR DESCRIPTION
Fixes bug where outbound connections were being repeatedly tried when an existing connection already existed.

I have tested this on a node and it fixes the problem I was having. 

There are quite a few other occurences of this in the code in both `fluxCommunication` and `appsService`. I thought it better to do a quick bugfix for this specific issue, and evaluate the rest of the code to make sure it doesn't break anything.

Couple of things I would like to do here: 

1/ Move all the string splitting stuff for the ip / port into a function on `serviceHelper` so at least it's all in one place.

2/ Fix the root problem - Fluxbench should give the 16127 port regardless of if it's a upnp node or not. This would clean up significant tech debt. Overloading the meaning of an <ip:port> with the upnp status makes the code complicated down the line. If we want to show that a node is upnp, we should expose a flag for it. 