### PR TITLE
Bugfix: unable to connect to terminal from new version to old version

### DIFF
--- a/HomeUI/src/views/apps/Management.vue
+++ b/HomeUI/src/views/apps/Management.vue
@@ -5859,6 +5859,7 @@ export default {
   },
   data() {
     return {
+      selectedFluxVersion: '5.13.0',
       progressVisable: false,
       operationTitle: '',
       appInfoObject: [],
@@ -6632,6 +6633,11 @@ export default {
           this.selectedAppVolume = this.appSpecification.compose[0].name;
         }
       }
+    },
+    selectedIp: {
+      handler() {
+        this.getFluxVersion();
+      },
     },
     appUpdateSpecification: {
       handler() {
@@ -8082,9 +8088,14 @@ export default {
       const url = this.selectedIp.split(':')[0];
       const urlPort = this.selectedIp.split(':')[1] || 16127;
       const zelidauth = localStorage.getItem('zelidauth');
-      let queryUrl = `https://${url.replace(/\./g, '-')}-${urlPort}.node.api.runonflux.io/terminal`;
+
+      const [major, minor] = this.selectedFluxVersion.split('.');
+
+      const namespace = major >= 5 && minor >= 13 ? 'terminal' : '';
+
+      let queryUrl = `https://${url.replace(/\./g, '-')}-${urlPort}.node.api.runonflux.io/${namespace}`;
       if (this.ipAccess) {
-        queryUrl = `http://${url}:${urlPort}/terminal`;
+        queryUrl = `http://${url}:${urlPort}/${namespace}`;
       }
       this.socket = io.connect(queryUrl);
 
@@ -10512,6 +10523,14 @@ export default {
           }
         }
         this.applicationManagementAndStatus = niceString;
+      }
+    },
+    async getFluxVersion() {
+      const res = await this.executeLocalCommand('/flux/version');
+      if (res?.data?.status === 'success') {
+        this.selectedFluxVersion = res.data.data;
+      } else {
+        this.selectedFluxVersion = '5.13.0';
       }
     },
     selectedIpChanged() {


### PR DESCRIPTION
Nodes >= 5.13.0 will have the "interactive terminal" endpoint as `/terminal` previously, this was `/`.

So if someone is using a 13 node and tries to connect to an older node, it would be broken as it will be trying the wrong namespace.

This patch fixes that.

Just gets the remote flux version on `selectedIP` change and tests if it needs to add the namespace or not. Once `5.13.0` is enforced, can removed this check.