### PR TITLE
Feature - Update ws payload size

### DIFF
--- a/ZelBack/src/lib/server.js
+++ b/ZelBack/src/lib/server.js
@@ -7,7 +7,7 @@ const compression = require('compression');
 // see https://github.com/HenningM/express-ws/issues/120
 const options = {
   wsOptions: {
-    maxPayload: 65535,
+    maxPayload: 1_048_576 * 16, // 16MiB,
   },
 };
 

--- a/apiServer.js
+++ b/apiServer.js
@@ -270,7 +270,7 @@ async function initiate() {
 
   const options = {
     wsOptions: {
-      maxPayload: 65535,
+      maxPayload: 1_048_576 * 16, // 16MiB
     },
   };
 


### PR DESCRIPTION
Just sets the websocket payload size to something more reasonable. We're only setting this so someone malicious can't overflow the memory on the system.