### PR TITLE
Add Tinode Chat

### DIFF
--- a/helpers/repositories.json
+++ b/helpers/repositories.json
@@ -208,7 +208,7 @@
    "bigmandave",
    "biosmarcel",
    "arkanus",
-   "chesscorp",tinode
+   "chesscorp",
    "guilhermebkel",
    "modem7",
    "marcolederdev",


### PR DESCRIPTION
Tinode Chat

https://github.com/tinode/chat - no encryption yet, but planned.

