### PR TITLE
Feature - markerCluster for flux maps

### DIFF
--- a/HomeUI/src/views/apps/Management.vue
+++ b/HomeUI/src/views/apps/Management.vue
@@ -3428,6 +3428,9 @@
             </b-table>
           </b-col>
           <b-col cols="12">
+            <flux-map class="mb-0" :show-all="false" :filter-nodes="mapLocations" />
+          </b-col>
+          <b-col cols="12">
             <b-pagination
               v-model="instances.currentPage"
               :total-rows="instances.totalRows"
@@ -5775,6 +5778,7 @@ import { mapState } from 'vuex';
 import ToastificationContent from '@core/components/toastification/ToastificationContent.vue';
 import ConfirmDialog from '@/views/components/ConfirmDialog.vue';
 import ListEntry from '@/views/components/ListEntry.vue';
+import FluxMap from '@/views/components/FluxMap.vue';
 import JsonViewer from 'vue-json-viewer';
 import FileUpload from '@/views/components/FileUpload.vue';
 import { useClipboard } from '@vueuse/core';
@@ -5861,6 +5865,7 @@ export default {
     // eslint-disable-next-line vue/no-unused-components
     BProgressBar,
     ConfirmDialog,
+    FluxMap,
     ListEntry,
     // eslint-disable-next-line vue/no-unused-components
     ToastificationContent,
@@ -6298,6 +6303,9 @@ export default {
     };
   },
   computed: {
+    mapLocations() {
+      return this.instances.data.map((i) => i.ip);
+    },
     appRunningTill() {
       const blockTime = 2 * 60 * 1000;
       const expires = this.callBResponse.data.expire || 22000;

--- a/HomeUI/src/views/apps/Management.vue
+++ b/HomeUI/src/views/apps/Management.vue
@@ -3428,9 +3428,6 @@
             </b-table>
           </b-col>
           <b-col cols="12">
-            <flux-map class="mb-0" :show-all="false" :filter-nodes="mapLocations" />
-          </b-col>
-          <b-col cols="12">
             <b-pagination
               v-model="instances.currentPage"
               :total-rows="instances.totalRows"
@@ -3439,6 +3436,11 @@
               size="sm"
               class="my-0"
             />
+          </b-col>
+        </b-row>
+        <b-row class="pt-1">
+          <b-col>
+            <flux-map class="mb-0" :show-all="false" :filter-nodes="mapLocations" />
           </b-col>
         </b-row>
       </b-tab>

--- a/HomeUI/src/views/apps/MyApps.vue
+++ b/HomeUI/src/views/apps/MyApps.vue
@@ -408,6 +408,11 @@
                           /> &nbsp;Locations&nbsp;</kbd>
                       </h3>
                       <b-row>
+                        <b-col class="p-0 m-0">
+                          <flux-map class="mb-0" :show-all="false" :filter-nodes="mapLocations" />
+                        </b-col>
+                      </b-row>
+                      <b-row>
                         <b-col
                           md="4"
                           sm="4"
@@ -988,6 +993,7 @@ import ToastificationContent from '@core/components/toastification/Toastificatio
 import ListEntry from '@/views/components/ListEntry.vue';
 import ConfirmDialog from '@/views/components/ConfirmDialog.vue';
 import Management from '@/views/apps/Management.vue';
+import FluxMap from '@/views/components/FluxMap.vue';
 import AppsService from '@/services/AppsService';
 import DaemonService from '@/services/DaemonService';
 
@@ -1011,6 +1017,7 @@ export default {
     Management,
     // eslint-disable-next-line vue/no-unused-components
     ToastificationContent,
+    FluxMap,
   },
   directives: {
     'b-tooltip': VBTooltip,
@@ -1122,6 +1129,9 @@ export default {
         return true;
       }
       return false;
+    },
+    mapLocations() {
+      return this.appLocations.map((l) => l.ip);
     },
   },
   mounted() {

--- a/HomeUI/src/views/components/FluxMap.vue
+++ b/HomeUI/src/views/components/FluxMap.vue
@@ -84,7 +84,6 @@ export default {
         url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
         zoom: 2,
         center: latLng(20, 0),
-        markers: [],
         clusterOptions: { chunkedLoading: true },
       },
       geoJsonOptions: {

--- a/HomeUI/src/views/components/FluxMap.vue
+++ b/HomeUI/src/views/components/FluxMap.vue
@@ -188,7 +188,6 @@ export default {
           const found = nodes.find((n) => n.ip === nodeIp);
           if (!found) {
             const url = this.nodeHttpsUrlFromEndpoint(nodeIp);
-            console.log('me url', url);
             missingTargets.push(`${url}/flux/info`);
           }
           return found;

--- a/HomeUI/src/views/components/FluxMap.vue
+++ b/HomeUI/src/views/components/FluxMap.vue
@@ -1,0 +1,244 @@
+<template>
+  <b-card>
+    <v-map :zoom="map.zoom" :center="map.center">
+      <v-tile-layer :url="map.url" />
+      <v-marker-cluster
+        v-if="nodesLoaded"
+        :options="map.clusterOptions"
+        @clusterclick="click"
+        @ready="ready"
+      >
+        <v-geo-json :geojson="geoJson" :options="geoJsonOptions" />
+      </v-marker-cluster>
+      <v-marker
+        v-if="nodesLoadedError"
+        :lat-lng="[20, -20]"
+        :icon="warning.icon"
+        :z-index-offset="warning.zIndexOffest"
+      />
+    </v-map>
+  </b-card>
+</template>
+<script>
+import axios from 'axios';
+
+import L, { latLng, Icon, icon } from 'leaflet';
+
+import {
+  LMap, LTileLayer, LGeoJson, LMarker,
+} from 'vue2-leaflet';
+
+import Vue2LeafletMarkerCluster from 'vue2-leaflet-markercluster';
+
+import iconUrl from 'leaflet/dist/images/marker-icon.png';
+import iconRetinaUrl from 'leaflet/dist/images/marker-icon-2x.png';
+import shadowUrl from 'leaflet/dist/images/marker-shadow.png';
+
+const DefaultIcon = icon({
+  ...Icon.Default.prototype.options,
+  iconUrl,
+  iconRetinaUrl,
+  shadowUrl,
+});
+
+L.Marker.prototype.options.icon = DefaultIcon;
+
+export default {
+  components: {
+    'v-map': LMap,
+    'v-tile-layer': LTileLayer,
+    'v-marker': LMarker,
+    'v-geo-json': LGeoJson,
+    'v-marker-cluster': Vue2LeafletMarkerCluster,
+  },
+  props: {
+    showAll: {
+      type: Boolean,
+      default: true,
+    },
+    filterNodes: {
+      type: Array,
+      default() {
+        return [];
+      },
+    },
+    nodes: {
+      type: Array,
+      default() {
+        return [];
+      },
+    },
+  },
+  data() {
+    return {
+      warning: {
+        icon: L.divIcon({
+          className: 'text-labels',
+          html: 'Unable to fetch Node data. Try again later.',
+        }),
+        zIndexOffset: 1000,
+      },
+      nodesLoadedError: false,
+      nodesLoaded: false,
+      map: {
+        url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+        zoom: 2,
+        center: latLng(20, 0),
+        markers: [],
+        clusterOptions: { chunkedLoading: true },
+      },
+      geoJsonOptions: {
+        onEachFeature: (feature, layer) => {
+          layer.bindPopup(
+            `
+            IP: ${feature.properties.ip}<br>
+            Tier: ${feature.properties.tier}<br>
+            ISP: ${feature.properties.org}`,
+            { className: 'custom-popup', keepInView: true },
+          );
+        },
+      },
+      geoJson: [
+        {
+          type: 'FeatureCollection',
+          crs: {
+            type: 'name',
+            properties: {
+              name: 'urn:ogc:def:crs:OGC:1.3:CRS84',
+            },
+          },
+          features: [],
+        },
+      ],
+    };
+  },
+  created() {
+    this.getNodes();
+  },
+  methods: {
+    click: (e) => console.log('clusterclick', e),
+    ready: (e) => console.log('ready', e),
+    buildGeoJson(nodes) {
+      const { features } = this.geoJson[0];
+
+      nodes.forEach((node) => {
+        const feature = {
+          type: 'Feature',
+          properties: {
+            ip: node.ip,
+            tier: node.tier,
+            org: node.geolocation.org,
+          },
+          geometry: {
+            type: 'Point',
+            coordinates: [node.geolocation.lon, node.geolocation.lat],
+          },
+        };
+        features.push(feature);
+      });
+    },
+    async getNodesViaApi() {
+      const url = 'https://stats.runonflux.io/fluxinfo?projection=geolocation,ip,tier';
+
+      const res = await axios.get(url).catch(() => {});
+
+      const {
+        status: httpStatus,
+        data: { status: apiStatus, data: nodes } = {},
+      } = res;
+
+      if (httpStatus !== 200 || apiStatus !== 'success') {
+        return [];
+      }
+
+      return nodes;
+    },
+    async getNodes() {
+      const nodes = this.nodes.length ? this.nodes : await this.getNodesViaApi();
+
+      if (!nodes.length) {
+        this.nodesLoadedError = true;
+        return;
+      }
+
+      const missingTargets = [];
+
+      const filteredNodes = this.showAll
+        ? nodes
+        : this.filterNodes.map((nodeIp) => {
+          const found = nodes.find((n) => n.ip === nodeIp);
+          if (!found) {
+            const endpoint = nodeIp.includes(':') ? nodeIp : `${nodeIp}:16127`;
+            missingTargets.push(`http://${endpoint}/flux/info`);
+          }
+          return found;
+        }).filter((node) => node);
+
+      const promises = missingTargets.map((target) => axios.get(target, { timeout: 3_000 }));
+      const settled = await Promise.allSettled(promises);
+
+      settled.forEach((result) => {
+        const { status, value } = result;
+        if (status !== 'fulfilled') return;
+
+        const { data: apiData, status: fluxApiStatus } = value.data;
+
+        if (fluxApiStatus === 'success') {
+          const { node, geolocation } = apiData;
+          const formatted = {
+            ip: node.status.ip,
+            tier: node.status.tier,
+            geolocation,
+          };
+          filteredNodes.push(formatted);
+        }
+      });
+
+      this.buildGeoJson(filteredNodes);
+      this.nodesLoaded = true;
+    },
+  },
+};
+</script>
+
+<style lang="scss">
+@import '~leaflet.markercluster/dist/MarkerCluster.css';
+@import '~leaflet.markercluster/dist/MarkerCluster.Default.css';
+@import '~leaflet/dist/leaflet.css';
+
+.vue2leaflet-map {
+  &.leaflet-container {
+    aspect-ratio: 3/1;
+  }
+}
+
+.text-labels {
+  font-size: 2em;
+  font-weight: 700;
+  color: white;
+  min-width: 300px;
+}
+
+.custom-popup .leaflet-popup-content-wrapper {
+  font-size: 1.2em;
+  font-weight: 700;
+}
+
+.dark-layout {
+  path,
+  .leaflet-layer,
+  .leaflet-control-zoom-in,
+  .leaflet-control-zoom-out,
+  .leaflet-control-attribution,
+  .custom-popup .leaflet-popup-content-wrapper,
+  .custom-popup .leaflet-popup-tip {
+    filter: invert(100%) hue-rotate(180deg) brightness(95%) contrast(90%);
+  }
+
+  .marker-cluster-small div span,
+  .marker-cluster-medium div span,
+  .marker-cluster-large div span {
+    filter: invert(100%);
+  }
+}
+</style>

--- a/HomeUI/src/views/components/FluxMap.vue
+++ b/HomeUI/src/views/components/FluxMap.vue
@@ -118,6 +118,26 @@ export default {
   methods: {
     click: (e) => console.log('clusterclick', e),
     ready: (e) => console.log('ready', e),
+    /**
+     * @param {string} endpoint The ip[:port] of the node
+     * @param {{urlType?: "home"|"api"}} options The optional parameters
+     * @returns {string} The full https node url
+     */
+    nodeHttpsUrlFromEndpoint(endpoint, options = {}) {
+      const scheme = 'https://';
+      const domain = 'node.api.runonflux.io';
+      const portMap = { api: 0, home: -1 };
+
+      const urlType = options.urlType || 'api';
+      const [ip, apiPort] = endpoint.includes(':') ? endpoint.split(':') : [endpoint, '16127'];
+
+      const ipAsName = ip.replace(/\./g, '-');
+      const port = +apiPort + portMap[urlType];
+
+      const url = `${scheme}${ipAsName}-${port}.${domain}`;
+
+      return url;
+    },
     buildGeoJson(nodes) {
       const { features } = this.geoJson[0];
 
@@ -168,8 +188,9 @@ export default {
         : this.filterNodes.map((nodeIp) => {
           const found = nodes.find((n) => n.ip === nodeIp);
           if (!found) {
-            const endpoint = nodeIp.includes(':') ? nodeIp : `${nodeIp}:16127`;
-            missingTargets.push(`http://${endpoint}/flux/info`);
+            const url = this.nodeHttpsUrlFromEndpoint(nodeIp);
+            console.log('me url', url);
+            missingTargets.push(`${url}/flux/info`);
           }
           return found;
         }).filter((node) => node);

--- a/HomeUI/src/views/dashboard/Map.vue
+++ b/HomeUI/src/views/dashboard/Map.vue
@@ -1,20 +1,6 @@
 <template>
   <div>
-    <b-card>
-      <l-map
-        :zoom="mapData.zoom"
-        :center="mapData.center"
-      >
-        <l-tile-layer :url="mapData.url" />
-        <l-marker
-          v-for="marker in mapData.markers"
-          :key="marker.id"
-          :lat-lng="marker.data"
-        >
-          <l-popup>{{ marker.label }}</l-popup>
-        </l-marker>
-      </l-map>
-    </b-card>
+    <flux-map :nodes="fluxList" class="m-0 p-0" />
     <b-row>
       <b-col
         md="6"
@@ -58,23 +44,9 @@ import {
   BRow,
   BCol,
 } from 'bootstrap-vue';
-import { Icon } from 'leaflet';
-import {
-  LMap, LTileLayer, LMarker, LPopup,
-} from 'vue2-leaflet';
 import VueApexCharts from 'vue-apexcharts';
 import DashboardService from '@/services/DashboardService';
-import 'leaflet/dist/leaflet.css';
-
-/* eslint-disable global-require */
-// eslint-disable-next-line no-underscore-dangle
-delete Icon.Default.prototype._getIconUrl;
-Icon.Default.mergeOptions({
-  iconRetinaUrl: require('leaflet/dist/images/marker-icon-2x.png'),
-  iconUrl: require('leaflet/dist/images/marker-icon.png'),
-  shadowUrl: require('leaflet/dist/images/marker-shadow.png'),
-});
-/* eslint-enable global-require */
+import FluxMap from '@/views/components/FluxMap.vue';
 
 const axios = require('axios');
 
@@ -83,28 +55,14 @@ export default {
     BCard,
     BRow,
     BCol,
-    LMap,
-    LTileLayer,
-    LMarker,
-    LPopup,
     VueApexCharts,
+    FluxMap,
   },
   data() {
     return {
-      fluxListLoading: true,
       fluxList: [],
       fluxNodeCount: 0,
       self: this,
-      mapData: {
-        url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-        zoom: 2,
-        center: [20, 0],
-        markers: [{
-          id: 0,
-          label: 'Hello!',
-          data: [47.313220, -1.319482, { draggable: 'false' }],
-        }],
-      },
       providerData: {
         series: [],
         chartOptions: {
@@ -151,46 +109,15 @@ export default {
   methods: {
     async getFluxList() {
       try {
-        this.fluxListLoading = true;
         const resLoc = await axios.get('https://stats.runonflux.io/fluxinfo?projection=geolocation,ip,tier');
         this.fluxList = resLoc.data.data;
         const resList = await DashboardService.fluxnodeCount();
         this.fluxNodeCount = resList.data.data.total;
-        this.fluxListLoading = false;
-        await this.generateMap();
         await this.generateGeographicPie();
         await this.generateProviderPie();
       } catch (error) {
         console.log(error);
       }
-    },
-    async generateMap() {
-      const nodeData = [];
-      this.fluxList.forEach((flux) => {
-        const existingPoint = nodeData.find((node) => (node.latitude === flux.geolocation.lat && node.longitude === flux.geolocation.lon));
-        if (existingPoint) {
-          if (existingPoint.title.split(['-']).length % 6) {
-            existingPoint.title += `   ${flux.ip} - ${flux.tier}   `;
-          } else {
-            existingPoint.title += `   ${flux.ip} - ${flux.tier}   \n`;
-          }
-        } else {
-          const point = {
-            latitude: flux.geolocation.lat,
-            longitude: flux.geolocation.lon,
-            title: `   ${flux.ip} - ${flux.tier}   `,
-          };
-          nodeData.push(point);
-        }
-      });
-      this.mapData.markers = [];
-      nodeData.forEach((node, index) => {
-        this.mapData.markers.push({
-          id: index,
-          label: node.title,
-          data: [node.latitude, node.longitude, { draggable: 'false' }],
-        });
-      });
     },
     async generateGeographicPie() {
       const labels = [];

--- a/package.json
+++ b/package.json
@@ -185,6 +185,7 @@
     "vue-sweetalert2": "~5.0.5",
     "vue-toastification": "~1.7.14",
     "vue2-leaflet": "~2.7.1",
+    "vue2-leaflet-markercluster": "~3.1.0",
     "vuex": "~3.6.2",
     "webpack": "~5.89.0",
     "webpack-bundle-analyzer": "~4.10.1",


### PR DESCRIPTION
**What this pull does**
* Adds a new `FluxMap` component.
* Implements dark mode for maps. (both light and dark, toggleable)
* Updates the dashboard map to use this new component.
* Adds map with nodes locations to `Applications -> Management -> My Active Apps`
* Adds markercluster dependency to dev deps.

Let me know if there are any other places you want me to add any new maps.

**markercluster background**

Markercluster is a map marker aggregation tool. It provides much more intuitive and easy to understand map displays when a large number of markers are used on a map.

Markercluster is great when working with large groups of markers like we are. Depending on the data format used, it is much faster when trying to paint 10k+ markers.

Markercluster also has sane defaults for multiple markers on the same spot, if this happens, it arranges the markers around the point with a "path" line to the origin. This means that we can keep the popup text to one per marker, instead of having to merge them manually.

**FluxMap component**

This component uses the data format from fluxstats as input. I.e. you can pass in a prop `nodes` with the data in the format:

```json
[{
  "geolocation": {
    "ip": "104.49.67.219",
    "continent": "North America",
    "continentCode": "NA",
    "country": "United States",
    "countryCode": "US",
    "region": "IN",
    "regionName": "Indiana",
    "lat": 41.4495,
    "lon": -87.4769,
    "org": "Private Customer - AT&T Internet Services"
  },
  "ip": "104.49.67.219:16157",
  "tier": "CUMULUS"
}]
```

it will then use this data to build a `geoJson` object, this is a standard mapping datatype used by many mapping softwares and is reuseable.

If you don't pass in any nodes, it will fetch the list from the fluxstats api - it will display a warning message (on the map) `Unable to fetch Node data. Try again later` if the api is unavailable

You can also pass in the `filterNodes` and `showAll` props, if you only want to show specific nodes from the `nodes` list. We use this on the myApps page.

Screenshots:

Dashboard page:

![Screenshot 2024-07-10 at 9 08 34 AM](https://github.com/RunOnFlux/flux/assets/22514713/617a7f93-b240-4b24-baa4-1bb028fee182)


My Active Apps:

![Screenshot 2024-07-10 at 9 07 14 AM](https://github.com/RunOnFlux/flux/assets/22514713/16a2b577-bc70-4b70-b9e0-e7d9800fc32e)

Markers on same spot:

![Screenshot 2024-07-10 at 9 09 32 AM](https://github.com/RunOnFlux/flux/assets/22514713/07557fed-9474-4d0e-9c40-d354dd5389ce)


GeoJson data format:

```javascript
[{
  type: 'FeatureCollection',
  crs: {
    type: 'name',
    properties: {
      name: 'urn:ogc:def:crs:OGC:1.3:CRS84',
    },
  },
  features: [],
}]
```

Where we add one feature per node, in the format:

```javascript
{
  type: 'Feature',
  properties: {
    ip: node.ip,
    tier: node.tier,
    org: node.geolocation.org,
  },
  geometry: {
    type: 'Point',
    coordinates: [node.geolocation.lon, node.geolocation.lat],
  },
}
```
