### PR TITLE
Bugfix - www-auth header not parsing correctly

### DIFF
--- a/ZelBack/src/services/utils/imageVerifier.js
+++ b/ZelBack/src/services/utils/imageVerifier.js
@@ -12,7 +12,7 @@ class ImageVerifier {
 
   static imagePattern = /^(?:(?<provider>(?:(?:[\w-]+(?:\.[\w-]+)+)(?::\d+)?)|[\w]+:\d+)\/)?\/?(?<namespace>(?:(?:[a-z0-9]+(?:(?:[._]|__|[-]*)[a-z0-9]+)*)\/){0,2})(?<repository>[a-z0-9-_.]+\/{0,1}[a-z0-9-_.]+)[:]?(?<tag>[\w][\w.-]{0,127})?/;
 
-  static wwwAuthHeaderPattern = /Bearer realm="(?<realm>(?:[0-9a-z:\-./]*?))"(?:,service="(?<service>(?:[0-9a-z:\-./]*?))")?(?:,scope="(?<scope>[0-9a-z:\-./]*?)")?/;
+  static wwwAuthHeaderPattern = /Bearer realm="(?<realm>(?:[0-9a-z:\-./]*?))"(?:,service="(?<service>(?:[0-9a-z:\-./]*?))")?(?:,scope="(?<scope>[0-9a-z:\-._/]*?)")?/;
 
   static supportedMediaTypes = [
     'application/vnd.oci.image.index.v1+json',

--- a/tests/unit/imageVerifier.test.js
+++ b/tests/unit/imageVerifier.test.js
@@ -388,6 +388,15 @@ describe('imageVerifier tests', () => {
       expect(result.service).to.eql('registry.docker.io');
       expect(result.scope).to.eql('repository:runonflux/secretwebsite:pull');
     });
+    it('should parse auth header with underscores correctly', async () => {
+      const authHeader = 'Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:jeffvaderflux/helloworld_params:pull"';
+
+      const result = ImageVerifier.parseAuthHeader(authHeader);
+
+      expect(result.realm).to.eql('https://auth.docker.io/token');
+      expect(result.service).to.eql('registry.docker.io');
+      expect(result.scope).to.eql('repository:jeffvaderflux/helloworld_params:pull');
+    });
   });
 
   describe('verifyImage tests', async () => {


### PR DESCRIPTION
Fix for incorrect www-authenticate header parsing. This was causing any image that had an underscore to be rejected (on register app page) as it couldn't match the repo for the authentication request.

Was missing the allowed underscore character.

Adds a test for this as well.

Tested on a live node - works fine now.