### PR TITLE
Don't compress response if the x-no-compression header is present

### DIFF
--- a/ZelBack/src/lib/fluxServer.js
+++ b/ZelBack/src/lib/fluxServer.js
@@ -23,7 +23,16 @@ class FluxServer {
   static supportedModes = ['http', 'https'];
 
   static defaultMiddlewares = [
-    compression(),
+    compression(compression({
+      filter: (req, res) => {
+        if (req.headers['x-no-compression']) {
+          // don't compress responses with this request header
+          return false;
+        }
+        // fallback to standard filter function
+        return compression.filter(req, res);
+      },
+    })),
     morgan('combined'),
     express.json(),
     cors(),


### PR DESCRIPTION
Several FluxOS endpoint use server-sent events to show progress to the user. For example '/apps/testappinstall/' details the install process as it goes.

I have been unable to get Flutter to read these streams, and managed to track the problem down to the express compression plugin.

This solution allows a client to send a "x-no-compression" header with the request to disable the response compression. If no such header is sent, compression will take place as normal. I am then able to read the SSE streams in Flux Cloud.