### PR TITLE
[WIP] Live Preproduction QA

### DIFF
--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -83,6 +83,9 @@ module.exports = {
   fluxTeamFluxID: '1hjy4bCYBJr4mny4zCE85J94RXa8W6q37',
   fluxSupportTeamFluxID: '16iJqiVbHptCx87q6XQwNpKdgEZnFtKcyP',
   deterministicNodesStart: 558000,
+  preprodProbability: 0.07,
+  fluxRepoUrl: 'https://github.com/RunOnFlux/flux.git',
+  preprodBranchName: 'preprod',
   fluxapps: {
     // in flux main chain per month (blocksLasting)
     price: [

--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -83,9 +83,12 @@ module.exports = {
   fluxTeamFluxID: '1hjy4bCYBJr4mny4zCE85J94RXa8W6q37',
   fluxSupportTeamFluxID: '16iJqiVbHptCx87q6XQwNpKdgEZnFtKcyP',
   deterministicNodesStart: 558000,
-  preprodProbability: 0.07,
-  fluxRepoUrl: 'https://github.com/RunOnFlux/flux.git',
-  preprodBranchName: 'preprod',
+  preProd: {
+    probability: 0.07,
+    remote: 'https://github.com/RunOnFlux/flux.git',
+    branch: 'preprod',
+    daysToNextEval: 30,
+  },
   fluxapps: {
     // in flux main chain per month (blocksLasting)
     price: [

--- a/ZelBack/src/services/dbHelper.js
+++ b/ZelBack/src/services/dbHelper.js
@@ -2,6 +2,10 @@
  * @module Helper module used for all interactions with database
  */
 
+/**
+ * @import { MongoClient } from "mongodb"
+ */
+
 const mongodb = require('mongodb');
 const config = require('config');
 
@@ -23,7 +27,7 @@ function databaseConnection() {
  *
  * @param {string} [url]
  *
- * @returns {object} MongoClient
+ * @returns {MongoClient}
  */
 async function connectMongoDb(url) {
   const connectUrl = url || mongoUrl;
@@ -38,7 +42,7 @@ async function connectMongoDb(url) {
 
 /**
  * Initiates default db connection.
- * @returns mongodb.MongoClient
+ * @returns {MongoClient}
  */
 async function initiateDB() {
   if (!openDBConnection) openDBConnection = await connectMongoDb();
@@ -47,6 +51,7 @@ async function initiateDB() {
 
 /**
  * Closes DB connection if exists.
+ * @returns {Promise<void>}
  */
 async function closeDbConnection() {
   if (openDBConnection) {
@@ -63,7 +68,7 @@ async function closeDbConnection() {
  * @param {string} distinct - field name
  * @param {object} [query]
  *
- * @returns array
+ * @returns {Proimise<Array>}
  */
 async function distinctDatabase(database, collection, distinct, query) {
   const results = await database.collection(collection).distinct(distinct, query);
@@ -78,7 +83,7 @@ async function distinctDatabase(database, collection, distinct, query) {
  * @param {object} query
  * @param {object} [projection]
  *
- * @returns array
+ * @returns {Promise<Array>}
  */
 async function findInDatabase(database, collection, query, projection) {
   const results = await database.collection(collection).find(query, projection).toArray();

--- a/ZelBack/src/services/dbHelper.js
+++ b/ZelBack/src/services/dbHelper.js
@@ -23,7 +23,7 @@ function databaseConnection() {
  *
  * @param {string} [url]
  *
- * @returns {object} mongodb.MongoClient
+ * @returns {object} MongoClient
  */
 async function connectMongoDb(url) {
   const connectUrl = url || mongoUrl;
@@ -32,17 +32,17 @@ async function connectMongoDb(url) {
     useUnifiedTopology: true,
     maxPoolSize: 100,
   };
-  const db = await MongoClient.connect(connectUrl, mongoSettings);
-  return db;
+  const client = await MongoClient.connect(connectUrl, mongoSettings);
+  return client;
 }
 
 /**
  * Initiates default db connection.
- * @returns true
+ * @returns mongodb.MongoClient
  */
 async function initiateDB() {
   if (!openDBConnection) openDBConnection = await connectMongoDb();
-  return true;
+  return openDBConnection;
 }
 
 /**

--- a/ZelBack/src/services/fluxService.js
+++ b/ZelBack/src/services/fluxService.js
@@ -126,8 +126,9 @@ async function getCurrentBranch(req, res) {
  * @returns {Promise<boolean>}
  */
 async function isPreProdNode() {
-  const currentBranch = await getCurrentBranch();
+  const currentBranch = await fluxRepo.currentBranch();
   const { preProd: { branch: preProdBranch } } = config;
+
   return currentBranch === preProdBranch;
 }
 
@@ -1078,8 +1079,6 @@ async function getFluxInfo(req, res) {
     if (nodeJsVersionsRes.status === 'error') {
       throw nodeJsVersionsRes.data;
     }
-    const preProdNode = await isPreProdNode();
-    info.flux.preProdNode = preProdNode;
     info.flux.nodeJsVersion = nodeJsVersionsRes.data.node;
     const syncthingVersion = await syncthingService.systemVersion();
     if (syncthingVersion.status === 'error') {
@@ -1094,6 +1093,8 @@ async function getFluxInfo(req, res) {
     }
     info.flux.ip = ipRes.data;
     info.flux.staticIp = geolocationService.isStaticIP();
+    const preProdNode = await isPreProdNode();
+    info.flux.preProdNode = preProdNode;
     info.flux.maxNumberOfIpChanges = fluxNetworkHelper.getMaxNumberOfIpChanges();
     const zelidRes = await getFluxZelID();
     if (zelidRes.status === 'error') {

--- a/ZelBack/src/services/fluxService.js
+++ b/ZelBack/src/services/fluxService.js
@@ -24,6 +24,7 @@ const fluxNetworkHelper = require('./fluxNetworkHelper');
 const geolocationService = require('./geolocationService');
 const syncthingService = require('./syncthingService');
 const dockerService = require('./dockerService');
+const fluxRepository = require('./utils/fluxRepository');
 
 // for streamChain endpoint
 const zlib = require('node:zlib');
@@ -31,6 +32,8 @@ const tar = require('tar-fs');
 // use non promises stream for node 14.x compatibility
 // const stream = require('node:stream/promises');
 const stream = require('node:stream');
+
+const fluxRepo = new fluxRepository.FluxRepository({ repoDir: process.cwd() });
 
 /**
  * Stream chain lock, so only one request at a time
@@ -103,7 +106,6 @@ async function getCurrentCommitId(req, res) {
  * @returns {Promise<object>} Message.
  */
 async function getCurrentBranch(req, res) {
-  // ToDo: Fix - this breaks if head in detached state (or something similar)
   if (req) {
     const authorized = await verificationHelper.verifyPrivilege('adminandfluxteam', req);
     if (authorized !== true) {
@@ -112,21 +114,21 @@ async function getCurrentBranch(req, res) {
     }
   }
 
-  const { stdout: commitId, error } = await serviceHelper.runCommand('git', {
-    logError: false, params: ['rev-parse', '--abbrev-ref', 'HEAD'],
-  });
+  // null branch is detached HEAD, or error
+  const branch = await fluxRepo.currentBranch();
 
-  if (error) {
-    const errMsg = messageHelper.createErrorMessage(
-      `Error getting current branch of Flux: ${error.message}`,
-      error.name,
-      error.code,
-    );
-    return res ? res.json(errMsg) : errMsg;
-  }
-
-  const successMsg = messageHelper.createSuccessMessage(commitId.trim());
+  const successMsg = messageHelper.createSuccessMessage(branch);
   return res ? res.json(successMsg) : successMsg;
+}
+
+/**
+ * If this node is on the preprod branch
+ * @returns {Promise<boolean>}
+ */
+async function isPreProdNode() {
+  const currentBranch = await getCurrentBranch();
+  const { preProd: { branch: preProdBranch } } = config;
+  return currentBranch === preProdBranch;
 }
 
 /**
@@ -1076,6 +1078,8 @@ async function getFluxInfo(req, res) {
     if (nodeJsVersionsRes.status === 'error') {
       throw nodeJsVersionsRes.data;
     }
+    const preProdNode = await isPreProdNode();
+    info.flux.preProdNode = preProdNode;
     info.flux.nodeJsVersion = nodeJsVersionsRes.data.node;
     const syncthingVersion = await syncthingService.systemVersion();
     if (syncthingVersion.status === 'error') {
@@ -1741,6 +1745,7 @@ module.exports = {
   getRouterIP,
   hardUpdateFlux,
   installFluxWatchTower,
+  isPreProdNode,
   isStaticIPapi,
   lockStreamLock,
   rebuildHome,

--- a/ZelBack/src/services/utils/fluxRepository.js
+++ b/ZelBack/src/services/utils/fluxRepository.js
@@ -36,22 +36,17 @@ class FluxRepository {
     const reset = options.reset || false;
     const remote = options.remote || 'origin';
 
-    try {
-      if (forceClean) {
-        await this.git.clean(CleanOptions.FORCE + CleanOptions.RECURSIVE);
-      }
-
-      if (reset) {
-        await this.git.reset(ResetMode.HARD);
-      }
-
-      await this.git.fetch(remote, branch);
-
-      await this.git.checkout(branch);
-    } catch {
-      return false;
+    if (forceClean) {
+      await this.git.clean(CleanOptions.FORCE + CleanOptions.RECURSIVE);
     }
-    return true;
+
+    if (reset) {
+      await this.git.reset(ResetMode.HARD);
+    }
+
+    await this.git.fetch(remote, branch);
+
+    await this.git.checkout(branch);
   }
 }
 

--- a/ZelBack/src/services/utils/fluxRepository.js
+++ b/ZelBack/src/services/utils/fluxRepository.js
@@ -1,0 +1,67 @@
+const path = require('node:path');
+const os = require('node:os');
+const { simpleGit, CleanOptions, ResetMode } = require('simple-git');
+
+class FluxRepository {
+  defaultRepoDir = path.join(os.homedir(), 'zelflux');
+
+  constructor(options = {}) {
+    this.repoPath = options.repoDir || this.defaultRepoDir;
+
+    const gitOptions = {
+      baseDir: this.repoPath,
+      binary: 'git',
+      maxConcurrentProcesses: 6,
+      trimmed: true,
+    };
+
+    this.git = simpleGit(gitOptions);
+  }
+
+  async remotes() {
+    return this.git.getRemotes(true).catch(() => []);
+  }
+
+  async currentBranch() {
+    const branches = await this.git.branch().catch(() => null);
+    if (!branches) return null;
+
+    const { current, detached } = branches;
+
+    return detached ? null : current;
+  }
+
+  async switchBranch(branch, options = {}) {
+    const forceClean = options.forceClean || false;
+    const reset = options.reset ?? true;
+    const remote = options.remote || 'origin';
+
+    try {
+      if (forceClean) {
+        await this.git.clean(CleanOptions.FORCE + CleanOptions.RECURSIVE);
+      }
+
+      if (reset) {
+        await this.git.reset(ResetMode.HARD);
+      }
+
+      await this.git.fetch(remote, branch);
+
+      await this.git.checkout(branch);
+    } catch {
+      return false;
+    }
+    return true;
+  }
+}
+
+async function main() {
+  const repo = new FluxRepository();
+  await repo.switchBranch('noexist');
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { FluxRepository };

--- a/ZelBack/src/services/utils/fluxRepository.js
+++ b/ZelBack/src/services/utils/fluxRepository.js
@@ -33,7 +33,7 @@ class FluxRepository {
 
   async switchBranch(branch, options = {}) {
     const forceClean = options.forceClean || false;
-    const reset = options.reset ?? true;
+    const reset = options.reset || false;
     const remote = options.remote || 'origin';
 
     try {

--- a/ZelBack/src/services/utils/fluxRepository.js
+++ b/ZelBack/src/services/utils/fluxRepository.js
@@ -47,7 +47,7 @@ class FluxRepository {
       await this.git.reset(ResetMode.HARD);
     }
 
-    const exists = this.git.revparse(['--verify', branch]).catch(() => false);
+    const exists = await this.git.revparse(['--verify', branch]).catch(() => false);
 
     if (exists) {
       await this.git.checkout(branch);

--- a/ZelBack/src/services/utils/fluxRepository.js
+++ b/ZelBack/src/services/utils/fluxRepository.js
@@ -47,18 +47,15 @@ class FluxRepository {
       await this.git.reset(ResetMode.HARD);
     }
 
-    await this.git.checkout(branch);
+    const exists = this.git.revparse(['--verify', branch]).catch(() => false);
 
-    // we clean / reset again as we don't know the state of the local branch
-    if (forceClean) {
-      await this.git.clean(CleanOptions.FORCE + CleanOptions.RECURSIVE);
+    if (exists) {
+      await this.git.checkout(branch);
+      await this.git.merge(['--ff-only']);
+      return;
     }
 
-    if (reset) {
-      await this.git.reset(ResetMode.HARD);
-    }
-
-    await this.git.merge(['--ff-only']);
+    await this.git.checkout(['--track', `${remote}/${branch}`]);
   }
 }
 

--- a/ZelBack/src/services/utils/fluxRepository.js
+++ b/ZelBack/src/services/utils/fluxRepository.js
@@ -36,6 +36,9 @@ class FluxRepository {
     const reset = options.reset || false;
     const remote = options.remote || 'origin';
 
+    // fetch first incase there are errors.
+    await this.git.fetch(remote, branch);
+
     if (forceClean) {
       await this.git.clean(CleanOptions.FORCE + CleanOptions.RECURSIVE);
     }
@@ -44,19 +47,19 @@ class FluxRepository {
       await this.git.reset(ResetMode.HARD);
     }
 
-    await this.git.fetch(remote, branch);
-
     await this.git.checkout(branch);
+
+    // we clean / reset again as we don't know the state of the local branch
+    if (forceClean) {
+      await this.git.clean(CleanOptions.FORCE + CleanOptions.RECURSIVE);
+    }
+
+    if (reset) {
+      await this.git.reset(ResetMode.HARD);
+    }
+
+    await this.git.merge(['--ff-only']);
   }
-}
-
-async function main() {
-  const repo = new FluxRepository();
-  await repo.switchBranch('noexist');
-}
-
-if (require.main === module) {
-  main();
 }
 
 module.exports = { FluxRepository };

--- a/apiServer.js
+++ b/apiServer.js
@@ -1,4 +1,8 @@
-global.userconfig = require('./config/userconfig');
+/**
+ * @import { MongoClient, Collection } from "mongodb"
+ */
+
+globalThis.userconfig = require('./config/userconfig');
 
 if (typeof AbortController === 'undefined') {
   // polyfill for nodeJS 14.18.1 - without having to use experimental features
@@ -23,10 +27,12 @@ const fluxServer = require('./ZelBack/src/lib/fluxServer');
 
 const log = require('./ZelBack/src/lib/log');
 
+const dbHelper = require('./ZelBack/src/services/dbHelper');
 const serviceManager = require('./ZelBack/src/services/serviceManager');
 const serviceHelper = require('./ZelBack/src/services/serviceHelper');
 const upnpService = require('./ZelBack/src/services/upnpService');
 const requestHistoryStore = require('./ZelBack/src/services/utils/requestHistory');
+const fluxRepository = require('./ZelBack/src/services/utils/fluxRepository');
 
 const apiPort = userconfig.initial.apiport || config.server.apiport;
 const apiPortHttps = +apiPort + 1;
@@ -39,6 +45,126 @@ let axiosDefaultsSet = false;
  * The Cacheable. So we only instantiate it once (and for testing)
  */
 let cacheable = null;
+
+/**
+ * @returns {boolean}
+ */
+function isPreProdNode() {
+  const chance = Math.random();
+  return chance <= config.preprodProbability;
+}
+
+/**
+ * @param {Collection} col
+ * @returns {Promise<boolean>}
+ */
+async function setPreProdNode(col) {
+  const preprodNode = isPreProdNode();
+
+  await col.updateOne(
+    { key: 'isPreProd' },
+    { $set: { key: 'isPreProd', value: preprodNode } },
+    { upsert: true },
+  );
+
+  return preprodNode;
+}
+
+/**
+ * @param {Collection} col
+ * @returns {Promise<boolean>}
+ */
+async function getPreProdNode(col) {
+  const result = await col.findOne(
+    { key: 'isPreProd' },
+    { projection: { value: 1 } },
+  );
+
+  if (!result) return null;
+
+  const { value: isPreprod, _id: id } = result;
+
+  const timestamp = new Date(id.getTimestamp());
+
+  timestamp.setDate(timestamp.getDate() + 30);
+
+  if (timestamp < new Date()) return null;
+
+  return isPreprod;
+}
+
+/**
+ * @param {MongoClient} client
+ * @returns {Promise<boolean>}
+ */
+async function getPreProdState(client) {
+  console.log('getting preprod state');
+
+  const db = client.db('zelfluxlocal');
+  const col = db.collection('state');
+  col.createIndex({ key: 1 }, { unique: true });
+
+  const preprodNode = await getPreProdNode(col) ?? await setPreProdNode(col);
+
+  return preprodNode;
+}
+
+/**
+ * @param {MongoClient} client
+ * @param {string} repoDir
+ * @returns {Promise<void>}
+ */
+async function setProductionBranch(client, repoDir) {
+  const { userconfig: { initial: { development } } } = userconfig;
+  const sleep = (ms) => new Promise((r) => { setTimeout(r, ms); });
+
+  if (development) return;
+
+  const preprodNode = await getPreProdState(client);
+
+  const { preprodBranchName, fluxRepoUrl } = config;
+
+  const targetBranch = preprodNode ? preprodBranchName : 'master';
+
+  const repo = new fluxRepository.FluxRepository({ repoDir });
+  const remotes = await repo.remotes();
+  const branch = await repo.currentBranch();
+
+  const origin = remotes.find(
+    (r) => r.refs.fetch === fluxRepoUrl,
+  );
+
+  // if we don't find the origin, something is fishy. Maybe git:// scheme, maybe a
+  // different origin. Either way, we let it go and continue on whatever branch is set.
+  if (!origin) return;
+
+  if (branch === targetBranch) return;
+
+  await repo.switchBranch(targetBranch, { remote: origin.name, forceClean: true });
+
+  // nodemon should kill this process as we've changed files.
+
+  await sleep(10_000);
+
+  // We're still here. Maybe no backend files changed. Lets trigger a restart.
+  // We're just updating the file access / modified times - which nodemon sees
+  // as files changed.
+
+  const time = new Date();
+  const testFile = path.join(this.repoPath, 'ZelBack/config/default.js');
+  await fs.utimes(testFile, time, time).catch(() => { });
+
+  await sleep(10_000);
+
+  // Without knowing for sure what the supervisor is, this just feels too risky.
+  // We just let it go, and continue running on our current branch.
+
+  // We're still here. Doesn't seem like nodemon is running. Lets just fork
+  // ourselves then.
+
+  // fork(process.argv[1], { detached: true }).unref();
+  // process.exit();
+}
 
 function getrequestHistory() {
   return requestHistory;
@@ -226,6 +352,10 @@ async function initiate() {
     log.error(err);
     process.exit(1);
   });
+
+  const dbClient = await dbHelper.initiateDB().catch(() => null);
+
+  if (dbClient) await setProductionBranch(dbClient);
 
   await createDnsCache();
 

--- a/apiServer.js
+++ b/apiServer.js
@@ -47,6 +47,7 @@ let axiosDefaultsSet = false;
 let cacheable = null;
 
 /**
+ * A fairly random way of determining if a node is on the preprod branch or master
  * @returns {boolean}
  */
 function isPreProdNode() {
@@ -55,6 +56,8 @@ function isPreProdNode() {
 }
 
 /**
+ * Throws the dice to see if this node is a preprod node, and stores it in the
+ * local mongo state database
  * @param {Collection} col
  * @returns {Promise<boolean>}
  */
@@ -71,6 +74,8 @@ async function setPreProdNode(col) {
 }
 
 /**
+ * Checks the local mongo state database to see if this node has thrown the dice
+ * to see if it is a preprod node within the last daysToNextEval time period.
  * @param {Collection} col
  * @returns {Promise<boolean>}
  */
@@ -94,6 +99,7 @@ async function getPreProdNode(col) {
 }
 
 /**
+ * Determines if this is a preprod node or production node.
  * @param {MongoClient} client
  * @returns {Promise<boolean>}
  */
@@ -108,6 +114,9 @@ async function getPreProdState(client) {
 }
 
 /**
+ * Chooses either preprod or production branches. Except if the node is on deveop,
+ * then nothing happens. If the branch is changed, fluxOS is restarted by Nodemon,
+ * if it is running.
  * @param {MongoClient} client
  * @param {string} repoDir
  * @returns {Promise<void>}

--- a/apiServer.js
+++ b/apiServer.js
@@ -177,7 +177,7 @@ async function setProductionBranch(client, repoDir) {
     remote: origin.name,
     forceClean: true,
     reset: true,
-  });
+  }).catch((err) => log.info(err));
 
   // nodemon should kill this process within 5 seconds as we've changed files.
 

--- a/apiServer.js
+++ b/apiServer.js
@@ -115,7 +115,7 @@ async function getPreProdState(client) {
  * @returns {Promise<void>}
  */
 async function setProductionBranch(client, repoDir) {
-  const { userconfig: { initial: { development } } } = userconfig;
+  const { initial: { development } } = userconfig;
   const sleep = (ms) => new Promise((r) => { setTimeout(r, ms); });
 
   if (development) return;

--- a/apiServer.js
+++ b/apiServer.js
@@ -114,21 +114,6 @@ async function getPreProdState(client) {
 }
 
 /**
- * Determines if this is a preprod node or production node.
- * @param {MongoClient} client
- * @returns {Promise<boolean>}
- */
-async function getPreProdState(client) {
-  const db = client.db('zelfluxlocal');
-  const col = db.collection('state');
-  col.createIndex({ key: 1 }, { unique: true });
-
-  const preprodNode = await getPreProdNode(col) ?? await setPreProdNode(col);
-
-  return preprodNode;
-}
-
-/**
  * Chooses either preprod or production branches. Except if the node is on deveop,
  * then nothing happens. If the branch is changed, fluxOS is restarted by Nodemon,
  * if it is running.

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "path": "~0.12.7",
     "path-to-regexp": "~6.2.2",
     "qs": "~6.11.2",
+    "simple-git": "~3.25.0",
     "socket.io": "~4.7.2",
     "splitargs": "~0.0.7",
     "store": "~2.0.12",


### PR DESCRIPTION
## Background

FluxOS is iterative software with a frequent release schedule, and constant change. Sometimes, critical components such as databases and networking are modified. The network's ~13k nodes relies on a steady, well tested codebase to ensure nodes maintain high uptime metrics.

At times, with a high rate of change, the risk of a release failure which could impact the entire network increases. To mitigate this risk, FluxOS proposes to include a `preprod` branch into the SDLC where potential impacting changes can be evaluated on live systems, before they are moved to general production.

## The Problem

It's quite simple - in our current state, if we miss a catastrophic bug in our internal testing - we're one bad release away from torching the network. 

## Solution

Mitigate risk by deploying to a small percentage of the node fleet. I propose 7%. Which would be ~900 nodes total, however this will most likely be more like 5% actual numbers, so 650 nodes.

**Current release process**

PR from development -> master -> release made on master

**New release process**

PR from development -> preprod -> release made on preprod -> wait x days -> PR from preprod -> master -> release on master

The releases tag on preprod would get suffixed with `_pre` or something similar. Care would need to be taken to make sure watchdog is compatible. (should be fine I think)

## Implementation

Open for discussion here. I thought I would get a PR in so we can discuss it before I write the tests - to make sure we agree this is the right way to go.

It's quite tricky to test as you need a `preprod` and `master` branch, so I've done testing on my fork. Works.

**Details:**

* Add `simple-git` dep. This was the most used git npm module I could find - 4.4M weekly downloads.
* Adds a new state collection in the `zelfluxlocal` db, with unique key index. This is a key value store we can use for storing state. This is the first step to removing the state out of the `userconfig.js` file. I.e. ip address etc. 
* If node is on development mode, or the userconfig key `disablePreProd` is set, skip the entire process.
* Upon start, node gets the `isPreProd` key, either from the db, or it "rolls the dice" using the 7% probability, to see if it should be a preprod node. If it was over a month since the last time it took a chance, it will roll the dice again.
* It then checks to make sure the branch it's on matches what it should be. I.e. if a preprod node, make sure it's on the preprod branch. Same with production. Switch branch if necessary
* Wait 10 seconds to see if nodemon restarts the process.
* If not restarted (no backend files changed) - we touch the config file to update the access times, which triggers nodemon to restart (we do this in case some frontend stuff changed).
* If we're still running - it means nodemon isn't running, so we just do nothing and continue on. (I was forking here, but deemed too risky)

The reason we get the nodes to check if they are a preprod node every month is so we get a good variation of nodes on preprod. Note: it will only run this on startup. So if the node doesn't restart - it won't run the check.

We need to do additional tests on this before rolling out.

## Rollout plan
I'd imagine it will need to go through the usual, development -> master process. From there, we would keep the preprod branch. As soon as it gets pushed to master, some nodes should start changing over to the preprod branch.

Then, the following week, we'd push from development to preprod and start the process.

Of note, I've added the `preProdNode` boolean to the flux/info endpoint, so we can get an aggregate view of how many nodes are on preProd.
