### PR TITLE
Bugfix - download progress

### DIFF
--- a/HomeUI/src/views/apps/LocalApps.vue
+++ b/HomeUI/src/views/apps/LocalApps.vue
@@ -3006,8 +3006,8 @@ export default {
           zelidauth,
         },
         onDownloadProgress(progressEvent) {
-          console.log(progressEvent.target.response);
-          self.output = JSON.parse(`[${progressEvent.target.response.replace(/}{/g, '},{')}]`);
+          console.log(progressEvent.event.target.response);
+          self.output = JSON.parse(`[${progressEvent.event.target.response.replace(/}{/g, '},{')}]`);
         },
       };
       const response = await AppsService.justAPI().get(`/apps/redeploy/${app}/${force}`, axiosConfig);
@@ -3035,8 +3035,8 @@ export default {
           zelidauth,
         },
         onDownloadProgress(progressEvent) {
-          console.log(progressEvent.target.response);
-          self.output = JSON.parse(`[${progressEvent.target.response.replace(/}{/g, '},{')}]`);
+          console.log(progressEvent.event.target.response);
+          self.output = JSON.parse(`[${progressEvent.event.target.response.replace(/}{/g, '},{')}]`);
         },
       };
       const response = await AppsService.justAPI().get(`/apps/appremove/${app}`, axiosConfig);
@@ -3073,8 +3073,8 @@ export default {
           zelidauth,
         },
         onDownloadProgress(progressEvent) {
-          console.log(progressEvent.target.response);
-          self.output = JSON.parse(`[${progressEvent.target.response.replace(/}{/g, '},{')}]`);
+          console.log(progressEvent.event.target.response);
+          self.output = JSON.parse(`[${progressEvent.event.target.response.replace(/}{/g, '},{')}]`);
         },
       };
       const response = await AppsService.justAPI().get(`/apps/installapplocally/${app}`, axiosConfig);

--- a/HomeUI/src/views/apps/Management.vue
+++ b/HomeUI/src/views/apps/Management.vue
@@ -8601,8 +8601,8 @@ export default {
           zelidauth,
         },
         onDownloadProgress(progressEvent) {
-          console.log(progressEvent.target.response);
-          self.output = JSON.parse(`[${progressEvent.target.response.replace(/}{/g, '},{')}]`);
+          console.log(progressEvent.event.target.response);
+          self.output = JSON.parse(`[${progressEvent.event.target.response.replace(/}{/g, '},{')}]`);
         },
       };
       let response;
@@ -9081,7 +9081,7 @@ export default {
               zelidauth,
             },
             onDownloadProgress(progressEvent) {
-              self.monitoringStream[`${component.name}_${self.appSpecification.name}`] = JSON.parse(`[${progressEvent.target.response.replace(/}{"read/g, '},{"read')}]`);
+              self.monitoringStream[`${component.name}_${self.appSpecification.name}`] = JSON.parse(`[${progressEvent.event.target.response.replace(/}{"read/g, '},{"read')}]`);
             },
           };
           // eslint-disable-next-line no-await-in-loop
@@ -9096,8 +9096,8 @@ export default {
             zelidauth,
           },
           onDownloadProgress(progressEvent) {
-            console.log(progressEvent.target.response);
-            self.monitoringStream[self.appName] = JSON.parse(`[${progressEvent.target.response.replace(/}{/g, '},{')}]`);
+            console.log(progressEvent.event.target.response);
+            self.monitoringStream[self.appName] = JSON.parse(`[${progressEvent.event.target.response.replace(/}{/g, '},{')}]`);
           },
         };
         // eslint-disable-next-line no-await-in-loop
@@ -9504,8 +9504,8 @@ export default {
           zelidauth,
         },
         onDownloadProgress(progressEvent) {
-          console.log(progressEvent.target.response);
-          self.output = JSON.parse(`[${progressEvent.target.response.replace(/}{/g, '},{')}]`);
+          console.log(progressEvent.event.target.response);
+          self.output = JSON.parse(`[${progressEvent.event.target.response.replace(/}{/g, '},{')}]`);
         },
       };
       const response = await this.executeLocalCommand(`/apps/redeploy/${app}/${force}`, null, axiosConfig);
@@ -9534,8 +9534,8 @@ export default {
           zelidauth,
         },
         onDownloadProgress(progressEvent) {
-          console.log(progressEvent.target.response);
-          self.output = JSON.parse(`[${progressEvent.target.response.replace(/}{/g, '},{')}]`);
+          console.log(progressEvent.event.target.response);
+          self.output = JSON.parse(`[${progressEvent.event.target.response.replace(/}{/g, '},{')}]`);
         },
       };
       const response = await this.executeLocalCommand(`/apps/appremove/${app}`, null, axiosConfig);

--- a/HomeUI/src/views/apps/MyFluxShare.vue
+++ b/HomeUI/src/views/apps/MyFluxShare.vue
@@ -510,8 +510,8 @@ export default {
             self.$set(self.downloaded, name, progressEvent.loaded);
             if (progressEvent.total) {
               self.$set(self.total, name, progressEvent.total);
-            } else if (progressEvent.target && progressEvent.target.response && progressEvent.target.response.size) {
-              self.$set(self.total, name, progressEvent.target.response.size);
+            } else if (progressEvent.target && progressEvent.event.target.response && progressEvent.event.target.response.size) {
+              self.$set(self.total, name, progressEvent.event.target.response.size);
             } else {
               self.$set(self.total, name, maxTotalSize);
             }

--- a/HomeUI/src/views/apps/RegisterFluxApp.vue
+++ b/HomeUI/src/views/apps/RegisterFluxApp.vue
@@ -3414,8 +3414,8 @@ export default {
           zelidauth,
         },
         onDownloadProgress(progressEvent) {
-          console.log(progressEvent.target.response);
-          self.output = JSON.parse(`[${progressEvent.target.response.replace(/}{/g, '},{')}]`);
+          console.log(progressEvent.event.target.response);
+          self.output = JSON.parse(`[${progressEvent.event.target.response.replace(/}{/g, '},{')}]`);
         },
       };
       let response;


### PR DESCRIPTION
Axios > 0.27.2 moves the `target` property under the `event` property for download progress.

This pull updates every use of this property to the correct target.

Have tested on a live node - in conjunction with the `flush()` fix that was put into place - we get live updates again.