### PR TITLE
Bugfix: Unhandled DNS lookup error and image parsing

### DIFF
--- a/HomeUI/src/router/routes/apps/apps.js
+++ b/HomeUI/src/router/routes/apps/apps.js
@@ -76,14 +76,14 @@ export default [
       else next({ name: 'error-404' });
     },
   },
-  // {
-  //   path: 'https://titan.runonflux.io',
-  //   name: 'apps-marketplace-sharednodes',
-  //   component: () => import('@/views/apps/marketplace/Marketplace.vue'),
-  //   meta: {
-  //     contentRenderer: 'sidebar-left',
-  //     contentClass: 'marketplace-application',
-  //     navActiveLink: 'apps-marketplace',
-  //   },
-  // },
+  {
+    path: 'https://titan.runonflux.io',
+    name: 'apps-marketplace-sharednodes',
+    component: () => import('@/views/apps/marketplace/Marketplace.vue'),
+    meta: {
+      contentRenderer: 'sidebar-left',
+      contentClass: 'marketplace-application',
+      navActiveLink: 'apps-marketplace',
+    },
+  },
 ];

--- a/ZelBack/src/services/utils/imageVerifier.js
+++ b/ZelBack/src/services/utils/imageVerifier.js
@@ -194,6 +194,7 @@ class ImageVerifier {
 
     if (match === null) {
       this.#parseErrorDetail = `Image tag: ${this.rawImageTag} is not in valid format [HOST[:PORT_NUMBER]/][NAMESPACE/]REPOSITORY[:TAG]`;
+      return;
     }
 
     const {

--- a/apiServer.js
+++ b/apiServer.js
@@ -221,6 +221,10 @@ async function initiate() {
       log.error('Flux api server port in use, shutting down.');
       // if shutting down clean, nodemon won't restart
       process.exit();
+    } else if (err.code === 'ENOTFOUND' && err.hostname) {
+      log.error('Uncaught DNS Lookup Error!!, swallowing.');
+      log.error(err);
+      return;
     }
 
     log.error(err);


### PR DESCRIPTION
Note: Have added the Titan link back that I mistakenly thought was no longer used. (Will fix console error this is creating in a future pull)

Two things going on here.

First, the image parsing was missing a return statement if no match at all was made (edge case), which somehow allowed for an image starting with a / to be accepted. I'm not sure how this app even got registered, as I tested it on the home.runonflux.io register page, and it throws an error.

I will add some tests in for this tomorrow.

Second, when FluxOS goes to remove the app (the image doesn't exist) it's causing a dns lookup to fail somewhere for the hostname "images" I can't track this down at the moment, so have put a hack in place so we catch this error globally, and continue on.

With patch:

```
Uncaught DNS Lookup Error!!, swallowing.
Error: cacheableLookup ENOTFOUND images
    at CacheableLookup.lookupAsync (file:///home/davew/zelflux/node_modules/cacheable-lookup/source/index.js:202:18) {
code: 'ENOTFOUND',
hostname: 'images'
}
```

It has to be one of the axios calls as that is the only thing using cacheable lookups. I will try find this tomorrow - I can replicate the error by putting this blob back in the db:

```
  {
    name: 'gridprueba',
    compose: [
      {
        name: 'Webserver',
        description: 'grid',
        repotag: '/nginx:latest',
        ports: [ 34349 ],
        domains: [ '' ],
        environmentParameters: [],
        commands: [],
        containerPorts: [ 80 ],
        containerData: '/tmp',
        cpu: 0.5,
        ram: 500,
        hdd: 15,
        tiered: false,
        secrets: '',
        repoauth: ''
      }
    ],
    contacts: [],
    description: 'asd',
    expire: 5000,
    geolocation: [],
    hash: '6718b5e140301c815ef2f8f0fec1a6ad8fa853f68b85a69828cfaa8f75470910',
    height: 1702605,
    instances: 3,
    nodes: [],
    owner: '1Ltfpyy1PuUuqaX8QT59nZ6UD2WURedBSF',
    staticip: false,
    version: 7
  }
```
