### PR TITLE
Bugfix: iptables timing

### DIFF
--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -110,9 +110,9 @@ async function startFluxFunctions() {
     }, 15 * 1000);
     setTimeout(async () => {
       log.info('Rechecking firewall app rules');
-      fluxNetworkHelper.purgeUFW();
       const fluxNetworkInterfaces = await dockerService.getFluxDockerNetworkPhysicalInterfaceNames();
-      fluxNetworkHelper.removeDockerContainerAccessToNonRoutable(fluxNetworkInterfaces);
+      await fluxNetworkHelper.removeDockerContainerAccessToNonRoutable(fluxNetworkInterfaces);
+      fluxNetworkHelper.purgeUFW();
       appsService.testAppMount(); // test if our node can mount a volume
     }, 30 * 1000);
     setTimeout(() => {

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -109,10 +109,10 @@ async function startFluxFunctions() {
       fluxCommunicationUtils.constantlyUpdateDeterministicFluxList(); // updates deterministic flux list for communication every 2 minutes, so we always trigger cache and have up to date value
     }, 15 * 1000);
     setTimeout(async () => {
-      log.info('Rechecking firewall app rules');
       const fluxNetworkInterfaces = await dockerService.getFluxDockerNetworkPhysicalInterfaceNames();
       await fluxNetworkHelper.removeDockerContainerAccessToNonRoutable(fluxNetworkInterfaces);
-      fluxNetworkHelper.purgeUFW();
+      log.info('Rechecking firewall app rules');
+      await fluxNetworkHelper.purgeUFW();
       appsService.testAppMount(); // test if our node can mount a volume
     }, 30 * 1000);
     setTimeout(() => {


### PR DESCRIPTION
I have experienced this on one of my nodes (and seen it mentioned in discord by one person)

This has only affected my ubuntu 20.04 node, (I only have one) so don't know if it's based on the versions in use on this system or something else.

![Screenshot 2024-08-10 at 11 38 49 AM](https://github.com/user-attachments/assets/a6371c6f-933b-4fde-83bc-ba348f79ea3d)

We were running the iptables rules and ufw rules at the same time - and ufw uses iptables under the hood so getting a lock on xtables.

This pull just runs these function synchronously, so they don't compete. Also moved the iptable deny rules before ufw (makes sense to deny host traffic first then clear ufw)

Tested on my Ubuntu 20.04 node - fixed the issue.