### PR TITLE
Refactor/freeupdates

### DIFF
--- a/HomeUI/src/views/apps/Management.vue
+++ b/HomeUI/src/views/apps/Management.vue
@@ -5079,6 +5079,12 @@
                     </h4>
                   </div>
                 </b-card-text>
+                <b-card-text v-if="freeUpdate">
+                  <br>
+                  <div class="text-center my-3">
+                    This update will have no cost. We offer up to 5 of these updates per day.
+                  </div>
+                </b-card-text>
                 <br>
                 <b-button
                   v-ripple.400="'rgba(255, 255, 255, 0.15)'"

--- a/HomeUI/src/views/apps/Management.vue
+++ b/HomeUI/src/views/apps/Management.vue
@@ -8694,7 +8694,7 @@ export default {
         if (blocksToExpire < 5000) {
           throw new Error('Your application will expire in less than one week, you need to extend subscription to be able to update specifications');
         } else {
-          return Math.ceil(blocksToExpire / 100) * 100;
+          return blocksToExpire;
         }
       }
       if (this.expireOptions[this.expirePosition]) {
@@ -8816,7 +8816,7 @@ export default {
         }
         this.appPricePerSpecsUSD = +response.data.data.usd;
         console.log(response.data.data);
-        if (!this.extendSubscription && this.appPricePerSpecsUSD <= 0.99) {
+        if (!this.extendSubscription && response.data.data.freeNetworkUpdate) {
           this.freeUpdate = true;
         } else if (Number.isNaN(+response.data.data.fluxDiscount)) {
           this.applicationPriceFluxError = true;

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -10154,7 +10154,7 @@ async function getAppFiatAndFluxPrice(req, res) {
       let freeAppUpdate = false;
       const appInfo = await dbHelper.findOneInDatabase(database, globalAppsInformation, query, projection);
       if (appInfo && appInfo.appSpecifications.expire && appSpecFormatted.expire) {
-        if (appSpecFormatted.instances === appInfo.appSpecifications.instances && (appSpecFormatted.expire + daemonHeight) - (appInfo.appSpecifications.expire + appInfo.height) < 130) { // free updates can only have maximum 100 blocks added for now
+        if (appSpecFormatted.instances === appInfo.appSpecifications.instances && (appSpecFormatted.expire + daemonHeight) - (appInfo.appSpecifications.expire + appInfo.height) <= 2) { // free updates should not extend app subscription
           if (appSpecFormatted.compose.length === appInfo.appSpecifications.compose.length) {
             let changes = false;
             for (let i = 0; i < appSpecFormatted.compose.length; i += 1) {

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -10419,39 +10419,6 @@ async function verifyAppRegistrationParameters(req, res) {
 }
 
 /**
- * To verify app if app update is not spamming the network with false updates
- * @param {object} appSpecifications App specifications.
- * @param {number} height Block height.
- */
-async function verifyAppUpdateIsNotSpammingNetwork(appSpecs, height) {
-  const appSpecifications = JSON.parse(JSON.stringify(appSpecs));
-  const db = dbHelper.databaseConnection();
-  const database = db.db(config.database.appsglobal.database);
-  const projection = {
-    projection: {
-      _id: 0,
-    },
-  };
-  log.info(`Searching permanent messages for ${appSpecifications.name}`);
-  const appsQuery = {
-    'appSpecifications.name': appSpecifications.name,
-  };
-  const permanentAppMessage = await dbHelper.findInDatabase(database, globalAppsMessages, appsQuery, projection);
-  const messagesInLastWeek = permanentAppMessage.filter((message) => message.height > height - 1440);
-  if (messagesInLastWeek && messagesInLastWeek.length > 1) {
-    const lastMessage = messagesInLastWeek[messagesInLastWeek.length - 1];
-    if (lastMessage.appSpecifications.expire && (appSpecifications.expire + height) - (lastMessage.appSpecifications.expire + lastMessage.height) < 1440) { // update with less than two days extension let's check specs
-      lastMessage.appSpecifications.expire = null;
-      // eslint-disable-next-line no-param-reassign
-      appSpecifications.expire = null;
-      if (JSON.stringify(lastMessage.appSpecifications) === JSON.stringify(appSpecifications)) {
-        throw new Error('Update App Specs not valid. Specs needs to be updated or expire period extended');
-      }
-    }
-  }
-}
-
-/**
  * To verify app update parameters. Checks for correct format, specs and non-duplication of values/resources.
  * @param {object} req Request.
  * @param {object} res Response.
@@ -10475,10 +10442,6 @@ async function verifyAppUpdateParameters(req, res) {
         throw new Error('Daemon not yet synced.');
       }
       const daemonHeight = syncStatus.data.height;
-
-      if (appSpecFormatted.expire) {
-        await verifyAppUpdateIsNotSpammingNetwork(appSpecFormatted, daemonHeight);
-      }
 
       // parameters are now proper format and assigned. Check for their validity, if they are within limits, have propper ports, repotag exists, string lengths, specs are ok
       await verifyAppSpecifications(appSpecFormatted, daemonHeight, true);


### PR DESCRIPTION
- Adds to getAppFiatAndFluxPrice method a new response property, freeNetworkUpdate;
 freeNetworkUpdate will be true if, instances, cpu, ram and disk was not changed, if expire was not extended and if there were less than 5 updates in the last day.
- Updates UI to no extend subscription when it was not selected to do it;
- Removes verifyAppUpdateIsNotSpammingNetwork check, message can go to temporary apps but will only be free updated on the top conditions.