### PR TITLE
Refactor Messages Rebroadcast

### DIFF
--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -83,6 +83,7 @@ module.exports = {
   fluxTeamFluxID: '1hjy4bCYBJr4mny4zCE85J94RXa8W6q37',
   fluxSupportTeamFluxID: '16iJqiVbHptCx87q6XQwNpKdgEZnFtKcyP',
   deterministicNodesStart: 558000,
+  messagesBroadcastRefactorStart: 1751250, // expected block at 13th Octobor 2024
   fluxapps: {
     // in flux main chain per month (blocksLasting)
     price: [

--- a/ZelBack/src/services/fluxCommunication.js
+++ b/ZelBack/src/services/fluxCommunication.js
@@ -394,7 +394,11 @@ function handleIncomingConnection(websocket, optionalPort) {
       if (messageNumber === 100000000) {
         messageNumber = 0;
       } */
-
+      // check rate limit
+      const rateOK = fluxNetworkHelper.lruRateLimit(`${ipv4Peer}:${port}`, 90);
+      if (!rateOK) {
+        return; // do not react to the message
+      }
       const msgObj = serviceHelper.ensureObject(msg.data);
       const { pubKey } = msgObj;
       const { timestamp } = msgObj;
@@ -446,11 +450,6 @@ function handleIncomingConnection(websocket, optionalPort) {
         return;
       }
       myCacheTemp.set(messageHash, msgObj);
-      // check rate limit
-      const rateOK = fluxNetworkHelper.lruRateLimit(`${ipv4Peer}:${port}`, 90);
-      if (!rateOK) {
-        return; // do not react to the message
-      }
 
       // check blocked list
       if (blockedPubKeysCache.has(pubKey)) {
@@ -734,6 +733,11 @@ async function initiateAndHandleConnection(connection) {
       if (messageNumber === 100000000) {
         messageNumber = 0;
       } */
+      // check rate limit
+      const rateOK = fluxNetworkHelper.lruRateLimit(`${ip}:${port}`, 90);
+      if (!rateOK) {
+        return; // do not react to the message
+      }
       const msgObj = serviceHelper.ensureObject(evt.data);
       const { pubKey } = msgObj;
       const { timestamp } = msgObj;
@@ -786,11 +790,6 @@ async function initiateAndHandleConnection(connection) {
       myCacheTemp.set(messageHash, msgObj);
       // incoming messages from outgoing connections
       const currentTimeStamp = Date.now(); // ms
-      // check rate limit
-      const rateOK = fluxNetworkHelper.lruRateLimit(`${ip}:${port}`, 90);
-      if (!rateOK) {
-        return; // do not react to the message
-      }
       // check blocked list
       if (blockedPubKeysCache.has(pubKey)) {
         try {

--- a/ZelBack/src/services/fluxCommunication.js
+++ b/ZelBack/src/services/fluxCommunication.js
@@ -405,8 +405,11 @@ function handleIncomingConnection(websocket, optionalPort) {
       const { requestMessageHash } = msgObj;
       if (messageHashPresent) {
         handleCheckMessageHashPresent(messageHashPresent, peer.ip, peer.port, false);
-      } else if (requestMessageHash) {
+        return;
+      }
+      if (requestMessageHash) {
         handleRequestMessageHash(requestMessageHash, peer.ip, peer.port, false);
+        return;
       }
       if (!pubKey || !timestamp || !signature || !version || !data) {
         try {
@@ -723,8 +726,11 @@ async function initiateAndHandleConnection(connection) {
       const { requestMessageHash } = msgObj;
       if (messageHashPresent) {
         handleCheckMessageHashPresent(messageHashPresent, ip, port, true);
-      } else if (requestMessageHash) {
+        return;
+      }
+      if (requestMessageHash) {
         handleRequestMessageHash(requestMessageHash, ip, port, true);
+        return;
       }
       if (!pubKey || !timestamp || !signature || !version || !data) {
         try {

--- a/ZelBack/src/services/fluxCommunication.js
+++ b/ZelBack/src/services/fluxCommunication.js
@@ -404,10 +404,28 @@ function handleIncomingConnection(websocket, optionalPort) {
       const { messageHashPresent } = msgObj;
       const { requestMessageHash } = msgObj;
       if (messageHashPresent) {
+        if (typeof messageHashPresent !== 'string' || messageHashPresent.length !== 40) {
+          try {
+            log.info(`Invalid message of type messageHashPresentreceived from outgoing peer ${peer.ip}:${peer.port}. Closing outgoing connection`);
+            websocket.close(4016, 'Message not valid, disconnect');
+          } catch (e) {
+            log.error(e);
+          }
+          return;
+        }
         handleCheckMessageHashPresent(messageHashPresent, peer.ip, peer.port, false);
         return;
       }
       if (requestMessageHash) {
+        if (typeof requestMessageHash !== 'string' || requestMessageHash.length !== 40) {
+          try {
+            log.info(`Invalid message of type requestMessageHash from incoming peer ${peer.ip}:${peer.port}. Closing incoming connection`);
+            websocket.close(4016, 'Message not valid, disconnect');
+          } catch (e) {
+            log.error(e);
+          }
+          return;
+        }
         handleRequestMessageHash(requestMessageHash, peer.ip, peer.port, false);
         return;
       }
@@ -725,10 +743,28 @@ async function initiateAndHandleConnection(connection) {
       const { messageHashPresent } = msgObj;
       const { requestMessageHash } = msgObj;
       if (messageHashPresent) {
+        if (typeof messageHashPresent !== 'string' || messageHashPresent.length !== 40) {
+          try {
+            log.info(`Invalid message of type messageHashPresentreceived from outgoing peer ${ip}:${port}. Closing outgoing connection`);
+            websocket.close(4017, 'Message not valid, disconnect');
+          } catch (e) {
+            log.error(e);
+          }
+          return;
+        }
         handleCheckMessageHashPresent(messageHashPresent, ip, port, true);
         return;
       }
       if (requestMessageHash) {
+        if (typeof requestMessageHash !== 'string' || requestMessageHash.length !== 40) {
+          try {
+            log.info(`Invalid message of type requestMessageHash from outgoing peer ${ip}:${port}. Closing outgoing connection`);
+            websocket.close(4017, 'Message not valid, disconnect');
+          } catch (e) {
+            log.error(e);
+          }
+          return;
+        }
         handleRequestMessageHash(requestMessageHash, ip, port, true);
         return;
       }

--- a/ZelBack/src/services/fluxCommunication.js
+++ b/ZelBack/src/services/fluxCommunication.js
@@ -72,7 +72,15 @@ async function handleAppMessages(message, fromIP, port) {
     const appsService = require('./appsService');
     const rebroadcastToPeers = await appsService.storeAppTemporaryMessage(message.data, true);
     if (rebroadcastToPeers === true) {
-      const messageString = serviceHelper.ensureString(message);
+      const syncStatus = daemonServiceMiscRpcs.isDaemonSynced();
+      const daemonHeight = syncStatus.data.height || 0;
+      let messageString = serviceHelper.ensureString(message);
+      if (daemonHeight >= config.messagesBroadcastRefactorStart) {
+        const dataObj = {
+          messageHashPresent: hash(message.data),
+        };
+        messageString = JSON.stringify(dataObj);
+      }
       const wsListOut = [];
       outgoingConnections.forEach((client) => {
         if (client.ip === fromIP && client.port === port) {
@@ -99,6 +107,68 @@ async function handleAppMessages(message, fromIP, port) {
 }
 
 /**
+ * To handle check if message hash is present, if node doesn't have that message hash will send to the client a message requesting for the message.
+ * @param {string} messageHash Message hash.
+ * @param {string} fromIP Sender's IP address.
+ * @param {string} port Sender's node Api port.
+ * @param {boolean} outgoingConnection says if ip/port is from incoming or outgoing connections.
+ */
+async function handleCheckMessageHashPresent(messageHash, fromIP, port, outgoingConnection) {
+  try {
+    if (!myCacheTemp.has(messageHash)) {
+      const dataObj = {
+        requestMessageHash: messageHash,
+      };
+      const dataString = JSON.stringify(dataObj);
+      if (outgoingConnection) {
+        const wsListOut = outgoingConnections.filter((aux) => aux.ip === fromIP && aux.port === port);
+        if (wsListOut && wsListOut.length > 0) {
+          fluxCommunicationMessagesSender.sendToAllPeers(dataString, wsListOut);
+        }
+      } else {
+        const wsList = incomingConnections.find((aux) => aux.ip === fromIP && aux.port === port);
+        if (wsList && wsList.length > 0) {
+          fluxCommunicationMessagesSender.sendToAllIncomingConnections(dataString, wsList);
+        }
+      }
+    }
+  } catch (error) {
+    log.error(error);
+  }
+}
+
+/**
+ * To handle a request of a message, from the message hash from one of the ws connections.
+ * @param {string} messageHash Message hash.
+ * @param {string} fromIP Sender's IP address.
+ * @param {string} port Sender's node Api port.
+ * @param {boolean} outgoingConnection says if ip/port is from incoming or outgoing connections.
+ */
+async function handleRequestMessageHash(messageHash, fromIP, port, outgoingConnection) {
+  try {
+    if (myCacheTemp.has(messageHash)) {
+      const message = myCacheTemp.get(messageHash);
+      if (message) {
+        const messageString = serviceHelper.ensureString(message);
+        if (outgoingConnection) {
+          const wsListOut = outgoingConnections.filter((aux) => aux.ip === fromIP && aux.port === port);
+          if (wsListOut && wsListOut.length > 0) {
+            fluxCommunicationMessagesSender.sendToAllPeers(messageString, wsListOut);
+          }
+        } else {
+          const wsList = incomingConnections.find((aux) => aux.ip === fromIP && aux.port === port);
+          if (wsList && wsList.length > 0) {
+            fluxCommunicationMessagesSender.sendToAllIncomingConnections(messageString, wsList);
+          }
+        }
+      }
+    }
+  } catch (error) {
+    log.error(error);
+  }
+}
+
+/**
  * To handle running app messages.
  * @param {object} message Message.
  * @param {string} fromIP Sender's IP address.
@@ -115,7 +185,15 @@ async function handleAppRunningMessage(message, fromIP, port) {
     const currentTimeStamp = Date.now();
     const timestampOK = fluxCommunicationUtils.verifyTimestampInFluxBroadcast(message, currentTimeStamp, 240000);
     if (rebroadcastToPeers === true && timestampOK) {
-      const messageString = serviceHelper.ensureString(message);
+      const syncStatus = daemonServiceMiscRpcs.isDaemonSynced();
+      const daemonHeight = syncStatus.data.height || 0;
+      let messageString = serviceHelper.ensureString(message);
+      if (daemonHeight >= config.messagesBroadcastRefactorStart) {
+        const dataObj = {
+          messageHashPresent: hash(message.data),
+        };
+        messageString = JSON.stringify(dataObj);
+      }
       const wsListOut = [];
       outgoingConnections.forEach((client) => {
         if (client.ip === fromIP && client.port === port) {
@@ -157,7 +235,15 @@ async function handleIPChangedMessage(message, fromIP, port) {
     const currentTimeStamp = Date.now();
     const timestampOK = fluxCommunicationUtils.verifyTimestampInFluxBroadcast(message, currentTimeStamp, 240000);
     if (rebroadcastToPeers && timestampOK) {
-      const messageString = serviceHelper.ensureString(message);
+      const syncStatus = daemonServiceMiscRpcs.isDaemonSynced();
+      const daemonHeight = syncStatus.data.height || 0;
+      let messageString = serviceHelper.ensureString(message);
+      if (daemonHeight >= config.messagesBroadcastRefactorStart) {
+        const dataObj = {
+          messageHashPresent: hash(message.data),
+        };
+        messageString = JSON.stringify(dataObj);
+      }
       const wsListOut = [];
       outgoingConnections.forEach((client) => {
         if (client.ip === fromIP && client.port === port) {
@@ -199,7 +285,15 @@ async function handleAppRemovedMessage(message, fromIP, port) {
     const currentTimeStamp = Date.now();
     const timestampOK = fluxCommunicationUtils.verifyTimestampInFluxBroadcast(message, currentTimeStamp, 240000);
     if (rebroadcastToPeers && timestampOK) {
-      const messageString = serviceHelper.ensureString(message);
+      const syncStatus = daemonServiceMiscRpcs.isDaemonSynced();
+      const daemonHeight = syncStatus.data.height || 0;
+      let messageString = serviceHelper.ensureString(message);
+      if (daemonHeight >= config.messagesBroadcastRefactorStart) {
+        const dataObj = {
+          messageHashPresent: hash(message.data),
+        };
+        messageString = JSON.stringify(dataObj);
+      }
       const wsListOut = [];
       outgoingConnections.forEach((client) => {
         if (client.ip === fromIP && client.port === port) {
@@ -307,6 +401,13 @@ function handleIncomingConnection(websocket, optionalPort) {
       const { signature } = msgObj;
       const { version } = msgObj;
       const { data } = msgObj;
+      const { messageHashPresent } = msgObj;
+      const { requestMessageHash } = msgObj;
+      if (messageHashPresent) {
+        handleCheckMessageHashPresent(messageHashPresent, peer.ip, peer.port, false);
+      } else if (requestMessageHash) {
+        handleRequestMessageHash(requestMessageHash, peer.ip, peer.port, false);
+      }
       if (!pubKey || !timestamp || !signature || !version || !data) {
         try {
           log.info(`Invalid received from incoming peer ${peer.ip}:${peer.port}. Closing incoming connection`);
@@ -323,7 +424,7 @@ function handleIncomingConnection(websocket, optionalPort) {
       if (myCacheTemp.has(messageHash)) {
         return;
       }
-      myCacheTemp.set(messageHash, messageHash);
+      myCacheTemp.set(messageHash, msgObj);
       // check rate limit
       const rateOK = fluxNetworkHelper.lruRateLimit(`${ipv4Peer}:${port}`, 90);
       if (!rateOK) {
@@ -618,6 +719,13 @@ async function initiateAndHandleConnection(connection) {
       const { signature } = msgObj;
       const { version } = msgObj;
       const { data } = msgObj;
+      const { messageHashPresent } = msgObj;
+      const { requestMessageHash } = msgObj;
+      if (messageHashPresent) {
+        handleCheckMessageHashPresent(messageHashPresent, ip, port, true);
+      } else if (requestMessageHash) {
+        handleRequestMessageHash(requestMessageHash, ip, port, true);
+      }
       if (!pubKey || !timestamp || !signature || !version || !data) {
         try {
           log.info(`Invalid received from outgoing peer ${ip}:${port}. Closing outgoing connection`);
@@ -633,7 +741,7 @@ async function initiateAndHandleConnection(connection) {
       if (myCacheTemp.has(messageHash)) {
         return;
       }
-      myCacheTemp.set(messageHash, messageHash);
+      myCacheTemp.set(messageHash, msgObj);
       // incoming messages from outgoing connections
       const currentTimeStamp = Date.now(); // ms
       // check rate limit

--- a/ZelBack/src/services/fluxCommunication.js
+++ b/ZelBack/src/services/fluxCommunication.js
@@ -126,7 +126,7 @@ async function handleCheckMessageHashPresent(messageHash, fromIP, port, outgoing
           fluxCommunicationMessagesSender.sendToAllPeers(dataString, wsListOut);
         }
       } else {
-        const wsList = incomingConnections.find((aux) => aux.ip === fromIP && aux.port === port);
+        const wsList = incomingConnections.filter((aux) => aux.ip === fromIP && aux.port === port);
         if (wsList && wsList.length > 0) {
           fluxCommunicationMessagesSender.sendToAllIncomingConnections(dataString, wsList);
         }
@@ -156,7 +156,7 @@ async function handleRequestMessageHash(messageHash, fromIP, port, outgoingConne
             fluxCommunicationMessagesSender.sendToAllPeers(messageString, wsListOut);
           }
         } else {
-          const wsList = incomingConnections.find((aux) => aux.ip === fromIP && aux.port === port);
+          const wsList = incomingConnections.filter((aux) => aux.ip === fromIP && aux.port === port);
           if (wsList && wsList.length > 0) {
             fluxCommunicationMessagesSender.sendToAllIncomingConnections(messageString, wsList);
           }

--- a/tests/unit/globalconfig/default.js
+++ b/tests/unit/globalconfig/default.js
@@ -77,6 +77,7 @@ module.exports = {
   minimumDockerAllowedVersion: '26.1.2',
   fluxTeamFluxID: '1NH9BP155Rp3HSf5ef6NpUbE8JcyLRruAM',
   deterministicNodesStart: 558000,
+  messagesBroadcastRefactorStart: 1751250, // expected block at 13th Octobor 2024
   fluxapps: {
     // in flux main chain per month (blocksLasting)
     price: [


### PR DESCRIPTION
- Start caching the message together with the messageHash;
- After change goes live, when a flux app message is processed and it's ok to be rebroadcast we start sending "messageHashPresent" to the other peers, the peers receive this message and if they haven't received yet that message hash, they reply back with a "requestMessageHash" with the hash of the message they need, and the node when it receives this message, check on cache for the message and send it back; 
 It's almost like a ping/pong on the websocket.
- This will reduce the bandwidth used on nodes, reducing largely the possibility of ISP router mark the data on the websockets as flooding and stopping block the data for some time;
- Goes live on block 1751250, 13th Octobor 2024;