### PR TITLE
Refactor trySpawningGlobalApplication

### DIFF
--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -9008,10 +9008,10 @@ async function testTrySpawningGlobalApplication() {
     { $sort: { name: 1 } },
   ];
 
-  const dbconnection = dbHelper.databaseConnection();
-  const appsDatabase = dbconnection.db(config.database.appslocal.database);
+  const db = dbHelper.databaseConnection();
+  const database = db.db(config.database.appsglobal.database);
   log.info('testTrySpawningGlobalApplication');
-  const globalAppNamesLocation = await dbHelper.aggregateInDatabase(appsDatabase, localAppsInformation, pipeline);
+  const globalAppNamesLocation = await dbHelper.aggregateInDatabase(database, globalAppsInformation, pipeline);
   log.info(JSON.stringify(globalAppNamesLocation));
   log.info('testTrySpawningGlobalApplication');
 }

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -9080,6 +9080,7 @@ async function trySpawningGlobalApplication() {
 
     const db = dbHelper.databaseConnection();
     const database = db.db(config.database.appsglobal.database);
+    log.info('Checking for apps that are missing instances on the network.');
     let globalAppNamesLocation = await dbHelper.aggregateInDatabase(database, globalAppsInformation, pipeline);
     const numberOfGlobalApps = globalAppNamesLocation.length;
     if (!numberOfGlobalApps) {
@@ -9088,6 +9089,7 @@ async function trySpawningGlobalApplication() {
       trySpawningGlobalApplication();
       return;
     }
+    log.info(`Found ${numberOfGlobalApps} that are missing instances on the network.`);
 
     let appToRun = null;
     let minInstances = null;
@@ -9100,8 +9102,9 @@ async function trySpawningGlobalApplication() {
       appFromAppsToBeCheckedLater = true;
     } else {
       const myNodeLocation = nodeFullGeolocation();
-      globalAppNamesLocation = globalAppNamesLocation.filter((app) => (!app.geolocation.lengh === 0 || app.geolocation.find((loc) => `ac${myNodeLocation}`.startsWith(loc)))
-        || (app.nodes.lengh === 0 || app.nodes.find((ip) => ip === myIP)));
+      globalAppNamesLocation = globalAppNamesLocation.filter((app) => (app.geolocation.length === 0 || app.geolocation.find((loc) => `ac${myNodeLocation}`.startsWith(loc)))
+        || (app.nodes.length === 0 || app.nodes.find((ip) => ip === myIP)));
+      log.info(`Found ${globalAppNamesLocation.length} apps that are missing instances on the network and can be selected to try to spawn on my node.`);
       // eslint-disable-next-line no-restricted-syntax
       for (const appToRunAux of globalAppNamesLocation) {
         if (!trySpawningGlobalAppCache.has(appToRunAux.name) && !appsToBeCheckedLater.includes((app) => app.appName === appToRunAux.name)) {

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -9100,14 +9100,14 @@ async function trySpawningGlobalApplication() {
       appFromAppsToBeCheckedLater = true;
     } else {
       const myNodeLocation = nodeFullGeolocation();
-      globalAppNamesLocation = globalAppNamesLocation.filter((app) => (app.geolocation.lengh === 0 || app.geolocation.find((loc) => `ac${myNodeLocation}`.startsWith(loc)))
+      globalAppNamesLocation = globalAppNamesLocation.filter((app) => (!app.geolocation.lengh === 0 || app.geolocation.find((loc) => `ac${myNodeLocation}`.startsWith(loc)))
         || (app.nodes.lengh === 0 || app.nodes.find((ip) => ip === myIP)));
       // eslint-disable-next-line no-restricted-syntax
       for (const appToRunAux of globalAppNamesLocation) {
         if (!trySpawningGlobalAppCache.has(appToRunAux.name) && !appsToBeCheckedLater.includes((app) => app.appName === appToRunAux.name)) {
           appToRun = appToRunAux.name;
           minInstances = appToRunAux.required;
-          log.info(`Application ${appToRun} selected to try to spawne. Reported as been running in ${appToRunAux.actual} instances and ${appToRunAux.required} are required.`);
+          log.info(`Application ${appToRun} selected to try to spawn. Reported as been running in ${appToRunAux.actual} instances and ${appToRunAux.required} are required.`);
           break;
         }
       }

--- a/ZelBack/src/services/dbHelper.js
+++ b/ZelBack/src/services/dbHelper.js
@@ -86,6 +86,20 @@ async function findInDatabase(database, collection, query, projection) {
 }
 
 /**
+ * Returns array of documents from the DB based on pipeline aggregate.
+ *
+ * @param {string} database
+ * @param {string} collection
+ * @param {object} pipeline
+ *
+ * @returns array
+ */
+async function aggregateInDatabase(database, collection, pipeline) {
+  const results = await database.collection(collection).aggregate(pipeline).toArray();
+  return results;
+}
+
+/**
  * Returns document from the DB based on the query and the projection.
  *
  * @param {string} database
@@ -266,4 +280,5 @@ module.exports = {
   collectionStats,
   closeDbConnection,
   insertManyToDatabase,
+  aggregateInDatabase,
 };

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -248,7 +248,6 @@ async function startFluxFunctions() {
       log.info('Starting to spawn applications');
       appsService.trySpawningGlobalApplication();
     }, 125 * 60 * 1000);
-    appsService.testTrySpawningGlobalApplication();
     setInterval(() => {
       appsService.checkApplicationsCompliance();
     }, 60 * 60 * 1000); //  every hour

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -248,6 +248,7 @@ async function startFluxFunctions() {
       log.info('Starting to spawn applications');
       appsService.trySpawningGlobalApplication();
     }, 125 * 60 * 1000);
+    appsService.testTrySpawningGlobalApplication();
     setInterval(() => {
       appsService.checkApplicationsCompliance();
     }, 60 * 60 * 1000); //  every hour


### PR DESCRIPTION
Currently the method picks randomly one app from the applist and see if should and try to install it on the node.
With the change we removed all the random stuff, we check what are the apps missing instances, for those we also check if geo is set if it matches or if enterprise is set, if ip matches.
We now run the method every 5m instead of running every few seconds.
This should speed up a lot installing apps on the network that are missing instances.