### PR TITLE
Flux Node Service

### DIFF
--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -9,6 +9,7 @@ module.exports = {
   server: {
     allowedPorts: [16127, 16137, 16147, 16157, 16167, 16177, 16187, 16197],
     apiport: 16127, // homeport is -1, ssl port is +1
+    hostInfoServiceAddress: '169.254.43.43',
   },
   database: {
     url: '127.0.0.1',

--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -9,7 +9,7 @@ module.exports = {
   server: {
     allowedPorts: [16127, 16137, 16147, 16157, 16167, 16177, 16187, 16197],
     apiport: 16127, // homeport is -1, ssl port is +1
-    hostInfoServiceAddress: '169.254.43.43',
+    fluxNodeServiceAddress: '169.254.43.43',
   },
   database: {
     url: '127.0.0.1',

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -681,7 +681,7 @@ async function appDockerCreate(appSpecifications, appName, isComponent, fullAppS
           'max-size': '20m',
         },
       },
-      ExtraHosts: [`fluxnode.service:${config.server.hostInfoServiceAddress}`],
+      ExtraHosts: [`fluxnode.service:${config.server.fluxNodeServiceAddress}`],
     },
   };
 

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -681,7 +681,7 @@ async function appDockerCreate(appSpecifications, appName, isComponent, fullAppS
           'max-size': '20m',
         },
       },
-      ExtraHosts: [`app.identity.service:${config.server.hostInfoServiceAddress}`],
+      ExtraHosts: [`fluxnode.hostinfo.service:${config.server.hostInfoServiceAddress}`],
     },
   };
 

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -681,7 +681,7 @@ async function appDockerCreate(appSpecifications, appName, isComponent, fullAppS
           'max-size': '20m',
         },
       },
-      ExtraHosts: [`fluxnode.hostinfo.service:${config.server.hostInfoServiceAddress}`],
+      ExtraHosts: [`fluxnode.service:${config.server.hostInfoServiceAddress}`],
     },
   };
 

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -1657,6 +1657,80 @@ async function allowNodeToBindPrivilegedPorts() {
   }
 }
 
+/**
+ * docker network including mask to allow to verification. For example: 172.23.123.0/24
+ * @returns {Promise<void>}
+ */
+async function allowOnlyDockerNetworksToHostInfoService() {
+  const firewallActive = await isFirewallActive();
+
+  if (!firewallActive) return;
+
+  const fluxAppDockerNetworks = '172.23.0.0/16';
+  const { hostInfoServiceAddress } = config.server;
+  const allowDockerNetworks = `LANG="en_US.UTF-8" && sudo ufw allow from ${fluxAppDockerNetworks} proto tcp to ${hostInfoServiceAddress}/32 port 80`;
+  // have to use iptables here as ufw won't filter loopback
+  const denyRule = `INPUT -i lo ! -s ${fluxAppDockerNetworks} -d ${hostInfoServiceAddress}/32 -j DROP`;
+  const checkDenyRule = `LANG="en_US.UTF-8" && sudo iptables -C ${denyRule}`;
+  const denyAllElse = `LANG="en_US.UTF-8" && sudo iptables -I ${denyRule}`;
+
+  const cmdAsync = util.promisify(nodecmd.get);
+
+  try {
+    const cmd = await cmdAsync(allowDockerNetworks);
+    if (serviceHelper.ensureString(cmd).includes('updated') || serviceHelper.ensureString(cmd).includes('existing') || serviceHelper.ensureString(cmd).includes('added')) {
+      log.info(`Firewall adjusted for network: ${fluxAppDockerNetworks} to address: ${hostInfoServiceAddress}/32`);
+    } else {
+      log.warn(`Failed to adjust Firewall for network: ${fluxAppDockerNetworks} to address: ${hostInfoServiceAddress}/32`);
+    }
+  } catch (err) {
+    log.error(err);
+  }
+
+  const denied = await cmdAsync(checkDenyRule).catch(async (err) => {
+    if (err.message.includes('Bad rule')) {
+      try {
+        await cmdAsync(denyAllElse);
+        log.info(`Firewall adjusted to deny access to: ${hostInfoServiceAddress}/32`);
+      } catch (error) {
+        log.error(error);
+      }
+    }
+  });
+
+  if (denied) log.info(`Fireall already denying access to ${hostInfoServiceAddress}/32`);
+}
+
+/**
+ * Adds the 169.254 adddress to the loopback interface for use with the flux host info service.
+ */
+async function addHostInfoServiceIpToLoopback() {
+  const cmdAsync = util.promisify(nodecmd.get);
+
+  // could also check exists first with:
+  //   ip -f inet addr show lo | grep 169.254.43.43/32
+  const ip = config.server.hostInfoServiceAddress;
+  const addIp = `sudo ip addr add ${ip}/32 dev lo`;
+
+  let ok = false;
+  try {
+    await cmdAsync(addIp);
+    ok = true;
+  } catch (err) {
+    if (err.message.includes('File exists')) {
+      ok = true;
+    } else {
+      log.error(err);
+    }
+  }
+
+  if (ok) {
+    log.info(`hostInfoService IP: ${ip} added to loopback interface`);
+  } else {
+    log.warn(`Failed to add hostInfoService IP ${ip} to loopback interface`);
+  }
+}
+
 module.exports = {
   isFluxAvailable,
   checkFluxAvailability,
@@ -1704,4 +1778,6 @@ module.exports = {
   allowNodeToBindPrivilegedPorts,
   removeDockerContainerAccessToNonRoutable,
   getMaxNumberOfIpChanges,
+  allowOnlyDockerNetworksToHostInfoService,
+  addHostInfoServiceIpToLoopback,
 };

--- a/ZelBack/src/services/fluxNodeService.js
+++ b/ZelBack/src/services/fluxNodeService.js
@@ -82,7 +82,7 @@ function start() {
   app.get('/hostinfo', getHostInfo);
   app.all('*', (_, res) => res.status(404).end());
 
-  const bindAddress = config.server.hostInfoServiceAddress;
+  const bindAddress = config.server.fluxNodeServiceAddress;
   server = app.listen(80, bindAddress, () => {
     log.info(`Server listening on port: 80 address: ${bindAddress}`);
   });

--- a/ZelBack/src/services/geolocationService.js
+++ b/ZelBack/src/services/geolocationService.js
@@ -15,7 +15,11 @@ async function setNodeGeolocation() {
   try {
     const myIP = await fluxNetworkHelper.getMyFluxIPandPort();
     if (!myIP) {
-      throw new Error('Flux IP not detected. Flux geolocation service is awaiting');
+      log.error('Flux IP not detected. Flux geolocation service is awaiting');
+      setTimeout(() => {
+        setNodeGeolocation();
+      }, 10 * 1000);
+      return;
     }
     if (!storedGeolocation || myIP !== storedIp || execution % 4 === 0) {
       log.info(`Checking geolocation of ${myIP}`);
@@ -66,9 +70,9 @@ async function setNodeGeolocation() {
       }
     }
     execution += 1;
-    setTimeout(() => { // executes again in 12h
+    setTimeout(() => { // executes again in 24h
       setNodeGeolocation();
-    }, 12 * 60 * 60 * 1000);
+    }, 24 * 60 * 60 * 1000);
   } catch (error) {
     log.error(`Failed to get Geolocation with ${error}`);
     log.error(error);

--- a/ZelBack/src/services/hostInfoService.js
+++ b/ZelBack/src/services/hostInfoService.js
@@ -1,0 +1,88 @@
+/**
+ * Service that will be available to all docker apps on the network to get Host information
+ * Host Public IP
+ * Host Unique Identifier
+ * Host Geolocation
+ */
+
+const config = require('config');
+const log = require('../lib/log');
+const messageHelper = require('./messageHelper');
+const geolocationService = require('./geolocationService');
+const fluxNetworkHelper = require('./fluxNetworkHelper');
+const generalService = require('./generalService');
+
+const express = require('express');
+
+let server = null;
+
+async function getHostInfo(req, res) {
+  try {
+    const hostInfo = {};
+    hostInfo.id = await generalService.nodeCollateral();
+    const myIP = await fluxNetworkHelper.getMyFluxIPandPort();
+    hostInfo.ip = myIP.split(':')[0];
+    const myGeo = await geolocationService.getNodeGeolocation();
+    if (myGeo) {
+      delete myGeo.ip;
+      delete myGeo.org;
+      hostInfo.geo = JSON.stringify(myGeo);
+    } else {
+      throw new Error('Geolocation information not available at the moment');
+    }
+    const message = messageHelper.createSuccessMessage(hostInfo);
+    res.json(message);
+  } catch (error) {
+    log.error(`getHostInfo: ${error}`);
+    const errorResponse = messageHelper.createErrorMessage(
+      error.message || error,
+      error.name,
+      error.code,
+    );
+    res.json(errorResponse);
+  }
+}
+
+function handleError(middleware, req, res, next) {
+  // eslint-disable-next-line consistent-return
+  middleware(req, res, (err) => {
+    if (err instanceof SyntaxError && err.status === 400 && 'body' in err) {
+      res.statusMessage = err.message;
+      return res.sendStatus(400);
+    }
+    if (err) {
+      log.error(err);
+      return res.sendStatus(400);
+    }
+
+    next();
+  });
+}
+
+function start() {
+  if (server) return;
+
+  const app = express();
+  app.use((req, res, next) => {
+    handleError(express.json(), req, res, next);
+  });
+  app.post('/hostinfo', getHostInfo);
+  app.all('*', (_, res) => res.status(404).end());
+
+  const bindAddress = config.server.hostInfoServiceAddress;
+  server = app.listen(80, bindAddress, () => {
+    log.info(`Server listening on port: 80 address: ${bindAddress}`);
+  });
+}
+
+function stop() {
+  if (server) {
+    server.close();
+    server = null;
+  }
+}
+
+module.exports = {
+  start,
+  stop,
+};

--- a/ZelBack/src/services/hostInfoService.js
+++ b/ZelBack/src/services/hostInfoService.js
@@ -25,7 +25,7 @@ async function getHostInfo(req, res) {
       res.json(errMessage);
     } else {
       const hostInfo = {};
-      const nodeCollateralInfo = await generalService.obtainNodeCollateralInformation();
+      const nodeCollateralInfo = await generalService.obtainNodeCollateralInformation().catch(() => { throw new Error('Host Identifier information not available at the moment'); });
       hostInfo.id = nodeCollateralInfo.txhash + nodeCollateralInfo.txindex;
       const myIP = await fluxNetworkHelper.getMyFluxIPandPort();
       if (myIP) {

--- a/ZelBack/src/services/hostInfoService.js
+++ b/ZelBack/src/services/hostInfoService.js
@@ -28,15 +28,20 @@ async function getHostInfo(req, res) {
       const nodeCollateralInfo = await generalService.getCollateralInfo();
       hostInfo.id = nodeCollateralInfo.txhash + nodeCollateralInfo.txindex;
       const myIP = await fluxNetworkHelper.getMyFluxIPandPort();
-      hostInfo.ip = myIP.split(':')[0];
-      const myGeo = await geolocationService.getNodeGeolocation();
-      if (myGeo) {
-        delete myGeo.ip;
-        delete myGeo.org;
-        hostInfo.geo = myGeo;
+      if (myIP) {
+        hostInfo.ip = myIP.split(':')[0];
+        const myGeo = await geolocationService.getNodeGeolocation();
+        if (myGeo) {
+          delete myGeo.ip;
+          delete myGeo.org;
+          hostInfo.geo = myGeo;
+        } else {
+          throw new Error('Geolocation information not available at the moment');
+        }
       } else {
-        throw new Error('Geolocation information not available at the moment');
+        throw new Error('Host IP information not available at the moment');
       }
+
       const message = messageHelper.createSuccessMessage(hostInfo);
       res.json(message);
     }

--- a/ZelBack/src/services/hostInfoService.js
+++ b/ZelBack/src/services/hostInfoService.js
@@ -24,13 +24,10 @@ async function getHostInfo(req, res) {
       const errMessage = messageHelper.errUnauthorizedMessage();
       res.json(errMessage);
     } else {
-      log.info('getHostInfo called');
       const hostInfo = {};
-      const nodeCollateralInfo = await generalService.getCollateralInfo();
+      const nodeCollateralInfo = await generalService.obtainNodeCollateralInformation();
       hostInfo.id = nodeCollateralInfo.txhash + nodeCollateralInfo.txindex;
-      log.info(`getHostInfo: ${hostInfo.id}`);
       const myIP = await fluxNetworkHelper.getMyFluxIPandPort();
-      log.info(`getHostInfo: ${myIP}`);
       if (myIP) {
         hostInfo.ip = myIP.split(':')[0];
         const myGeo = await geolocationService.getNodeGeolocation();

--- a/ZelBack/src/services/hostInfoService.js
+++ b/ZelBack/src/services/hostInfoService.js
@@ -74,7 +74,7 @@ function start() {
   app.use((req, res, next) => {
     handleError(express.json(), req, res, next);
   });
-  app.post('/hostinfo', getHostInfo);
+  app.get('/hostinfo', getHostInfo);
   app.all('*', (_, res) => res.status(404).end());
 
   const bindAddress = config.server.hostInfoServiceAddress;

--- a/ZelBack/src/services/hostInfoService.js
+++ b/ZelBack/src/services/hostInfoService.js
@@ -28,6 +28,7 @@ async function getHostInfo(req, res) {
       const nodeCollateralInfo = await generalService.getCollateralInfo();
       hostInfo.id = nodeCollateralInfo.txhash + nodeCollateralInfo.txindex;
       const myIP = await fluxNetworkHelper.getMyFluxIPandPort();
+      log.info(myIP);
       if (myIP) {
         hostInfo.ip = myIP.split(':')[0];
         const myGeo = await geolocationService.getNodeGeolocation();

--- a/ZelBack/src/services/hostInfoService.js
+++ b/ZelBack/src/services/hostInfoService.js
@@ -24,11 +24,13 @@ async function getHostInfo(req, res) {
       const errMessage = messageHelper.errUnauthorizedMessage();
       res.json(errMessage);
     } else {
+      log.info('getHostInfo called');
       const hostInfo = {};
       const nodeCollateralInfo = await generalService.getCollateralInfo();
       hostInfo.id = nodeCollateralInfo.txhash + nodeCollateralInfo.txindex;
+      log.info(`getHostInfo: ${hostInfo.id}`);
       const myIP = await fluxNetworkHelper.getMyFluxIPandPort();
-      log.info(myIP);
+      log.info(`getHostInfo: ${myIP}`);
       if (myIP) {
         hostInfo.ip = myIP.split(':')[0];
         const myGeo = await geolocationService.getNodeGeolocation();

--- a/ZelBack/src/services/hostInfoService.js
+++ b/ZelBack/src/services/hostInfoService.js
@@ -25,14 +25,15 @@ async function getHostInfo(req, res) {
       res.json(errMessage);
     } else {
       const hostInfo = {};
-      hostInfo.id = await generalService.nodeCollateral();
+      const nodeCollateralInfo = await generalService.getCollateralInfo();
+      hostInfo.id = nodeCollateralInfo.txhash + nodeCollateralInfo.txindex;
       const myIP = await fluxNetworkHelper.getMyFluxIPandPort();
       hostInfo.ip = myIP.split(':')[0];
       const myGeo = await geolocationService.getNodeGeolocation();
       if (myGeo) {
         delete myGeo.ip;
         delete myGeo.org;
-        hostInfo.geo = JSON.stringify(myGeo);
+        hostInfo.geo = myGeo;
       } else {
         throw new Error('Geolocation information not available at the moment');
       }

--- a/ZelBack/src/services/hostInfoService.js
+++ b/ZelBack/src/services/hostInfoService.js
@@ -42,7 +42,7 @@ async function getHostInfo(req, res) {
         throw new Error('Host IP information not available at the moment');
       }
 
-      const message = messageHelper.createSuccessMessage(hostInfo);
+      const message = messageHelper.createDataMessage(hostInfo);
       res.json(message);
     }
   } catch (error) {

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -38,8 +38,8 @@ async function startFluxFunctions() {
         upnpService.adjustFirewallForUPNP();
       }, 1 * 60 * 60 * 1000); // every 1 hours
     }
-    fluxNetworkHelper.addHostInfoServiceIpToLoopback();
-    fluxNetworkHelper.allowOnlyDockerNetworksToHostInfoService();
+    await fluxNetworkHelper.addHostInfoServiceIpToLoopback();
+    await fluxNetworkHelper.allowOnlyDockerNetworksToHostInfoService();
     hostInfoService.start();
     await daemonServiceUtils.buildFluxdClient();
     log.info('Checking docker log for corruption...');

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -127,10 +127,8 @@ async function startFluxFunctions() {
     setInterval(() => {
       appsService.restorePortsSupport(); // restore fluxos and apps ports/upnp
     }, 10 * 60 * 1000); // every 10 minutes
-    setTimeout(() => {
-      log.info('Starting setting Node Geolocation');
-      geolocationService.setNodeGeolocation();
-    }, 90 * 1000);
+    log.info('Starting setting Node Geolocation');
+    geolocationService.setNodeGeolocation();
     setTimeout(() => {
       const { daemon: { zmqport } } = config;
       log.info(`Ensuring zmq is enabled for fluxd on port: ${zmqport}`);

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -17,6 +17,7 @@ const pgpService = require('./pgpService');
 const dockerService = require('./dockerService');
 const backupRestoreService = require('./backupRestoreService');
 const systemService = require('./systemService');
+const hostInfoService = require('./hostInfoService');
 
 const apiPort = userconfig.initial.apiport || config.server.apiport;
 const development = userconfig.initial.development || false;
@@ -37,6 +38,9 @@ async function startFluxFunctions() {
         upnpService.adjustFirewallForUPNP();
       }, 1 * 60 * 60 * 1000); // every 1 hours
     }
+    fluxNetworkHelper.addHostInfoServiceIpToLoopback();
+    fluxNetworkHelper.allowOnlyDockerNetworksToHostInfoService();
+    hostInfoService.start();
     await daemonServiceUtils.buildFluxdClient();
     log.info('Checking docker log for corruption...');
     await dockerService.dockerLogsFix();

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -17,7 +17,7 @@ const pgpService = require('./pgpService');
 const dockerService = require('./dockerService');
 const backupRestoreService = require('./backupRestoreService');
 const systemService = require('./systemService');
-const hostInfoService = require('./hostInfoService');
+const fluxNodeService = require('./fluxNodeService');
 
 const apiPort = userconfig.initial.apiport || config.server.apiport;
 const development = userconfig.initial.development || false;
@@ -38,9 +38,9 @@ async function startFluxFunctions() {
         upnpService.adjustFirewallForUPNP();
       }, 1 * 60 * 60 * 1000); // every 1 hours
     }
-    await fluxNetworkHelper.addHostInfoServiceIpToLoopback();
-    await fluxNetworkHelper.allowOnlyDockerNetworksToHostInfoService();
-    hostInfoService.start();
+    await fluxNetworkHelper.addFluxNodeServiceIpToLoopback();
+    await fluxNetworkHelper.allowOnlyDockerNetworksToFluxNodeService();
+    fluxNodeService.start();
     await daemonServiceUtils.buildFluxdClient();
     log.info('Checking docker log for corruption...');
     await dockerService.dockerLogsFix();

--- a/tests/unit/globalconfig/default.js
+++ b/tests/unit/globalconfig/default.js
@@ -5,7 +5,7 @@ module.exports = {
   server: {
     allowedPorts: [11, 13, 16127, 16137, 16147, 16157, 16167, 16177, 16187, 16197],
     apiport: 16127, // homeport is -1, ssl port is +1
-    hostInfoServiceAddress: '169.254.43.43',
+    fluxNodeServiceAddress: '169.254.43.43',
   },
   database: {
     url: database,

--- a/tests/unit/globalconfig/default.js
+++ b/tests/unit/globalconfig/default.js
@@ -5,6 +5,7 @@ module.exports = {
   server: {
     allowedPorts: [11, 13, 16127, 16137, 16147, 16157, 16167, 16177, 16187, 16197],
     apiport: 16127, // homeport is -1, ssl port is +1
+    hostInfoServiceAddress: '169.254.43.43',
   },
   database: {
     url: database,


### PR DESCRIPTION
Flux Node Service it's a service created that the docker containers have access.
Changes done:
- Improvements on the geolocation service;
- Adds a new service that is only available to call on flux docker containers.
The service for now only have one route hostinfo that returns 3 properties, host identifier, host public ip and host geolocation.
![image](https://github.com/user-attachments/assets/5d2367a5-fab0-41be-8831-eccb0dee943a)

