### PR TITLE
[WIP] FluxOS Image path integration

### DIFF
--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -46,7 +46,9 @@ const { invalidMessages } = require('./invalidMessages');
 const fluxCommunicationUtils = require('./fluxCommunicationUtils');
 
 const fluxDirPath = path.join(__dirname, '../../../');
-const appsFolder = `${fluxDirPath}ZelApps/`;
+// ToDo: Fix all the string concatenation in this file and use path.join()
+const appsFolderPath = process.env.FLUX_APPS_FOLDER || path.join(fluxDirPath, 'ZelApps');
+const appsFolder = `${appsFolderPath}/`;
 
 const cmdAsync = util.promisify(nodecmd.get);
 const crontabLoad = util.promisify(systemcrontab.load);

--- a/ZelBack/src/services/backupRestoreService.js
+++ b/ZelBack/src/services/backupRestoreService.js
@@ -8,7 +8,9 @@ const util = require('util');
 const exec = util.promisify(require('child_process').exec);
 
 const fluxDirPath = path.join(__dirname, '../../../');
-const appsFolder = `${fluxDirPath}ZelApps/`;
+// ToDo: Fix all the string concatenation in this file and use path.join()
+const appsFolderPath = process.env.FLUX_APPS_FOLDER || path.join(fluxDirPath, 'ZelApps');
+const appsFolder = `${appsFolderPath}/`;
 
 /**
  * Validates if a file path belongs to a specific set of upload types within the appsFolder.
@@ -168,7 +170,7 @@ async function getRemoteFileSize(req, res) {
       }
       const response = messageHelper.createDataMessage(fileSize);
       return res ? res.json(response) : response;
-    // eslint-disable-next-line no-else-return
+      // eslint-disable-next-line no-else-return
     } else {
       const errorResponse = messageHelper.errUnauthorizedMessage();
       return res ? res.json(errorResponse) : errorResponse;
@@ -209,7 +211,7 @@ async function removeBackupFile(req, res) {
       const output = await IOUtils.removeFile(filepath);
       const response = messageHelper.createSuccessMessage(output);
       return res.json(response);
-    // eslint-disable-next-line no-else-return
+      // eslint-disable-next-line no-else-return
     } else {
       const errMessage = messageHelper.errUnauthorizedMessage();
       return res.json(errMessage);
@@ -252,7 +254,7 @@ async function downloadLocalFile(req, res) {
       const cmd = `sudo chmod 777 "${filepath}"`;
       await exec(cmd, { maxBuffer: 1024 * 1024 * 10 });
       return res.download(filepath, fileName);
-    // eslint-disable-next-line no-else-return
+      // eslint-disable-next-line no-else-return
     } else {
       const errMessage = messageHelper.errUnauthorizedMessage();
       return res.json(errMessage);

--- a/ZelBack/src/services/benchmarkService.js
+++ b/ZelBack/src/services/benchmarkService.js
@@ -17,8 +17,9 @@ let response = messageHelper.createErrorMessage();
 let benchdClient = null;
 
 async function buildBenchdClient() {
+  // just use process.cwd() or os.homedir() or something
   const homeDirPath = path.join(__dirname, '../../../../');
-  const fluxbenchdPath = path.join(homeDirPath, '.fluxbenchmark');
+  const fluxbenchdPath = process.env.FLUXBENCH_PATH || path.join(homeDirPath, '.fluxbenchmark');
 
   const exists = await fs.stat(fluxbenchdPath).catch(() => false);
 

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -9,7 +9,9 @@ const deviceHelper = require('./deviceHelper');
 const log = require('../lib/log');
 
 const fluxDirPath = path.join(__dirname, '../../../');
-const appsFolder = `${fluxDirPath}ZelApps/`;
+// ToDo: Fix all the string concatenation in this file and use path.join()
+const appsFolderPath = process.env.FLUX_APPS_FOLDER || path.join(fluxDirPath, 'ZelApps');
+const appsFolder = `${appsFolderPath}/`;
 
 const docker = new Docker();
 

--- a/ZelBack/src/services/fluxshareService.js
+++ b/ZelBack/src/services/fluxshareService.js
@@ -678,6 +678,10 @@ async function fluxShareFileExists(req, res) {
       let { file } = req.params;
       file = file || req.query.file;
 
+      if (!file) {
+        throw new Error('No File specified');
+      }
+
       const filepath = path.join(appsFolder, 'ZelShare', file);
       let fileExists = true;
       try {

--- a/ZelBack/src/services/fluxshareService.js
+++ b/ZelBack/src/services/fluxshareService.js
@@ -15,6 +15,9 @@ const generalService = require('./generalService');
 const log = require('../lib/log');
 const IOUtils = require('./IOUtils');
 
+const dirpath = path.join(__dirname, '../../../');
+const appsFolder = process.env.FLUX_APPS_FOLDER || path.join(dirpath, 'ZelApps');
+
 /**
  * Delete a specific FluxShare file.
  * @param {string} file Name of file to be deleted.
@@ -88,8 +91,7 @@ function getAllFiles(dirPath, arrayOfFiles) {
  * @returns {number} Total file size (GB).
  */
 function getFluxShareSize() {
-  const dirpath = path.join(__dirname, '../../../');
-  const directoryPath = `${dirpath}ZelApps/ZelShare`;
+  const directoryPath = path.join(appsFolder, 'ZelShare');
 
   const arrayOfFiles = getAllFiles(directoryPath);
 
@@ -300,8 +302,7 @@ async function fluxShareDownloadFolder(req, res, authorized = false) {
         return;
       }
 
-      const dirpath = path.join(__dirname, '../../../');
-      const folderpath = `${dirpath}ZelApps/ZelShare/${folder}`;
+      const folderpath = path.join(appsFolder, 'ZelShare', folder);
 
       // beautify name
       const folderNameArray = folderpath.split('/');
@@ -360,8 +361,7 @@ async function fluxShareDownloadFile(req, res) {
         return;
       }
 
-      const dirpath = path.join(__dirname, '../../../');
-      const filepath = `${dirpath}ZelApps/ZelShare/${file}`;
+      const filepath = path.join(appsFolder, 'ZelShare', file);
 
       // beautify name
       const fileNameArray = file.split('/');
@@ -392,8 +392,7 @@ async function fluxShareDownloadFile(req, res) {
       }
 
       // check if file is file. If directory use zelshareDwonloadFolder
-      const dirpath = path.join(__dirname, '../../../');
-      const filepath = `${dirpath}ZelApps/ZelShare/${file}`;
+      const filepath = path.join(appsFolder, 'ZelShare', file);
       const fileStats = await fs.promises.lstat(filepath);
       const isDirectory = fileStats.isDirectory();
 
@@ -452,14 +451,13 @@ async function fluxShareRename(req, res) {
       const fileURI = encodeURIComponent(oldpath);
       await fluxShareDatabaseFileDeleteMultiple(fileURI);
 
-      const dirpath = path.join(__dirname, '../../../');
-      const oldfullpath = `${dirpath}ZelApps/ZelShare/${oldpath}`;
-      let newfullpath = `${dirpath}ZelApps/ZelShare/${newname}`;
+      const oldfullpath = path.join(appsFolder, 'ZelShare', oldpath);
+      let newfullpath = path.join(appsFolder, 'ZelShare', newname);
       const fileURIArray = fileURI.split('%2F');
       fileURIArray.pop();
       if (fileURIArray.length > 0) {
         const renamingFolder = fileURIArray.join('/');
-        newfullpath = `${dirpath}ZelApps/ZelShare/${renamingFolder}/${newname}`;
+        newfullpath = path.join(appsFolder, 'ZelShare', renamingFolder, newname);
       }
       await fs.promises.rename(oldfullpath, newfullpath);
 
@@ -504,8 +502,7 @@ async function fluxShareRemoveFile(req, res) {
 
       await fluxShareDatabaseFileDelete(fileURI);
 
-      const dirpath = path.join(__dirname, '../../../');
-      const filepath = `${dirpath}ZelApps/ZelShare/${file}`;
+      const filepath = path.join(appsFolder, 'ZelShare', file);
       await fs.promises.unlink(filepath);
 
       const response = messageHelper.createSuccessMessage('File Removed');
@@ -545,8 +542,7 @@ async function fluxShareRemoveFolder(req, res) {
         throw new Error('No folder specified');
       }
 
-      const dirpath = path.join(__dirname, '../../../');
-      const filepath = `${dirpath}ZelApps/ZelShare/${folder}`;
+      const filepath = path.join(appsFolder, 'ZelShare', folder);
       // await fs.promises.rmdir(filepath);
       await IOUtils.removeDirectory(filepath);
       const response = messageHelper.createSuccessMessage('Folder Removed');
@@ -583,8 +579,7 @@ async function fluxShareGetFolder(req, res) {
       let { folder } = req.params;
       folder = folder || req.query.folder || '';
 
-      const dirpath = path.join(__dirname, '../../../');
-      const filepath = `${dirpath}ZelApps/ZelShare/${folder}`;
+      const filepath = path.join(appsFolder, 'ZelShare', folder);
       const options = {
         withFileTypes: false,
       };
@@ -654,8 +649,7 @@ async function fluxShareCreateFolder(req, res) {
       let { folder } = req.params;
       folder = folder || req.query.folder || '';
 
-      const dirpath = path.join(__dirname, '../../../');
-      const filepath = `${dirpath}ZelApps/ZelShare/${folder}`;
+      const filepath = path.join(appsFolder, 'ZelShare', folder);
 
       await fs.promises.mkdir(filepath);
 
@@ -684,8 +678,7 @@ async function fluxShareFileExists(req, res) {
       let { file } = req.params;
       file = file || req.query.file;
 
-      const dirpath = path.join(__dirname, '../../../');
-      const filepath = `${dirpath}ZelApps/ZelShare/${file}`;
+      const filepath = path.join(appsFolder, 'ZelShare', file);
       let fileExists = true;
       try {
         await fs.promises.access(filepath, fs.constants.F_OK); // check file exists and write ability
@@ -802,8 +795,8 @@ async function fluxShareUpload(req, res) {
     if (folder) {
       folder += '/';
     }
-    const dirpath = path.join(__dirname, '../../../');
-    const uploadDir = `${dirpath}ZelApps/ZelShare/${folder}`;
+    const uploadDir = path.join(appsFolder, 'ZelShare', folder);
+
     const options = {
       multiples: true,
       uploadDir,

--- a/ZelBack/src/services/syncthingService.js
+++ b/ZelBack/src/services/syncthingService.js
@@ -47,15 +47,14 @@ const asyncLock = new AsyncLock();
 const stc = new FluxController();
 
 /**
- * To get syncthing config xml file
- * @returns {Promise<(string | null)>} config gile (XML).
+ *
+ * Temporary function until Arcane is deployed
+ * @param {string} configDir The uesrs config dir
+ * @param {string} syncthingDir The syncthing config dir
+ * @param {string} configFile  The syncthing config file
+ * @returns {Promise<boolean>}
  */
-async function getConfigFile() {
-  const homedir = os.homedir();
-  const configDir = path.join(homedir, '.config');
-  const syncthingDir = path.join(configDir, 'syncthing');
-  const configFile = path.join(syncthingDir, 'config.xml');
-
+async function changeSyncthingOwnership(configDir, syncthingDir, configFile) {
   const user = os.userInfo().username;
   const owner = `${user}:${user}`;
 
@@ -66,7 +65,7 @@ async function getConfigFile() {
     params: [owner, configDir],
   });
 
-  if (chownConfigDirError) return null;
+  if (chownConfigDirError) return false;
 
   const { error: chownSyncthingError } = await serviceHelper.runCommand('chown', {
     runAsRoot: true,
@@ -74,7 +73,7 @@ async function getConfigFile() {
     params: [owner, syncthingDir],
   });
 
-  if (chownSyncthingError) return null;
+  if (chownSyncthingError) return false;
 
   const { error: chmodError } = await serviceHelper.runCommand('chmod', {
     runAsRoot: true,
@@ -82,7 +81,26 @@ async function getConfigFile() {
     params: ['644', configFile],
   });
 
-  if (chmodError) return null;
+  if (chmodError) return false;
+
+  return true;
+}
+
+/**
+ * To get syncthing config xml file
+ * @returns {Promise<(string | null)>} config file (XML).
+ */
+async function getConfigFile() {
+  const homedir = os.homedir();
+  const configDir = path.join(homedir, '.config');
+  const syncthingDir = process.env.SYNCTHING_PATH || path.join(configDir, 'syncthing');
+  const configFile = path.join(syncthingDir, 'config.xml');
+
+  // only arcane will have this env param
+  if (!process.env.SYNCTHING_PATH) {
+    const ownershipChanged = await changeSyncthingOwnership(configDir, syncthingDir, configFile);
+    if (!ownershipChanged) return null;
+  }
 
   let result = null;
   // this should never reject as chown would error first but just in case
@@ -2478,6 +2496,66 @@ async function stopSyncthingSentinel() {
 }
 
 /**
+ * Temporary function until moved over to Arcane
+ * @param {boolean} installed If syncthing is installed
+ * @returns {Promise<void>}
+ */
+async function ensureSyncthingRunning(installed) {
+  if (!installed || !await getDeviceId()) {
+    log.error('Unable to get syncthing deviceId. Reconfiguring syncthing.');
+    await stopSyncthing();
+    await installSyncthingIdempotently();
+    await configureDirectories();
+
+    const homedir = os.homedir();
+    const syncthingHome = path.join(homedir, '.config/syncthing');
+    const logFile = path.join(syncthingHome, 'syncthing.log');
+
+    log.info('Spawning Syncthing instance...');
+
+    // if nodeJS binary has the CAP_SETUID capability, can then set the uid to 0,
+    // without having to call sudo. IMO, Flux should be run as it's own user, not just
+    // whatever the operator installed as.
+    // this can throw
+
+    // having issues with nodemon and pm2. Using pm2 --no-treekill stops syncthing getting
+    // killed, but then get issues with nodemon not dying.
+
+    // adding old spawn with shell in the interim.
+
+    childProcess.spawn(
+      `sudo nohup syncthing --logfile ${logFile} --logflags=3 --log-max-old-files=2 --log-max-size=26214400 --allow-newer-config --no-browser --home ${syncthingHome} >/dev/null 2>&1 </dev/null &`,
+      { shell: true },
+    ).unref();
+
+    // childProcess.spawn(
+    //   'sudo',
+    //   [
+    //     'nohup',
+    //     'syncthing',
+    //     '--logfile',
+    //     logFile,
+    //     '--logflags=3',
+    //     '--log-max-old-files=2',
+    //     '--log-max-size=26214400',
+    //     '--allow-newer-config',
+    //     '--no-browser',
+    //     '--home',
+    //     syncthingHome,
+    //   ],
+    //   {
+    //     detached: true,
+    //     stdio: 'ignore',
+    //     // uid: 0,
+    //   },
+    // ).unref();
+
+    // let syncthing set itself up
+    await stc.sleep(5 * 1000);
+  }
+}
+
+/**
  * Main syncthing runner. Controller (stc) will loop this function
  * @returns {number} ms until next iteration
  */
@@ -2490,60 +2568,11 @@ async function runSyncthingSentinel() {
   }
 
   try {
-    if (!installed || !await getDeviceId()) {
-      log.error('Unable to get syncthing deviceId. Reconfiguring syncthing.');
-      await stopSyncthing();
-      await installSyncthingIdempotently();
-      await configureDirectories();
-
-      const homedir = os.homedir();
-      const syncthingHome = path.join(homedir, '.config/syncthing');
-      const logFile = path.join(syncthingHome, 'syncthing.log');
-
-      if (stc.aborted) return 0;
-
-      log.info('Spawning Syncthing instance...');
-
-      // if nodeJS binary has the CAP_SETUID capability, can then set the uid to 0,
-      // without having to call sudo. IMO, Flux should be run as it's own user, not just
-      // whatever the operator installed as.
-      // this can throw
-
-      // having issues with nodemon and pm2. Using pm2 --no-treekill stops syncthing getting
-      // killed, but then get issues with nodemon not dying.
-
-      // adding old spawn with shell in the interim.
-
-      childProcess.spawn(
-        `sudo nohup syncthing --logfile ${logFile} --logflags=3 --log-max-old-files=2 --log-max-size=26214400 --allow-newer-config --no-browser --home ${syncthingHome} >/dev/null 2>&1 </dev/null &`,
-        { shell: true },
-      ).unref();
-
-      // childProcess.spawn(
-      //   'sudo',
-      //   [
-      //     'nohup',
-      //     'syncthing',
-      //     '--logfile',
-      //     logFile,
-      //     '--logflags=3',
-      //     '--log-max-old-files=2',
-      //     '--log-max-size=26214400',
-      //     '--allow-newer-config',
-      //     '--no-browser',
-      //     '--home',
-      //     syncthingHome,
-      //   ],
-      //   {
-      //     detached: true,
-      //     stdio: 'ignore',
-      //     // uid: 0,
-      //   },
-      // ).unref();
-
-      // let syncthing set itself up
-      await stc.sleep(5 * 1000);
+    if (!process.env.SYNCTHING_PATH) {
+      await ensureSyncthingRunning();
     }
+
+    if (stc.aborted) return 0;
 
     // every 8 minutes call adjustSyncthing to check service folders
     // this will also run on first iteration

--- a/ZelBack/src/services/systemService.js
+++ b/ZelBack/src/services/systemService.js
@@ -521,7 +521,13 @@ async function mongoDBConfig() {
   log.info('MongoDB file config verification...');
   try {
     const hashCurrent = hash(await fs.readFile('/etc/mongod.conf'));
-    const vailidHashes = ['4646c649230b8125c7894d618313039f20d1901b', '1b20cbacf63c4400d0bf90188615db78b9a7602e'];
+    // 6a6fa is latest fluxOS image config
+    // other 2 ar existing fluxOS config files
+    const vailidHashes = [
+      '6a6fa72bf83ee5d8f665bed2119e649366f47645',
+      '4646c649230b8125c7894d618313039f20d1901b',
+      '1b20cbacf63c4400d0bf90188615db78b9a7602e',
+    ];
     if (vailidHashes.indexOf(hashCurrent) !== -1) {
       log.info('MongoDB config verification passed.');
       return;

--- a/ZelBack/src/services/utils/daemonConfig.js
+++ b/ZelBack/src/services/utils/daemonConfig.js
@@ -83,7 +83,7 @@ class DaemonConfig {
 
     const { fluxPath, zelPath } = DaemonConfig.daemonConfigPaths[this.platform];
 
-    const fluxConf = path.join(this.baseDir, fluxPath);
+    const fluxConf = process.env.FLUXD_CONFIG_PATH || path.join(this.baseDir, fluxPath);
     const zelConf = path.join(this.baseDir, zelPath);
 
     const fluxExists = await fs.stat(fluxConf).catch(() => false);

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "config": "~3.3.9",
     "cors": "~2.8.5",
     "crontab": "~1.4.2",
-    "daemonrpc": "file:lib/daemonrpc",
     "dockerode": "~3.3.5",
     "express": "~4.19.2",
     "fast-xml-parser": "~4.3.2",
@@ -120,8 +119,7 @@
     "tar": "^7.4.3",
     "ws": "~7.5.9",
     "xterm": "~5.1.0",
-    "zeltrezjs": "~2.12.0",
-    "zeromq": "~5.3.1"
+    "zeltrezjs": "~2.12.0"
   },
   "devDependencies": {
     "@babel/core": "~7.23.6",
@@ -195,5 +193,9 @@
     "xterm-addon-serialize": "~0.11.0",
     "xterm-addon-unicode11": "~0.6.0",
     "xterm-addon-web-links": "~0.9.0"
+  },
+  "optionalDependencies": {
+    "zeromq5": "npm:zeromq@~5.3.1",
+    "zeromq6": "npm:zeromq@~6.0.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -196,6 +196,6 @@
   },
   "optionalDependencies": {
     "zeromq5": "npm:zeromq@~5.3.1",
-    "zeromq6": "npm:zeromq@~6.0.8"
+    "zeromq6": "npm:zeromq@~6.1.2"
   }
 }

--- a/tests/unit/fluxshareService.test.js
+++ b/tests/unit/fluxshareService.test.js
@@ -1027,11 +1027,15 @@ describe('idService tests', () => {
           test: 'test2',
         },
       };
-      sinon.stub(fs.promises, 'access').throws('error');
+
+      const expected = {
+        status: 'error',
+        data: { code: undefined, name: 'Error', message: 'No File specified' },
+      };
 
       await fluxshareService.fluxShareFileExists(req, res);
 
-      sinon.assert.calledOnceWithExactly(res.json, { status: 'success', data: { fileExists: false } });
+      sinon.assert.calledOnceWithExactly(res.write, JSON.stringify(expected));
     });
   });
 


### PR DESCRIPTION
Update paths for Arcane. 

We now use the following non hardcoded paths from `process.env` (If they don't exist it falls back to the old paths):

```
FLUXD_CONFIG_PATH
SYNCTHING_PATH
FLUXBENCH_PATH
FLUX_APPS_FOLDER
```

I have also moved the `zeromq` dep to optional. It's not actually being used in the code yet, but it's good to have installed for when we do. (All existing nodes have it already anyway)

I had to move this to optional as Ubuntu 24.04 will not run version 5.x due to GLIBC versions. Optional is good as it will only install it if it can. 

ToDo:
*  Live image testing on both old and new nodes.
* ~~Run the test suite and fix broken tests.~~