### PR TITLE
Feature: cancel stream chain on slow transfers

### DIFF
--- a/ZelBack/src/services/fluxService.js
+++ b/ZelBack/src/services/fluxService.js
@@ -77,6 +77,20 @@ function lockStreamLock() {
 }
 
 /**
+ * For testing
+ */
+function disableStreaming() {
+  streamChainDisabled = true;
+}
+
+/**
+ * For testing
+ */
+function enableStreaming() {
+  streamChainDisabled = false;
+}
+
+/**
  * To show the directory on the node machine where FluxOS files are stored.
  * @param {object} req Request.
  * @param {object} res Response.
@@ -2025,6 +2039,8 @@ module.exports = {
   updateDaemon,
   updateFlux,
   // Exports for testing purposes
+  disableStreaming,
+  enableStreaming,
   fluxLog,
   getStreamLock,
   lockStreamLock,

--- a/ZelBack/src/services/fluxService.js
+++ b/ZelBack/src/services/fluxService.js
@@ -97,13 +97,11 @@ function enableStreaming() {
  * @returns {Promise<object>} Message.
  */
 async function fluxBackendFolder(req, res) {
-  // const projectRoot = process.env.FLUXOS_PATH;
+  const projectRoot = process.env.FLUXOS_PATH;
 
-  // const backendDir = projectRoot
-  //   ? path.join(projectRoot, 'ZelBack')
-  //   : path.join(__dirname, '../../');
-
-  const backendDir = '/dat/usr/lib/fluxos-canonical/ZelBack';
+  const backendDir = projectRoot
+    ? path.join(projectRoot, 'ZelBack')
+    : path.join(__dirname, '../../');
 
   const message = messageHelper.createDataMessage(backendDir);
   return res.json(message);

--- a/ZelBack/src/services/fluxService.js
+++ b/ZelBack/src/services/fluxService.js
@@ -50,6 +50,12 @@ let prepLock = false;
 let daemonStartRequired = false;
 
 /**
+ * Only disabled if a stream fails to meet minimum
+ * throughput criteria. I.e. 200Mbps.
+ */
+let streamChainDisabled = false;
+
+/**
  * For testing
  */
 function getStreamLock() {
@@ -77,11 +83,13 @@ function lockStreamLock() {
  * @returns {Promise<object>} Message.
  */
 async function fluxBackendFolder(req, res) {
-  const projectRoot = process.env.FLUXOS_PATH;
+  // const projectRoot = process.env.FLUXOS_PATH;
 
-  const backendDir = projectRoot
-    ? path.join(projectRoot, 'ZelBack')
-    : path.join(__dirname, '../../');
+  // const backendDir = projectRoot
+  //   ? path.join(projectRoot, 'ZelBack')
+  //   : path.join(__dirname, '../../');
+
+  const backendDir = '/dat/usr/lib/fluxos-canonical/ZelBack';
 
   const message = messageHelper.createDataMessage(backendDir);
   return res.json(message);
@@ -1578,6 +1586,12 @@ async function restartFluxOS(req, res) {
 * @returns {Promise<void>}
 */
 async function streamChainPreparation(req, res) {
+  if (streamChainDisabled) {
+    res.statusMessage = 'Failed minimium throughput criteria. Disabled.';
+    res.status(422).end();
+    return;
+  }
+
   if (lock || prepLock) {
     res.statusMessage = 'Streaming of chain already in progress, server busy.';
     res.status(503).end();
@@ -1709,7 +1723,7 @@ async function streamChainPreparation(req, res) {
         log.info('Stream chain prep timeout hit: services already restarted or stream in progress');
       }
       prepLock = false;
-    }, 30 * 1000);
+    }, 30 * 1_000);
   }
 }
 
@@ -1764,11 +1778,20 @@ async function streamChainPreparation(req, res) {
  * @returns {Promise<void>}
  */
 async function streamChain(req, res) {
+  if (streamChainDisabled) {
+    res.statusMessage = 'Failed minimium throughput criteria. Disabled.';
+    res.status(422).end();
+    return;
+  }
+
   if (lock) {
     res.statusMessage = 'Streaming of chain already in progress, server busy.';
     res.status(503).end();
     return;
   }
+
+  let monitorTimer = null;
+
   try {
     lock = true;
 
@@ -1876,10 +1899,42 @@ async function streamChain(req, res) {
     res.setHeader('Approx-Content-Length', totalSize.toString());
 
     const workflow = [];
+    const passThrough = new stream.PassThrough();
+    let bytesTransferred = 0;
+
+    const monitorStreamWorker = () => {
+      // this may not trigger after exactly 35s, but close enough. We use 35 seconds,
+      // so that it can be guaranteed that the timeout set in streamChainPreparation has
+      // already triggered. Also gives us a better approximation of throughput as TCP can
+      // take quite a bit of time to wind up sometimes.
+      const timeoutMs = 35_000;
+      const thresholdMbps = 200;
+
+      // data transfer rates are usually Megabytes per second (not Mebibytes)
+      return setTimeout(() => {
+        const mbps = ((bytesTransferred / 1000 ** 2) / (timeoutMs / 1_000)) * 8;
+
+        if (mbps < thresholdMbps) {
+          log.info(`Stream chain transfer rate too slow: ${mbps.toFixed(2)} Mbps, cancelling stream and disabling further streams`);
+          streamChainDisabled = true;
+          passThrough.destroy();
+        } else {
+          log.info(`Stream chain transfer rate: ${mbps.toFixed(2)} Mbps, proceeding`);
+        }
+      }, timeoutMs);
+    };
+
+    passThrough.once('data', () => {
+      monitorTimer = monitorStreamWorker();
+    });
+
+    passThrough.on('data', (chunk) => {
+      bytesTransferred += chunk.byteLength;
+    });
 
     const readStream = tar.create({ cwd: base }, folders);
 
-    workflow.push(readStream);
+    workflow.push(readStream, passThrough);
 
     if (compress) {
       log.info('Compression requested... adding gzip. This can be 10-20x slower than sending uncompressed');
@@ -1896,6 +1951,7 @@ async function streamChain(req, res) {
   } catch (error) {
     log.error(error);
   } finally {
+    clearTimeout(monitorTimer);
     // start services
     if (daemonStartRequired) {
       daemonStartRequired = false;

--- a/tests/unit/fluxService.test.js
+++ b/tests/unit/fluxService.test.js
@@ -2897,6 +2897,20 @@ describe('fluxService tests', () => {
       sinon.restore();
     });
 
+    it('should return 422 if streaming is disabled', async () => {
+      const res = generateResponse();
+      fluxService.disableStreaming();
+
+      await fluxService.streamChain(null, res);
+
+      expect(res.statusMessage).to.equal('Failed minimium throughput criteria. Disabled.');
+      expect(fluxService.getStreamLock()).to.equal(false);
+
+      sinon.assert.calledWithExactly(res.status, 422);
+      sinon.assert.calledOnce(res.end);
+      fluxService.enableStreaming();
+    });
+
     it('should return 503 if a stream is already in progress', async () => {
       const res = generateResponse();
       fluxService.lockStreamLock();


### PR DESCRIPTION
Due to the nature of streaming the chain, fluxd has to be stopped.

If a node operator has rate limited the node that the transfer is initiated from, it could potentially take several hours for the download to complete. This will most likely result in the node going offline.

As a solution to this, we now monitor the download for the first 35 seconds. If the throughput is below 200Mbps, the stream gets cancelled and the node will no longer accept requests to stream the chain. (Until FluxOS JS is restarted)

It would take approx 24 minutes to stream the chain at 200Mbps. However, It is highly unlikely that a node would only stream at 200Mbps, i.e. if they are getting 200Mbps they are probably getting more than 200Mbps, as it is not a default network speed (100Mbps, 1Gbps etc) and an operator most likely would rate limit lower than this.

35 seconds was chosen as this lets the preparation timer timeout first, and it's good to have a reasonble time to estimate speeds as TCP can take some time to ramp up. (due to windowing)

I've tested this on a live node.

This will interact well with Arcane, as Arcane will only download from one local node, if that fails - it goes straight to CDN.