### PR TITLE
Polyfill for Node 14.18.1 Promise.any

### DIFF
--- a/ZelBack/src/services/fluxService.js
+++ b/ZelBack/src/services/fluxService.js
@@ -34,6 +34,31 @@ const stream = require('node:stream');
 
 const isArcane = Boolean(process.env.FLUXOS_PATH);
 
+// remove this when nodes are off 14.18.1
+function promiseAnyPolyfill(promisesArray) {
+  const promiseErrors = new Array(promisesArray.length);
+
+  return new Promise((resolve, reject) => {
+    promisesArray.forEach((promise, index) => {
+      Promise.resolve(promise)
+        .then(resolve)
+        .catch((error) => {
+          promiseErrors[index] = error;
+
+          if (index === promisesArray.length - 1) {
+            reject(promiseErrors);
+          }
+        });
+    });
+  });
+}
+
+if (typeof Promise.any === 'undefined') {
+  // polyfill for nodeJS 14.18.1
+  // eslint-disable-next-line global-require
+  globalThis.Promise.any = promiseAnyPolyfill;
+}
+
 /**
  * Stream chain lock, so only one request at a time
  */


### PR DESCRIPTION
Small patch for `fluxService` to allow for use of `Promise.any` of older NodeJS

We could probably just mode this to `apiServer` but not much point if all nodes will be off 14.18.1 soon.

This is the only place we are using `Promise.any`