### PR TITLE
Update ip fetches from fluxd to fluxbenchd

### DIFF
--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -14,7 +14,6 @@ const messageHelper = require('./messageHelper');
 const daemonServiceMiscRpcs = require('./daemonService/daemonServiceMiscRpcs');
 const daemonServiceUtils = require('./daemonService/daemonServiceUtils');
 const daemonServiceFluxnodeRpcs = require('./daemonService/daemonServiceFluxnodeRpcs');
-const daemonServiceBenchmarkRpcs = require('./daemonService/daemonServiceBenchmarkRpcs');
 const daemonServiceWalletRpcs = require('./daemonService/daemonServiceWalletRpcs');
 const benchmarkService = require('./benchmarkService');
 const verificationHelper = require('./verificationHelper');
@@ -363,10 +362,10 @@ function getDosStateValue() {
 
 /**
  * To get Flux IP adress and port.
- * @returns {string} IP address and port.
+ * @returns {Promise<string>} IP address and port.
  */
 async function getMyFluxIPandPort() {
-  const benchmarkResponse = await daemonServiceBenchmarkRpcs.getBenchmarks();
+  const benchmarkResponse = await benchmarkService.getBenchmarks();
   let myIP = null;
   if (benchmarkResponse.status === 'success') {
     const benchmarkResponseData = JSON.parse(benchmarkResponse.data);
@@ -730,7 +729,7 @@ async function adjustExternalIP(ip) {
       myCache.set(ip, ip);
       const newIP = userconfig.initial.apiport !== 16127 ? `${ip}:${userconfig.initial.apiport}` : ip;
       const oldIP = userconfig.initial.apiport !== 16127 ? `${oldUserConfigIp}:${userconfig.initial.apiport}` : oldUserConfigIp;
-      log.info(`New public Ip detected: ${newIP}, old Ip:${oldIP} , updating the FluxNode info in the network`);
+      log.info(`New public Ip detected: ${newIP}, old Ip: ${oldIP} , updating the FluxNode info on the network`);
       const measuredUptime = fluxUptime();
       if (await ipChangesOverLimit() && measuredUptime.status === 'success' && measuredUptime.data > config.fluxapps.minUpTime) {
         log.info('IP changes over the limit allowed, one in 20 hours');
@@ -867,7 +866,7 @@ async function checkMyFluxAvailability(retryNumber = 0) {
         const benchMyIP = benchIpResponse.data.length > 5 ? benchIpResponse.data : null;
         if (benchMyIP && benchMyIP.split(':')[0] !== myIP.split(':')[0]) {
           daemonServiceUtils.setStandardCache('getbenchmarks[]', null);
-          log.info('FluxBench reported a new IP');
+          log.info('New IP found... updating network');
           dosState = 0;
           setDosMessage(null);
           await adjustExternalIP(benchMyIP.split(':')[0]);

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -365,16 +365,19 @@ function getDosStateValue() {
  * @returns {Promise<string>} IP address and port.
  */
 async function getMyFluxIPandPort() {
+  // I'm not sure of the intent here, but it does what it used to do.
+  // Fetches the ip, sets the ip to the fetched value on success, or sets
+  // it to null on error.
+  //
+  // I'm not sure we should be setting it to null, a bench call could fail
+  // for whatever reason, I believe we should only be setting this on success,
+  // or we should count failures to allow for bad rpc calls.
   const benchmarkResponse = await benchmarkService.getBenchmarks();
-  let myIP = null;
-  if (benchmarkResponse.status === 'success') {
-    const benchmarkResponseData = JSON.parse(benchmarkResponse.data);
-    if (benchmarkResponseData.ipaddress) {
-      myIP = benchmarkResponseData.ipaddress.length > 5 ? benchmarkResponseData.ipaddress : null;
-    }
-  }
-  setMyFluxIp(myIP);
-  return myIP;
+  const { status, data: { ipaddress = null } = {} } = benchmarkResponse;
+  const ip = status === 'success' ? ipaddress : null;
+
+  setMyFluxIp(ip);
+  return ip;
 }
 
 /**

--- a/tests/unit/fluxNetworkHelper.test.js
+++ b/tests/unit/fluxNetworkHelper.test.js
@@ -12,7 +12,6 @@ const log = require('../../ZelBack/src/lib/log');
 const serviceHelper = require('../../ZelBack/src/services/serviceHelper');
 const daemonServiceMiscRpcs = require('../../ZelBack/src/services/daemonService/daemonServiceMiscRpcs');
 const daemonServiceUtils = require('../../ZelBack/src/services/daemonService/daemonServiceUtils');
-const daemonServiceBenchmarkRpcs = require('../../ZelBack/src/services/daemonService/daemonServiceBenchmarkRpcs');
 const daemonServiceWalletRpcs = require('../../ZelBack/src/services/daemonService/daemonServiceWalletRpcs');
 const daemonServiceFluxnodeRpcs = require('../../ZelBack/src/services/daemonService/daemonServiceFluxnodeRpcs');
 const fluxCommunicationUtils = require('../../ZelBack/src/services/fluxCommunicationUtils');
@@ -187,14 +186,14 @@ describe('fluxNetworkHelper tests', () => {
   });
 
   describe('getMyFluxIPandPort tests', () => {
-    let daemonStub;
+    let benchStub;
 
     beforeEach(() => {
-      daemonStub = sinon.stub(daemonServiceBenchmarkRpcs, 'getBenchmarks');
+      benchStub = sinon.stub(benchmarkService, 'getBenchmarks');
     });
 
     afterEach(() => {
-      daemonStub.restore();
+      benchStub.restore();
     });
 
     it('should return IP and Port if benchmark response is correct', async () => {
@@ -203,24 +202,24 @@ describe('fluxNetworkHelper tests', () => {
         status: 'success',
         data: JSON.stringify({ ipaddress: ip }),
       };
-      daemonStub.resolves(getBenchmarkResponseData);
+      benchStub.resolves(getBenchmarkResponseData);
 
       const getIpResult = await fluxNetworkHelper.getMyFluxIPandPort();
 
       expect(getIpResult).to.equal(ip);
-      sinon.assert.calledOnce(daemonStub);
+      sinon.assert.calledOnce(benchStub);
     });
 
     it('should return null if daemon\'s response is invalid', async () => {
       const getBenchmarkResponseData = {
         status: 'error',
       };
-      daemonStub.resolves(getBenchmarkResponseData);
+      benchStub.resolves(getBenchmarkResponseData);
 
       const getIpResult = await fluxNetworkHelper.getMyFluxIPandPort();
 
       expect(getIpResult).to.be.null;
-      sinon.assert.calledOnce(daemonStub);
+      sinon.assert.calledOnce(benchStub);
     });
 
     it('should return null if daemon\'s response IP is too short', async () => {
@@ -229,12 +228,12 @@ describe('fluxNetworkHelper tests', () => {
         status: 'success',
         data: JSON.stringify({ ipaddress: ip }),
       };
-      daemonStub.resolves(getBenchmarkResponseData);
+      benchStub.resolves(getBenchmarkResponseData);
 
       const getIpResult = await fluxNetworkHelper.getMyFluxIPandPort();
 
       expect(getIpResult).to.be.null;
-      sinon.assert.calledOnce(daemonStub);
+      sinon.assert.calledOnce(benchStub);
     });
   });
 
@@ -1096,13 +1095,6 @@ describe('fluxNetworkHelper tests', () => {
         },
       };
       sinon.stub(serviceHelper, 'axiosGet').resolves(axiosGetResponse);
-      const getBenchmarkStub = {
-        status: 'success',
-        data: JSON.stringify({
-          ipaddress: '129.0.0.1',
-        }),
-      };
-      sinon.stub(daemonServiceBenchmarkRpcs, 'getBenchmarks').resolves(getBenchmarkStub);
 
       const result = await fluxNetworkHelper.checkMyFluxAvailability();
 
@@ -1224,7 +1216,7 @@ describe('fluxNetworkHelper tests', () => {
           amount: '1000.00',
           rank: 0,
         }];
-      getBenchmarksStub = sinon.stub(daemonServiceBenchmarkRpcs, 'getBenchmarks');
+      getBenchmarksStub = sinon.stub(benchmarkService, 'getBenchmarks');
       isDaemonSyncedStub = sinon.stub(daemonServiceMiscRpcs, 'isDaemonSynced');
       deterministicFluxListStub = sinon.stub(fluxCommunicationUtils, 'deterministicFluxList');
       getFluxNodeStatusStub = sinon.stub(daemonServiceFluxnodeRpcs, 'getFluxNodeStatus');

--- a/tests/unit/fluxNetworkHelper.test.js
+++ b/tests/unit/fluxNetworkHelper.test.js
@@ -200,7 +200,7 @@ describe('fluxNetworkHelper tests', () => {
       const ip = '127.0.0.1:5050';
       const getBenchmarkResponseData = {
         status: 'success',
-        data: JSON.stringify({ ipaddress: ip }),
+        data: { ipaddress: ip },
       };
       benchStub.resolves(getBenchmarkResponseData);
 
@@ -1228,11 +1228,11 @@ describe('fluxNetworkHelper tests', () => {
       sinon.restore();
     });
 
-    it('should not change dosMessage ', async () => {
+    it('should not change dosMessage', async () => {
       const ip = '127.0.0.1:5050';
       const getBenchmarkResponseData = {
         status: 'success',
-        data: JSON.stringify({ ipaddress: ip }),
+        data: { ipaddress: ip },
       };
       getBenchmarksStub.resolves(getBenchmarkResponseData);
       isDaemonSyncedStub.returns({ data: { synced: true } });
@@ -1277,7 +1277,7 @@ describe('fluxNetworkHelper tests', () => {
       const ip = '127.0.0.1:5050';
       const getBenchmarkResponseData = {
         status: 'success',
-        data: JSON.stringify({ ipaddress: ip }),
+        data: { ipaddress: ip },
       };
       getBenchmarksStub.resolves(getBenchmarkResponseData);
       isDaemonSyncedStub.returns({ data: { synced: true } });
@@ -1301,7 +1301,7 @@ describe('fluxNetworkHelper tests', () => {
       const ip = '127.0.0.1:5050';
       const getBenchmarkResponseData = {
         status: 'success',
-        data: JSON.stringify({ ipaddress: ip }),
+        data: { ipaddress: ip },
       };
       getBenchmarksStub.resolves(getBenchmarkResponseData);
       isDaemonSyncedStub.returns({ data: { synced: true } });

--- a/tests/unit/fluxNetworkHelper.test.js
+++ b/tests/unit/fluxNetworkHelper.test.js
@@ -1,10 +1,11 @@
 /* eslint-disable no-underscore-dangle */
+global.userconfig = require('../../config/userconfig');
+
 const chai = require('chai');
 const sinon = require('sinon');
 const WebSocket = require('ws');
 const path = require('path');
 const chaiAsPromised = require('chai-as-promised');
-const proxyquire = require('proxyquire');
 const fs = require('fs').promises;
 const util = require('util');
 const log = require('../../ZelBack/src/lib/log');
@@ -15,19 +16,13 @@ const daemonServiceBenchmarkRpcs = require('../../ZelBack/src/services/daemonSer
 const daemonServiceWalletRpcs = require('../../ZelBack/src/services/daemonService/daemonServiceWalletRpcs');
 const daemonServiceFluxnodeRpcs = require('../../ZelBack/src/services/daemonService/daemonServiceFluxnodeRpcs');
 const fluxCommunicationUtils = require('../../ZelBack/src/services/fluxCommunicationUtils');
+const fluxNetworkHelper = require('../../ZelBack/src/services/fluxNetworkHelper');
 const benchmarkService = require('../../ZelBack/src/services/benchmarkService');
 const verificationHelper = require('../../ZelBack/src/services/verificationHelper');
 
 const {
   outgoingConnections, outgoingPeers, incomingPeers, incomingConnections,
 } = require('../../ZelBack/src/services/utils/establishedConnections');
-
-const adminConfig = require('../../config/userconfig');
-
-const fluxNetworkHelper = proxyquire(
-  '../../ZelBack/src/services/fluxNetworkHelper',
-  { '../../../config/userconfig': adminConfig },
-);
 
 chai.use(chaiAsPromised);
 const { expect } = chai;
@@ -1166,7 +1161,7 @@ describe('fluxNetworkHelper tests', () => {
     });
 
     it('should not write to file if the config already has same exact ip', () => {
-      const newIp = adminConfig.initial.ipaddress;
+      const newIp = userconfig.initial.ipaddress;
 
       fluxNetworkHelper.adjustExternalIP(newIp);
 


### PR DESCRIPTION
This moves the IP fetches (via benchmark) from fluxd to fluxbenchd. This removes unnecessary complexity from the IP fetch chain.

Here is an overview:
* Fixes the broken `fluxNetworkHelper` tests - these wern't passing the userconfig correctly. This also removes proxquire, as it's not needed. It wasn't noticed before that these were broken as they were never run as standalone tests. (I run them standalone on docker)
* Uses fluxbenchd instead of fluxd for benchmarks
* Removes no longer needed json parsing.

I have left a couple of comments in the `getMyFluxIPandPort` function - I'm not sure we should be setting the ip to null on a failed rpc call?

I have this running on a test node now - I'd like to run it for at least a couple more hours though