### PR TITLE
Disable console logging on non tty apps

### DIFF
--- a/ZelBack/src/lib/log.js
+++ b/ZelBack/src/lib/log.js
@@ -70,7 +70,7 @@ function debug(args) {
     return;
   }
   try {
-    console.log(args);
+    if (process.stdout.isTTY) console.log(args);
     // write to file
     const filepath = `${homeDirPath}debug.log`;
     writeToFile(filepath, args);

--- a/ZelBack/src/lib/log.js
+++ b/ZelBack/src/lib/log.js
@@ -10,6 +10,8 @@ const levels = {
   debug: 3,
 };
 
+const isArcane = Boolean(process.env.FLUXOS_PATH);
+
 const logLevel = config && config.logLevel ? config.logLevel : levels.debug;
 
 const homeDirPath = path.join(__dirname, '../../../');
@@ -70,7 +72,7 @@ function debug(args) {
     return;
   }
   try {
-    if (process.stdout.isTTY) console.log(args);
+    if (!isArcane) console.log(args);
     // write to file
     const filepath = `${homeDirPath}debug.log`;
     writeToFile(filepath, args);


### PR DESCRIPTION
This is a simple change, however might have some implications so I thought I would do up a PR for discussion.

This is just a quick fix until we redo the logging module and clean up all the excessive logging, so it's more succinct. I.e. not logging entire axios errors, all the websocket errors etc. 

By default, Gravity logs to both to files and stdout, which is quite costly in terms of performance.

All this pull does is disable console logging if no tty is attached - this is 99% of the time. You only get a tty attached if you start it directly, I.e. `node app.js` in the terminal.

This is causing high memory usage for `systemd-journald` as it is logging all of Gravity's stdout output.