### PR TITLE
Feature - allow limiting listfluxnodes response

### DIFF
--- a/ZelBack/src/routes.js
+++ b/ZelBack/src/routes.js
@@ -56,10 +56,10 @@ module.exports = (app) => {
     daemonServiceNodeRpcs.listFluxNodes(req, res);
   });
   app.get('/daemon/viewdeterministicfluxnodelist/:filter?', cache('30 seconds'), (req, res) => {
-    daemonServiceNodeRpcs.viewDeterministicFluxNodeList(req, res);
+    daemonServiceNodeRpcs.listFluxNodes(req, res);
   });
   app.get('/daemon/viewdeterministiczelnodelist/:filter?', cache('30 seconds'), (req, res) => { // DEPRECATED
-    daemonServiceNodeRpcs.viewDeterministicFluxNodeList(req, res);
+    daemonServiceNodeRpcs.listFluxNodes(req, res);
   });
   app.get('/daemon/getfluxnodecount', cache('30 seconds'), (req, res) => {
     daemonServiceNodeRpcs.getFluxNodeCount(req, res);

--- a/ZelBack/src/services/daemonService/daemonServiceFluxnodeRpcs.js
+++ b/ZelBack/src/services/daemonService/daemonServiceFluxnodeRpcs.js
@@ -43,8 +43,8 @@ async function listFluxNodes(req, res) {
   response = await daemonServiceUtils.executeCall(rpccall, rpcparameters);
 
   // we allow a 7 digit limit (zero is not allowed)
-  const limitResponse = response.status === 'success'
-    && limit
+  const limitResponse = limit
+    && response.status === 'success'
     && /^[1-9]\d{0,6}$/.test(limit);
 
   if (limitResponse) {

--- a/ZelBack/src/services/daemonService/daemonServiceFluxnodeRpcs.js
+++ b/ZelBack/src/services/daemonService/daemonServiceFluxnodeRpcs.js
@@ -42,10 +42,10 @@ async function listFluxNodes(req, res) {
 
   response = await daemonServiceUtils.executeCall(rpccall, rpcparameters);
 
-  // we allow a 7 digit filter (zero is not allowed)
+  // we allow a 7 digit limit (zero is not allowed)
   const limitResponse = response.status === 'success'
     && limit
-    && /^[1-9]\d{1,7}$/.test(limit);
+    && /^[1-9]\d{0,6}$/.test(limit);
 
   if (limitResponse) {
     // slice works with string numbers so we don't need to convert

--- a/tests/unit/daemonServiceFluxnodeRpcs.test.js
+++ b/tests/unit/daemonServiceFluxnodeRpcs.test.js
@@ -218,7 +218,7 @@ describe('daemonServiceFluxnodeRpcs tests', () => {
       const result = await daemonServiceFluxnodeRpcs.listFluxNodes(req);
 
       expect(result).to.equal(expectedResponse);
-      sinon.assert.calledOnceWithExactly(daemonServiceUtilsStub, 'listzelnodes', []);
+      sinon.assert.calledOnceWithExactly(daemonServiceUtilsStub, 'listfluxnodes', []);
     });
 
     it('should trigger rpc, response passed', async () => {
@@ -238,7 +238,7 @@ describe('daemonServiceFluxnodeRpcs tests', () => {
 
       expect(result).to.equal(`Response: ${expectedResponse}`);
       sinon.assert.calledOnceWithExactly(res.json, expectedResponse);
-      sinon.assert.calledOnceWithExactly(daemonServiceUtilsStub, 'listzelnodes', []);
+      sinon.assert.calledOnceWithExactly(daemonServiceUtilsStub, 'listfluxnodes', []);
     });
 
     it('should trigger rpc, data passed in params, no response passed', async () => {
@@ -256,7 +256,7 @@ describe('daemonServiceFluxnodeRpcs tests', () => {
       const result = await daemonServiceFluxnodeRpcs.listFluxNodes(req);
 
       expect(result).to.equal(expectedResponse);
-      sinon.assert.calledOnceWithExactly(daemonServiceUtilsStub, 'listzelnodes', [req.params.filter]);
+      sinon.assert.calledOnceWithExactly(daemonServiceUtilsStub, 'listfluxnodes', [req.params.filter]);
     });
 
     it('should trigger rpc, data passed in query, no response passed', async () => {
@@ -274,7 +274,7 @@ describe('daemonServiceFluxnodeRpcs tests', () => {
       const result = await daemonServiceFluxnodeRpcs.listFluxNodes(req);
 
       expect(result).to.equal(expectedResponse);
-      sinon.assert.calledOnceWithExactly(daemonServiceUtilsStub, 'listzelnodes', [req.query.filter]);
+      sinon.assert.calledOnceWithExactly(daemonServiceUtilsStub, 'listfluxnodes', [req.query.filter]);
     });
   });
 


### PR DESCRIPTION
This pull does the following:

* Allows limiting response size for `listfluxnodes` aka `viewdeterministiczelnodelist`.
* Tidies up the routes so that they all point at the same backend rpc.

I have a need on Arcane where I want to pull some nodes from the list, but I don't want to pull the entire list as it's ~7Mib and can be quite slow. Using a limit, I can get the first 100 nodes, and the response is a lot faster / smaller.

The backend RPCs are all the same in fluxd so we may as well just use one:

![Screenshot 2025-04-26 at 9 24 18 AM](https://github.com/user-attachments/assets/72ca47a0-7fb9-4e3e-94d3-12fe6b769cff)

I've tested this on one of my nodes