### PR TITLE
hotfix: getAppSpecsUsdPrice

### DIFF
--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -13643,10 +13643,10 @@ async function downloadAppsFile(req, res) {
  */
 async function getAppSpecsUSDPrice(req, res) {
   try {
-    const resMessage = serviceHelper.createDataMessage(config.fluxapps.usdprice);
+    const resMessage = messageHelper.createDataMessage(config.fluxapps.usdprice);
     res.json(resMessage);
   } catch (error) {
-    const errMessage = serviceHelper.createErrorMessage(error.message, error.name, error.code);
+    const errMessage = messageHelper.createErrorMessage(error.message, error.name, error.code);
     res.json(errMessage);
     log.error(error);
   }

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -37,12 +37,13 @@ async function startFluxFunctions() {
       setInterval(() => {
         upnpService.adjustFirewallForUPNP();
       }, 1 * 60 * 60 * 1000); // every 1 hours
-      setTimeout(() => {
-        appsService.callOtherNodeToKeepUpnpPortsOpen();
-        setInterval(() => {
-          appsService.callOtherNodeToKeepUpnpPortsOpen();
-        }, 4 * 60 * 1000);
-      }, 1 * 60 * 1000);
+      // temporarily disabled until we validate the service
+      // setTimeout(() => {
+      //   appsService.callOtherNodeToKeepUpnpPortsOpen();
+      //   setInterval(() => {
+      //     appsService.callOtherNodeToKeepUpnpPortsOpen();
+      //   }, 4 * 60 * 1000);
+      // }, 1 * 60 * 1000);
     }
     await fluxNetworkHelper.addFluxNodeServiceIpToLoopback();
     await fluxNetworkHelper.allowOnlyDockerNetworksToFluxNodeService();


### PR DESCRIPTION
Fixes api call to `getappspecsusdprice` - now uses correct module for message creation.

Stops api call from crashing Gravity.

Also disables the upnp port check until this is tested.