### PR TITLE
Whitelist the docker hub for weedshaker

### DIFF
--- a/helpers/repositories.json
+++ b/helpers/repositories.json
@@ -465,5 +465,6 @@
    "testnet32/flights_scraper",
    "kingsimpa69/50-50.io",
    "archivebox",
-   "jlesage/firefox"
+   "jlesage/firefox",
+   "weedshaker"
 ]


### PR DESCRIPTION
# Application whitelist

- Whitelist is in a place acting as a first defence against malicious people that want to misuse Flux in order to for example mine cryptocurrencies or distribute illegal or copyrighted material. 
- To whitelist an application for Flux, please adjust helpers/repositories.json file by adding your desired whitelist for a specific docker image organisation (recommended), docker image or target a specific tag of an image:
- Valid Examples: runonflux, runonflux/website, runonflux/website:latest, public.ecr.aws/docker/library/hello-world:linux, ghcr.io/handshake-org/hsd

# What do you want to Run On Flux?
a websocket

*Please describe what application(s) do you plan to run.*
an instance of a websocket based on the forked code from y-websocket. https://github.com/Weedshaker/y-websocket/tree/master

# Is your desired application running somewhere already?
yes

*Please provide a POC link to application if it is already running somewhere. (optional)*

# Is your application open source?
yes

*Please provide a source code (optional)*
https://github.com/Weedshaker/y-websocket/tree/master

# Checklist:

- [x] Whitelist of application is only modifying repositories.json file
- [x] repositories.json is still a valid JSON file
- [x] Only whitelists single docker image organisation (one whitelist at a time, more whitelists, more PRs)
- [x] No other whitelist has been deleted
- [x] I agree with ToS https://cdn.runonflux.io/Flux_Terms_of_Service.pdf
- [x] Application follows ToS - Application is not malicious. Application is not a scam. Application does what is meant to do and does not mislead in any way. Application does not do anything illegal. Application is not a mining application (not even bandwidth mining).
- [x] In case application receives multiple reports, behaves maliciously, it will be blacklisted and removed from the network.
