### PR TITLE
Sync permanent app message on node startup

### DIFF
--- a/ZelBack/src/routes.js
+++ b/ZelBack/src/routes.js
@@ -331,7 +331,7 @@ module.exports = (app) => {
   app.get('/apps/temporarymessages/:hash?', cache('5 seconds'), (req, res) => {
     appsService.getAppsTemporaryMessages(req, res);
   });
-  app.get('/apps/permanentmessages/:hash?/:owner?/:appname?', cache('30 seconds'), (req, res) => {
+  app.get('/apps/permanentmessages/:hash?/:owner?/:appname?', cache('2 minutes'), (req, res) => {
     appsService.getAppsPermanentMessages(req, res);
   });
   app.get('/apps/globalappsspecifications/:hash?/:owner?/:appname?', cache('30 seconds'), (req, res) => {

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -14489,7 +14489,7 @@ async function syncAppsMessages() {
     };
     log.info('syncAppsMessages - Getting permanentmessages from api.runonflux.io');
     const response = await serviceHelper.axiosGet('http://api.runonflux.io/apps/permanentmessages', axiosConfig).catch((error) => log.error(error));
-    if (!response || !response.data || response.status !== 'success') {
+    if (!response || !response.data || response.data.status !== 'success' || !response.data.data) {
       log.info('Failed to get permanentappmessages from api.runonflux.io');
       return;
     }
@@ -14499,8 +14499,8 @@ async function syncAppsMessages() {
     };
     const db = dbHelper.databaseConnection();
     const database = db.db(config.database.appsglobal.database);
-    log.info(`syncAppsMessages - Inserting ${response.data.length} permanentappmessages on db.`);
-    await dbHelper.insertManyToDatabase(database, globalAppsMessages, response.data, options);
+    log.info(`syncAppsMessages - Inserting ${response.data.data.length} permanentappmessages on db.`);
+    await dbHelper.insertManyToDatabase(database, globalAppsMessages, response.data.data, options);
     log.info('syncAppsMessages - Finished.');
   } catch (error) {
     log.error(error);

--- a/ZelBack/src/services/explorerService.js
+++ b/ZelBack/src/services/explorerService.js
@@ -806,6 +806,8 @@ async function initiateBlockProcessor(restoreDatabase, deepRestore, reindexOrRes
       // what if 2 app adjustment come in the same block?
       // log.info(resultE, resultF);
       log.info('Preparation done');
+      // let's try to sync permanent app messages from Arcane Node
+      await appsService.syncAppsMessages();
     }
     if (daemonHeight > scannedBlockHeight) {
       if (scannedBlockHeight !== 0 && restoreDatabase === true) {


### PR DESCRIPTION
This will sync permanent app messages on node fresh startup with call to api.runonflux.io.
api.runonflux.io is now pointing to only arcane nodes, so we know the data from it is legit.
This should speed up a lot the node time to sync and reduce cpu usage on sync stage.