### PR TITLE
Improvements for v8 app specs

### DIFF
--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -9897,7 +9897,7 @@ async function trySpawningGlobalApplication() {
 
       log.info(`trySpawningGlobalApplication - Application ${appToRun} selected to try to spawn. Reported as been running in ${appToRunAux.actual} instances and ${appToRunAux.required} are required.`);
       if (appToRunAux.enterprise && !isArcane) {
-        log.info('trySpawningGlobalApplication - app missing one instance failed the 15% probability check to install');
+        log.info('trySpawningGlobalApplication - app can only install on ArcaneOS');
         spawnErrorsLongerAppCache.set(appHash, appHash);
         await serviceHelper.delay(5 * 60 * 1000);
         trySpawningGlobalApplication();
@@ -9950,10 +9950,11 @@ async function trySpawningGlobalApplication() {
     }
 
     // get app specifications
-    const appSpecifications = await getApplicationGlobalSpecifications(appToRun);
+    let appSpecifications = await getApplicationGlobalSpecifications(appToRun);
     if (!appSpecifications) {
       throw new Error(`trySpawningGlobalApplication - Specifications for application ${appToRun} were not found!`);
     }
+    appSpecifications = await checkAndDecryptAppSpecs(appSpecifications);
 
     // eslint-disable-next-line no-restricted-syntax
     const dbopen = dbHelper.databaseConnection();

--- a/ZelBack/src/services/fluxService.js
+++ b/ZelBack/src/services/fluxService.js
@@ -2022,13 +2022,27 @@ async function streamChain(req, res) {
   }
 }
 
+// Return boolean true if system is running ArcaneOS
+async function isSystemSecure() {
+  try {
+    const benchmarkResponse = await benchmarkService.getBenchmarks();
+    if (benchmarkResponse.status === 'error') {
+      throw new Error('Not possible to check if node is ArcaneOS.');
+    }
+    return benchmarkResponse.data.systemsecure;
+  } catch (error) {
+    log.error(error);
+    return false;
+  }
+}
+
 /**
  * Returns information if node is running ArcaneOS
  * @param {object} req Request.
  * @param {object} res Response.
  */
 async function isArcaneOs(req, res) {
-  const response = messageHelper.createDataMessage(isArcane);
+  const response = messageHelper.createDataMessage(await isSystemSecure());
   res.json(response);
 }
 


### PR DESCRIPTION
List of changes:
- Add now property called arcaneSender to fluxappregister and fluxappupdate types that identifies if the node sending the message it's Arcane Node;
- Improve code to remove duplicated code on storeAppTemporaryMessage;
- If message is v8 enteprise check if sender is ArcaneOs if not do not accept message;
- If message is v8 enteprise, validate the app if the node receiving is ArcaneOS;
- Fix we were storing and sending v8 entperprise apps decrypted instead of encrypted;
- Fix decrypting app specs on try spawn global apps;
- Other fixes and code improvements.