### PR TITLE
Get all app messages on one shot after explorer is synced for first time

### DIFF
--- a/ZelBack/src/routes.js
+++ b/ZelBack/src/routes.js
@@ -1429,4 +1429,7 @@ module.exports = (app) => {
   app.get('/apps/downloadfolder/:appname?/:component?/:folder?', (req, res) => {
     appsService.downloadAppsFolder(req, res);
   });
+  app.get('/explorer/issynced', cache('30 seconds'), (req, res) => {
+    explorerService.isExplorerSynced(req, res);
+  });
 };

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -8911,7 +8911,7 @@ async function checkAndSyncAppHashes() {
           // eslint-disable-next-line no-continue
           continue;
         } */
-        log.info(`checkAndSyncAppHashes - Explorer is not synced on ${client.ip}:${client.port}`);
+        log.info(`checkAndSyncAppHashes - Explorer is synced on ${client.ip}:${client.port}`);
         axiosConfig = {
           timeout: 120000,
         };
@@ -8946,6 +8946,7 @@ async function checkAndSyncAppHashes() {
           }
         }
         finished = true;
+        log.info('checkAndSyncAppHashes - Process finished');
       }
     }
     checkAndSyncAppHashesWasEverExecuted = true;

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -8898,7 +8898,7 @@ async function checkAndSyncAppHashes() {
         let axiosConfig = {
           timeout: 5000,
         };
-        log.info(`checkAndSyncAppHashes - Getting explorer sync status from ${client.ip}:${client.port}`);
+        /* log.info(`checkAndSyncAppHashes - Getting explorer sync status from ${client.ip}:${client.port}`);
         // eslint-disable-next-line no-await-in-loop
         const response = await serviceHelper.axiosGet(`http://${client.ip}:${client.port}/explorer/sync`, axiosConfig).catch((error) => log.error(error));
         if (!response || !response.data || response.data.status !== 'success') {
@@ -8910,7 +8910,7 @@ async function checkAndSyncAppHashes() {
           log.info(`checkAndSyncAppHashes - Explorer is not synced on ${client.ip}:${client.port}`);
           // eslint-disable-next-line no-continue
           continue;
-        }
+        } */
         log.info(`checkAndSyncAppHashes - Explorer is not synced on ${client.ip}:${client.port}`);
         axiosConfig = {
           timeout: 120000,

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -8946,6 +8946,8 @@ async function checkAndSyncAppHashes() {
           }
         }
         finished = true;
+        // eslint-disable-next-line no-await-in-loop, no-use-before-define
+        await expireGlobalApplications();
         log.info('checkAndSyncAppHashes - Process finished');
       }
     }
@@ -9874,6 +9876,13 @@ async function trySpawningGlobalApplication() {
     // check if we are synced
     const synced = await generalService.checkSynced();
     if (synced !== true) {
+      log.info('Flux not yet synced');
+      await serviceHelper.delay(config.fluxapps.installation.delay * 1000);
+      trySpawningGlobalApplication();
+      return;
+    }
+
+    if (!checkAndSyncAppHashesWasEverExecuted) {
       log.info('Flux not yet synced');
       await serviceHelper.delay(config.fluxapps.installation.delay * 1000);
       trySpawningGlobalApplication();

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -8954,6 +8954,7 @@ async function checkAndSyncAppHashes() {
     checkAndSyncAppHashesWasEverExecuted = true;
   } catch (error) {
     log.error(error);
+    checkAndSyncAppHashesWasEverExecuted = true;
   }
 }
 

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -8902,16 +8902,16 @@ async function checkAndSyncAppHashes() {
         // eslint-disable-next-line no-await-in-loop
         const response = await serviceHelper.axiosGet(`http://${client.ip}:${client.port}/explorer/sync`, axiosConfig).catch((error) => log.error(error));
         if (!response || !response.data || response.data.status !== 'success') {
-          log.info(`Failed to get explorer sync status from ${client.ip}:${client.port}`);
+          log.info(`checkAndSyncAppHashes - Failed to get explorer sync status from ${client.ip}:${client.port}`);
           // eslint-disable-next-line no-continue
           continue;
         }
         if (!response.data.data) {
-          log.info(`Explorer is not synced on ${client.ip}:${client.port}`);
+          log.info(`checkAndSyncAppHashes - Explorer is not synced on ${client.ip}:${client.port}`);
           // eslint-disable-next-line no-continue
           continue;
         }
-        log.info(`Explorer is not synced on ${client.ip}:${client.port}`);
+        log.info(`checkAndSyncAppHashes - Explorer is not synced on ${client.ip}:${client.port}`);
         axiosConfig = {
           timeout: 120000,
         };
@@ -8919,7 +8919,7 @@ async function checkAndSyncAppHashes() {
         // eslint-disable-next-line no-await-in-loop
         const appsResponse = await serviceHelper.axiosGet(`http://${client.ip}:${client.port}/apps/permanentmessages`, axiosConfig).catch((error) => log.error(error));
         if (!appsResponse || !appsResponse.data || appsResponse.data.status !== 'success' || !appsResponse.data.data) {
-          log.info(`Failed to get permanent app messages from ${client.ip}:${client.port}`);
+          log.info(`checkAndSyncAppHashes - Failed to get permanent app messages from ${client.ip}:${client.port}`);
           // eslint-disable-next-line no-continue
           continue;
         }
@@ -8936,6 +8936,8 @@ async function checkAndSyncAppHashes() {
             await storeAppTemporaryMessage(appMessage, true);
             // eslint-disable-next-line no-await-in-loop
             await checkAndRequestApp(appMessage.hash, appMessage.txid, appMessage.height, appMessage.value, 2);
+            // eslint-disable-next-line no-await-in-loop
+            await serviceHelper.delay(50);
           } catch (error) {
             log.error(error);
           }

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -8898,7 +8898,7 @@ async function checkAndSyncAppHashes() {
         let axiosConfig = {
           timeout: 5000,
         };
-        /* log.info(`checkAndSyncAppHashes - Getting explorer sync status from ${client.ip}:${client.port}`);
+        log.info(`checkAndSyncAppHashes - Getting explorer sync status from ${client.ip}:${client.port}`);
         // eslint-disable-next-line no-await-in-loop
         const response = await serviceHelper.axiosGet(`http://${client.ip}:${client.port}/explorer/sync`, axiosConfig).catch((error) => log.error(error));
         if (!response || !response.data || response.data.status !== 'success') {
@@ -8910,7 +8910,7 @@ async function checkAndSyncAppHashes() {
           log.info(`checkAndSyncAppHashes - Explorer is not synced on ${client.ip}:${client.port}`);
           // eslint-disable-next-line no-continue
           continue;
-        } */
+        }
         log.info(`checkAndSyncAppHashes - Explorer is synced on ${client.ip}:${client.port}`);
         axiosConfig = {
           timeout: 120000,

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -8900,7 +8900,7 @@ async function checkAndSyncAppHashes() {
         };
         log.info(`checkAndSyncAppHashes - Getting explorer sync status from ${client.ip}:${client.port}`);
         // eslint-disable-next-line no-await-in-loop
-        const response = await serviceHelper.axiosGet(`http://${client.ip}:${client.port}/explorer/sync`, axiosConfig).catch((error) => log.error(error));
+        const response = await serviceHelper.axiosGet(`http://${client.ip}:${client.port}/explorer/issynced`, axiosConfig).catch((error) => log.error(error));
         if (!response || !response.data || response.data.status !== 'success') {
           log.info(`checkAndSyncAppHashes - Failed to get explorer sync status from ${client.ip}:${client.port}`);
           // eslint-disable-next-line no-continue

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -8892,7 +8892,7 @@ async function checkAndSyncAppHashes() {
     if (numberOfMissingApps > results.length * 0.95) {
       let finished = false;
       let i = 0;
-      while (!finished || i <= 5) {
+      while (!finished && i <= 5) {
         i += 1;
         const client = outgoingPeers[Math.floor(Math.random() * outgoingPeers.length)];
         let axiosConfig = {

--- a/ZelBack/src/services/explorerService.js
+++ b/ZelBack/src/services/explorerService.js
@@ -26,6 +26,7 @@ let operationBlocked = false;
 let initBPfromNoBlockTimeout;
 let initBPfromErrorTimeout;
 let appsTransactions = [];
+let isSynced = false;
 
 // updateFluxAppsPeriod can be between every 4 to 9 blocks
 const updateFluxAppsPeriod = Math.floor(Math.random() * 6 + 4);
@@ -563,7 +564,7 @@ async function processBlock(blockHeight, isInsightExplorer) {
       upsert: true,
     };
     // this should run only when node is synced
-    const isSynced = !(blockDataVerbose.confirmations >= 2);
+    isSynced = !(blockDataVerbose.confirmations >= 2);
     if (isSynced) {
       if (blockHeight % 2 === 0) {
         if (blockDataVerbose.height >= config.fluxapps.epochstart) {
@@ -1529,6 +1530,16 @@ async function getAddressBalance(req, res) {
   }
 }
 
+/**
+ * To get if explorer is synced.
+ * @param {object} req Request.
+ * @param {object} res Response.
+ */
+async function isExplorerSynced(req, res) {
+  const resMessage = messageHelper.createDataMessage(isSynced);
+  res.json(resMessage);
+}
+
 // testing purposes
 function setBlockProccessingCanContinue(value) {
   blockProccessingCanContinue = value;
@@ -1571,4 +1582,5 @@ module.exports = {
 
   // temporary function
   fixExplorer,
+  isExplorerSynced,
 };

--- a/ZelBack/src/services/explorerService.js
+++ b/ZelBack/src/services/explorerService.js
@@ -351,7 +351,7 @@ async function processInsight(blockDataVerbose, database) {
 
 async function insertTransactions(transactions, database) {
   if (transactions.length > 0) {
-    log.info(`Explorer - insertTransactions - Inserting ${transactions.length} transactions to apps ashes collection`);
+    log.info(`Explorer - insertTransactions - Inserting ${transactions.length} transactions to apps hashes collection`);
     try {
       const options = {
         ordered: false,


### PR DESCRIPTION
List of changes:
- Create new API to return if node explorer is synced;
- After explorer is synced for the first time on the continuousFluxAppHashesCheck function we call the new method checkAndSyncAppHashes;
- The new method will be executed only once;
- checkAndSyncAppHashes function, checks if we are missing over 95% of the app messages, if that the case we random connect to a outgoing peer and check if it has the explorer synced, if it is synced, we get all permanent app messages from it. After we order them by height and start processing them. The process is the same as receiving the message like it was sent over websocket, we call the method that does the validations and stores them on the temporary app messages and after we call the method that checks if that message was paid and moves it to permanent app messages and inserts it on globalapps if it is supposed to.

What we are doing here, is if the node is new, or mongodb was cleared, and it was syncing for the first time, instead of being spamming the network with messages, we get all the messages at once from one of the peer nodes, and process them. This should reduce a lot the bandwidth use and cpu usage across the network.

This is executed only once, after it starts using the normal mechanism.

This is a update over the PR done one the feature/syncmongo.