### PR TITLE
Detect broken apps on the network

### DIFF
--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -48,6 +48,7 @@ module.exports = {
         appsTemporaryMessages: 'zelappstemporarymessages', // storages for all flux apps messages that are not yet confirmed on the flux network
         appsLocations: 'zelappslocation', // stores location of flux apps as documents containing name, hash, ip, obtainedAt
         appsInstallingLocations: 'appsinstallinglocations', // stores install location of flux apps as documents containing name, ip, obtainedAt
+        appsInstallingErrorsLocations: 'appsInstallingErrorsLocations', // stores install errors location of flux apps as documents containing name, hash, ip, obtainedAt
       },
     },
     chainparams: {

--- a/ZelBack/src/routes.js
+++ b/ZelBack/src/routes.js
@@ -358,13 +358,13 @@ module.exports = (app) => {
   app.get('/apps/installinglocation/:appname?', cache('30 seconds'), (req, res) => {
     appsService.getAppInstallingLocation(req, res);
   });
-  app.get('/apps/installlinglocations', cache('30 seconds'), (req, res) => {
+  app.get('/apps/installinglocations', cache('30 seconds'), (req, res) => {
     appsService.getAppsInstallingLocations(req, res);
   });
   app.get('/apps/installingerrorslocation/:appname?', cache('30 seconds'), (req, res) => {
     appsService.getAppInstallingErrorsLocation(req, res);
   });
-  app.get('/apps/installlingerrorslocations', cache('30 seconds'), (req, res) => {
+  app.get('/apps/installingerrorslocations', cache('30 seconds'), (req, res) => {
     appsService.getAppsInstallingErrorsLocations(req, res);
   });
   app.post('/apps/calculateprice', (req, res) => { // returns price in flux for both new registration of app and update of app

--- a/ZelBack/src/routes.js
+++ b/ZelBack/src/routes.js
@@ -361,6 +361,12 @@ module.exports = (app) => {
   app.get('/apps/installlinglocations', cache('30 seconds'), (req, res) => {
     appsService.getAppsInstallingLocations(req, res);
   });
+  app.get('/apps/installingerrorslocation/:appname?', cache('30 seconds'), (req, res) => {
+    appsService.getAppInstallingErrorsLocation(req, res);
+  });
+  app.get('/apps/installlingerrorslocations', cache('30 seconds'), (req, res) => {
+    appsService.getAppsInstallingErrorsLocations(req, res);
+  });
   app.post('/apps/calculateprice', (req, res) => { // returns price in flux for both new registration of app and update of app
     appsService.getAppPrice(req, res);
   });

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -10461,9 +10461,12 @@ async function trySpawningGlobalApplication() {
     log.info(`trySpawningGlobalApplication - App ${appToRun} hash: ${appHash}`);
 
     const installingAppErrorsList = await appInstallingErrorsLocation(appToRun);
-    if (installingAppErrorsList.find((app) => !app.expireAt && app.hash === appHash)) {
+    /* if (installingAppErrorsList.find((app) => !app.expireAt && app.hash === appHash)) {
       spawnErrorsLongerAppCache.set(appHash, appHash);
       throw new Error(`trySpawningGlobalApplication - App ${appToRun} is marked as having errors on app installing errors locations.`);
+    } */
+    if (installingAppErrorsList.length > 0) {
+      log.info(`trySpawningGlobalApplication - App ${appToRun} have failed previously to install on ${installingAppErrorsList.length} different nodes`);
     }
 
     runningAppList = await appLocation(appToRun);

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -3809,29 +3809,31 @@ async function registerAppLocally(appSpecs, componentSpecs, res, test = false) {
         await installApplicationHard(specificationsToInstall, appName, isComponent, res, appSpecifications, test);
       }
     } catch (error) {
-      const errorResponse = messageHelper.createErrorMessage(
-        error.message || error,
-        error.name,
-        error.code,
-      );
-      const broadcastedAt = Date.now();
-      const newAppRunningMessage = {
-        type: 'fluxappinstallingerror',
-        version: 1,
-        name: appSpecifications.name,
-        hash: appSpecifications.hash, // hash of application specifics that are running
-        error: serviceHelper.ensureString(errorResponse),
-        ip: myIP,
-        broadcastedAt,
-      };
-      // store it in local database first
-      // eslint-disable-next-line no-await-in-loop, no-use-before-define
-      await storeAppInstallingErrorMessage(newAppRunningMessage);
-      // broadcast messages about running apps to all peers
-      await fluxCommunicationMessagesSender.broadcastMessageToOutgoing(newAppRunningMessage);
-      await serviceHelper.delay(500);
-      await fluxCommunicationMessagesSender.broadcastMessageToIncoming(newAppRunningMessage);
-      // broadcast messages about running apps to all peers
+      if (!test) {
+        const errorResponse = messageHelper.createErrorMessage(
+          error.message || error,
+          error.name,
+          error.code,
+        );
+        const broadcastedAt = Date.now();
+        const newAppRunningMessage = {
+          type: 'fluxappinstallingerror',
+          version: 1,
+          name: appSpecifications.name,
+          hash: appSpecifications.hash, // hash of application specifics that are running
+          error: serviceHelper.ensureString(errorResponse),
+          ip: myIP,
+          broadcastedAt,
+        };
+        // store it in local database first
+        // eslint-disable-next-line no-await-in-loop, no-use-before-define
+        await storeAppInstallingErrorMessage(newAppRunningMessage);
+        // broadcast messages about running apps to all peers
+        await fluxCommunicationMessagesSender.broadcastMessageToOutgoing(newAppRunningMessage);
+        await serviceHelper.delay(500);
+        await fluxCommunicationMessagesSender.broadcastMessageToIncoming(newAppRunningMessage);
+        // broadcast messages about running apps to all peers
+      }
       throw error;
     }
     if (!test) {

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -10209,7 +10209,7 @@ async function getPeerAppsInstallingErrorMessages() {
         timeout: 30000,
       };
       log.info(`getPeerAppsInstallingErrorMessages - Getting app installing errors from ${client.ip}:${client.port}`);
-      const url = `http://${client.ip}:${client.port}/apps/installlingerrorslocations`;
+      const url = `http://${client.ip}:${client.port}/apps/installingerrorslocations`;
       // eslint-disable-next-line no-await-in-loop
       const appsResponse = await serviceHelper.axiosGet(url, axiosConfig).catch((error) => log.error(error));
       if (!appsResponse || !appsResponse.data || appsResponse.data.status !== 'success' || !appsResponse.data.data) {

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -64,6 +64,7 @@ const globalAppsInformation = config.database.appsglobal.collections.appsInforma
 const globalAppsTempMessages = config.database.appsglobal.collections.appsTemporaryMessages;
 const globalAppsLocations = config.database.appsglobal.collections.appsLocations;
 const globalAppsInstallingLocations = config.database.appsglobal.collections.appsInstallingLocations;
+const globalAppsInstallingErrorsLocations = config.database.appsglobal.collections.appsInstallingErrorsLocations;
 
 const supportedArchitectures = ['amd64', 'arm64'];
 
@@ -3790,22 +3791,48 @@ async function registerAppLocally(appSpecs, componentSpecs, res, test = false) {
     }
 
     const specificationsToInstall = isComponent ? appComponent : appSpecifications;
-
-    if (specificationsToInstall.version >= 4) { // version is undefined for component
-      // eslint-disable-next-line no-restricted-syntax
-      for (const appComponentSpecs of specificationsToInstall.compose) {
-        isComponent = true;
-        const hddTier = `hdd${tier}`;
-        const ramTier = `ram${tier}`;
-        const cpuTier = `cpu${tier}`;
-        appComponentSpecs.cpu = test ? 0.2 : appComponentSpecs[cpuTier] || appComponentSpecs.cpu;
-        appComponentSpecs.ram = test ? 300 : appComponentSpecs[ramTier] || appComponentSpecs.ram;
-        appComponentSpecs.hdd = test ? 2 : appComponentSpecs[hddTier] || appComponentSpecs.hdd;
-        // eslint-disable-next-line no-await-in-loop
-        await installApplicationHard(appComponentSpecs, appName, isComponent, res, appSpecifications, test);
+    try {
+      if (specificationsToInstall.version >= 4) { // version is undefined for component
+        // eslint-disable-next-line no-restricted-syntax
+        for (const appComponentSpecs of specificationsToInstall.compose) {
+          isComponent = true;
+          const hddTier = `hdd${tier}`;
+          const ramTier = `ram${tier}`;
+          const cpuTier = `cpu${tier}`;
+          appComponentSpecs.cpu = test ? 0.2 : appComponentSpecs[cpuTier] || appComponentSpecs.cpu;
+          appComponentSpecs.ram = test ? 300 : appComponentSpecs[ramTier] || appComponentSpecs.ram;
+          appComponentSpecs.hdd = test ? 2 : appComponentSpecs[hddTier] || appComponentSpecs.hdd;
+          // eslint-disable-next-line no-await-in-loop
+          await installApplicationHard(appComponentSpecs, appName, isComponent, res, appSpecifications, test);
+        }
+      } else {
+        await installApplicationHard(specificationsToInstall, appName, isComponent, res, appSpecifications, test);
       }
-    } else {
-      await installApplicationHard(specificationsToInstall, appName, isComponent, res, appSpecifications, test);
+    } catch (error) {
+      const errorResponse = messageHelper.createErrorMessage(
+        error.message || error,
+        error.name,
+        error.code,
+      );
+      const broadcastedAt = Date.now();
+      const newAppRunningMessage = {
+        type: 'fluxappinstallingerror',
+        version: 1,
+        name: appSpecifications.name,
+        hash: appSpecifications.hash, // hash of application specifics that are running
+        error: serviceHelper.ensureString(errorResponse),
+        ip: myIP,
+        broadcastedAt,
+      };
+      // store it in local database first
+      // eslint-disable-next-line no-await-in-loop, no-use-before-define
+      await storeAppInstallingErrorMessage(newAppRunningMessage);
+      // broadcast messages about running apps to all peers
+      await fluxCommunicationMessagesSender.broadcastMessageToOutgoing(newAppRunningMessage);
+      await serviceHelper.delay(500);
+      await fluxCommunicationMessagesSender.broadcastMessageToIncoming(newAppRunningMessage);
+      // broadcast messages about running apps to all peers
+      throw error;
     }
     if (!test) {
       const broadcastedAt = Date.now();
@@ -7027,6 +7054,81 @@ async function storeAppInstallingMessage(message) {
 }
 
 /**
+ * To store a message for a app error installing.
+ * @param {object} message Message.
+ * @returns {boolean} True if message is successfully stored and rebroadcasted. Returns false if message is old. Throws an error if invalid.
+ */
+async function storeAppInstallingErrorMessage(message) {
+  /* message object
+  * @param type string
+  * @param version number
+  * @param broadcastedAt number
+  * @param name string
+  * @param hash string
+  * @param ip string
+  * @param error string
+  */
+  if (!message || typeof message !== 'object' || typeof message.type !== 'string' || typeof message.version !== 'number'
+    || typeof message.broadcastedAt !== 'number' || typeof message.ip !== 'string' || typeof message.name !== 'string'
+    || typeof message.hash !== 'number' || typeof message.error !== 'string') {
+    return new Error('Invalid Flux App Installing Error message for storing');
+  }
+
+  if (message.version !== 1) {
+    return new Error(`Invalid Flux App Installing Error message for storing version ${message.version} not supported`);
+  }
+
+  const validTill = message.broadcastedAt + (60 * 60 * 1000); // 60 minutes
+  if (validTill < Date.now()) {
+    log.warn(`Rejecting old/not valid fluxappinstallingerror message, message:${JSON.stringify(message)}`);
+    // reject old message
+    return false;
+  }
+
+  const db = dbHelper.databaseConnection();
+  const database = db.db(config.database.appsglobal.database);
+
+  const newAppInstallingErrorMessage = {
+    name: message.name,
+    hash: message.hash,
+    ip: message.ip,
+    error: message.error,
+    broadcastedAt: new Date(message.broadcastedAt),
+    startCacheAt: new Date(message.broadcastedAt),
+    expireAt: new Date(validTill),
+  };
+
+  let queryFind = { name: newAppInstallingErrorMessage.name, hash: newAppInstallingErrorMessage.hash, ip: newAppInstallingErrorMessage.ip };
+  const projection = { _id: 0 };
+  // we already have the exact same data
+  // eslint-disable-next-line no-await-in-loop
+  const result = await dbHelper.findOneInDatabase(database, globalAppsInstallingErrorsLocations, queryFind, projection);
+  if (result && result.broadcastedAt && result.broadcastedAt >= newAppInstallingErrorMessage.broadcastedAt) {
+    // found a message that was already stored/probably from duplicated message processsed
+    return false;
+  }
+
+  let update = { $set: newAppInstallingErrorMessage };
+  const options = {
+    upsert: true,
+  };
+  // eslint-disable-next-line no-await-in-loop
+  await dbHelper.updateOneInDatabase(database, globalAppsInstallingErrorsLocations, queryFind, update, options);
+
+  queryFind = { name: newAppInstallingErrorMessage.name, hash: newAppInstallingErrorMessage.hash };
+  // we already have the exact same data
+  // eslint-disable-next-line no-await-in-loop
+  const results = await dbHelper.countInDatabase(database, globalAppsInstallingErrorsLocations, queryFind);
+  if (results > 5) {
+    update = { $set: { startCacheAt: null, expireAt: null } };
+    // eslint-disable-next-line no-await-in-loop
+    await dbHelper.updateInDatabase(database, globalAppsInstallingErrorsLocations, queryFind, update);
+  }
+  // all stored, rebroadcast
+  return true;
+}
+
+/**
  * To update DB with new node IP that is running app.
  * @param {object} message Message.
  * @returns {boolean} True if message is valid. Returns false if message is old. Throws an error if invalid/wrong properties.
@@ -9278,7 +9380,7 @@ async function getAppsLocations(req, res) {
 }
 
 /**
- * To get app locations or a location of an app
+ * To get app installing locations or a location of an app
  * @param {string} appname Application Name.
  */
 async function appInstallingLocation(appname) {
@@ -9302,13 +9404,61 @@ async function appInstallingLocation(appname) {
 }
 
 /**
- * To get app locations.
+ * To get app installing locations.
  * @param {object} req Request.
  * @param {object} res Response.
  */
 async function getAppsInstallingLocations(req, res) {
   try {
     const results = await appInstallingLocation();
+    const resultsResponse = messageHelper.createDataMessage(results);
+    res.json(resultsResponse);
+  } catch (error) {
+    log.error(error);
+    const errorResponse = messageHelper.createErrorMessage(
+      error.message || error,
+      error.name,
+      error.code,
+    );
+    res.json(errorResponse);
+  }
+}
+
+/**
+ * To get app installing errors locations or a location of an app
+ * @param {string} appname Application Name.
+ */
+async function appInstallingErrorsLocation(appname) {
+  const dbopen = dbHelper.databaseConnection();
+  const database = dbopen.db(config.database.appsglobal.database);
+  let query = {};
+  if (appname) {
+    query = { name: new RegExp(`^${appname}$`, 'i') }; // case insensitive
+  }
+  const projection = {
+    projection: {
+      _id: 0,
+      name: 1,
+      hash: 1,
+      ip: 1,
+      error: 1,
+      broadcastedAt: 1,
+      cachedAt: 1,
+      expireAt: 1,
+    },
+  };
+  const results = await dbHelper.findInDatabase(database, globalAppsInstallingErrorsLocations, query, projection);
+  return results;
+}
+
+/**
+ * To get app installing errors locations.
+ * @param {object} req Request.
+ * @param {object} res Response.
+ */
+async function getAppsInstallingErrorsLocations(req, res) {
+  try {
+    const results = await appInstallingErrorsLocation();
     const resultsResponse = messageHelper.createDataMessage(results);
     res.json(resultsResponse);
   } catch (error) {
@@ -9361,6 +9511,32 @@ async function getAppInstallingLocation(req, res) {
       throw new Error('No Flux App name specified');
     }
     const results = await appInstallingLocation(appname);
+    const resultsResponse = messageHelper.createDataMessage(results);
+    res.json(resultsResponse);
+  } catch (error) {
+    log.error(error);
+    const errorResponse = messageHelper.createErrorMessage(
+      error.message || error,
+      error.name,
+      error.code,
+    );
+    res.json(errorResponse);
+  }
+}
+
+/**
+ * To get a specific app's installing error locations.
+ * @param {object} req Request.
+ * @param {object} res Response.
+ */
+async function getAppInstallingErrorsLocation(req, res) {
+  try {
+    let { appname } = req.params;
+    appname = appname || req.query.appname;
+    if (!appname) {
+      throw new Error('No Flux App name specified');
+    }
+    const results = await appInstallingErrorsLocation(appname);
     const resultsResponse = messageHelper.createDataMessage(results);
     res.json(resultsResponse);
   } catch (error) {
@@ -10216,6 +10392,12 @@ async function trySpawningGlobalApplication() {
     trySpawningGlobalAppCache.set(appHash, appHash);
     log.info(`trySpawningGlobalApplication - App ${appToRun} hash: ${appHash}`);
 
+    const installingAppErrorsList = await appInstallingErrorsLocation(appToRun);
+    if (installingAppErrorsList.find((app) => !app.expireAt && app.hash === appHash)) {
+      spawnErrorsLongerAppCache.set(appHash, appHash);
+      throw new Error(`trySpawningGlobalApplication - App ${appToRun} is marked as having errors on app installing errors locations.`);
+    }
+
     runningAppList = await appLocation(appToRun);
 
     const adjustedIP = myIP.split(':')[0]; // just IP address
@@ -10528,20 +10710,7 @@ async function trySpawningGlobalApplication() {
       registerOk = false;
     }
     if (!registerOk) {
-      broadcastedAt = Date.now();
       log.info('trySpawningGlobalApplication - Error on registerAppLocally');
-      const appRemovedMessage = {
-        type: 'fluxappremoved',
-        version: 1,
-        appName: appSpecifications.name,
-        ip: myIP,
-        broadcastedAt,
-      };
-      log.info('trySpawningGlobalApplication - Broadcasting appremoved message to the network');
-      // broadcast messages about app removed to all peers
-      await fluxCommunicationMessagesSender.broadcastMessageToOutgoing(appRemovedMessage);
-      await serviceHelper.delay(500);
-      await fluxCommunicationMessagesSender.broadcastMessageToIncoming(appRemovedMessage);
       await serviceHelper.delay(30 * 60 * 1000);
       trySpawningGlobalApplication();
       return;
@@ -10876,11 +11045,15 @@ async function expireGlobalApplications() {
     const appNamesToExpire = appsToExpire.map((res) => res.name);
     // remove appNamesToExpire apps from global database
     // eslint-disable-next-line no-restricted-syntax
-    for (const appName of appNamesToExpire) {
-      log.info(`Expiring application ${appName}`);
-      const queryDeleteApp = { name: appName };
+    for (const app of appsToExpire) {
+      log.info(`Expiring application ${app.name}`);
+      const queryDeleteApp = { name: app.name };
       // eslint-disable-next-line no-await-in-loop
       await dbHelper.findOneAndDeleteInDatabase(databaseApps, globalAppsInformation, queryDeleteApp, projectionApps);
+
+      const queryDeleteAppErrors = { name: app.name, hash: app.hash };
+      // eslint-disable-next-line no-await-in-loop
+      await dbHelper.removeDocumentsFromCollection(databaseApps, globalAppsInstallingErrorsLocations, queryDeleteAppErrors);
     }
 
     // get list of locally installed apps.
@@ -15009,4 +15182,7 @@ module.exports = {
   storeAppInstallingMessage,
   getAppInstallingLocation,
   getAppsInstallingLocations,
+  storeAppInstallingErrorMessage,
+  getAppInstallingErrorsLocation,
+  getAppsInstallingErrorsLocations,
 };

--- a/ZelBack/src/services/dbHelper.js
+++ b/ZelBack/src/services/dbHelper.js
@@ -139,6 +139,20 @@ async function findOneAndUpdateInDatabase(database, collection, query, update, o
 }
 
 /**
+ * Counts document from the DB based on the query
+ *
+ * @param {string} database
+ * @param {string} collection
+ * @param {object} query
+ *
+ * @returns count of documents
+ */
+async function countInDatabase(database, collection, query) {
+  const result = await database.collection(collection).countDocuments(query);
+  return result;
+}
+
+/**
  * Inserts one document into the database, into a specific collection.
  *
  * @param {string} database
@@ -281,4 +295,5 @@ module.exports = {
   closeDbConnection,
   insertManyToDatabase,
   aggregateInDatabase,
+  countInDatabase,
 };

--- a/ZelBack/src/services/dbHelper.js
+++ b/ZelBack/src/services/dbHelper.js
@@ -114,6 +114,19 @@ async function findOneInDatabase(database, collection, query, projection) {
 }
 
 /**
+ * Executes bulkwrite operations on database.
+ *
+ * @param {string} database
+ * @param {string} collection
+ * @param {object} operations
+ * @returns void
+ */
+async function bulkWriteInDatabase(database, collection, operations) {
+  const result = await database.collection(collection).bulkWrite(operations);
+  return result;
+}
+
+/**
  * Updates document from the DB based on the query and update operators and returns it.
  *
  * @param {string} database
@@ -296,4 +309,5 @@ module.exports = {
   insertManyToDatabase,
   aggregateInDatabase,
   countInDatabase,
+  bulkWriteInDatabase,
 };

--- a/ZelBack/src/services/explorerService.js
+++ b/ZelBack/src/services/explorerService.js
@@ -813,7 +813,12 @@ async function initiateBlockProcessor(restoreDatabase, deepRestore, reindexOrRes
             throw error;
           }
         });
-        log.info(resultE, resultF, resultG, resultH);
+        const resultI = await dbHelper.dropCollection(databaseGlobal, config.database.appsglobal.collections.appsInstallingErrorsLocations).catch((error) => {
+          if (error.message !== 'ns not found') {
+            throw error;
+          }
+        });
+        log.info(resultE, resultF, resultG, resultH, resultI);
       }
       await databaseGlobal.collection(config.database.appsglobal.collections.appsMessages).createIndex({ hash: 1 }, { name: 'query for getting zelapp message based on hash', unique: true });
       await databaseGlobal.collection(config.database.appsglobal.collections.appsMessages).createIndex({ txid: 1 }, { name: 'query for getting zelapp message based on txid' });
@@ -838,6 +843,7 @@ async function initiateBlockProcessor(restoreDatabase, deepRestore, reindexOrRes
       await database.collection(config.database.appsglobal.collections.appsLocations).createIndex({ name: 1, ip: 1, broadcastedAt: 1 }, { name: 'query for getting app to ensure we possess a message' });
       await database.collection(config.database.appsglobal.collections.appsInstallingLocations).createIndex({ name: 1 }, { name: 'query for getting zelapp install location based on zelapp specs name' });
       await database.collection(config.database.appsglobal.collections.appsInstallingLocations).createIndex({ name: 1, ip: 1 }, { name: 'query for getting flux app install location based on specs name and node ip' });
+      await database.collection(config.database.appsglobal.collections.appsInstallingErrorsLocations).createIndex({ name: 1, hash: 1 }, { name: 'query for getting flux app install errors location based on specs name and hash' });
       // what if 2 app adjustment come in the same block?
       // log.info(resultE, resultF);
       log.info('Preparation done');

--- a/ZelBack/src/services/explorerService.js
+++ b/ZelBack/src/services/explorerService.js
@@ -843,7 +843,9 @@ async function initiateBlockProcessor(restoreDatabase, deepRestore, reindexOrRes
       await database.collection(config.database.appsglobal.collections.appsLocations).createIndex({ name: 1, ip: 1, broadcastedAt: 1 }, { name: 'query for getting app to ensure we possess a message' });
       await database.collection(config.database.appsglobal.collections.appsInstallingLocations).createIndex({ name: 1 }, { name: 'query for getting zelapp install location based on zelapp specs name' });
       await database.collection(config.database.appsglobal.collections.appsInstallingLocations).createIndex({ name: 1, ip: 1 }, { name: 'query for getting flux app install location based on specs name and node ip' });
+      await database.collection(config.database.appsglobal.collections.appsInstallingErrorsLocations).createIndex({ name: 1 }, { name: 'query for getting flux app install errors location based on specs name' });
       await database.collection(config.database.appsglobal.collections.appsInstallingErrorsLocations).createIndex({ name: 1, hash: 1 }, { name: 'query for getting flux app install errors location based on specs name and hash' });
+      await database.collection(config.database.appsglobal.collections.appsInstallingErrorsLocations).createIndex({ name: 1, hash: 1, ip: 1 }, { name: 'query for getting flux app install errors location based on specs name and hash and node ip' });
       // what if 2 app adjustment come in the same block?
       // log.info(resultE, resultF);
       log.info('Preparation done');

--- a/ZelBack/src/services/fluxCommunicationUtils.js
+++ b/ZelBack/src/services/fluxCommunicationUtils.js
@@ -156,6 +156,16 @@ async function verifyFluxBroadcast(data, obtainedFluxNodesList, currentTimeStamp
           return false;
         }
       }
+    } else if (dataObj.data && dataObj.data.type === 'fluxappinstallingerror') {
+      node = zl.find((key) => key.pubkey === pubKey && dataObj.data.ip && dataObj.data.ip === key.ip); // check ip is on the network and belongs to broadcasted public key
+      if (!node) {
+        zl = await deterministicFluxList();
+        node = zl.find((key) => key.pubkey === pubKey && dataObj.data.ip === key.ip); // check ip is on the network and belongs to broadcasted public key
+        if (!node) {
+          log.warn(`Invalid fluxappinstallingerror message, ip: ${dataObj.data.ip} pubkey: ${pubKey}`); // most of invalids are caused because our deterministic list is cached for couple of minutes
+          return false;
+        }
+      }
     } else if (dataObj.data && dataObj.data.type === 'fluxipchanged') {
       node = zl.find((key) => key.pubkey === pubKey && dataObj.data.oldIP && dataObj.data.oldIP === key.ip); // check ip is on the network and belongs to broadcasted public key
       if (!node) {

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -101,7 +101,9 @@ async function startFluxFunctions() {
     log.info('Flux Apps installing locations prepared');
     // we keep installing error messages for 60 minutes
     await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingErrorsLocations).createIndex({ cachedAt: 1 }, { expireAfterSeconds: 3600 });
-    await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingErrorsLocations).createIndex({ name: 1, hash: 1 }, { name: 'query for getting flux app install errors location based on specs name' });
+    await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingErrorsLocations).createIndex({ name: 1 }, { name: 'query for getting flux app install errors location based on specs name' });
+    await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingErrorsLocations).createIndex({ name: 1, hash: 1 }, { name: 'query for getting flux app install errors location based on specs name and hash' });
+    await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingErrorsLocations).createIndex({ name: 1, hash: 1, ip: 1 }, { name: 'query for getting flux app install errors location based on specs name and hash and node ip' });
     log.info('Flux Apps installing locations prepared');
     fluxNetworkHelper.adjustFirewall();
     log.info('Firewalls checked');

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -99,6 +99,10 @@ async function startFluxFunctions() {
     await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingLocations).createIndex({ name: 1 }, { name: 'query for getting flux app install location based on specs name' });
     await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingLocations).createIndex({ name: 1, ip: 1 }, { name: 'query for getting flux app install location based on specs name and node ip' });
     log.info('Flux Apps installing locations prepared');
+    // we keep installing error messages for 60 minutes
+    await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingErrorsLocations).createIndex({ cachedAt: 1 }, { expireAfterSeconds: 3600 });
+    await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingErrorsLocations).createIndex({ name: 1, hash: 1 }, { name: 'query for getting flux app install errors location based on specs name' });
+    log.info('Flux Apps installing locations prepared');
     fluxNetworkHelper.adjustFirewall();
     log.info('Firewalls checked');
     fluxNetworkHelper.allowNodeToBindPrivilegedPorts();

--- a/tests/unit/globalconfig/default.js
+++ b/tests/unit/globalconfig/default.js
@@ -44,6 +44,7 @@ module.exports = {
         appsTemporaryMessages: 'zelappstemporarymessages', // storages for all flux apps messages that are not yet confirmed on the flux network
         appsLocations: 'zelappslocation', // stores location of flux apps as documents containing name, hash, ip, obtainedAt
         appsInstallingLocations: 'appsInstallingLocations',
+        appsInstallingErrorsLocations: 'appsInstallingErrorsLocations', // stores install errors location of flux apps as documents containing name, hash, ip, obtainedAt
       },
     },
     chainparams: {


### PR DESCRIPTION
Currently if one application is broken and can't install/run, we have the entire network non stop trying to install the app, what causes lots of resources used lost.
This PR prevents that.
If one application fails to install/start, it broadcasts a new message to the network, fluxappinstalling error, with the error that happen.
If the nodes receive more than 5 errors in one hour, the messages are no longer deleted.
If one node broadcast app running for that app name and app hash, the information from that app is deleted from the app installing errors collection.

List of changes:
- Routes
-- Add two new api's to get app installing errors information;

- AppServices
-- Add a try catch specific around the call of installApplicationHard on register registerAppLocally, if there is a error send new message type fluxappinstallingerror to the network;
-- Changed trySpawningGlobalAplicationm on first execution, we call the method getPeerAppsInstallingErrorMessages, that will get from a peer with higher uptime the db info from the app installing error locations;
-- Method to store the new app message type and methods to give support to the new api's;
-- Changed updateAppSpecifications and expireGlobalAplications to delete info from app from the new db with errors;

- dbHelpder
-- Added bulkWriteInDatabase for bulk operations;
-- Added countInDatabase to get the count of documents on a collection.

- fluxCommunications
-- Added method handleAppInstallingErrorMessage and adapt other methods to process the new message type.

- fluxCommunicationUtils
-- Added a check to validate that the node sending the fluxappinstallingerror message match the ip sent on the message.

- serviceManager
-- Inserts new indexes on nodes