### PR TITLE
Improve network issues detection on the nodes

### DIFF
--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -13414,19 +13414,15 @@ async function checkMyAppsAvailability() {
     }
 
     log.info(`checkMyAppsAvailability - Testing port ${testingPort}.`);
-    const portNotWorking = portsNotWorking.includes(testingPort);
-    if (portNotWorking) {
-      log.info(`checkMyAppsAvailability - Testing port ${testingPort} is part of the list of ports not working on this node.`);
-      failedPort = null;
-      // skip this check, port is not possible to run on flux
-      await serviceHelper.delay(15 * 1000);
-      checkMyAppsAvailability();
-      return;
-    }
     let iBP = fluxNetworkHelper.isPortBanned(testingPort);
     if (iBP) {
       log.info(`checkMyAppsAvailability - Testing port ${testingPort} is banned.`);
       failedPort = null;
+      if (originalPortFailed && testingPort > originalPortFailed) {
+        portToTest = originalPortFailed - 1;
+      } else if (originalPortFailed) {
+        portToTest = null;
+      }
       // skip this check, port is not possible to run on flux
       await serviceHelper.delay(15 * 1000);
       checkMyAppsAvailability();
@@ -13437,6 +13433,11 @@ async function checkMyAppsAvailability() {
       if (iBP) {
         log.info(`checkMyAppsAvailability - Testing port ${testingPort} is UPNP banned.`);
         failedPort = null;
+        if (originalPortFailed && testingPort > originalPortFailed) {
+          portToTest = originalPortFailed - 1;
+        } else if (originalPortFailed) {
+          portToTest = null;
+        }
         // skip this check, port is not possible to run on flux
         await serviceHelper.delay(15 * 1000);
         checkMyAppsAvailability();
@@ -13447,6 +13448,11 @@ async function checkMyAppsAvailability() {
     if (isPortUserBlocked) {
       log.info(`checkMyAppsAvailability - Testing port ${testingPort} is user blocked.`);
       failedPort = null;
+      if (originalPortFailed && testingPort > originalPortFailed) {
+        portToTest = originalPortFailed - 1;
+      } else if (originalPortFailed) {
+        portToTest = null;
+      }
       // skip this check, port is not allowed for this flux node by user
       await serviceHelper.delay(15 * 1000);
       checkMyAppsAvailability();
@@ -13455,6 +13461,11 @@ async function checkMyAppsAvailability() {
     if (appPorts.includes(testingPort)) {
       log.info(`checkMyAppsAvailability - Skipped checking ${testingPort} - in use.`);
       failedPort = null;
+      if (originalPortFailed && testingPort > originalPortFailed) {
+        portToTest = originalPortFailed - 1;
+      } else if (originalPortFailed) {
+        portToTest = null;
+      }
       // skip this check
       await serviceHelper.delay(15 * 1000);
       checkMyAppsAvailability();
@@ -13477,6 +13488,11 @@ async function checkMyAppsAvailability() {
         lastUPNPMapFailed = true;
         log.info(`checkMyAppsAvailability - Testing port ${testingPort} failed to create on UPNP mappings. Possible already assigned?`);
         failedPort = null;
+        if (originalPortFailed && testingPort > originalPortFailed) {
+          portToTest = originalPortFailed - 1;
+        } else if (originalPortFailed) {
+          portToTest = null;
+        }
         throw new Error('Failed to create map UPNP port');
       }
       lastUPNPMapFailed = false;

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -13607,7 +13607,9 @@ async function checkMyAppsAvailability() {
         dosMessage = dosMountMessage || dosDuplicateAppMessage || null;
         await serviceHelper.delay(15 * 1000);
       } else {
-        portToTest = portsNotWorking[Math.floor(Math.random() * portsNotWorking.length)];
+        const randomIndex = Math.floor(Math.random() * portsNotWorking.length);
+        portToTest = portsNotWorking[randomIndex];
+        portsNotWorking.splice(randomIndex, 1);
         await serviceHelper.delay(1 * 60 * 1000);
       }
     }

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -13323,9 +13323,8 @@ let failedPort;
 let testingPort;
 const portsNotWorking = [];
 let originalPortFailed;
-let portToTest = false;
+let portToTest = 10000;
 let lastUPNPMapFailed = false;
-let checkMyAppsAvailabilityFirstRun = true;
 async function checkMyAppsAvailability() {
   const isUPNP = upnpService.isUPNP();
   try {
@@ -13408,12 +13407,7 @@ async function checkMyAppsAvailability() {
       testingPort = failedPort || Math.floor(Math.random() * (max - min) + min);
     }
 
-    if (checkMyAppsAvailabilityFirstRun) {
-      testingPort = 10000;
-      checkMyAppsAvailabilityFirstRun = false;
-    }
-
-    log.info(`checkMyAppsAvailability - Testing port ${testingPort}.`);
+     log.info(`checkMyAppsAvailability - Testing port ${testingPort}.`);
     let iBP = fluxNetworkHelper.isPortBanned(testingPort);
     if (iBP) {
       log.info(`checkMyAppsAvailability - Testing port ${testingPort} is banned.`);

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -13323,7 +13323,7 @@ let failedPort;
 let testingPort;
 const portsNotWorking = [];
 let originalPortFailed;
-let portToTest = 10000;
+let portToTest = Math.floor(Math.random() * (25000 - 10000 + 1)) + 10000;
 let lastUPNPMapFailed = false;
 async function checkMyAppsAvailability() {
   const isUPNP = upnpService.isUPNP();

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -13407,7 +13407,7 @@ async function checkMyAppsAvailability() {
       testingPort = failedPort || Math.floor(Math.random() * (max - min) + min);
     }
 
-     log.info(`checkMyAppsAvailability - Testing port ${testingPort}.`);
+    log.info(`checkMyAppsAvailability - Testing port ${testingPort}.`);
     let iBP = fluxNetworkHelper.isPortBanned(testingPort);
     if (iBP) {
       log.info(`checkMyAppsAvailability - Testing port ${testingPort} is banned.`);


### PR DESCRIPTION
We have find out there are several nodes on the network configured with the original port forwarding configuration only allowing apps ports from range 30k to 40k.
This PR fix that by improving the checkMyAppsAvailability() function;

List of changes:
- On first run execute the test on port 10000;
- When a test fails, next we starting testing last failing port +1 until we have a success test, after we start testing original test failed -1 until success;
- After we have 100 ports failed the remaining we start randomly testing one of the 100 ports that have failed;
- Decrease the time between tests when it's failing and the amount of ports that have failed so far is bellow 100;
- Change DOS message for easy understand of the problem for the node operator.