### PR TITLE
Bugfix: pre 6.1.0 v7 signatures unable to be verified

### DIFF
--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -4949,11 +4949,11 @@ async function verifyAppMessageUpdateSignature(type, version, appSpec, timestamp
       // try the old secrets / repoauth
       comp.secrets = secrets;
       comp.repoauth = repoauth;
-
-      const messageToVerifyC = type + version + JSON.stringify(appSpecsClone) + timestamp;
-      // we can just use the btc / eth verifier as v7 specs came out at 1688749251
-      isValidSignature = signatureVerifier.verifySignature(messageToVerifyC, appSpec.owner, signature);
     });
+
+    const messageToVerifyC = type + version + JSON.stringify(appSpecsClone) + timestamp;
+    // we can just use the btc / eth verifier as v7 specs came out at 1688749251
+    isValidSignature = signatureVerifier.verifySignature(messageToVerifyC, appSpec.owner, signature);
   }
   if (isValidSignature !== true) {
     log.debug(`${messageToVerify}, ${appOwner}, ${signature}`);

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -4953,7 +4953,7 @@ async function verifyAppMessageUpdateSignature(type, version, appSpec, timestamp
 
     const messageToVerifyC = type + version + JSON.stringify(appSpecsClone) + timestamp;
     // we can just use the btc / eth verifier as v7 specs came out at 1688749251
-    isValidSignature = signatureVerifier.verifySignature(messageToVerifyC, appSpec.owner, signature);
+    isValidSignature = signatureVerifier.verifySignature(messageToVerifyC, appOwner, signature);
   }
   if (isValidSignature !== true) {
     log.debug(`${messageToVerify}, ${appOwner}, ${signature}`);

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -4938,7 +4938,7 @@ async function verifyAppMessageUpdateSignature(type, version, appSpec, timestamp
   } else if (isValidSignature !== true && appSpec.version === 7) {
     const appSpecsClone = JSON.parse(JSON.stringify(appSpec));
 
-    appSpecsClone.componse.forEach((component) => {
+    appSpecsClone.compose.forEach((component) => {
       // previously the order was secrets / repoauth. Now it's repoauth / secrets.
       const comp = component;
       const { secrets, repoauth } = comp;

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -4842,7 +4842,7 @@ async function verifyAppMessageSignature(type, version, appSpec, timestamp, sign
   } else if (isValidSignature !== true && appSpec.version === 7) {
     const appSpecsClone = JSON.parse(JSON.stringify(appSpec));
 
-    appSpecsClone.forEach((component) => {
+    appSpecsClone.compose.forEach((component) => {
       // previously the order was secrets / repoauth. Now it's repoauth / secrets.
       const comp = component;
       const { secrets, repoauth } = comp;
@@ -4938,7 +4938,7 @@ async function verifyAppMessageUpdateSignature(type, version, appSpec, timestamp
   } else if (isValidSignature !== true && appSpec.version === 7) {
     const appSpecsClone = JSON.parse(JSON.stringify(appSpec));
 
-    appSpecsClone.forEach((component) => {
+    appSpecsClone.componse.forEach((component) => {
       // previously the order was secrets / repoauth. Now it's repoauth / secrets.
       const comp = component;
       const { secrets, repoauth } = comp;

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -4838,6 +4838,26 @@ async function verifyAppMessageSignature(type, version, appSpec, timestamp, sign
     if (timestamp > 1688947200000) {
       isValidSignature = signatureVerifier.verifySignature(messageToVerifyB, appSpec.owner, signature); // btc, eth
     }
+    // fix for repoauth / secrets order change for apps created after 1750273721000
+  } else if (isValidSignature !== true && appSpec.version === 7) {
+    const appSpecsClone = JSON.parse(JSON.stringify(appSpec));
+
+    appSpecsClone.forEach((component) => {
+      // previously the order was secrets / repoauth. Now it's repoauth / secrets.
+      const comp = component;
+      const { secrets, repoauth } = comp;
+
+      delete comp.secrets;
+      delete comp.repoauth;
+
+      // try the old secrets / repoauth
+      comp.secrets = secrets;
+      comp.repoauth = repoauth;
+
+      const messageToVerifyC = type + version + JSON.stringify(appSpecsClone) + timestamp;
+      // we can just use the btc / eth verifier as v7 specs came out at 1688749251
+      isValidSignature = signatureVerifier.verifySignature(messageToVerifyC, appSpec.owner, signature);
+    });
   }
   if (isValidSignature !== true) {
     log.debug(`${messageToVerify}, ${appSpec.owner}, ${signature}`);
@@ -4914,6 +4934,26 @@ async function verifyAppMessageUpdateSignature(type, version, appSpec, timestamp
     if (isValidSignature !== true && marketplaceApp) {
       isValidSignature = signatureVerifier.verifySignature(messageToVerifyB, fluxSupportTeamFluxID, signature); // btc, eth
     }
+    // fix for repoauth / secrets order change for apps created after 1750273721000
+  } else if (isValidSignature !== true && appSpec.version === 7) {
+    const appSpecsClone = JSON.parse(JSON.stringify(appSpec));
+
+    appSpecsClone.forEach((component) => {
+      // previously the order was secrets / repoauth. Now it's repoauth / secrets.
+      const comp = component;
+      const { secrets, repoauth } = comp;
+
+      delete comp.secrets;
+      delete comp.repoauth;
+
+      // try the old secrets / repoauth
+      comp.secrets = secrets;
+      comp.repoauth = repoauth;
+
+      const messageToVerifyC = type + version + JSON.stringify(appSpecsClone) + timestamp;
+      // we can just use the btc / eth verifier as v7 specs came out at 1688749251
+      isValidSignature = signatureVerifier.verifySignature(messageToVerifyC, appSpec.owner, signature);
+    });
   }
   if (isValidSignature !== true) {
     log.debug(`${messageToVerify}, ${appOwner}, ${signature}`);

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -4853,11 +4853,11 @@ async function verifyAppMessageSignature(type, version, appSpec, timestamp, sign
       // try the old secrets / repoauth
       comp.secrets = secrets;
       comp.repoauth = repoauth;
-
-      const messageToVerifyC = type + version + JSON.stringify(appSpecsClone) + timestamp;
-      // we can just use the btc / eth verifier as v7 specs came out at 1688749251
-      isValidSignature = signatureVerifier.verifySignature(messageToVerifyC, appSpec.owner, signature);
     });
+
+    const messageToVerifyC = type + version + JSON.stringify(appSpecsClone) + timestamp;
+    // we can just use the btc / eth verifier as v7 specs came out at 1688749251
+    isValidSignature = signatureVerifier.verifySignature(messageToVerifyC, appSpec.owner, signature);
   }
   if (isValidSignature !== true) {
     log.debug(`${messageToVerify}, ${appSpec.owner}, ${signature}`);


### PR DESCRIPTION
Version 6.1.0 introduced a subtle bug where the order of the specformatter options for secrets and repoauth got transposed. This means the signatures that are stored in the db were different from the data that was trying to be verified.

So now, for v7 specs, anything after 6.1.0 has the specs formatted a different way from pre 6.1.0.

This means that any node syncing after 6.1.0 is missing around 17200 app messages.

This pull retries with the specs formatted in the old way if it fails on the first attempt. Obviously this isn't great - so would be good to get all specs migrated to v8+ in the future so we can remove this hack.

In the future we could look at recursive alphanumeric sorting of keys so that we can avoid storing / formatting the specs in a particular order