### PR TITLE
Remove allow of inbound 53, reallow ssh (if apps configured)

### DIFF
--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -24,6 +24,8 @@ const {
   outgoingConnections, outgoingPeers, incomingPeers, incomingConnections,
 } = require('./utils/establishedConnections');
 
+const isArcane = Boolean(process.env.FLUXOS_PATH);
+
 let dosState = 0; // we can start at bigger number later
 let dosMessage = null;
 
@@ -1462,11 +1464,15 @@ async function adjustFirewall() {
       await cmdAsync(execAllowE);
       await cmdAsync(execAllowF);
       log.info('Firewall adjusted for DNS traffic');
+
       // fix up for ssh being misteriously removed (needs tracing)
-      // this should also be limit, but existing nodes use allow (needs to be updated)
-      const execAllowFluxadmSsh = 'LANG="en_US.UTF-8" && sudo ufw insert 1 allow to any app FluxadmSSH > /dev/null 2>&1';
+      if (isArcane) {
+        // this should also be limit, but existing nodes use allow (needs to be updated)
+        const execAllowFluxadmSsh = 'LANG="en_US.UTF-8" && sudo ufw insert 1 allow to any app FluxadmSSH > /dev/null 2>&1';
+        await cmdAsync(execAllowFluxadmSsh);
+      }
+
       const execAllowOpenSsh = 'LANG="en_US.UTF-8" && sudo ufw insert 1 limit to any app OpenSSH > /dev/null 2>&1';
-      await cmdAsync(execAllowFluxadmSsh);
       await cmdAsync(execAllowOpenSsh);
 
       const commandGetRouterIP = 'ip rout | head -n1 | awk \'{print $3}\'';


### PR DESCRIPTION
This PR is to mitigate the misterous operation that is removing ssh access in some situations.

We also remove the inbound 53 rule - this is quite a security risk, we should not be allowing inbound dns. This is how DNS Amplification attacks happen. (If people are running open resolvers on 53/udp) There is never a good reason to open 53 inbound (unless you are running public dns)

Just adds back the OpenSSH application (and the FluxadmSSH application)

Note - if nodes don't have the OpenSSH app (it is enabled by default) then this operation will fail silently.

Edit - I've tested this on a couple of Arcane nodes - works fine.