### PR TITLE
Add port check logic, fix EADDRINUSE on servers, general clean up

### DIFF
--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -188,11 +188,8 @@ module.exports = {
     multisigAddressChange: 1670000,
     epochstart: 694000,
     publicepochstart: 705000,
-    portMin: 31000, // ports 30000 - 30999 are reserved for local applications
-    portMax: 39999,
-    portBlockheightChange: isDevelopment ? 1390000 : 1420000,
-    portMinNew: 1,
-    portMaxNew: 65535,
+    portMin: 1,
+    portMax: 65535,
     bannedPorts: ['16100-16299', '26100-26299', '30000-30099', 8384, 27017, 22, 23, 25, 3389, 5900, 5800, 161, 512, 513, 5901, 3388, 4444, 123, 53],
     enterprisePorts: ['0-1023', 8080, 8081, 8443, 6667],
     upnpBannedPorts: [],

--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -188,6 +188,9 @@ module.exports = {
     multisigAddressChange: 1670000,
     epochstart: 694000,
     publicepochstart: 705000,
+    portMinLegacy: 31000, // ports 30000 - 30999 are reserved for local applications
+    portMaxLegacy: 39999,
+    portBlockheightChange: isDevelopment ? 1390000 : 1420000,
     portMin: 1,
     portMax: 65535,
     bannedPorts: ['16100-16299', '26100-26299', '30000-30099', 8384, 27017, 22, 23, 25, 3389, 5900, 5800, 161, 512, 513, 5901, 3388, 4444, 123, 53],

--- a/ZelBack/src/lib/fluxServer.js
+++ b/ZelBack/src/lib/fluxServer.js
@@ -130,7 +130,7 @@ class FluxServer {
         })
         .once('listening', () => {
           this.server.removeAllListeners('error');
-          resolve();
+          resolve(null);
         });
       this.server.listen(port);
     });

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -5773,8 +5773,8 @@ function verifyTypeCorrectnessOfApp(appSpecification) {
  * @returns {boolean} True if no errors are thrown.
  */
 function verifyRestrictionCorrectnessOfApp(appSpecifications, height) {
-  const minPort = height >= config.fluxapps.portBlockheightChange ? config.fluxapps.portMinNew : config.fluxapps.portMin;
-  const maxPort = height >= config.fluxapps.portBlockheightChange ? config.fluxapps.portMaxNew : config.fluxapps.portMax;
+  const minPort = height >= config.fluxapps.portBlockheightChange ? config.fluxapps.portMin : config.fluxapps.portMinLegacy;
+  const maxPort = height >= config.fluxapps.portBlockheightChange ? config.fluxapps.portMax : config.fluxapps.portMaxLegacy;
   if (appSpecifications.version !== 1 && appSpecifications.version !== 2 && appSpecifications.version !== 3 && appSpecifications.version !== 4 && appSpecifications.version !== 5 && appSpecifications.version !== 6 && appSpecifications.version !== 7 && appSpecifications.version !== 8) {
     throw new Error('Flux App message version specification is invalid');
   }
@@ -12794,8 +12794,8 @@ async function deploymentInformation(req, res) {
     }
     // search in chainparams db for chainmessages of p version
     const appPrices = await getChainParamsPriceUpdates();
-    const minPort = daemonHeight >= config.fluxapps.portBlockheightChange ? config.fluxapps.portMinNew : config.fluxapps.portMin;
-    const maxPort = daemonHeight >= config.fluxapps.portBlockheightChange ? config.fluxapps.portMaxNew : config.fluxapps.portMax;
+    const minPort = daemonHeight >= config.fluxapps.portBlockheightChange ? config.fluxapps.portMin : config.fluxapps.portMinLegacy;
+    const maxPort = daemonHeight >= config.fluxapps.portBlockheightChange ? config.fluxapps.portMax : config.fluxapps.portMaxLegacy;
     const information = {
       price: appPrices,
       appSpecsEnforcementHeights: config.fluxapps.appSpecsEnforcementHeights,

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -14184,7 +14184,7 @@ async function checkMyAppsAvailability() {
   const setNextPort = () => {
     if (originalPortFailed && testingPort > originalPortFailed) {
       nextTestingPort = originalPortFailed - 1;
-    } else if (originalPortFailed) {
+    } else {
       nextTestingPort = null;
       originalPortFailed = null;
     }

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -12794,8 +12794,7 @@ async function deploymentInformation(req, res) {
     }
     // search in chainparams db for chainmessages of p version
     const appPrices = await getChainParamsPriceUpdates();
-    const minPort = daemonHeight >= config.fluxapps.portBlockheightChange ? config.fluxapps.portMin : config.fluxapps.portMinLegacy;
-    const maxPort = daemonHeight >= config.fluxapps.portBlockheightChange ? config.fluxapps.portMax : config.fluxapps.portMaxLegacy;
+    const { fluxapps: { minPort, maxPort } } = config;
     const information = {
       price: appPrices,
       appSpecsEnforcementHeights: config.fluxapps.appSpecsEnforcementHeights,

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -14146,7 +14146,7 @@ async function checkMyAppsAvailability() {
    * app error = 4m           - Something on the fluxNode is broken
    */
   const timeouts = {
-    default: 60_000_000,
+    default: 3_600_000,
     error: 60_000,
     failure: 15_000,
     dos: 300_000,

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -301,10 +301,8 @@ async function checkAppAvailability(req, res) {
         throw new Error('Unable to verify request authenticity');
       }
 
-      const syncStatus = daemonServiceMiscRpcs.isDaemonSynced();
-      const daemonHeight = syncStatus.data.height;
-      const minPort = daemonHeight >= config.fluxapps.portBlockheightChange ? config.fluxapps.portMinNew : config.fluxapps.portMin - 1000;
-      const maxPort = daemonHeight >= config.fluxapps.portBlockheightChange ? config.fluxapps.portMaxNew : config.fluxapps.portMax;
+      const { fluxapps: { minPort, maxPort } } = config;
+
       // eslint-disable-next-line no-restricted-syntax
       for (const port of ports) {
         const iBP = isPortBanned(+port);
@@ -1288,7 +1286,7 @@ async function denyPort(port) {
     return cmdStat;
   }
   const portBanned = isPortBanned(+port);
-  if (+port < (config.fluxapps.portMinNew) || +port > config.fluxapps.portMaxNew || portBanned) {
+  if (portBanned || +port < config.fluxapps.portMin || +port > config.fluxapps.portMax) {
     cmdStat.message = 'Port out of deletable app ports range';
     return cmdStat;
   }
@@ -1322,7 +1320,7 @@ async function deleteAllowPortRule(port) {
     return cmdStat;
   }
   const portBanned = isPortBanned(+port);
-  if (+port < (config.fluxapps.portMinNew) || +port > config.fluxapps.portMaxNew || portBanned) {
+  if (portBanned || +port < config.fluxapps.portMin || +port > config.fluxapps.portMax) {
     cmdStat.message = 'Port out of deletable app ports range';
     return cmdStat;
   }
@@ -1353,7 +1351,7 @@ async function deleteDenyPortRule(port) {
     return cmdStat;
   }
   const portBanned = isPortBanned(+port);
-  if (+port < (config.fluxapps.portMinNew) || +port > config.fluxapps.portMaxNew || portBanned) {
+  if (portBanned || +port < config.fluxapps.portMin || +port > config.fluxapps.portMax) {
     cmdStat.message = 'Port out of deletable app ports range';
     return cmdStat;
   }
@@ -1384,7 +1382,7 @@ async function deleteAllowOutPortRule(port) {
     return cmdStat;
   }
   const portBanned = isPortBanned(+port);
-  if (+port < (config.fluxapps.portMinNew) || +port > config.fluxapps.portMaxNew || portBanned) {
+  if (portBanned || +port < config.fluxapps.portMin || +port > config.fluxapps.portMax) {
     cmdStat.message = 'Port out of deletable app ports range';
     return cmdStat;
   }

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -551,7 +551,7 @@ async function getFluxNodePublicKey(privatekey) {
 
 /**
  * To get a random connection.
- * @returns {string} IP:Port or just IP if default.
+ * @returns {Promise<string>} IP:Port or just IP if default.
  */
 async function getRandomConnection() {
   const nodeList = await fluxCommunicationUtils.deterministicFluxList();
@@ -1431,7 +1431,7 @@ async function allowPortApi(req, res) {
 
 /**
  * To check if a firewall is active.
- * @returns {boolean} True if a firewall is active. Otherwise false.
+ * @returns {Promise<boolean>} True if a firewall is active. Otherwise false.
  */
 async function isFirewallActive() {
   try {

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -169,21 +169,38 @@ function isPortUPNPBanned(port) {
 }
 
 /**
- * To perform a basic check if port on an ip is opened
- * @param {string} ip IP address.
- * @param {number} port Port.
- * @returns {boolean} Returns true if opened, otherwise false
+ * To perform a basic check if TCP port on an ip is open. I.e. that we receive a
+ * SYN-ACK in response to a SYN. If connected, we send an RST and close the port.
+ * @param {string} ip IP address
+ * @param {number} port Port
+ * @param {{timeout?:Number}} options
+ * @returns {Promise<boolean>} Returns true if opened, otherwise false
  */
-async function isPortOpen(ip, port) {
-  try {
-    const exec = `nc -w 5 -z -v ${ip} ${port} </dev/null; echo $?`;
-    const cmdAsync = util.promisify(nodecmd.get);
-    const result = await cmdAsync(exec);
-    return !+result;
-  } catch (error) {
-    log.error(error);
-    return false;
-  }
+async function isPortOpen(ip, port, options = {}) {
+  const timeout = options.timeout || 5_000;
+
+  const call = new Promise((resolve, reject) => {
+    const socket = new net.Socket();
+
+    const timer = setTimeout(() => {
+      socket.destroy();
+    }, timeout);
+
+    socket.connect(port, ip, () => {
+      clearTimeout(timer);
+      socket.resetAndDestroy();
+      resolve(true);
+    });
+
+    socket.on('error', () => {
+      clearTimeout(timer);
+      reject();
+    });
+  });
+
+  const connected = await call.catch(() => false);
+
+  return connected;
 }
 
 /**

--- a/ZelBack/src/services/idService.js
+++ b/ZelBack/src/services/idService.js
@@ -149,7 +149,7 @@ async function loginPhrase(req, res) {
     const dosAppsState = appsService.getAppsDOSState();
     if (dosAppsState.status === 'success') {
       // nodeHardwareSpecsGood is not part of response yet
-      if (dosAppsState.data.dosState > 10) {
+      if (dosAppsState.data.dosState >= 100) {
         const errMessage = messageHelper.createErrorMessage(dosAppsState.data.dosMessage, 'DOS', dosAppsState.data.dosState);
         log.error(errMessage);
         res.json(errMessage);

--- a/ZelBack/src/services/utils/fluxHttpTestServer.js
+++ b/ZelBack/src/services/utils/fluxHttpTestServer.js
@@ -1,0 +1,41 @@
+const http = require('node:http');
+
+class FluxHttpTestServer extends http.Server {
+  /**
+   * The reason this class is necessary is because we allow old nodeJS versions.
+   * Anything after v18.2.0 we could just use closeAllConnections(), and this
+   * class wouldn't be necessary.
+   *
+   * When the sockets are destroyed, the close handler is called.
+   */
+  #connections = {};
+
+  #currentConnectionId = 0;
+
+  constructor() {
+    super(() => { });
+
+    this.addListener('connection', (socket) => this.#handleConnection(socket));
+  }
+
+  #handleConnection(socket) {
+    const connectionid = this.#currentConnectionId;
+    this.#connections[connectionid] = socket;
+    this.#currentConnectionId += 1;
+
+    socket.on('close', () => {
+      delete this.#connections[connectionid];
+    });
+  }
+
+  close(callback) {
+    super.close(callback);
+
+    Object.keys(this.#connections).forEach((key) => {
+      const socket = this.#connections[key];
+      socket.destroy();
+    });
+  }
+}
+
+module.exports = { FluxHttpTestServer };

--- a/apiServer.js
+++ b/apiServer.js
@@ -229,12 +229,7 @@ async function initiate() {
 
   process.on('uncaughtException', (err) => {
     const dnsErrors = ['ENOTFOUND', 'EAI_AGAIN', 'ESERVFAIL'];
-    // the express server port in use is uncatchable for some reason
-    // remove this in future
-    if (err.code === 'EADDRINUSE') {
-      // if shutting down clean, nodemon won't restart
-      logErrorAndExit('Flux api server port in use, shutting down.');
-    } else if (dnsErrors.includes(err.code) && err.hostname) {
+    if (dnsErrors.includes(err.code) && err.hostname) {
       log.error('Uncaught DNS Lookup Error!!, swallowing.');
       log.error(err);
       return;
@@ -270,10 +265,17 @@ async function initiate() {
     mode: 'https', key, cert, expressApp: httpServer.app,
   });
 
-  await httpServer.listen(apiPort);
-  log.info(`Flux listening on port ${apiPort}!`);
+  await httpServer.listen(apiPort).catch((err) => {
+    // if shutting down clean, nodemon won't restart
+    logErrorAndExit(`Flux api server unable to start. Error: ${err}`);
+  });
 
-  await httpsServer.listen(apiPortHttps);
+  await httpsServer.listen(apiPortHttps).catch((err) => {
+    // if shutting down clean, nodemon won't restart
+    logErrorAndExit(`Flux api server unable to start. Error: ${err}`);
+  });
+
+  log.info(`Flux listening on port ${apiPort}!`);
   log.info(`Flux https listening on port ${apiPortHttps}!`);
 
   setAxiosDefaults([httpServer.socketIo, httpsServer.socketIo]);

--- a/apiServer.js
+++ b/apiServer.js
@@ -265,15 +265,21 @@ async function initiate() {
     mode: 'https', key, cert, expressApp: httpServer.app,
   });
 
-  await httpServer.listen(apiPort).catch((err) => {
-    // if shutting down clean, nodemon won't restart
-    logErrorAndExit(`Flux api server unable to start. Error: ${err}`);
-  });
+  const httpError = await httpServer.listen(apiPort).catch((err) => err);
 
-  await httpsServer.listen(apiPortHttps).catch((err) => {
+  if (httpError) {
     // if shutting down clean, nodemon won't restart
-    logErrorAndExit(`Flux api server unable to start. Error: ${err}`);
-  });
+    logErrorAndExit(`Flux api server unable to start. Error: ${httpError}`);
+    return '';
+  }
+
+  const httpsError = await httpsServer.listen(apiPortHttps).catch((err) => err);
+
+  if (httpsError) {
+    // if shutting down clean, nodemon won't restart
+    logErrorAndExit(`Flux api server unable to start. Error: ${httpsError}`);
+    return '';
+  }
 
   log.info(`Flux listening on port ${apiPort}!`);
   log.info(`Flux https listening on port ${apiPortHttps}!`);

--- a/apiServer.js
+++ b/apiServer.js
@@ -269,7 +269,7 @@ async function initiate() {
 
   if (httpError) {
     // if shutting down clean, nodemon won't restart
-    logErrorAndExit(`Flux api server unable to start. Error: ${httpError}`);
+    logErrorAndExit(`Flux api server unable to start. ${httpError}`);
     return '';
   }
 
@@ -277,7 +277,7 @@ async function initiate() {
 
   if (httpsError) {
     // if shutting down clean, nodemon won't restart
-    logErrorAndExit(`Flux api server unable to start. Error: ${httpsError}`);
+    logErrorAndExit(`Flux api server unable to start. ${httpsError}`);
     return '';
   }
 

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "express": "~4.19.2",
     "fast-xml-parser": "~4.3.2",
     "formidable": "~2.1.2",
-    "http-shutdown": "~1.2.2",
     "inquirer": "~8.2.6",
     "js-yaml": "~4.1.0",
     "lru-cache": "~10.1.0",

--- a/tests/unit/fluxNetworkHelper.test.js
+++ b/tests/unit/fluxNetworkHelper.test.js
@@ -19,6 +19,8 @@ const fluxNetworkHelper = require('../../ZelBack/src/services/fluxNetworkHelper'
 const benchmarkService = require('../../ZelBack/src/services/benchmarkService');
 const verificationHelper = require('../../ZelBack/src/services/verificationHelper');
 
+const net = require('node:net');
+
 const {
   outgoingConnections, outgoingPeers, incomingPeers, incomingConnections,
 } = require('../../ZelBack/src/services/utils/establishedConnections');
@@ -74,7 +76,9 @@ describe('fluxNetworkHelper tests', () => {
         },
       };
       stub = sinon.stub(serviceHelper, 'axiosGet').resolves(fluxAvailabilitySuccessResponse);
-      sinon.stub(util, 'promisify').returns(() => Promise.resolve());
+      sinon.stub(net.Socket.prototype, 'connect').callsFake((_port, _ip, callback) => {
+        callback();
+      });
       const expectedAddress = 'http://127.0.0.1:16127/flux/version';
       const expectedAddressHome = 'http://127.0.0.1:16126';
       const expectedMessage = {
@@ -107,7 +111,9 @@ describe('fluxNetworkHelper tests', () => {
         },
       };
       stub = sinon.stub(serviceHelper, 'axiosGet').resolves(fluxAvailabilitySuccessResponse);
-      sinon.stub(util, 'promisify').returns(() => Promise.resolve());
+      sinon.stub(net.Socket.prototype, 'connect').callsFake((port, ip, callback) => {
+        callback();
+      });
       const expectedAddress = 'http://127.0.0.1:16127/flux/version';
       const expectedAddressHome = 'http://127.0.0.1:16126';
       const expectedMessage = {
@@ -262,7 +268,9 @@ describe('fluxNetworkHelper tests', () => {
         },
       });
       stub = sinon.stub(serviceHelper, 'axiosGet').resolves(mockResponse);
-      sinon.stub(util, 'promisify').returns(() => Promise.resolve());
+      sinon.stub(net.Socket.prototype, 'connect').callsFake((_port, _ip, callback) => {
+        callback();
+      });
       const expectedAddress = 'http://127.0.0.1:16127/flux/version';
       const expectedAddressHome = 'http://127.0.0.1:16126';
 
@@ -286,7 +294,9 @@ describe('fluxNetworkHelper tests', () => {
         },
       });
       stub = sinon.stub(serviceHelper, 'axiosGet').resolves(mockResponse);
-      sinon.stub(util, 'promisify').returns(() => Promise.resolve());
+      sinon.stub(net.Socket.prototype, 'connect').callsFake((_port, _ip, callback) => {
+        callback();
+      });
       const expectedAddress = 'http://127.0.0.1:16127/flux/version';
       const expectedAddressHome = 'http://127.0.0.1:16126';
 

--- a/tests/unit/globalconfig/default.js
+++ b/tests/unit/globalconfig/default.js
@@ -182,11 +182,11 @@ module.exports = {
     multisigAddressChange: 1670000,
     epochstart: 694000,
     publicepochstart: 705000,
-    portMin: 31000, // ports 30000 - 30999 are reserved for local applications
-    portMax: 39999,
+    portMinLegacy: 31000, // ports 30000 - 30999 are reserved for local applications
+    portMaxLegacy: 39999,
     portBlockheightChange: 1420000,
-    portMinNew: 1,
-    portMaxNew: 65535,
+    portMin: 1,
+    portMax: 65535,
     bannedPorts: ['16100-16299', '26100-26299', '30000-30099', 8384, 27017, 22, 23, 25, 3389, 5900, 5800, 161, 512, 513, 5901, 3388, 4444, 123, 53],
     upnpBannedPorts: ['81-442', 2189],
     enterprisePorts: ['0-1023', 8080, 8081, 8443, 6667],


### PR DESCRIPTION
### This PR does the following:

* Adds logic to the port checker (and simplifies things) to handle failed state and sets a hysteresis to get back to a "normal" state
* Moves the test http server to a local variable and tidies up the testing server used by checkInstallingAppPortAvailable
* Moves the dosState to just use 100 - whatever the failure. Previous, it was 25 for failed ports and then it had to get to 100 to remove apps. Now it's just 100 everywhere.
* Removes all the serviceHelper delays - we just wait for the httpServer to be listening now (and don't need to wait for UPnP) there is an inbuilt delay anyway as we have to wait 1/2 RTT for the request to get to the remote end anyway. This was slowing down the total failure time significantly. (15 seconds per iteration * 125 iterations = over 30 minutes)
* Removes the janky call to netcat to test the port - we just use a socket now. (the netcat call was actually broken on some nodes, and was returning that the port was open even when it wasn't)
* Fixes the issue with the test http Server - this wasn't being caught properly if a port was already listening and was crashing the entire app.
* Fixes the EADDRINUSE error that was raised for the fluxServer http servers. We now handle this locally instead of on the process
* Removes the entire old / new portMin, portMax. This was broken. We were using the scanned height which is wrong. It should have been the current network block height (it's gone now anyway) Have updated it to PortMinLegacy etc, the only place this is now used is to verify correctness of apps  at the height they existed
* Totally removes the `http-shutdown` package. Just do this in house now. All it does is destroy all sockets when the server is closed. If we were on nodeJS 18.2.x - we could just use native node tools.

This means that if a node goes DOS for ports - apps will be uninstalled. The reason for this is that if the node goes DOS due to ports, it is more than likely that the app is broken anyway. I.e. it may have been fine when it was installed, but now it's not. Previously, this would have taken another 225 iterations before the apps were removed (several hours), where they're most likely broken anyway.

In most cases - this won't matter anyway as the node will go dos before any apps are installed.

Hopefully, this should be the last PR before I move the functionality to a class, update the algorithm, and write tests for it.

Here are the states:

    * Normal
          No broken ports, or broken ports less than 80 and a "good" port test
    * Normal - Rising edge
          I.e. broken ports increasing but threshold not reached. This state could
          also be considered normal, and could take many many hours to cross the threshold
    * Failed - Rising edge
          Threshold crossed. There are 100 ports in portsNotWorking. At this time the
          dosState starts rising 4 per fail. (takes 25 ports once in this state to DOS)
    * Failed - DOS
          There are 100 ports in the portsNotWorking array. 25 of those ports
          have failed a second time. Node is in DOS state.
    * Failed - Lowering edge
          Same as failed, however the node is now considered "working" and is removing
          ports from the portsNotWorking array. It will remain in this state until 20 ports
          have been removed from the portsNotWorking array. (hysteresis) Once this happens, the node
          is then considered in the "normal" state - and the portsNotWorking array is cleared

### Test methodology

Since we can't really write unit tests for this (recursion) without modifying the actual function logic, I did some integration testing.

I ran a test http server on one public ip, then on another public IP, ran the `checkMyAppsAvailability` function with the failure interval at one second, and the dos interval at 3 seconds. (so really fast)

The http server was set to fail the first 130 requests, which simulates that the port isn't open. This puts the node into DOS. Then after that http server was testing the ports were valid, and the node would go below the hysterisis value of 80 ports and go back to normal state