### PR TITLE
Bugfix: fix v8 app messages

### DIFF
--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -1210,8 +1210,8 @@ async function appMonitorStream(req, res) {
  */
 async function getAppFolderSize(appName) {
   try {
-    const dirpath = path.join(__dirname, '../../../');
-    const directoryPath = `${dirpath}ZelApps/${appName}`;
+    const appsDirPath = process.env.FLUX_APPS_FOLDER || path.join(fluxDirPath, 'ZelApps');
+    const directoryPath = path.join(appsDirPath, appName);
     const exec = `sudo du -s --block-size=1 ${directoryPath}`;
     const cmdres = await cmdAsync(exec);
     const size = serviceHelper.ensureString(cmdres).split('\t')[0] || 0;

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -8030,10 +8030,6 @@ async function decryptEnterpriseFromSession(base64Encrypted, appName, daemonHeig
 
   const decryptedEnterprise = JSON.parse(jsonEnterprise);
 
-  // this is kind of broken. The frontend passes the specs with the compose
-  // properties as strings. It should parse them up front and just pass us the
-  // entire object
-
   if (decryptedEnterprise) {
     return decryptedEnterprise;
   }
@@ -10029,7 +10025,13 @@ async function getApplicationGlobalSpecifications(appName) {
   };
   const dbAppSpec = await dbHelper.findOneInDatabase(database, globalAppsInformation, query, projection);
 
-  // fix this
+  // This is abusing the spec formatter. It's not meant for this. This whole thing
+  // is kind of broken. The reason we have to use the spec formatter here is the
+  // frontend is passing properties as strings (then stringify the whole object)
+  // the frontend should parse the strings up front, and just pass an encrypted,
+  // stringified object.
+  //
+  // Will fix this in v9 specs. Move to model based specs with pre sorted keys.
   let appSpec = await checkAndDecryptAppSpecs(dbAppSpec);
   if (appSpec && appSpec.version >= 8 && appSpec.enterprise) {
     const { height, hash } = appSpec;
@@ -10100,7 +10102,13 @@ async function getApplicationSpecifications(appName) {
     appInfo = allApps.find((app) => app.name.toLowerCase() === appName.toLowerCase());
   }
 
-  // fix this
+  // This is abusing the spec formatter. It's not meant for this. This whole thing
+  // is kind of broken. The reason we have to use the spec formatter here is the
+  // frontend is passing properties as strings (then stringify the whole object)
+  // the frontend should parse the strings up front, and just pass an encrypted,
+  // stringified object.
+  //
+  // Will fix this in v9 specs. Move to model based specs with pre sorted keys.
   appInfo = await checkAndDecryptAppSpecs(appInfo);
   if (appInfo && appInfo.version >= 8 && appInfo.enterprise) {
     const { height, hash } = appInfo;
@@ -10470,7 +10478,7 @@ async function getApplicationSpecificationAPI(req, res) {
     const mainAppName = appname.split('_')[1] || appname;
 
     if (!specifications) {
-      throw new Error(`Application not found: ${appname}`);
+      throw new Error('Application not found');
     }
 
     const isEnterprise = Boolean(

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -3782,12 +3782,14 @@ async function registerAppLocally(appSpecs, componentSpecs, res, test = false) {
         appSpecifications.version >= 8 && appSpecifications.enterprise,
       );
 
+      const dbSpecs = JSON.parse(JSON.stringify(appSpecifications));
+
       if (isEnterprise) {
-        appSpecifications.compose = [];
-        appSpecifications.contacts = [];
+        dbSpecs.compose = [];
+        dbSpecs.contacts = [];
       }
 
-      await dbHelper.insertOneToDatabase(appsDatabase, localAppsInformation, appSpecifications);
+      await dbHelper.insertOneToDatabase(appsDatabase, localAppsInformation, dbSpecs);
       const hddTier = `hdd${tier}`;
       const ramTier = `ram${tier}`;
       const cpuTier = `cpu${tier}`;
@@ -4249,12 +4251,14 @@ async function softRegisterAppLocally(appSpecs, componentSpecs, res) {
         appSpecifications.version >= 8 && appSpecifications.enterprise,
       );
 
+      const dbSpecs = JSON.parse(JSON.stringify(appSpecifications));
+
       if (isEnterprise) {
-        appSpecifications.compose = [];
-        appSpecifications.contacts = [];
+        dbSpecs.compose = [];
+        dbSpecs.contacts = [];
       }
 
-      await dbHelper.insertOneToDatabase(appsDatabase, localAppsInformation, appSpecifications);
+      await dbHelper.insertOneToDatabase(appsDatabase, localAppsInformation, dbSpecs);
       const hddTier = `hdd${tier}`;
       const ramTier = `ram${tier}`;
       const cpuTier = `cpu${tier}`;
@@ -10461,7 +10465,7 @@ async function getApplicationSpecificationAPI(req, res) {
     const mainAppName = appname.split('_')[1] || appname;
 
     if (!specifications) {
-      throw new Error('Application not found');
+      throw new Error(`Application not found: ${appname}`);
     }
 
     const isEnterprise = Boolean(
@@ -12138,13 +12142,15 @@ async function reinstallOldApplications() {
               appSpecifications.version >= 8 && appSpecifications.enterprise,
             );
 
+            const dbSpecs = JSON.parse(JSON.stringify(appSpecifications));
+
             if (isEnterprise) {
-              appSpecifications.compose = [];
-              appSpecifications.contacts = [];
+              dbSpecs.compose = [];
+              dbSpecs.contacts = [];
             }
 
             // eslint-disable-next-line no-await-in-loop
-            await dbHelper.insertOneToDatabase(appsDatabase, localAppsInformation, appSpecifications);
+            await dbHelper.insertOneToDatabase(appsDatabase, localAppsInformation, dbSpecs);
             log.warn(`Composed application ${appSpecifications.name} updated.`);
             log.warn(`Restarting application ${appSpecifications.name}`);
             // eslint-disable-next-line no-await-in-loop, no-use-before-define
@@ -12279,13 +12285,15 @@ async function reinstallOldApplications() {
                 appSpecifications.version >= 8 && appSpecifications.enterprise,
               );
 
+              const dbSpecs = JSON.parse(JSON.stringify(appSpecifications));
+
               if (isEnterprise) {
-                appSpecifications.compose = [];
-                appSpecifications.contacts = [];
+                dbSpecs.compose = [];
+                dbSpecs.contacts = [];
               }
 
               // eslint-disable-next-line no-await-in-loop
-              await dbHelper.insertOneToDatabase(appsDatabase, localAppsInformation, appSpecifications);
+              await dbHelper.insertOneToDatabase(appsDatabase, localAppsInformation, dbSpecs);
               log.warn(`Composed application ${appSpecifications.name} updated.`);
               log.warn(`Restarting application ${appSpecifications.name}`);
               // eslint-disable-next-line no-await-in-loop, no-use-before-define

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -10028,11 +10028,14 @@ async function getApplicationGlobalSpecifications(appName) {
     },
   };
   const dbAppSpec = await dbHelper.findOneInDatabase(database, globalAppsInformation, query, projection);
+
+  // fix this
   let appSpec = await checkAndDecryptAppSpecs(dbAppSpec);
   if (appSpec && appSpec.version >= 8 && appSpec.enterprise) {
-    const { height } = appSpec;
+    const { height, hash } = appSpec;
     appSpec = specificationFormatter(appSpec);
     appSpec.height = height;
+    appSpec.hash = hash;
   }
   return appSpec;
 }
@@ -10097,11 +10100,13 @@ async function getApplicationSpecifications(appName) {
     appInfo = allApps.find((app) => app.name.toLowerCase() === appName.toLowerCase());
   }
 
+  // fix this
   appInfo = await checkAndDecryptAppSpecs(appInfo);
   if (appInfo && appInfo.version >= 8 && appInfo.enterprise) {
-    const { height } = appInfo;
+    const { height, hash } = appInfo;
     appInfo = specificationFormatter(appInfo);
     appInfo.height = height;
+    appInfo.hash = hash;
   }
   return appInfo;
 }

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -10095,7 +10095,9 @@ async function getApplicationSpecifications(appName) {
 
   appInfo = await checkAndDecryptAppSpecs(appInfo);
   if (appInfo && appInfo.version >= 8 && appInfo.enterprise) {
+    const { height } = appInfo;
     appInfo = specificationFormatter(appInfo);
+    appInfo.height = height;
   }
   return appInfo;
 }

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -10,6 +10,8 @@ const generalService = require('./generalService');
 const fluxNetworkHelper = require('./fluxNetworkHelper');
 const log = require('../lib/log');
 
+const isArcane = Boolean(process.env.FLUXOS_PATH);
+
 const fluxDirPath = path.join(__dirname, '../../../');
 // ToDo: Fix all the string concatenation in this file and use path.join()
 const appsFolderPath = process.env.FLUX_APPS_FOLDER || path.join(fluxDirPath, 'ZelApps');
@@ -920,7 +922,9 @@ async function appDockerCreate(appSpecifications, appName, isComponent, fullAppS
   if (backingFs && backingFs[1] === 'xfs') {
     // check that we have quota
 
-    const hasQuotaPossibility = await deviceHelper.hasQuotaOptionForMountTarget('/var/lib/docker');
+    const mountTarget = isArcane ? '/dat/var/lib/docker' : '/var/lib/docker';
+
+    const hasQuotaPossibility = await deviceHelper.hasQuotaOptionForMountTarget(mountTarget);
 
     if (hasQuotaPossibility) {
       options.HostConfig.StorageOpt = { size: `${config.fluxapps.hddFileSystemMinimum}G` }; // must also have 'pquota' mount option

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -966,7 +966,7 @@ async function checkMyFluxAvailability(retryNumber = 0) {
   };
   const apiPort = userconfig.initial.apiport || config.server.apiport;
   const resMyAvailability = await serviceHelper.axiosGet(`http://${askingIP}:${askingIpPort}/flux/checkfluxavailability?ip=${myIP}&port=${apiPort}`, axiosConfigAux).catch((error) => {
-    log.error(`${askingIP} is not reachable`);
+    log.error(`${askingIP}:${askingIpPort} is not reachable`);
     log.error(error);
     availabilityError = true;
   });


### PR DESCRIPTION
Bug:

Prior v8 code was causing a registered app to expire immediately, as it had no height, so it was contiuously being installed on many nodes. Was also causing the apprunning message to not be stored as it had no hash.

This PR does the following:

* Fixes the v8 messages. Since the frontend is stringifying the compose / contacts properties, we are using the specificationFormatter to rehydrate these on a register or update message. When we do this, it was removing the height and hash - so we manually add these back in
* Fixes the getAppFolderSize on Arcane, the `/var/lib/docker` path was hardcoded
* Make sure we strip off any unencrypted data before storing in the db
* Strip the unencrypted data off api calls if decrypt not requested
* Add the port to the log if the checkMyFluxAvailabilty peer is uncontactable