### PR TITLE
Update fluxd getchaintips call

### DIFF
--- a/ZelBack/src/services/daemonService/daemonServiceBlockchainRpcs.js
+++ b/ZelBack/src/services/daemonService/daemonServiceBlockchainRpcs.js
@@ -209,9 +209,18 @@ async function getBlockHeader(req, res) {
  * @returns {object} Message.
  */
 async function getChainTips(req, res) {
-  const rpccall = 'getChainTips';
+  let { minheight } = req?.params || {};
+  minheight = minheight || req?.query?.minheight;
 
-  response = await daemonServiceUtils.executeCall(rpccall);
+  const rpccall = 'getChainTips';
+  const rpcparameters = [];
+
+  if (minheight !== undefined && minheight !== null) {
+    minheight = serviceHelper.ensureNumber(minheight);
+    rpcparameters.push(minheight);
+  }
+
+  response = await daemonServiceUtils.executeCall(rpccall, rpcparameters);
 
   return res ? res.json(response) : response;
 }


### PR DESCRIPTION
getchaintips call was updated on latest daemon update to receive blockheight as parameter.
What was changed:
- We get the daemon version and cache it;
- If daemon version is higher than 7020050 means we are on daemon v8.0.0;
- Update to start calling getchaintips passing the last blockheight that was checked + 1;