### PR TITLE
Improvements on trySpawningGlobalApplication

### DIFF
--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -10969,7 +10969,7 @@ async function trySpawningGlobalApplication() {
         return;
       }
       if (appToRunAux.enterprise && !isArcane) {
-        log.info('trySpawningGlobalApplication - app can only install on ArcaneOS');
+        log.info(`trySpawningGlobalApplication - Application ${appToRun} can only install on ArcaneOS`);
         spawnErrorsLongerAppCache.set(appHash, '');
         await serviceHelper.delay(5 * 60 * 1000);
         trySpawningGlobalApplication();
@@ -11040,7 +11040,7 @@ async function trySpawningGlobalApplication() {
     const appExists = apps.find((app) => app.name === appSpecifications.name);
     if (appExists) { // double checked in installation process.
       log.info(`trySpawningGlobalApplication - Application ${appSpecifications.name} is already installed`);
-      await serviceHelper.delay(30 * 60 * 1000);
+      await serviceHelper.delay(5 * 60 * 1000);
       trySpawningGlobalApplication();
       return;
     }
@@ -11079,7 +11079,7 @@ async function trySpawningGlobalApplication() {
     const portsPubliclyAvailable = await checkInstallingAppPortAvailable(appPorts);
     if (portsPubliclyAvailable === false) {
       log.error(`trySpawningGlobalApplication - Some of application ports of ${appSpecifications.name} are not available publicly. Installation aborted.`);
-      await serviceHelper.delay(30 * 60 * 1000);
+      await serviceHelper.delay(5 * 60 * 1000);
       trySpawningGlobalApplication();
       return;
     }
@@ -11108,7 +11108,7 @@ async function trySpawningGlobalApplication() {
       const sameIpRangeNode = runningAppList.find((location) => location.ip.includes(myIpWithoutPort.substring(0, secondLastIndex)));
       if (sameIpRangeNode) {
         log.info(`trySpawningGlobalApplication - Application ${appToRun} uses syncthing and it is already spawned on Fluxnode with same ip range`);
-        await serviceHelper.delay(30 * 60 * 1000);
+        await serviceHelper.delay(5 * 60 * 1000);
         trySpawningGlobalApplication();
         return;
       }
@@ -11130,7 +11130,7 @@ async function trySpawningGlobalApplication() {
             };
             appsSyncthingToBeCheckedLater.push(appToCheck);
             // eslint-disable-next-line no-await-in-loop
-            await serviceHelper.delay(30 * 60 * 1000);
+            await serviceHelper.delay(5 * 60 * 1000);
             trySpawningGlobalAppCache.delete(appHash);
             trySpawningGlobalApplication();
             return;
@@ -11213,21 +11213,6 @@ async function trySpawningGlobalApplication() {
     const compositedSpecification = appSpecifications.compose || [appSpecifications]; // use compose array if v4+ OR if not defined its <= 3 do an array of appSpecs.
     // eslint-disable-next-line no-restricted-syntax
     for (const componentToInstall of compositedSpecification) {
-      // eslint-disable-next-line no-restricted-syntax
-      for (const installedApp of apps) {
-        const installedAppCompositedSpecification = installedApp.compose || [installedApp];
-        // eslint-disable-next-line no-restricted-syntax
-        for (const component of installedAppCompositedSpecification) {
-          if (component.repotag === componentToInstall.repotag && componentToInstall.repotag.startsWith('presearch/node')) { // applies to presearch specifically
-            log.info(`trySpawningGlobalApplication - ${componentToInstall.repotag} Image is already running on this Flux`);
-            // eslint-disable-next-line no-await-in-loop
-            await serviceHelper.delay(30 * 60 * 1000);
-            trySpawningGlobalApplication();
-            return;
-          }
-        }
-      }
-
       // check image is whitelisted and repotag is available for download
       // eslint-disable-next-line no-await-in-loop
       await verifyRepository(componentToInstall.repotag, { repoauth: componentToInstall.repoauth, architecture }).catch((error) => {
@@ -11285,7 +11270,7 @@ async function trySpawningGlobalApplication() {
       const index = installingAppList.findIndex((x) => x.ip === myIP);
       if (runningAppList.length + index + 1 > minInstances) {
         log.info(`trySpawningGlobalApplication - Application ${appToRun} is already spawned or being installed on ${runningAppList.length + installingAppList.length} instances, my instance is number ${runningAppList.length + index + 1}`);
-        await serviceHelper.delay(30 * 60 * 1000);
+        await serviceHelper.delay(5 * 60 * 1000);
         trySpawningGlobalApplication();
         return;
       }
@@ -11301,7 +11286,7 @@ async function trySpawningGlobalApplication() {
     }
     if (!registerOk) {
       log.info('trySpawningGlobalApplication - Error on registerAppLocally');
-      await serviceHelper.delay(30 * 60 * 1000);
+      await serviceHelper.delay(5 * 60 * 1000);
       trySpawningGlobalApplication();
       return;
     }

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -10975,25 +10975,6 @@ async function trySpawningGlobalApplication() {
         trySpawningGlobalApplication();
         return;
       }
-
-      if (appToRunAux.required === appToRunAux.actual + 1 && appToRunAux.nodes.length === 0 && Math.random() > 0.15) {
-        log.info('trySpawningGlobalApplication - app missing one instance failed the 15% probability check to install');
-        await serviceHelper.delay(5 * 60 * 1000);
-        trySpawningGlobalApplication();
-        return;
-      }
-      if (appToRunAux.required === appToRunAux.actual + 2 && appToRunAux.nodes.length === 0 && Math.random() > 0.40) {
-        log.info('trySpawningGlobalApplication - app missing two instances failed the 40% probability check to install');
-        await serviceHelper.delay(10 * 60 * 1000);
-        trySpawningGlobalApplication();
-        return;
-      }
-      if (appToRunAux.required > appToRunAux.actual + 2 && appToRunAux.nodes.length === 0 && Math.random() > 0.60) {
-        log.info('trySpawningGlobalApplication - app missing more than two instances failed the 60% probability check to install');
-        await serviceHelper.delay(10 * 60 * 1000);
-        trySpawningGlobalApplication();
-        return;
-      }
     }
 
     trySpawningGlobalAppCache.set(appHash, '');

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -10994,9 +10994,6 @@ async function trySpawningGlobalApplication() {
       spawnErrorsLongerAppCache.set(appHash, '');
       throw new Error(`trySpawningGlobalApplication - App ${appToRun} is marked as having errors on app installing errors locations.`);
     }
-    if (installingAppErrorsList.length > 0) {
-      log.info(`trySpawningGlobalApplication - App ${appToRun} have failed previously to install on ${installingAppErrorsList.length} different nodes`);
-    }
 
     runningAppList = await appLocation(appToRun);
 

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -11200,7 +11200,7 @@ async function trySpawningGlobalApplication() {
         delay = true;
       }
       if (delay) {
-        await serviceHelper.delay(30 * 60 * 1000);
+        await serviceHelper.delay(5 * 60 * 1000);
         trySpawningGlobalApplication();
         return;
       }


### PR DESCRIPTION
List of changes:
- Remove probability to select one app to try to install it as now we are sending the app message fluxappinstalling to make sure we are not installing more instances than required;
- Get apps installed on top to filter from the apps that can be selected to install on the node;
- Adjust some logs;
- Remove some specific old code related with presearch when we were spawning the app on marketplace without port;
- Remove commented code so start up again checking if the app are failing to install across the network;
- Adjust all delays to run the function again after 5 minutes if it didn't finish with success.