### PR TITLE
Add port check logic, fix EADDRINUSE on servers, general clean up

### DIFF
--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -188,11 +188,11 @@ module.exports = {
     multisigAddressChange: 1670000,
     epochstart: 694000,
     publicepochstart: 705000,
-    portMin: 31000, // ports 30000 - 30999 are reserved for local applications
-    portMax: 39999,
+    portMinLegacy: 31000, // ports 30000 - 30999 are reserved for local applications
+    portMaxLegacy: 39999,
     portBlockheightChange: isDevelopment ? 1390000 : 1420000,
-    portMinNew: 1,
-    portMaxNew: 65535,
+    portMin: 1,
+    portMax: 65535,
     bannedPorts: ['16100-16299', '26100-26299', '30000-30099', 8384, 27017, 22, 23, 25, 3389, 5900, 5800, 161, 512, 513, 5901, 3388, 4444, 123, 53],
     enterprisePorts: ['0-1023', 8080, 8081, 8443, 6667],
     upnpBannedPorts: [],

--- a/ZelBack/src/lib/fluxServer.js
+++ b/ZelBack/src/lib/fluxServer.js
@@ -130,7 +130,7 @@ class FluxServer {
         })
         .once('listening', () => {
           this.server.removeAllListeners('error');
-          resolve();
+          resolve(null);
         });
       this.server.listen(port);
     });

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -5,8 +5,6 @@ const path = require('node:path');
 const crypto = require('node:crypto');
 const https = require('https');
 const axios = require('axios');
-const express = require('express');
-const http = require('http');
 // eslint-disable-next-line import/no-extraneous-dependencies
 const nodecmd = require('node-cmd');
 const archiver = require('archiver');
@@ -16,7 +14,6 @@ const systemcrontab = require('crontab');
 const util = require('util');
 const fs = require('fs').promises;
 const execShell = util.promisify(require('child_process').exec);
-const httpShutdown = require('http-shutdown');
 const fluxCommunicationMessagesSender = require('./fluxCommunicationMessagesSender');
 const fluxNetworkHelper = require('./fluxNetworkHelper');
 const {
@@ -46,6 +43,7 @@ const { invalidMessages } = require('./invalidMessages');
 const fluxCommunicationUtils = require('./fluxCommunicationUtils');
 const cacheManager = require('./utils/cacheManager').default;
 const networkStateService = require('./networkStateService');
+const fluxHttpTestServer = require('./utils/fluxHttpTestServer');
 
 const fluxDirPath = path.join(__dirname, '../../../');
 // ToDo: Fix all the string concatenation in this file and use path.join()
@@ -71,10 +69,6 @@ const globalAppsInstallingErrorsLocations = config.database.appsglobal.collectio
 const supportedArchitectures = ['amd64', 'arm64'];
 
 const isArcane = Boolean(process.env.FLUXOS_PATH);
-
-const testingAppExpress = express();
-let testingAppserver = http.createServer(testingAppExpress);
-testingAppserver = httpShutdown(testingAppserver);
 
 const spawnErrorsLongerAppCache = cacheManager.appSpawnErrorCache;
 const trySpawningGlobalAppCache = cacheManager.appSpawnCache;
@@ -5768,8 +5762,8 @@ function verifyTypeCorrectnessOfApp(appSpecification) {
  * @returns {boolean} True if no errors are thrown.
  */
 function verifyRestrictionCorrectnessOfApp(appSpecifications, height) {
-  const minPort = height >= config.fluxapps.portBlockheightChange ? config.fluxapps.portMinNew : config.fluxapps.portMin;
-  const maxPort = height >= config.fluxapps.portBlockheightChange ? config.fluxapps.portMaxNew : config.fluxapps.portMax;
+  const minPort = height >= config.fluxapps.portBlockheightChange ? config.fluxapps.portMin : config.fluxapps.portMinLegacy;
+  const maxPort = height >= config.fluxapps.portBlockheightChange ? config.fluxapps.portMax : config.fluxapps.portMaxLegacy;
   if (appSpecifications.version !== 1 && appSpecifications.version !== 2 && appSpecifications.version !== 3 && appSpecifications.version !== 4 && appSpecifications.version !== 5 && appSpecifications.version !== 6 && appSpecifications.version !== 7 && appSpecifications.version !== 8) {
     throw new Error('Flux App message version specification is invalid');
   }
@@ -12816,8 +12810,7 @@ async function deploymentInformation(req, res) {
     }
     // search in chainparams db for chainmessages of p version
     const appPrices = await getChainParamsPriceUpdates();
-    const minPort = daemonHeight >= config.fluxapps.portBlockheightChange ? config.fluxapps.portMinNew : config.fluxapps.portMin;
-    const maxPort = daemonHeight >= config.fluxapps.portBlockheightChange ? config.fluxapps.portMaxNew : config.fluxapps.portMax;
+    const { fluxapps: { minPort, maxPort } } = config;
     const information = {
       price: appPrices,
       appSpecsEnforcementHeights: config.fluxapps.appSpecsEnforcementHeights,
@@ -14108,21 +14101,19 @@ async function callOtherNodeToKeepUpnpPortsOpen() {
 /**
  *
  * @param {Number} testingPort The target port
+ * @param {http.Server} testHttpServer The test http server
  * @param {{skipFirewall?: Boolean, skipUpnp?: Boolean, skipHttpServer?: Boolean}} options Options
  */
-async function handleTestShutdown(testingPort, options = {}) {
+async function handleTestShutdown(testingPort, testHttpServer, options = {}) {
   const skipFirewall = options.skipFirewall || false;
   const skipUpnp = options.skipUpnp || false;
   const skipHttpServer = options.skipHttpServer || false;
 
-  const updateFirewall = skipFirewall ? false : await fluxNetworkHelper
-    .isFirewallActive()
-    .catch((e) => {
-      log.error(e);
-      // if we can't determine if the firewall is active or not, we just try
-      // to remove it anyway
-      return true;
-    });
+  // fail open on the firewall check
+  const updateFirewall = skipFirewall
+    ? false
+    : isArcane
+    || await fluxNetworkHelper.isFirewallActive().catch(() => true);
 
   if (updateFirewall) {
     await fluxNetworkHelper
@@ -14137,80 +14128,100 @@ async function handleTestShutdown(testingPort, options = {}) {
   }
 
   if (!skipHttpServer) {
-    testingAppserver.removeAllListeners();
-    testingAppserver.shutdown((err) => {
+    testHttpServer.close((err) => {
       if (err) {
-        log.error(`testingAppserver shutdown failed: ${err.message}`);
+        log.error(`testHttpServer shutdown failed: ${err.message}`);
       }
     });
   }
 }
 
-// any function that uses module level globals to keep state should be moved to
-//  a class.
+let testingPort = null;
+let originalPortFailed = null;
+let lastUPNPMapFailed = false;
+let nextTestingPort = Math.floor(Math.random() * (25000 - 10000 + 1)) + 10000;
+const portsNotWorking = new Set();
 
 /**
- * Periodically check for our applications port range is available
+ * Periodically check that our applications port range is usable. I.e, we open
+ * the firewall, map the port (if UPnP) and set up a TCP listener on the port.
+ * We then request another node validate that we respond with a SYN-ACK when
+ * they send a SYN.
+ * @returns {Promise<void>}
  */
-// changed this to a set. Means we don't have to worry about duplicates etc
-const portsNotWorking = new Set();
-let testingPort = null;
-let originalPortFailed = false;
-let lastUPNPMapFailed = false;
-let setPortToTest = Math.floor(Math.random() * (25000 - 10000 + 1)) + 10000;
 async function checkMyAppsAvailability() {
-  const isUpnp = upnpService.isUPNP();
+  /**
+   * default timeout = 1h     - Normal state  \
+   * error timeout = 60s      - Something unexpected happened  \
+   * failure timeout = 15s    - Our port testing failed  \
+   * dos timeout = 5m         - We're DOS  \
+   * app error = 4m           - Something on the fluxNode is broken
+   */
+  const timeouts = {
+    default: 3_600_000,
+    error: 60_000,
+    failure: 15_000,
+    dos: 300_000,
+    appError: 240_000,
+  };
 
+  /**
+   * dos              - Dos is a number between 0-100. The threshold is the upper limit
+   * ports high edge  - The upper limit after which the dos counter will increment
+   * ports low edge   - The lower limit after which the node can resume normal state
+   */
+  const thresholds = {
+    dos: 100,
+    portsHighEdge: 100,
+    portsLowEdge: 80,
+  };
+
+  if (dosMountMessage || dosDuplicateAppMessage) {
+    dosMessage = dosMountMessage || dosDuplicateAppMessage;
+    dosState = thresholds.dos;
+
+    await serviceHelper.delay(timeouts.appError);
+    setImmediate(checkMyAppsAvailability);
+    return;
+  }
+
+  const isUpnp = upnpService.isUPNP();
+  const testHttpServer = new fluxHttpTestServer.FluxHttpTestServer();
+
+  /**
+   * Sets the next port if we come across a port that is banned or excluded etc
+   *
+   * @returns {void}
+   */
   const setNextPort = () => {
     if (originalPortFailed && testingPort > originalPortFailed) {
-      setPortToTest = originalPortFailed - 1;
-    } else if (originalPortFailed) {
-      setPortToTest = null;
+      nextTestingPort = originalPortFailed - 1;
+    } else {
+      nextTestingPort = null;
       originalPortFailed = null;
     }
   };
 
+  /**
+   * Picks a random port from the existing set of not working ports
+   *
+   * @returns {Array} The array of not working ports. Just so any caller
+   * doesn't have to convert to an Array
+   */
+  const setRandomPort = () => {
+    const ports = Array.from(portsNotWorking);
+    const randomIndex = Math.floor(Math.random() * ports.length);
+    nextTestingPort = ports[randomIndex];
+
+    return ports;
+  };
+
   try {
-    const dbopen = dbHelper.databaseConnection();
-    const database = dbopen.db(config.database.daemon.database);
-    const query = { generalScannedHeight: { $gte: 0 } };
-    const projection = {
-      projection: {
-        _id: 0,
-        generalScannedHeight: 1,
-      },
-    };
-
-    const currentHeight = await dbHelper.findOneInDatabase(
-      database,
-      scannedHeightCollection,
-      query,
-      projection,
-    );
-
-    if (!currentHeight) {
-      // removed the throw here. Just keep the control flow in the loop
-      log.error('No scanned height found');
-      await serviceHelper.delay(4 * 60 * 1000);
-      checkMyAppsAvailability();
-      return;
-    }
-
-    if (dosMountMessage || dosDuplicateAppMessage) {
-      dosMessage = dosMountMessage || dosDuplicateAppMessage;
-      dosState = 100;
-      // added a sleep and recurse here, I assume it's possible for the DOS level to get
-      // remove elsewhere, so we should check this again.
-      await serviceHelper.delay(4 * 60 * 1000);
-      checkMyAppsAvailability();
-      return;
-    }
-
     const syncStatus = daemonServiceMiscRpcs.isDaemonSynced();
     if (!syncStatus.data.synced) {
       log.info('Flux Node daemon not synced. Application checks are disabled');
-      await serviceHelper.delay(4 * 60 * 1000);
-      checkMyAppsAvailability();
+      await serviceHelper.delay(timeouts.appError);
+      setImmediate(checkMyAppsAvailability);
       return;
     }
 
@@ -14219,32 +14230,29 @@ async function checkMyAppsAvailability() {
 
     if (!isNodeConfirmed) {
       log.info('Flux Node not Confirmed. Application checks are disabled');
-      await serviceHelper.delay(4 * 60 * 1000);
-      checkMyAppsAvailability();
+      await serviceHelper.delay(timeouts.appError);
+      setImmediate(checkMyAppsAvailability);
       return;
     }
 
     const localSocketAddress = await fluxNetworkHelper.getMyFluxIPandPort();
     if (!localSocketAddress) {
       log.info('No Public IP found. Application checks are disabled');
-      await serviceHelper.delay(4 * 60 * 1000);
-      checkMyAppsAvailability();
+      await serviceHelper.delay(timeouts.appError);
+      setImmediate(checkMyAppsAvailability);
       return;
     }
 
-    const [myIP, myPort = '16127'] = localSocketAddress.split(':');
-
     const installedAppsRes = await installedApps();
     if (installedAppsRes.status !== 'success') {
-      // removed the throw here. Keep the control flow local.
       log.error('Failed to get installed Apps');
-      await serviceHelper.delay(4 * 60 * 1000);
-      checkMyAppsAvailability();
+
+      await serviceHelper.delay(timeouts.appError);
+      setImmediate(checkMyAppsAvailability);
       return;
     }
 
     const apps = installedAppsRes.data;
-    const pubKey = await fluxNetworkHelper.getFluxNodePublicKey();
     const appPorts = [];
 
     apps.forEach((app) => {
@@ -14263,74 +14271,89 @@ async function checkMyAppsAvailability() {
       }
     });
 
-    if (setPortToTest) {
-      testingPort = setPortToTest;
+    if (nextTestingPort) {
+      testingPort = nextTestingPort;
     } else {
-      const minPort = currentHeight.generalScannedHeight
-        >= config.fluxapps.portBlockheightChange
-        ? config.fluxapps.portMinNew
-        : config.fluxapps.portMin - 1000;
+      const { fluxapps: { portMin, portMax } } = config;
 
-      const maxPort = currentHeight.generalScannedHeight
-        >= config.fluxapps.portBlockheightChange
-        ? config.fluxapps.portMaxNew
-        : config.fluxapps.portMax;
-
-      testingPort = Math.floor(Math.random() * (maxPort - minPort) + minPort);
+      testingPort = Math.floor(Math.random() * (portMax - portMin) + portMin);
     }
 
-    log.info(`checkMyAppsAvailability - Testing port ${testingPort}.`);
-    let iBP = fluxNetworkHelper.isPortBanned(testingPort);
+    log.info(`checkMyAppsAvailability - Testing port ${testingPort}`);
 
-    if (iBP) {
+    const isPortBanned = fluxNetworkHelper.isPortBanned(testingPort);
+
+    if (isPortBanned) {
       log.info(
-        `checkMyAppsAvailability - Testing port ${testingPort} is banned.`,
+        `checkMyAppsAvailability - Testing port ${testingPort} is banned`,
       );
 
       setNextPort();
-      await serviceHelper.delay(15 * 1000);
-      checkMyAppsAvailability();
+      await serviceHelper.delay(timeouts.failure);
+      setImmediate(checkMyAppsAvailability);
       return;
     }
 
     if (isUpnp) {
-      iBP = fluxNetworkHelper.isPortUPNPBanned(testingPort);
-      if (iBP) {
+      const isPortUpnpBanned = fluxNetworkHelper.isPortUPNPBanned(testingPort);
+
+      if (isPortUpnpBanned) {
         log.info(
-          `checkMyAppsAvailability - Testing port ${testingPort} is UPNP banned.`,
+          `checkMyAppsAvailability - Testing port ${testingPort} is UPNP banned`,
         );
 
         setNextPort();
-        await serviceHelper.delay(15 * 1000);
-        checkMyAppsAvailability();
+        await serviceHelper.delay(timeouts.failure);
+        setImmediate(checkMyAppsAvailability);
         return;
       }
     }
 
     const isPortUserBlocked = fluxNetworkHelper.isPortUserBlocked(testingPort);
+
     if (isPortUserBlocked) {
       log.info(
-        `checkMyAppsAvailability - Testing port ${testingPort} is user blocked.`,
+        `checkMyAppsAvailability - Testing port ${testingPort} is user blocked`,
       );
 
       setNextPort();
-      await serviceHelper.delay(15 * 1000);
-      checkMyAppsAvailability();
+      await serviceHelper.delay(timeouts.failure);
+      setImmediate(checkMyAppsAvailability);
       return;
     }
 
     if (appPorts.includes(testingPort)) {
       log.info(
-        `checkMyAppsAvailability - Skipped checking ${testingPort} - in use.`,
+        `checkMyAppsAvailability - Skipped checking ${testingPort} - in use`,
       );
 
       setNextPort();
-      await serviceHelper.delay(15 * 1000);
-      checkMyAppsAvailability();
+      await serviceHelper.delay(timeouts.failure);
+      setImmediate(checkMyAppsAvailability);
       return;
     }
 
-    const firewallActive = await fluxNetworkHelper.isFirewallActive();
+    const remoteSocketAddress = await networkStateService.getRandomSocketAddress(
+      localSocketAddress,
+    );
+
+    if (!remoteSocketAddress) {
+      await serviceHelper.delay(timeouts.appError);
+      setImmediate(checkMyAppsAvailability);
+      return;
+    }
+
+    if (failedNodesTestPortsCache.has(remoteSocketAddress)) {
+      // same as above. This is unlikley, just wait the 15 seconds
+      await serviceHelper.delay(timeouts.failure);
+      setImmediate(checkMyAppsAvailability);
+      return;
+    }
+
+    const firewallActive = isArcane
+      ? true
+      : await fluxNetworkHelper.isFirewallActive();
+
     if (firewallActive) {
       await fluxNetworkHelper.allowPort(testingPort);
     }
@@ -14341,258 +14364,271 @@ async function checkMyAppsAvailability() {
         'Flux_Test_App',
       );
 
+      // upnp dos takes precedence over both port dos and others
       if (!upnpMapResult) {
         if (lastUPNPMapFailed) {
-          dosState += 0.4;
-          if (dosState > 10) {
-            dosMessage = 'Not possible to run applications on the node, router returning exceptions when creating UPNP ports mappings.';
+          dosState += 4;
+          if (dosState >= thresholds.dos) {
+            dosMessage = 'Not possible to run applications on the node, '
+              + 'router returning exceptions when creating UPNP ports mappings';
           }
         }
         lastUPNPMapFailed = true;
         log.info(
-          `checkMyAppsAvailability - Testing port ${testingPort} failed to create on UPnP mappings`,
+          `checkMyAppsAvailability - Testing port ${testingPort} `
+          + 'failed to create UPnP mapping',
         );
 
         setNextPort();
 
-        await handleTestShutdown(testingPort, {
+        await handleTestShutdown(testingPort, testHttpServer, {
           skipFirewall: !firewallActive,
           skipUpnp: true,
           skipHttpServer: true,
         });
 
-        // changed this to two minutes if we are not DOS (and 15 minutes otherwise).
         // If we are failing mappings, we still need o fail 25 times before we go DOS.
-        const upnpDelay = dosMessage ? 15 * 60 * 1000 : 2 * 60 * 1000;
+        const upnpDelay = dosMessage ? timeouts.dos : timeouts.error;
         await serviceHelper.delay(upnpDelay);
-        checkMyAppsAvailability();
+        setImmediate(checkMyAppsAvailability);
         return;
       }
+
       lastUPNPMapFailed = false;
     }
 
-    await serviceHelper.delay(5 * 1000);
+    // Tested: This catches EADDRINUSE. Previously, this was crashing the entire app
+    // note - if you kill the port with:
+    //    ss --kill state listening src :<the port>
+    // nodeJS does not raise an error.
+    const listening = new Promise((resolve, reject) => {
+      testHttpServer
+        .once('error', (err) => {
+          testHttpServer.removeAllListeners('listening');
+          reject(err.message);
+        })
+        .once('listening', () => {
+          testHttpServer.removeAllListeners('error');
+          resolve(null);
+        });
+      testHttpServer.listen(testingPort);
+    });
 
-    // these event listeners need to be removed on every iteration to prevent a
-    // memory leak
-    testingAppserver
-      .listen(testingPort)
-      .on('error', (err) => {
-        throw err.message;
-      })
-      .on('uncaughtException', (err) => {
-        throw err.message;
-      });
+    const error = await listening.catch((err) => err);
 
-    await serviceHelper.delay(10 * 1000);
+    if (error) {
+      log.warn(`Unable to listen on port: ${testingPort}.Error: ${error}`);
 
-    const randomSocketAddress = await networkStateService.getRandomSocketAddress(localSocketAddress);
+      setNextPort();
 
-    if (!randomSocketAddress) {
-      await handleTestShutdown(testingPort, {
+      await handleTestShutdown(testingPort, testHttpServer, {
         skipFirewall: !firewallActive,
         skipUpnp: !isUpnp,
+        skipHttpServer: true,
       });
-      // changed this to 4 minutes. If we can't get a random connection, we have
-      // other problems. (i.e. it's an error state, or node just started)
-      await serviceHelper.delay(4 * 60 * 1000);
-      checkMyAppsAvailability();
+
+      await serviceHelper.delay(timeouts.error);
+      setImmediate(checkMyAppsAvailability);
       return;
     }
 
-    const [askingIP, askingIpPort = '16127'] = randomSocketAddress.split(':');
-
-    if (myIP === askingIP) {
-      await handleTestShutdown(testingPort, {
-        skipFirewall: !firewallActive,
-        skipUpnp: !isUpnp,
-      });
-      // safer just to wait here, no harm in waiiting 15 seconds in unlikely event
-      // that we pull ourselves from the list (or we should just remove it first)
-      await serviceHelper.delay(15 * 1000);
-      checkMyAppsAvailability();
-      return;
-    }
-
-    if (failedNodesTestPortsCache.has(askingIP)) {
-      await handleTestShutdown(testingPort, {
-        skipFirewall: !firewallActive,
-        skipUpnp: !isUpnp,
-      });
-      // same as above. This is unlikley, just wait the 15 seconds
-      await serviceHelper.delay(15 * 1000);
-      checkMyAppsAvailability();
-      return;
-    }
-
-    const timeout = 30000;
+    // The other end only waits 5 seconds anyway
+    const timeout = 10_000;
+    // we set an empty content-type header here. This is for when we fix
+    // the api, that the checkappavailability call will work will old and new
+    // nodes while we transition
     const axiosConfig = {
       timeout,
+      headers: {
+        'content-type': '',
+      },
     };
 
+    const pubKey = await fluxNetworkHelper.getFluxNodePublicKey();
+    const [localIp, localPort = '16127'] = localSocketAddress.split(':');
+    const [remoteIp, remotePort = '16127'] = remoteSocketAddress.split(':');
+
     const data = {
-      ip: myIP,
-      port: myPort,
+      ip: localIp,
+      port: localPort,
       appname: 'appPortsTest',
       ports: [testingPort],
       pubKey,
     };
-    const stringData = JSON.stringify(data);
-    const signature = await signCheckAppData(stringData);
+
+    const signature = await signCheckAppData(JSON.stringify(data));
     data.signature = signature;
 
-    // this will be problematic in the future (when we fix the api to respect
-    // content-type headers). As we are stringifying the data, axios doesn't
-    // add the appropriate header. (i.e. stop stringifying)
     const resMyAppAvailability = await axios
       .post(
-        `http://${askingIP}:${askingIpPort}/flux/checkappavailability`,
+        `http://${remoteIp}:${remotePort}/flux/checkappavailability`,
         JSON.stringify(data),
         axiosConfig,
       )
       .catch(() => {
         log.error(
-          `checkMyAppsAvailability - ${askingIP} for app availability is not reachable`,
+          `checkMyAppsAvailability - ${remoteSocketAddress} `
+          + 'for app availability is not reachable',
         );
-        setPortToTest = testingPort;
-        failedNodesTestPortsCache.set(askingIP, '');
+        nextTestingPort = testingPort;
+        failedNodesTestPortsCache.set(remoteSocketAddress, '');
         return null;
       });
 
-    if (!resMyAppAvailability) {
-      await handleTestShutdown(testingPort, {
-        skipFirewall: !firewallActive,
-        skipUpnp: !isUpnp,
-      });
-      await serviceHelper.delay(15 * 1000);
-      checkMyAppsAvailability();
-      return;
-    }
-
-    let portTestFailed = false;
-    if (resMyAppAvailability.data.status === 'error') {
-      log.warn(
-        `checkMyAppsAvailability - Applications port range unavailability detected from ${askingIP}:${askingIpPort} on ${testingPort}`,
-      );
-
-      log.warn(JSON.stringify(data));
-
-      portTestFailed = true;
-      dosState += 0.4;
-
-      // this is what actually sets the port to test on the next iteration (if
-      // no broken ports have been found)
-      if (!originalPortFailed) {
-        originalPortFailed = testingPort;
-        setPortToTest = testingPort < 65535 ? testingPort + 1 : testingPort - 1;
-      } else if (
-        testingPort >= originalPortFailed
-        && testingPort + 1 <= 65535
-      ) {
-        setPortToTest = testingPort + 1;
-      } else if (testingPort - 1 > 0) {
-        setPortToTest = testingPort - 1;
-      } else {
-        setPortToTest = null;
-        originalPortFailed = null;
-      }
-    } else if (
-      resMyAppAvailability.data.status === 'success'
-    ) {
-      log.info(
-        `${resMyAppAvailability.data.data.message} Detected from ${askingIP}:${askingIpPort} on ${testingPort}`,
-      );
-
-      // We have found a good working port. So we start iterating downwards to either
-      // find more broken ports, or a good port, where we reset
-      if (
-        originalPortFailed
-        && originalPortFailed >= testingPort
-        && originalPortFailed - 1 > 0
-      ) {
-        setPortToTest = originalPortFailed - 1;
-      } else {
-        setPortToTest = null;
-        originalPortFailed = null;
-      }
-    } else {
-      // we shouldn't get here, but just in case we clean up and retry
-      await handleTestShutdown(testingPort, {
-        skipFirewall: !firewallActive,
-        skipUpnp: !isUpnp,
-      });
-      await serviceHelper.delay(2 * 60 * 1000);
-      checkMyAppsAvailability();
-    }
-
-    if (dosState > 10) {
-      dosMessage = `Ports tested not reachable from outside, DMZ or UPNP required! All ports that have failed: ${JSON.stringify(
-        Array.from(portsNotWorking),
-      )}`;
-    }
-
-    await handleTestShutdown(testingPort, {
+    await handleTestShutdown(testingPort, testHttpServer, {
       skipFirewall: !firewallActive,
       skipUpnp: !isUpnp,
     });
 
-    if (!portTestFailed) {
-      dosState = 0;
-      dosMessage = dosMountMessage || dosDuplicateAppMessage || null;
-
-      portsNotWorking.delete(testingPort);
-
-      // this was based off the setPortToTest. However, what was happening, if we
-      // are selecting random ports from the list, there is a good chance that the
-      // port is below the original port, and it would go back to 1 hour checks
-      // even if a single port passed. So changed this to allow for 20 not working
-      // ports, before going back to 1 hour
-      const waitMs = portsNotWorking.size > 20 ? 1 * 60 * 1000 : 60 * 60 * 1000;
-      await serviceHelper.delay(waitMs);
-      checkMyAppsAvailability();
+    if (!resMyAppAvailability) {
+      await serviceHelper.delay(timeouts.failure);
+      setImmediate(checkMyAppsAvailability);
       return;
     }
 
-    // we use this to get the index and for logging
-    const ports = Array.from(portsNotWorking);
+    // at this point - testing is complete. Analyze the result and set up the
+    // next test (if applicable)
 
-    if (portsNotWorking.size < 100) {
-      portsNotWorking.add(testingPort);
-      // we just append this so the error logging is correct
-      ports.push(testingPort);
-      dosState = 0;
-      dosMessage = dosMountMessage || dosDuplicateAppMessage || null;
-      await serviceHelper.delay(15 * 1000);
-    } else {
-      // Moved the port add / slice to the success state. Having it here was mutating
-      // the portsNotWorking array on each iteration (i.e. bouncing 100 / 101 items)
-      const randomIndex = Math.floor(Math.random() * ports.length);
-      setPortToTest = ports[randomIndex];
-      await serviceHelper.delay(1 * 60 * 1000);
+    const {
+      data: {
+        status: responseStatus = null,
+        data: { message: responseMessasge = 'No response' } = {
+          message: 'No response',
+        },
+      },
+    } = resMyAppAvailability;
+
+    if (!['success', 'error'].includes(responseStatus)) {
+      // we retry the same port but with another node
+      log.warning('checkMyAppsAvailability - Unexpected response '
+        + `status: ${responseStatus}`);
+
+      await serviceHelper.delay(timeouts.error);
+      setImmediate(checkMyAppsAvailability);
+      return;
     }
 
-    log.error(
-      `checkMyAppsAvailability - portsNotWorking ${JSON.stringify(
-        ports,
-      )}.`,
-    );
+    /**
+     * States
+     *
+     * Normal
+     *   No broken ports, or broken ports less than 80 and a "good" port test
+     * Normal - Rising edge
+     *   I.e. broken ports increasing but threshold not reached. This state could
+     *   also be considered normal, and could take many many hours to cross the threshold
+     * Failed - Rising edge
+     *   Threshold crossed. There are 100 ports in portsNotWorking. At this time the
+     *   dosState starts rising 4 per fail. (takes 25 ports once in this state to DOS)
+     * Failed - DOS
+     *    There are 100 ports in the portsNotWorking array. 25 of those ports
+     *   have failed a second time. Node is in DOS state.
+     * Failed - Lowering edge
+     *   Same as failed, however the node is now considered "working" and is removing
+     *   ports from the portsNotWorking array. It will remain in this state until 20 ports
+     *   have been removed from the portsNotWorking array. (hysteresis) Once this happens, the node
+     *   is then considered in the "normal" state - and the portsNotWorking array is cleared
+     */
 
-    checkMyAppsAvailability();
+    const portTestFailed = responseStatus === 'error';
+    let waitMs = 0;
+
+    if (portTestFailed && portsNotWorking.size < thresholds.portsHighEdge) {
+      // Normal - Rising edge
+      portsNotWorking.add(testingPort);
+
+      if (!originalPortFailed) {
+        originalPortFailed = testingPort;
+        nextTestingPort = testingPort < 65535 ? testingPort + 1 : testingPort - 1;
+      } else if (
+        testingPort >= originalPortFailed
+        && testingPort + 1 <= 65535
+      ) {
+        nextTestingPort = testingPort + 1;
+      } else if (testingPort - 1 > 0) {
+        nextTestingPort = testingPort - 1;
+      } else {
+        nextTestingPort = null;
+        originalPortFailed = null;
+      }
+
+      waitMs = timeouts.failure;
+    } else if (portTestFailed && dosState < thresholds.dos) {
+      // Failed - Rising edge (by default takes 25 of these to get to 100)
+      dosState += 4;
+      setRandomPort();
+
+      waitMs = timeouts.failure;
+    } else if (portTestFailed && dosState >= thresholds.dos) {
+      // Failed - DOS. At this point - all apps will be removed off node
+      // by monitorNodeStatus
+      const failedPorts = setRandomPort();
+
+      // this dosMessage takes priority over dosMountMessage or dosDuplicateAppMessage
+      dosMessage = 'Ports tested not reachable from outside, DMZ or UPNP '
+        + `required! All ports that have failed: ${JSON.stringify(
+          failedPorts,
+        )}`;
+
+      waitMs = timeouts.dos;
+    } else if (!portTestFailed && portsNotWorking.size > thresholds.portsLowEdge) {
+      // Failed - Lowering edge, the hysteresis stops bouncing between states
+      portsNotWorking.delete(testingPort);
+      setRandomPort();
+
+      waitMs = timeouts.failure;
+    } else {
+      // Normal. This means that if we have less than 80 ports failed
+      // (and we haven't gone DOS), and we get a good port, it will reset
+      // the not working list
+      portsNotWorking.clear();
+      nextTestingPort = null;
+      originalPortFailed = null;
+      // we have to set this here. As the mount or duplicate messages could be set
+      // in between when we last checked and now
+      dosMessage = dosMountMessage || dosDuplicateAppMessage || null;
+      dosState = dosMessage ? thresholds.dos : 0;
+
+      waitMs = timeouts.default;
+    }
+
+    if (portTestFailed) {
+      log.error(
+        `checkMyAppsAvailability - Port ${testingPort} unreachable. `
+        + `Detected from ${remoteIp}:${remotePort}. DosState: ${dosState}`,
+      );
+    } else {
+      log.info(
+        `${responseMessasge} Detected from ${remoteIp}:${remotePort} on `
+        + `port ${testingPort}. DosState: ${dosState}`,
+      );
+    }
+
+    if (portsNotWorking.size) {
+      log.error(
+        `checkMyAppsAvailability - Count: ${portsNotWorking.size}. `
+        + `portsNotWorking: ${JSON.stringify(
+          Array.from(portsNotWorking),
+        )}`,
+      );
+    }
+
+    await serviceHelper.delay(waitMs);
+    setImmediate(checkMyAppsAvailability);
   } catch (error) {
     // this whole catch block is problematic. We are assuming that the rules have been
     // allowed, the rule has been mapped, and that the testing server has been
     // started. While all of these are then caught, we're logging errors that
     // aren't necessary. We should only remove stuff if it's been added. (and just
     // catch the errors as they are happening instead of using a catch all block)
-    if (dosMountMessage || dosDuplicateAppMessage) {
+    if (!dosMessage && (dosMountMessage || dosDuplicateAppMessage)) {
       dosMessage = dosMountMessage || dosDuplicateAppMessage;
     }
 
-    await handleTestShutdown(testingPort, { skipUpnp: !isUpnp });
+    await handleTestShutdown(testingPort, testHttpServer, { skipUpnp: !isUpnp });
 
     log.error(`checkMyAppsAvailability - Error: ${error}`);
-    await serviceHelper.delay(4 * 60 * 1000);
-    checkMyAppsAvailability();
+    await serviceHelper.delay(timeouts.appError);
+    setImmediate(checkMyAppsAvailability);
   }
 }
 

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -14637,9 +14637,8 @@ async function checkMyAppsAvailability() {
  * @param {array} portsToTest array of ports we will be testing
  * @returns boolean if ports are publicly available. So app installation can proceed
  */
-let beforeAppInstallTestingServers = [];
 async function checkInstallingAppPortAvailable(portsToTest = []) {
-  beforeAppInstallTestingServers = [];
+  const beforeAppInstallTestingServers = [];
   const isUPNP = upnpService.isUPNP();
   let portsStatus = false;
   try {
@@ -14687,18 +14686,36 @@ async function checkInstallingAppPortAvailable(portsToTest = []) {
           throw new Error('Failed to create map UPNP port');
         }
       }
-      const beforeAppInstallTestingExpress = express();
-      let beforeAppInstallTestingServer = http.createServer(beforeAppInstallTestingExpress);
-      beforeAppInstallTestingServer = httpShutdown(beforeAppInstallTestingServer);
+      const testHttpServer = new fluxHttpTestServer.FluxHttpTestServer();
+
       // eslint-disable-next-line no-await-in-loop
       await serviceHelper.delay(5 * 1000);
-      beforeAppInstallTestingServers.push(beforeAppInstallTestingServer);
-      beforeAppInstallTestingServer.listen(portToTest).on('error', (err) => {
-        throw err.message;
-      }).on('uncaughtException', (err) => {
-        throw err.message;
+
+      beforeAppInstallTestingServers.push(testHttpServer);
+
+      // Tested: This catches EADDRINUSE. Previously, this was crashing the entire app
+      // note - if you kill the port with:
+      //    ss --kill state listening src :<the port>
+      // nodeJS does not raise an error.
+      const listening = new Promise((resolve, reject) => {
+        testHttpServer
+          .once('error', (err) => {
+            testHttpServer.removeAllListeners('listening');
+            reject(err.message);
+          })
+          .once('listening', () => {
+            testHttpServer.removeAllListeners('error');
+            resolve(null);
+          });
+        testHttpServer.listen(portToTest);
       });
+
+      // eslint-disable-next-line no-await-in-loop
+      const error = await listening.catch((err) => err);
+
+      if (error) throw error;
     }
+
     await serviceHelper.delay(10 * 1000);
     const timeout = 30000;
     const axiosConfig = {
@@ -14720,7 +14737,9 @@ async function checkInstallingAppPortAvailable(portsToTest = []) {
     while (!finished && i < 5) {
       i += 1;
       // eslint-disable-next-line no-await-in-loop
-      const randomSocketAddress = await networkStateService.getRandomSocketAddress(localSocketAddress);
+      const randomSocketAddress = await networkStateService.getRandomSocketAddress(
+        localSocketAddress,
+      );
 
       // this should never happen as the list should be populated here
       if (!randomSocketAddress) {
@@ -14743,7 +14762,7 @@ async function checkInstallingAppPortAvailable(portsToTest = []) {
             // if we aren't already testing ports, we set it here, otherwise, just continue
             if (!originalPortFailed) {
               originalPortFailed = portToRetest;
-              setPortToTest = portToRetest < 65535 ? testingPort + 1 : testingPort - 1;
+              nextTestingPort = portToRetest < 65535 ? testingPort + 1 : testingPort - 1;
             }
           }
         }
@@ -14767,7 +14786,7 @@ async function checkInstallingAppPortAvailable(portsToTest = []) {
       }
     }
     beforeAppInstallTestingServers.forEach((beforeAppInstallTestingServer) => {
-      beforeAppInstallTestingServer.shutdown((err) => {
+      beforeAppInstallTestingServer.close((err) => {
         if (err) {
           log.error(`beforeAppInstallTestingServer Shutdown failed: ${err.message}`);
         }

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -126,21 +126,38 @@ function isPortUPNPBanned(port) {
 }
 
 /**
- * To perform a basic check if port on an ip is opened
- * @param {string} ip IP address.
- * @param {number} port Port.
- * @returns {boolean} Returns true if opened, otherwise false
+ * To perform a basic check if TCP port on an ip is open. I.e. that we receive a
+ * SYN-ACK in response to a SYN. If connected, we send an RST and close the port.
+ * @param {string} ip IP address
+ * @param {number} port Port
+ * @param {{timeout?:Number}} options
+ * @returns {Promise<boolean>} Returns true if opened, otherwise false
  */
-async function isPortOpen(ip, port) {
-  try {
-    const exec = `nc -w 5 -z -v ${ip} ${port} </dev/null; echo $?`;
-    const cmdAsync = util.promisify(nodecmd.get);
-    const result = await cmdAsync(exec);
-    return !+result;
-  } catch (error) {
-    log.error(error);
-    return false;
-  }
+async function isPortOpen(ip, port, options = {}) {
+  const timeout = options.timeout || 5_000;
+
+  const call = new Promise((resolve, reject) => {
+    const socket = new net.Socket();
+
+    const timer = setTimeout(() => {
+      socket.destroy();
+    }, timeout);
+
+    socket.connect(port, ip, () => {
+      clearTimeout(timer);
+      socket.resetAndDestroy();
+      resolve(true);
+    });
+
+    socket.on('error', () => {
+      clearTimeout(timer);
+      reject();
+    });
+  });
+
+  const connected = await call.catch(() => false);
+
+  return connected;
 }
 
 /**
@@ -244,10 +261,8 @@ async function checkAppAvailability(req, res) {
         throw new Error('Unable to verify request authenticity');
       }
 
-      const syncStatus = daemonServiceMiscRpcs.isDaemonSynced();
-      const daemonHeight = syncStatus.data.height;
-      const minPort = daemonHeight >= config.fluxapps.portBlockheightChange ? config.fluxapps.portMinNew : config.fluxapps.portMin - 1000;
-      const maxPort = daemonHeight >= config.fluxapps.portBlockheightChange ? config.fluxapps.portMaxNew : config.fluxapps.portMax;
+      const { fluxapps: { minPort, maxPort } } = config;
+
       // eslint-disable-next-line no-restricted-syntax
       for (const port of ports) {
         const iBP = isPortBanned(+port);

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -1193,7 +1193,7 @@ async function denyPort(port) {
     return cmdStat;
   }
   const portBanned = isPortBanned(+port);
-  if (+port < (config.fluxapps.portMinNew) || +port > config.fluxapps.portMaxNew || portBanned) {
+  if (portBanned || +port < config.fluxapps.portMin || +port > config.fluxapps.portMax) {
     cmdStat.message = 'Port out of deletable app ports range';
     return cmdStat;
   }
@@ -1227,7 +1227,7 @@ async function deleteAllowPortRule(port) {
     return cmdStat;
   }
   const portBanned = isPortBanned(+port);
-  if (+port < (config.fluxapps.portMinNew) || +port > config.fluxapps.portMaxNew || portBanned) {
+  if (portBanned || +port < config.fluxapps.portMin || +port > config.fluxapps.portMax) {
     cmdStat.message = 'Port out of deletable app ports range';
     return cmdStat;
   }
@@ -1258,7 +1258,7 @@ async function deleteDenyPortRule(port) {
     return cmdStat;
   }
   const portBanned = isPortBanned(+port);
-  if (+port < (config.fluxapps.portMinNew) || +port > config.fluxapps.portMaxNew || portBanned) {
+  if (portBanned || +port < config.fluxapps.portMin || +port > config.fluxapps.portMax) {
     cmdStat.message = 'Port out of deletable app ports range';
     return cmdStat;
   }
@@ -1289,7 +1289,7 @@ async function deleteAllowOutPortRule(port) {
     return cmdStat;
   }
   const portBanned = isPortBanned(+port);
-  if (+port < (config.fluxapps.portMinNew) || +port > config.fluxapps.portMaxNew || portBanned) {
+  if (portBanned || +port < config.fluxapps.portMin || +port > config.fluxapps.portMax) {
     cmdStat.message = 'Port out of deletable app ports range';
     return cmdStat;
   }

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -1353,7 +1353,7 @@ async function allowPortApi(req, res) {
 
 /**
  * To check if a firewall is active.
- * @returns {boolean} True if a firewall is active. Otherwise false.
+ * @returns {Promise<boolean>} True if a firewall is active. Otherwise false.
  */
 async function isFirewallActive() {
   try {

--- a/ZelBack/src/services/idService.js
+++ b/ZelBack/src/services/idService.js
@@ -149,7 +149,7 @@ async function loginPhrase(req, res) {
     const dosAppsState = appsService.getAppsDOSState();
     if (dosAppsState.status === 'success') {
       // nodeHardwareSpecsGood is not part of response yet
-      if (dosAppsState.data.dosState > 10) {
+      if (dosAppsState.data.dosState >= 100) {
         const errMessage = messageHelper.createErrorMessage(dosAppsState.data.dosMessage, 'DOS', dosAppsState.data.dosState);
         log.error(errMessage);
         res.json(errMessage);

--- a/ZelBack/src/services/utils/fluxHttpTestServer.js
+++ b/ZelBack/src/services/utils/fluxHttpTestServer.js
@@ -1,0 +1,41 @@
+const http = require('node:http');
+
+class FluxHttpTestServer extends http.Server {
+  /**
+   * The reason this class is necessary is because we allow old nodeJS versions.
+   * Anything after v18.2.0 we could just use closeAllConnections(), and this
+   * class wouldn't be necessary.
+   *
+   * When the sockets are destroyed, the close handler is called.
+   */
+  #connections = {};
+
+  #currentConnectionId = 0;
+
+  constructor() {
+    super(() => { });
+
+    this.addListener('connection', (socket) => this.#handleConnection(socket));
+  }
+
+  #handleConnection(socket) {
+    const connectionid = this.#currentConnectionId;
+    this.#connections[connectionid] = socket;
+    this.#currentConnectionId += 1;
+
+    socket.on('close', () => {
+      delete this.#connections[connectionid];
+    });
+  }
+
+  close(callback) {
+    super.close(callback);
+
+    Object.keys(this.#connections).forEach((key) => {
+      const socket = this.#connections[key];
+      socket.destroy();
+    });
+  }
+}
+
+module.exports = { FluxHttpTestServer };

--- a/apiServer.js
+++ b/apiServer.js
@@ -228,12 +228,7 @@ async function initiate() {
 
   process.on('uncaughtException', (err) => {
     const dnsErrors = ['ENOTFOUND', 'EAI_AGAIN', 'ESERVFAIL'];
-    // the express server port in use is uncatchable for some reason
-    // remove this in future
-    if (err.code === 'EADDRINUSE') {
-      // if shutting down clean, nodemon won't restart
-      logErrorAndExit('Flux api server port in use, shutting down.');
-    } else if (dnsErrors.includes(err.code) && err.hostname) {
+    if (dnsErrors.includes(err.code) && err.hostname) {
       log.error('Uncaught DNS Lookup Error!!, swallowing.');
       log.error(err);
       return;
@@ -267,10 +262,23 @@ async function initiate() {
     mode: 'https', key, cert, expressApp: httpServer.app,
   });
 
-  await httpServer.listen(apiPort);
-  log.info(`Flux listening on port ${apiPort}!`);
+  const httpError = await httpServer.listen(apiPort).catch((err) => err);
 
-  await httpsServer.listen(apiPortHttps);
+  if (httpError) {
+    // if shutting down clean, nodemon won't restart
+    logErrorAndExit(`Flux api server unable to start. ${httpError}`);
+    return '';
+  }
+
+  const httpsError = await httpsServer.listen(apiPortHttps).catch((err) => err);
+
+  if (httpsError) {
+    // if shutting down clean, nodemon won't restart
+    logErrorAndExit(`Flux api server unable to start. ${httpsError}`);
+    return '';
+  }
+
+  log.info(`Flux listening on port ${apiPort}!`);
   log.info(`Flux https listening on port ${apiPortHttps}!`);
 
   setAxiosDefaults([httpServer.socketIo, httpsServer.socketIo]);

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "express": "~4.19.2",
     "fast-xml-parser": "~4.3.2",
     "formidable": "~2.1.2",
-    "http-shutdown": "~1.2.2",
     "inquirer": "~8.2.6",
     "js-yaml": "~4.1.0",
     "mongodb": "~4.17.2",

--- a/tests/unit/fluxNetworkHelper.test.js
+++ b/tests/unit/fluxNetworkHelper.test.js
@@ -20,6 +20,9 @@ const benchmarkService = require('../../ZelBack/src/services/benchmarkService');
 const verificationHelper = require('../../ZelBack/src/services/verificationHelper');
 const networkStateService = require('../../ZelBack/src/services/networkStateService');
 const dbHelper = require('../../ZelBack/src/services/dbHelper');
+
+const net = require('node:net');
+
 const {
   outgoingConnections, outgoingPeers, incomingPeers, incomingConnections,
 } = require('../../ZelBack/src/services/utils/establishedConnections');
@@ -75,7 +78,9 @@ describe('fluxNetworkHelper tests', () => {
         },
       };
       stub = sinon.stub(serviceHelper, 'axiosGet').resolves(fluxAvailabilitySuccessResponse);
-      sinon.stub(util, 'promisify').returns(() => Promise.resolve());
+      sinon.stub(net.Socket.prototype, 'connect').callsFake((_port, _ip, callback) => {
+        callback();
+      });
       const expectedAddress = 'http://127.0.0.1:16127/flux/version';
       const expectedAddressHome = 'http://127.0.0.1:16126';
       const expectedMessage = {
@@ -108,7 +113,9 @@ describe('fluxNetworkHelper tests', () => {
         },
       };
       stub = sinon.stub(serviceHelper, 'axiosGet').resolves(fluxAvailabilitySuccessResponse);
-      sinon.stub(util, 'promisify').returns(() => Promise.resolve());
+      sinon.stub(net.Socket.prototype, 'connect').callsFake((port, ip, callback) => {
+        callback();
+      });
       const expectedAddress = 'http://127.0.0.1:16127/flux/version';
       const expectedAddressHome = 'http://127.0.0.1:16126';
       const expectedMessage = {
@@ -263,7 +270,9 @@ describe('fluxNetworkHelper tests', () => {
         },
       });
       stub = sinon.stub(serviceHelper, 'axiosGet').resolves(mockResponse);
-      sinon.stub(util, 'promisify').returns(() => Promise.resolve());
+      sinon.stub(net.Socket.prototype, 'connect').callsFake((_port, _ip, callback) => {
+        callback();
+      });
       const expectedAddress = 'http://127.0.0.1:16127/flux/version';
       const expectedAddressHome = 'http://127.0.0.1:16126';
 
@@ -287,7 +296,9 @@ describe('fluxNetworkHelper tests', () => {
         },
       });
       stub = sinon.stub(serviceHelper, 'axiosGet').resolves(mockResponse);
-      sinon.stub(util, 'promisify').returns(() => Promise.resolve());
+      sinon.stub(net.Socket.prototype, 'connect').callsFake((_port, _ip, callback) => {
+        callback();
+      });
       const expectedAddress = 'http://127.0.0.1:16127/flux/version';
       const expectedAddressHome = 'http://127.0.0.1:16126';
 

--- a/tests/unit/globalconfig/default.js
+++ b/tests/unit/globalconfig/default.js
@@ -182,11 +182,11 @@ module.exports = {
     multisigAddressChange: 1670000,
     epochstart: 694000,
     publicepochstart: 705000,
-    portMin: 31000, // ports 30000 - 30999 are reserved for local applications
-    portMax: 39999,
+    portMinLegacy: 31000, // ports 30000 - 30999 are reserved for local applications
+    portMaxLegacy: 39999,
     portBlockheightChange: 1420000,
-    portMinNew: 1,
-    portMaxNew: 65535,
+    portMin: 1,
+    portMax: 65535,
     bannedPorts: ['16100-16299', '26100-26299', '30000-30099', 8384, 27017, 22, 23, 25, 3389, 5900, 5800, 161, 512, 513, 5901, 3388, 4444, 123, 53],
     upnpBannedPorts: ['81-442', 2189],
     enterprisePorts: ['0-1023', 8080, 8081, 8443, 6667],


### PR DESCRIPTION
**NEED TO RETEST ON NODE AGAIN**

### This PR does the following:

* Adds logic to the port checker (and simplifies things) to handle failed state and sets a hysteresis to get back to a "normal" state
* Moves the test http server to a local variable and tidies up the testing server used by checkInstallingAppPortAvailable
* Moves the dosState to just use 100 - whatever the failure. Previous, it was 25 for failed ports and then it had to get to 100 to remove apps. Now it's just 100 everywhere.
* Removes all the serviceHelper delays - we just wait for the httpServer to be listening now (and don't need to wait for UPnP) there is an inbuilt delay anyway as we have to wait 1/2 RTT for the request to get to the remote end anyway. This was slowing down the total failure time significantly. (15 seconds per iteration * 125 iterations = over 30 minutes)
* Removes the janky call to netcat to test the port - we just use a socket now. (the netcat call was actually broken on some nodes, and was returning that the port was open even when it wasn't)
* Fixes the issue with the test http Server - this wasn't being caught properly if a port was already listening and was crashing the entire app.
* Fixes the EADDRINUSE error that was raised for the fluxServer http servers. We now handle this locally instead of on the process
* Removes the entire old / new portMin, portMax. This was broken. We were using the scanned height which is wrong. It should have been the current network block height (it's gone now anyway) Have updated it to PortMinLegacy etc, the only place this is now used is to verify correctness of apps  at the height they existed
* Totally removes the `http-shutdown` package. Just do this in house now. All it does is destroy all sockets when the server is closed. If we were on nodeJS 18.2.x - we could just use native node tools.

This means that if a node goes DOS for ports - apps will be uninstalled. The reason for this is that if the node goes DOS due to ports, it is more than likely that the app is broken anyway. I.e. it may have been fine when it was installed, but now it's not. Previously, this would have taken another 225 iterations before the apps were removed (several hours), where they're most likely broken anyway.

In most cases - this won't matter anyway as the node will go dos before any apps are installed.

Hopefully, this should be the last PR before I move the functionality to a class, update the algorithm, and write tests for it.

Here are the states:

    * Normal
          No broken ports, or broken ports less than 80 and a "good" port test
    * Normal - Rising edge
          I.e. broken ports increasing but threshold not reached. This state could
          also be considered normal, and could take many many hours to cross the threshold
    * Failed - Rising edge
          Threshold crossed. There are 100 ports in portsNotWorking. At this time the
          dosState starts rising 4 per fail. (takes 25 ports once in this state to DOS)
    * Failed - DOS
          There are 100 ports in the portsNotWorking array. 25 of those ports
          have failed a second time. Node is in DOS state.
    * Failed - Lowering edge
          Same as failed, however the node is now considered "working" and is removing
          ports from the portsNotWorking array. It will remain in this state until 20 ports
          have been removed from the portsNotWorking array. (hysteresis) Once this happens, the node
          is then considered in the "normal" state - and the portsNotWorking array is cleared

### Test methodology

Since we can't really write unit tests for this (recursion) without modifying the actual function logic, I did some integration testing.

I ran a test http server on one public ip, then on another public IP, ran the `checkMyAppsAvailability` function with the failure interval at one second, and the dos interval at 3 seconds. (so really fast)

The http server was set to fail the first 130 requests, which simulates that the port isn't open. This puts the node into DOS. Then after that http server was testing the ports were valid, and the node would go below the hysterisis value of 80 ports and go back to normal state