### PR TITLE
Bugfix: Syncthing cache and app installation

### DIFF
--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -14691,7 +14691,7 @@ async function checkInstallingAppPortAvailable(portsToTest = []) {
         throw new Error('Unable to get random test connection');
       }
 
-      const [askingIP, askingIpPort = '16127'] = randomSocketAddress;
+      const [askingIP, askingIpPort = '16127'] = randomSocketAddress.split(':');
 
       // first check against our IP address
       // eslint-disable-next-line no-await-in-loop

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -81,7 +81,7 @@ const trySpawningGlobalAppCache = cacheManager.appSpawnCache;
 const myShortCache = cacheManager.fluxRatesCache;
 const myLongCache = cacheManager.appPriceBlockedRepoCache;
 const failedNodesTestPortsCache = cacheManager.testPortsCache;
-const receiveOnlySyncthingAppsCache = cacheManager.syncthingAppsCache;
+const receiveOnlySyncthingAppsCache = new Map();
 const appsStopedCache = cacheManager.stoppedAppsCache;
 const syncthingDevicesIDCache = cacheManager.syncthingDevicesCache;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flux",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "description": "Flux, Your Gateway to a Decentralized World",
   "repository": {
     "type": "git",


### PR DESCRIPTION
#1521 introduced some issues for installing apps and running apps.

This patch fixes the following:

* Unable to spawn global apps as unable to verify the ports to install
* Syncthing apps stopping and restarting as the appId was being removed from the cache