### PR TITLE
Decrypt specs for app removal and port restore

### DIFF
--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -2650,6 +2650,12 @@ async function removeAppLocally(app, res, force = false, endResponse = true, sen
 
     let appId = dockerService.getAppIdentifier(app); // get app or app component identifier
 
+    // do this temporarily - otherwise we have to move a bunch of functions around
+    // eslint-disable-next-line no-use-before-define
+    appSpecifications = await checkAndDecryptAppSpecs(appSpecifications);
+    // eslint-disable-next-line no-use-before-define
+    appSpecifications = specificationFormatter(appSpecifications);
+
     if (appSpecifications.version >= 4 && !isComponent) {
       // it is a composed application
       // eslint-disable-next-line no-restricted-syntax
@@ -2931,12 +2937,18 @@ async function softRemoveAppLocally(app, res) {
 
   const appsQuery = { name: appName };
   const appsProjection = {};
-  const appSpecifications = await dbHelper.findOneInDatabase(appsDatabase, localAppsInformation, appsQuery, appsProjection);
+  let appSpecifications = await dbHelper.findOneInDatabase(appsDatabase, localAppsInformation, appsQuery, appsProjection);
   if (!appSpecifications) {
     throw new Error('Flux App not found');
   }
 
   let appId = dockerService.getAppIdentifier(app);
+
+  // do this temporarily - otherwise we have to move a bunch of functions around
+  // eslint-disable-next-line no-use-before-define
+  appSpecifications = await checkAndDecryptAppSpecs(appSpecifications);
+  // eslint-disable-next-line no-use-before-define
+  appSpecifications = specificationFormatter(appSpecifications);
 
   if (appSpecifications.version >= 4 && !isComponent) {
     // it is a composed application
@@ -6355,8 +6367,21 @@ async function assignedPortsInstalledApps() {
   const query = {};
   const projection = { projection: { _id: 0 } };
   const results = await dbHelper.findInDatabase(database, localAppsInformation, query, projection);
+
+  const decryptedApps = [];
+
+  // if the app isn't decrypted, this just returns the spec as is
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const spec of results) {
+    // temp: - move the functions around for the no-use-before
+    // eslint-disable-next-line
+    const decrypted = await checkAndDecryptAppSpecs(spec);
+    decryptedApps.push(decrypted);
+  }
+
   const apps = [];
-  results.forEach((app) => {
+  decryptedApps.forEach((app) => {
     // there is no app
     if (app.version === 1) {
       const appSpecs = {


### PR DESCRIPTION
There is an issue with v8 Enterprise apps where it cannot remove the app as the specs need to be decrypted.

This also fixes the issue where the ports aren't "restored" for enterprise apps as the specs wern't decrypted.

I've tested the app removal for enterpriese - it works.
I've tested port restore for non enterpriese - it works.

* Decrypts specs for app removal.
* Decrypts specs for port restore for apps.

<img width="2192" height="932" alt="Screenshot 2025-07-25 at 3 47 18 PM" src="https://github.com/user-attachments/assets/9822c103-77c8-4052-a3f1-78504b5d96a4" />
