### PR TITLE
Fix runningSince message format

### DIFF
--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -3821,7 +3821,7 @@ async function registerAppLocally(appSpecs, componentSpecs, res, test = false) {
         hash: appSpecifications.hash, // hash of application specifics that are running
         ip: myIP,
         broadcastedAt,
-        runningSince: broadcastedAt,
+        runningSince: new Date(broadcastedAt).toISOString(),
         osUptime: os.uptime(),
         staticIp: geolocationService.isStaticIP(),
       };
@@ -11504,7 +11504,7 @@ async function checkAndNotifyPeersOfRunningApps() {
       for (const application of applicationsToBroadcast) {
         const queryFind = { name: application.name, ip: myIP };
         const projection = { _id: 0, runningSince: 1 };
-        let runningOnMyNodeSince = Date.now();
+        let runningOnMyNodeSince = new Date().toISOString();
         // we already have the exact same data
         // eslint-disable-next-line no-await-in-loop
         const result = await dbHelper.findOneInDatabase(database, globalAppsLocations, queryFind, projection);


### PR DESCRIPTION
Some `fluxapprunning` messages have the incorrect `runningSince` format.

This PR maintains the same format for all fluxapprunning messages

Correct:

<img width="1208" height="504" alt="Screenshot 2025-07-28 at 2 52 06 PM" src="https://github.com/user-attachments/assets/c774ac4a-7d28-4b32-b5fe-fb5e31673548" />

Incorrect:

<img width="1194" height="468" alt="Screenshot 2025-07-28 at 2 51 59 PM" src="https://github.com/user-attachments/assets/e471a841-4b5a-42e7-89ca-b6a70a8a9dad" />
