### PR TITLE
Stagger multiport bench per IP

### DIFF
--- a/ZelBack/src/services/explorerService.js
+++ b/ZelBack/src/services/explorerService.js
@@ -627,9 +627,9 @@ async function processBlock(blockHeight, isInsightExplorer) {
       if (blockDataVerbose.height % config.fluxapps.benchUpnpPeriod === 0) {
         try {
           // every node behind the same ip will benchmark at the same time. I.e.
-          // we spread the network out (grouped by ip) over an hour so we don't
+          // we spread the network out (grouped by ip) over 4 hours so we don't
           // absolutely hammer the speedtest servers at the same time.
-          const maxBenchDelay = 3_600_000;
+          const maxBenchDelay = 4 * 3_600_000;
           const socketAddress = await fluxNetworkhelper.getMyFluxIPandPort();
 
           // socketAddress can be null. If it is, we just use an empty string. This

--- a/ZelBack/src/services/explorerService.js
+++ b/ZelBack/src/services/explorerService.js
@@ -643,7 +643,7 @@ async function processBlock(blockHeight, isInsightExplorer) {
           const benchDelayMs = serviceHelper.randomDelayMs(maxBenchDelay, { initializer });
           const benchDelayS = Math.round((benchDelayMs / 1000) * 100) / 100;
 
-          log.info(`Starting multiport bench in: ${benchDelayS}s`);
+          log.info(`Random seed: ${initializer}. Starting multiport bench in: ${benchDelayS}s`);
 
           setTimeout(benchmarkService.executeUpnpBench, benchDelayMs);
         } catch (error) {

--- a/ZelBack/src/services/explorerService.js
+++ b/ZelBack/src/services/explorerService.js
@@ -640,7 +640,7 @@ async function processBlock(blockHeight, isInsightExplorer) {
           const ip = socketAddress ? socketAddress.split(':')[0] : '';
           // This is: string + number = string
           const initializer = ip + blockDataVerbose.height;
-          const benchDelayMs = serviceHelper.randomDelay(maxBenchDelay, { initializer });
+          const benchDelayMs = serviceHelper.randomDelayMs(maxBenchDelay, { initializer });
           const benchDelayS = Math.round((benchDelayMs + Number.EPSILON) * 100) / 100;
 
           log.info(`Starting multiport bench in: ${benchDelayS}s`);

--- a/ZelBack/src/services/explorerService.js
+++ b/ZelBack/src/services/explorerService.js
@@ -641,7 +641,7 @@ async function processBlock(blockHeight, isInsightExplorer) {
           // This is: string + number = string
           const initializer = ip + blockDataVerbose.height;
           const benchDelayMs = serviceHelper.randomDelayMs(maxBenchDelay, { initializer });
-          const benchDelayS = Math.round((benchDelayMs + Number.EPSILON) * 100) / 100;
+          const benchDelayS = Math.round((benchDelayMs / 1000) * 100) / 100;
 
           log.info(`Starting multiport bench in: ${benchDelayS}s`);
 

--- a/ZelBack/src/services/explorerService.js
+++ b/ZelBack/src/services/explorerService.js
@@ -13,6 +13,7 @@ const daemonServiceTransactionRpcs = require('./daemonService/daemonServiceTrans
 const daemonServiceBlockchainRpcs = require('./daemonService/daemonServiceBlockchainRpcs');
 const appsService = require('./appsService');
 const benchmarkService = require('./benchmarkService');
+const fluxNetworkhelper = require('./fluxNetworkHelper');
 
 const coinbaseFusionIndexCollection = config.database.daemon.collections.coinbaseFusionIndex; // fusion
 const utxoIndexCollection = config.database.daemon.collections.utxoIndex;
@@ -420,7 +421,7 @@ async function insertAndRequestAppHashes(apps, database) {
       const appsToRemove = [];
       // eslint-disable-next-line no-restricted-syntax
       for (const app of apps) {
-      // eslint-disable-next-line no-await-in-loop
+        // eslint-disable-next-line no-await-in-loop
         const messageReceived = await appsService.checkAndRequestApp(app.hash, app.txid, app.height, app.value, 2);
         if (messageReceived) {
           appsToRemove.push(app);
@@ -625,7 +626,22 @@ async function processBlock(blockHeight, isInsightExplorer) {
       }
       if (blockDataVerbose.height % config.fluxapps.benchUpnpPeriod === 0) {
         try {
-          benchmarkService.executeUpnpBench();
+          const socketAddress = await fluxNetworkhelper.getMyFluxIPandPort();
+
+          // socketAddress can be null. If it is, we just use an empty string. This
+          // has the effect of creating an initializer of just the block number. If
+          // this happens, every node on the network that uses the block number will
+          // run the bench at the same time. However this is an extreme edge case, as
+          // all nodes should just return the ip.
+          const ip = socketAddress ? socketAddress.split(':')[0] : '';
+          // This is: string + number = string
+          const initializer = ip + blockDataVerbose.height;
+          const benchDelayMs = serviceHelper.randomDelay(3_600_000, { initializer });
+          const benchDelayS = Math.round((benchDelayMs + Number.EPSILON) * 100) / 100;
+
+          log.info(`Starting multiport bench in: ${benchDelayS}`);
+
+          setTimeout(benchmarkService.executeUpnpBench, benchDelayMs);
         } catch (error) {
           log.error(error);
         }

--- a/ZelBack/src/services/explorerService.js
+++ b/ZelBack/src/services/explorerService.js
@@ -626,6 +626,10 @@ async function processBlock(blockHeight, isInsightExplorer) {
       }
       if (blockDataVerbose.height % config.fluxapps.benchUpnpPeriod === 0) {
         try {
+          // every node behind the same ip will benchmark at the same time. I.e.
+          // we spread the network out (grouped by ip) over an hour so we don't
+          // absolutely hammer the speedtest servers at the same time.
+          const maxBenchDelay = 3_600_000;
           const socketAddress = await fluxNetworkhelper.getMyFluxIPandPort();
 
           // socketAddress can be null. If it is, we just use an empty string. This
@@ -636,10 +640,10 @@ async function processBlock(blockHeight, isInsightExplorer) {
           const ip = socketAddress ? socketAddress.split(':')[0] : '';
           // This is: string + number = string
           const initializer = ip + blockDataVerbose.height;
-          const benchDelayMs = serviceHelper.randomDelay(3_600_000, { initializer });
+          const benchDelayMs = serviceHelper.randomDelay(maxBenchDelay, { initializer });
           const benchDelayS = Math.round((benchDelayMs + Number.EPSILON) * 100) / 100;
 
-          log.info(`Starting multiport bench in: ${benchDelayS}`);
+          log.info(`Starting multiport bench in: ${benchDelayS}s`);
 
           setTimeout(benchmarkService.executeUpnpBench, benchDelayMs);
         } catch (error) {

--- a/ZelBack/src/services/serviceHelper.js
+++ b/ZelBack/src/services/serviceHelper.js
@@ -187,7 +187,7 @@ function parseInterval(userInterval) {
  * To delay by a number of milliseconds.
  * @param {number} userInterval The interval to delay for. See parseInterval
  * for specifics.
- * @returns {Promise} Promise object.
+ * @returns {Promise<void>} Promise object.
  */
 function delay(userInterval) {
   const ms = parseInterval(userInterval);
@@ -205,7 +205,7 @@ function delay(userInterval) {
  * the same.
  * @param {number} maxDelayMs
  * @param {{initializer?: string, minDelayMs?: number}} options
- * @returns
+ * @returns {Promise<void>}
  */
 function randomDelay(maxDelayMs, options = {}) {
   const initializer = options.initializer || null;
@@ -215,7 +215,7 @@ function randomDelay(maxDelayMs, options = {}) {
     ? () => {
       const seed = cyrb128(initializer);
       const rand = splitmix32(seed[0]);
-      return rand;
+      return rand();
     }
     : Math.random;
 

--- a/ZelBack/src/services/serviceHelper.js
+++ b/ZelBack/src/services/serviceHelper.js
@@ -205,9 +205,9 @@ function delay(userInterval) {
  * the same.
  * @param {number} maxDelayMs
  * @param {{initializer?: string, minDelayMs?: number}} options
- * @returns {Promise<void>}
+ * @returns {number}
  */
-function randomDelay(maxDelayMs, options = {}) {
+function randomDelayMs(maxDelayMs, options = {}) {
   const initializer = options.initializer || null;
   const minDelayMs = options.minDelayMs || 0;
 
@@ -223,7 +223,7 @@ function randomDelay(maxDelayMs, options = {}) {
     randFunc() * (maxDelayMs - minDelayMs + 1) + minDelayMs,
   );
 
-  return delay(ms);
+  return ms;
 }
 
 /**
@@ -723,7 +723,7 @@ module.exports = {
   minVersionSatisfy,
   parseVersion,
   parseInterval,
-  randomDelay,
+  randomDelayMs,
   runCommand,
   validIpv4Address,
   normalizeNodeIpApiPort,

--- a/ZelBack/src/services/serviceHelper.js
+++ b/ZelBack/src/services/serviceHelper.js
@@ -198,9 +198,9 @@ function delay(userInterval) {
 }
 
 /**
- * To delay (sleep) for a random number of ms. By default between 0 and maxDelayMs
+ * To generate a random delay in ms. By default between 0 and maxDelayMs
  *
- * Takes an optional initializer, for seeded random sleep times. If an initializer
+ * Takes an optional initializer, for seeded random delay times. If an initializer
  * is used, this function will return the same random number if the initializer is
  * the same.
  * @param {number} maxDelayMs

--- a/ZelBack/src/services/serviceHelper.js
+++ b/ZelBack/src/services/serviceHelper.js
@@ -1,3 +1,5 @@
+/* eslint no-bitwise: 0 */
+
 const util = require('node:util');
 const path = require('node:path');
 const fs = require('node:fs/promises');
@@ -28,6 +30,62 @@ const MAX_CHILD_PROCESS_TIME = 15 * 60 * 1000;
  * Allows for exclusive locks when running child processes
  */
 const locks = new Map();
+
+/**
+ *
+ * @param {string} initializer
+ * @returns {Array}
+ */
+function cyrb128(initializer) {
+  let h1 = 1779033703;
+  let h2 = 3144134277;
+  let h3 = 1013904242;
+  let h4 = 2773480762;
+
+  for (let i = 0, k; i < initializer.length; i += 1) {
+    k = initializer.charCodeAt(i);
+    h1 = h2 ^ Math.imul(h1 ^ k, 597399067);
+    h2 = h3 ^ Math.imul(h2 ^ k, 2869860233);
+    h3 = h4 ^ Math.imul(h3 ^ k, 951274213);
+    h4 = h1 ^ Math.imul(h4 ^ k, 2716044179);
+  }
+
+  h1 = Math.imul(h3 ^ (h1 >>> 18), 597399067);
+  h2 = Math.imul(h4 ^ (h2 >>> 22), 2869860233);
+  h3 = Math.imul(h1 ^ (h3 >>> 17), 951274213);
+  h4 = Math.imul(h2 ^ (h4 >>> 19), 2716044179);
+
+  h1 ^= (h2 ^ h3 ^ h4);
+  h2 ^= h1;
+  h3 ^= h1;
+  h4 ^= h1;
+
+  const seed = [h1 >>> 0, h2 >>> 0, h3 >>> 0, h4 >>> 0];
+
+  return seed;
+}
+
+/**
+ *
+ * @param {number} seed
+ * @returns {number}
+ */
+function splitmix32(seed) {
+  let a = seed;
+
+  return () => {
+    a |= 0;
+    a = a + 0x9e3779b9 | 0;
+    let t = a ^ a >>> 16;
+    t = Math.imul(t, 0x21f0aaad);
+    t ^= t >>> 15;
+    t = Math.imul(t, 0x735a2d97);
+
+    const value = ((t ^= t >>> 15) >>> 0) / 4294967296;
+
+    return value;
+  };
+}
 
 /**
  *  Parse a human readable time string into milliseconds, for timers
@@ -137,6 +195,35 @@ function delay(userInterval) {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
+}
+
+/**
+ * To delay (sleep) for a random number of ms. By default between 0 and maxDelayMs
+ *
+ * Takes an optional initializer, for seeded random sleep times. If an initializer
+ * is used, this function will return the same random number if the initializer is
+ * the same.
+ * @param {number} maxDelayMs
+ * @param {{initializer?: string, minDelayMs?: number}} options
+ * @returns
+ */
+function randomDelay(maxDelayMs, options = {}) {
+  const initializer = options.initializer || null;
+  const minDelayMs = options.minDelayMs || 0;
+
+  const randFunc = initializer
+    ? () => {
+      const seed = cyrb128(initializer);
+      const rand = splitmix32(seed[0]);
+      return rand;
+    }
+    : Math.random;
+
+  const ms = Math.floor(
+    randFunc() * (maxDelayMs - minDelayMs + 1) + minDelayMs,
+  );
+
+  return delay(ms);
 }
 
 /**
@@ -636,6 +723,7 @@ module.exports = {
   minVersionSatisfy,
   parseVersion,
   parseInterval,
+  randomDelay,
   runCommand,
   validIpv4Address,
   normalizeNodeIpApiPort,

--- a/apiServer.js
+++ b/apiServer.js
@@ -164,6 +164,10 @@ async function logErrorAndExit(msg, options = {}) {
 
   if (msg) log.error(msg);
 
+  const delayS = Math.round((delay / 1000) * 100) / 100;
+
+  log.info(`Waiting: ${delayS}s, before exiting with code: ${exitCode}`);
+
   await new Promise((r) => { setTimeout(r, delay); });
   process.exit(exitCode);
 }
@@ -180,10 +184,16 @@ async function loadUpnpIfRequired() {
     }
     if ((userconfig.initial.apiport && userconfig.initial.apiport !== config.server.apiport) || userconfig.initial.routerIP) {
       if (verifyUpnp !== true) {
-        await logErrorAndExit(`Flux port ${userconfig.initial.apiport} specified but UPnP failed to verify support. Shutting down.`);
+        await logErrorAndExit(
+          `Flux port ${userconfig.initial.apiport} specified but UPnP failed to verify support. Shutting down.`,
+          { exitCode: 1, delay: 120_000 },
+        );
       }
       if (setupUpnp !== true) {
-        await logErrorAndExit(`Flux port ${userconfig.initial.apiport} specified but UPnP failed to map to api or home port. Shutting down.`);
+        await logErrorAndExit(
+          `Flux port ${userconfig.initial.apiport} specified but UPnP failed to map to api or home port. Shutting down.`,
+          { exitCode: 1, delay: 120_000 },
+        );
       }
     }
   } catch (error) {
@@ -223,7 +233,7 @@ async function configReload() {
  */
 async function initiate() {
   if (!config.server.allowedPorts.includes(+apiPort)) {
-    await logErrorAndExit(`Flux port ${apiPort} is not supported. Shutting down.`, { exitCode: 1 });
+    await logErrorAndExit(`Flux port ${apiPort} is not supported. Shutting down.`);
   }
 
   process.on('uncaughtException', (err) => {

--- a/tests/images/entrypoint.sh
+++ b/tests/images/entrypoint.sh
@@ -3,8 +3,9 @@
 USER=fluxtesting
 HASH_LOCATION=tests/images/.package_hash
 
-if ! docker ps 2>&1 >/dev/null
-then
+sudo chown $USER:$USER /var/run/docker.sock
+
+if ! docker ps 2>&1 >/dev/null; then
   echo "Docker not available... exiting"
   exit
 fi
@@ -26,10 +27,9 @@ EXISTING_HASH=$(cat $HASH_LOCATION 2>/dev/null || echo 0)
 # save as array, as referencing CURRENT_HASH will give first item
 CURRENT_HASH=($(sha256sum package.json))
 
-if [[ $EXISTING_HASH != $CURRENT_HASH ]]
-then
+if [[ $EXISTING_HASH != $CURRENT_HASH ]]; then
   # only echo hash on success
-  npm install && echo "$CURRENT_HASH" > $HASH_LOCATION
+  npm install --omit-dev && echo "$CURRENT_HASH" > $HASH_LOCATION
 fi
 
 # create directories etc
@@ -47,5 +47,10 @@ echo "FLUX DATABASE: $FLUX_DATABASE"
 echo "DOCKER CMD: $@"
 
 touch {debug,info,warn,error}.log
+
+if [[ -n $MANUAL_TEST ]]; then
+  "$@"
+  exit
+fi
 
 npx mocha "$@" --exit; rm -f {debug,info,warn,error}.log

--- a/tests/unit/serviceHelper.test.js
+++ b/tests/unit/serviceHelper.test.js
@@ -740,4 +740,60 @@ describe('serviceHelper tests', () => {
       }
     });
   });
+
+  describe('randomDelayMs tests', () => {
+    it('should return the same delay for the same initializer', () => {
+      const initializer = '1.1.1.11976543';
+
+      const result1 = serviceHelper.randomDelayMs(10_000, { initializer });
+      const result2 = serviceHelper.randomDelayMs(10_000, { initializer });
+      expect(result1).to.equal(result2);
+    });
+
+    it('should return a different delay for a different initializer', () => {
+      const initializer1 = '1.1.1.11976543';
+      const initializer2 = '1.1.1.11976544';
+
+      const result1 = serviceHelper.randomDelayMs(10_000, { initializer1 });
+      const result2 = serviceHelper.randomDelayMs(10_000, { initializer2 });
+      expect(result1).to.not.equal(result2);
+    });
+
+    it('should always return a random delay between the min and max', () => {
+      const ip = '1.1.1.1';
+      const block = 2_000_000;
+
+      const minSize = 10_000;
+      const maxSize = 100_000;
+
+      for (let i = 0; i < 10_000; i += 1) {
+        const initializer = ip + (block + i);
+        const result = serviceHelper.randomDelayMs(
+          maxSize,
+          { initializer, minDelayMs: minSize },
+        );
+
+        expect(result).to.be.greaterThanOrEqual(minSize);
+        expect(result).to.be.lessThanOrEqual(maxSize);
+      }
+    });
+
+    it('should return a different random number if no initializer is used', () => {
+      const maxSize = Number.MAX_VALUE;
+
+      const valueCount = 1000;
+      // since we are using random, there is a chance, lol, like a small chance,
+      // that we can get the same number. To make sure this chance is essentially
+      // zero, we allow for 5 same numbers
+      const expectedCount = 995;
+
+      const numbers = Array(valueCount).fill().map(
+        () => serviceHelper.randomDelayMs(maxSize),
+      );
+
+      const unique = new Set(numbers);
+
+      expect(unique.size).to.be.greaterThanOrEqual(expectedCount);
+    });
+  });
 });


### PR DESCRIPTION
Comes with tests. I've tested this on a node - working.

## Problem

Gravity benchmarks UPnP nodes at the same time across the network. This is a large problem for speedtesting as we are effectively DDoSing many servers as we are testing them all at the same time. Especially nodes with huge throughput rates.

The reason this is done is to check all nodes on the same hypervisor to make sure they aren't allocating resources they don't have. I.e. 8 Nimbus nodes sharing a 50Mbps connection.

## Solution

Use the IP of the node as a proxy for the Hypervisor (and upstream network connection). This isn't perfect as people can run multiple IPs on the same Hypervisor but it's pretty good.

Instead of running all nodes on the same block - we now group them by ip and run them at random times over 1 hour. I.e. If an operator is running 16 nodes on 2 different ips, all 8 nodes on IP 1 will run at a a random time between 0-3600 seconds, and all 8 nodes on IP B will also run at a random time between 0-3600.

The random time is the SAME for each of the nodes on the same ip. I.e. - the random timer is seeded.

The Potato block is still the trigger that starts the timers that run the multiport bench. So all nodes will have completed the multiport bench within 1 hour of the Potato block

## Random distribution

Here is the distribution across buckets (each bucket is 1000, i.e. 0-999, 1000-1999 etc) with 10000 random numbers:

```
Map(10) {
  0 => 983,
  1 => 992,
  2 => 996,
  3 => 995,
  4 => 1013,
  5 => 1027,
  6 => 1002,
  7 => 993,
  8 => 1020,
  9 => 979
}
```

## Bonus

This PR also fixes an issue we have if a node fails to verify UPnP support on initial Gravity start (for whatever reason) it was exiting with code 0. This means that process supervisors  would not restart the service (if set to restart on failure) as the process exited successfully. We now exit with error code 1, after waiting 2 minutes. I've tested this - working.