### PR TITLE
[WIP] Fix verify message hash and valueSat in permanent messages

### DIFF
--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -4757,35 +4757,56 @@ async function verifyAppHash(message) {
   const specifications = message.appSpecifications || message.zelAppSpecifications;
   let messToHash = message.type + message.version + JSON.stringify(specifications) + message.timestamp + message.signature;
   let messageHASH = await generalService.messageHash(messToHash);
+
+  if (messageHASH === message.hash) return true;
+
+  const appSpecsCopy = JSON.parse(JSON.stringify(specifications));
+
+  if (specifications.version <= 3) {
+    // as of specification changes, adjust our appSpecs order of owner and repotag
+    // in new scheme it is always version, name, description, owner, repotag... Old format was version, name, description, repotag, owner
+    delete appSpecsCopy.version;
+    delete appSpecsCopy.name;
+    delete appSpecsCopy.description;
+    delete appSpecsCopy.repotag;
+    delete appSpecsCopy.owner;
+
+    const appSpecOld = {
+      version: specifications.version,
+      name: specifications.name,
+      description: specifications.description,
+      repotag: specifications.repotag,
+      owner: specifications.owner,
+      ...appSpecsCopy,
+    };
+    messToHash = message.type + message.version + JSON.stringify(appSpecOld) + message.timestamp + message.signature;
+    messageHASH = await generalService.messageHash(messToHash);
+  } else if (specifications.version === 7) {
+    // fix for repoauth / secrets order change for apps created after 1750273721000
+    appSpecsCopy.compose.forEach((component) => {
+      // previously the order was secrets / repoauth. Now it's repoauth / secrets.
+      const comp = component;
+      const { secrets, repoauth } = comp;
+
+      delete comp.secrets;
+      delete comp.repoauth;
+
+      // try the old secrets / repoauth
+      comp.secrets = secrets;
+      comp.repoauth = repoauth;
+    });
+
+    messToHash = message.type + message.version + JSON.stringify(appSpecsCopy) + message.timestamp + message.signature;
+    messageHASH = await generalService.messageHash(messToHash);
+  }
+
   if (messageHASH !== message.hash) {
-    if (specifications.version <= 3) {
-      // as of specification changes, adjust our appSpecs order of owner and repotag
-      // in new scheme it is always version, name, description, owner, repotag... Old format was version, name, description, repotag, owner
-      const appSpecsCopy = JSON.parse(JSON.stringify(specifications));
-      delete appSpecsCopy.version;
-      delete appSpecsCopy.name;
-      delete appSpecsCopy.description;
-      delete appSpecsCopy.repotag;
-      delete appSpecsCopy.owner;
-      const appSpecOld = {
-        version: specifications.version,
-        name: specifications.name,
-        description: specifications.description,
-        repotag: specifications.repotag,
-        owner: specifications.owner,
-        ...appSpecsCopy,
-      };
-      messToHash = message.type + message.version + JSON.stringify(appSpecOld) + message.timestamp + message.signature;
-      messageHASH = await generalService.messageHash(messToHash);
-      if (messageHASH !== message.hash) {
-        log.error(`Hashes dont match - expected - ${message.hash} - calculated - ${messageHASH} for the message ${JSON.stringify(message)}`);
-        throw new Error('Invalid Flux App hash received');
-      }
-      return true;
-    }
     log.error(`Hashes dont match - expected - ${message.hash} - calculated - ${messageHASH} for the message ${JSON.stringify(message)}`);
     throw new Error('Invalid Flux App hash received');
   }
+
+  // ToDo: fix this function. Should just return true / false and the upper layer deals with it,
+  // none of this needs to be async, crypto.createHash is synchronous
   return true;
 }
 
@@ -6770,7 +6791,7 @@ async function getPreviousAppSpecifications(specifications, verificationTimestam
   const decryptedPrev = await checkAndDecryptAppSpecs(appSpecs, { daemonHeight: heightForDecrypt });
   // eslint-disable-next-line no-use-before-define
   const formattedPrev = specificationFormatter(decryptedPrev);
-  
+
   return formattedPrev;
 }
 
@@ -9551,7 +9572,7 @@ async function checkAndSyncAppHashes() {
             // eslint-disable-next-line no-await-in-loop
             await storeAppTemporaryMessage(appMessage, true);
             // eslint-disable-next-line no-await-in-loop
-            await checkAndRequestApp(appMessage.hash, appMessage.txid, appMessage.height, appMessage.value, 2);
+            await checkAndRequestApp(appMessage.hash, appMessage.txid, appMessage.height, appMessage.valueSat, 2);
             // eslint-disable-next-line no-await-in-loop
             await serviceHelper.delay(50);
           } catch (error) {
@@ -10980,9 +11001,9 @@ async function trySpawningGlobalApplication() {
 
       // filter apps that failed to install before
       globalAppNamesLocation = globalAppNamesLocation.filter((app) => !runningApps.data.find((appsRunning) => appsRunning.Names[0].slice(5) === app.name)
-      && !spawnErrorsLongerAppCache.has(app.hash)
-      && !trySpawningGlobalAppCache.has(app.hash)
-      && !appsToBeCheckedLater.includes((appAux) => appAux.appName === app.name));
+        && !spawnErrorsLongerAppCache.has(app.hash)
+        && !trySpawningGlobalAppCache.has(app.hash)
+        && !appsToBeCheckedLater.includes((appAux) => appAux.appName === app.name));
       // filter apps that are non enterprise or are marked to install on my node
       globalAppNamesLocation = globalAppNamesLocation.filter((app) => app.nodes.length === 0 || app.nodes.find((ip) => ip === myIP) || app.version >= 8);
       // filter apps that dont have geolocation or that are forbidden to spawn on my node geolocation


### PR DESCRIPTION
**Still need to test this (and write the code to fix up the permanent messages)

## Problem

### Apps permanent messages

When a node first syncs, it can download the permanent messages off another node. There is a typo in the parsing, so the `valueSat` field ends up as `NaN` - which can manifest as a problem in different ways.

### Verifying message hashes

Since someone broke the ordering of the spec formatter for v7 (me) it causes issues with message hashing and verifying. A fix was put in place in the past for message verifying - but not for hashing.

## Solution

This PR just fixes the permanent message parsing on initial sync, and the `verifyAppHash` function, so that it retries verifying the hash with the old format.

There is also a cleanup function in `serviceManager` to tidy up the permanent messages using the value from the appsHashes collection. This is only run if any objects are found that have NaN for valueSat.