### PR TITLE
Feature: Rebuild apps information collection on start

### DIFF
--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -8122,9 +8122,12 @@ async function checkAndDecryptAppSpecs(appSpec, options = {}) {
     };
     const allPermanentAppMessage = await dbHelper.findInDatabase(database, globalAppsMessages, appsQuery, projection);
     const lastUpdate = allPermanentAppMessage[allPermanentAppMessage.length - 1];
-    // There seems to be some apps that have made there way into localApps but aren't on permanent
-    // messages. If so - we just return height of zero
-    daemonHeight = lastUpdate ? lastUpdate.height : 0;
+
+    if (!lastUpdate) {
+      throw new Error(`App: ${appSpecs.name} does not exist in global messages`);
+    }
+
+    daemonHeight = lastUpdate.height;
   }
 
   const enterprise = await decryptEnterpriseFromSession(

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -8122,7 +8122,9 @@ async function checkAndDecryptAppSpecs(appSpec, options = {}) {
     };
     const allPermanentAppMessage = await dbHelper.findInDatabase(database, globalAppsMessages, appsQuery, projection);
     const lastUpdate = allPermanentAppMessage[allPermanentAppMessage.length - 1];
-    daemonHeight = lastUpdate.height;
+    // There seems to be some apps that have made there way into localApps but aren't on permanent
+    // messages. If so - we just return height of zero
+    daemonHeight = lastUpdate ? lastUpdate.height : 0;
   }
 
   const enterprise = await decryptEnterpriseFromSession(

--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -2557,7 +2557,7 @@ async function appUninstallHard(appName, appId, appSpecifications, isComponent, 
  * @param {boolean} force Defaults to false. Force determines if a check for app not found is skipped.
  * @param {boolean} endResponse Defaults to true.
  * @param {boolean} sendMessage Defaults to false. When sendMessage is true we broadcast the appremoved message to the network.
- * @returns {void} Return statement is only used here to interrupt the function and nothing is returned.
+ * @returns {Promise<void>} Return statement is only used here to interrupt the function and nothing is returned.
  */
 async function removeAppLocally(app, res, force = false, endResponse = true, sendMessage = false) {
   try {

--- a/ZelBack/src/services/dbHelper.js
+++ b/ZelBack/src/services/dbHelper.js
@@ -764,7 +764,7 @@ async function validateAppsInformation() {
     response.reindexed = true;
     response.appsToRemove = appsToRemove;
   } catch (err) {
-    log.error('Unable to validate apps information. Error: {err}');
+    log.error(`Unable to validate apps information. Error: ${err}`);
   }
   return response;
 }

--- a/ZelBack/src/services/dbHelper.js
+++ b/ZelBack/src/services/dbHelper.js
@@ -1,3 +1,5 @@
+const log = require('../lib/log');
+
 /**
  * @module Helper module used for all interactions with database
  */
@@ -16,7 +18,7 @@ let openDBConnection = null;
 /**
  * Returns MongoDB connection, if it was initiated before, otherwise returns null.
  *
- * @returns {mongodb.MongoClient}
+ * @returns {mongodb.MongoClient | null}
  */
 function databaseConnection() {
   return openDBConnection;
@@ -32,8 +34,6 @@ function databaseConnection() {
 async function connectMongoDb(url) {
   const connectUrl = url || mongoUrl;
   const mongoSettings = {
-    useNewUrlParser: true,
-    useUnifiedTopology: true,
     maxPoolSize: 100,
   };
   const client = await MongoClient.connect(connectUrl, mongoSettings);
@@ -84,35 +84,41 @@ async function distinctDatabase(database, collection, distinct, query) {
  *
  * @returns {Promise<Arrray>}
  */
-async function findInDatabase(database, collection, query, options) {
+async function findInDatabase(database, collection, query = {}, options = {}) {
   const results = await database.collection(collection).find(query, options).toArray();
   return results;
 }
 
 /**
- * Returns array of documents from the DB based on pipeline aggregate.
+ * Returns either a db cursor or array of documents based on pipeline aggregate.
  *
- * @param {string} database
+ * @param {mongodb.Db} database
  * @param {string} collection
- * @param {object} pipeline
+ * @param {Array<Object>} pipeline
+ * @param {{returnArray?: boolean}} options
  *
- * @returns array
+ * @returns {Promise<mongodb.AggregationCursor | Array>}
  */
-async function aggregateInDatabase(database, collection, pipeline) {
-  const results = await database.collection(collection).aggregate(pipeline).toArray();
-  return results;
+async function aggregateInDatabase(database, collection, pipeline, options = {}) {
+  const returnArray = options.returnArray ?? true;
+
+  const dbCursor = database.collection(collection).aggregate(pipeline);
+
+  const returnValue = returnArray ? await dbCursor.toArray() : dbCursor;
+
+  return returnValue;
 }
 
 /**
  * Returns document from the DB based on the query and the projection.
  *
- * @param {string} database
+ * @param {mongodb.Db} database
  * @param {string} collection
- * @param {object} query
- * @param {object} [projection]
- * @returns document
+ * @param {Object} query
+ * @param {Object} projection
+ * @returns {Object}
  */
-async function findOneInDatabase(database, collection, query, projection) {
+async function findOneInDatabase(database, collection, query = {}, projection = {}) {
   const result = await database.collection(collection).findOne(query, projection);
   return result;
 }
@@ -294,24 +300,536 @@ async function collectionStats(database, collection) {
   return result;
 }
 
+async function findValueSatNanInAppsMessages() {
+  const {
+    database: {
+      appsglobal: {
+        database: dbName, collections: { appsMessages: collectionName },
+      },
+    },
+  } = config;
+
+  const client = databaseConnection();
+  const db = client.db(dbName);
+  const query = { valueSat: NaN };
+  const options = { projection: { _id: 0, hash: 1 } };
+
+  const result = await findInDatabase(db, collectionName, query, options);
+
+  // ToDo: Fix the db helper so this is configurable
+  const brokenMessageHashes = result.map((item) => item.hash);
+
+  return brokenMessageHashes;
+}
+
+async function findValueSatInAppsHashes() {
+  const {
+    database: {
+      daemon: {
+        database: dbName, collections: { appsHashes: collectionName },
+      },
+    },
+  } = config;
+
+  const client = databaseConnection();
+  const db = client.db(dbName);
+  const query = {};
+  const options = { projection: { _id: 0, hash: 1, value: 1 } };
+
+  const results = await findInDatabase(db, collectionName, query, options);
+
+  const hashToValueMap = new Map();
+
+  results.forEach((result) => {
+    hashToValueMap.set(result.hash, result.value);
+  });
+
+  return hashToValueMap;
+}
+
+async function updateValueSatInAppsMessages(brokenHashes, hashMap) {
+  const {
+    database: {
+      appsglobal: {
+        database: dbName, collections: { appsMessages: collectionName },
+      },
+    },
+  } = config;
+
+  const client = databaseConnection();
+  const db = client.db(dbName);
+
+  const updateChunk = async (hashes) => {
+    const operations = [];
+
+    hashes.forEach((hash) => {
+      const valueSat = hashMap.get(hash);
+
+      if (valueSat) {
+        const operation = {
+          updateOne: {
+            filter: { hash },
+            update: { $set: { valueSat } },
+            upsert: true,
+          },
+        };
+
+        operations.push(operation);
+      }
+    });
+
+    await bulkWriteInDatabase(db, collectionName, operations);
+  };
+
+  const hashCount = brokenHashes.length;
+  const chunkSize = 5000;
+  let startIndex = 0;
+  let endIndex = Math.min(chunkSize, hashCount);
+
+  while (startIndex < hashCount) {
+    const chunk = brokenHashes.slice(startIndex, endIndex);
+    // eslint-disable-next-line no-await-in-loop
+    await updateChunk(chunk);
+
+    startIndex = endIndex;
+    endIndex += chunk.length;
+  }
+}
+
+async function repairNanInAppsMessagesDb() {
+  const brokenHashes = await findValueSatNanInAppsMessages();
+
+  if (!brokenHashes.length) return;
+
+  const hashMap = await findValueSatInAppsHashes();
+
+  await updateValueSatInAppsMessages(brokenHashes, hashMap);
+}
+
+/**
+ *
+ * @param {mongodb.Db} appsGlobalDb
+ * @param {string} appsMessagesCol mongo collection name
+ * @param {string} appsInformationCol mongo collection name
+ * @param {number} scannedHeight
+ * @returns {Promise<boolean>}
+ */
+async function isReindexAppsInformationRequired(
+  appsGlobalDb,
+  appsMessagesCol,
+  appsInformationCol,
+  scannedHeight,
+) {
+  const appsMessagesPipeline = [
+    { $sort: { 'appSpecifications.name': 1, height: -1 } },
+    {
+      $group: {
+        _id: '$appSpecifications.name',
+        maxHeightMsg: { $first: '$$ROOT' },
+      },
+    },
+    {
+      $match: {
+        $expr: {
+          $gte: [
+            {
+              $add: [
+                '$maxHeightMsg.height',
+                { $ifNull: ['$maxHeightMsg.appSpecifications.expire', 22000] },
+              ],
+            },
+            scannedHeight,
+          ],
+        },
+      },
+    },
+    {
+      $count: 'count',
+    },
+  ];
+
+  const appsInformationPipeline = [
+    {
+      $set: {
+        expireHeight: { $add: ['$height', { $ifNull: ['$expire', 22000] }] },
+      },
+    },
+    {
+      $match: {
+        expireHeight: { $gte: scannedHeight },
+      },
+    },
+    {
+      $count: 'count',
+    },
+  ];
+
+  try {
+    await appsGlobalDb
+      .collection(appsMessagesCol)
+      .createIndex(
+        {
+          'appSpecifications.name': 1,
+          height: -1,
+        },
+        { name: 'sortAppMessagesForGroupBy' },
+      );
+
+    const messagesCursor = await aggregateInDatabase(
+      appsGlobalDb,
+      appsMessagesCol,
+      appsMessagesPipeline,
+      { returnArray: false },
+    );
+    const informationCursor = await aggregateInDatabase(
+      appsGlobalDb,
+      appsInformationCol,
+      appsInformationPipeline,
+      { returnArray: false },
+    );
+
+    const appsFromMessages = await messagesCursor.next();
+    const appsFromInformation = await informationCursor.next();
+
+    if (!appsFromMessages) {
+      log.warning('No apps from apps messages found, unable to validate apps information');
+      return false;
+    }
+
+    if (!appsFromInformation) {
+      log.info('No apps information apps found, reindexing colleciton');
+      return true;
+    }
+
+    log.info(
+      `Apps reindex validation. Found ${appsFromMessages.count} apps from appsMessages.`
+      + ` Found ${appsFromInformation.count} apps from appsInformation`,
+    );
+
+    const reindexRequired = appsFromMessages.count !== appsFromInformation.count;
+
+    return reindexRequired;
+  } catch (err) {
+    log.error(`isReindexAppsInformationRequired - Mongodb Error: ${err}`);
+    return false;
+  }
+}
+
+/**
+ * Rebuilds the appsInformation collection from a dbCursor containing the appropriate
+ * preformed records.
+ * @param {mongodb.AggregationCursor} appsDbCursor
+ * @param {mongodb.Db} globalDb
+ * @param {mongodb.Db} localDb
+ * @param {string} globalAppsInformationCol mongo collection name
+ * @param {string} localAppsInformationCol mongo collection name
+ * @returns {Promise<Array<string>} Any installed app (by name) that need to be removed
+ */
+async function syncAppsInformationCollection(
+  appsDbCursor,
+  globalDb,
+  localDb,
+  globalAppsInformationCol,
+  localAppsInformationCol,
+) {
+  const installedAppsArray = await findInDatabase(
+    localDb,
+    localAppsInformationCol,
+  );
+  const installedApps = new Set(installedAppsArray.map((app) => app.name));
+
+  const insertChunk = async (appInfos) => {
+    await insertManyToDatabase(
+      globalDb,
+      globalAppsInformationCol,
+      appInfos,
+    );
+  };
+
+  const chunkSize = 500;
+  const appInfoChunk = [];
+
+  // eslint-disable-next-line no-restricted-syntax
+  for await (const appInfo of appsDbCursor) {
+    appInfoChunk.push(appInfo);
+
+    if (installedApps.has(appInfo.name)) installedApps.delete(appInfo.name);
+
+    if (appInfoChunk.length >= chunkSize) {
+      await insertChunk(appInfoChunk);
+      appInfoChunk.length = 0;
+    }
+  }
+
+  if (appInfoChunk.length) await insertChunk(appInfoChunk);
+
+  return Array.from(installedApps);
+}
+
+/**
+ * @param {mongodb.Db} appsGlobalDb mongo db
+ * @param {mongodb.Db} appsLocalDb mongo db
+ * @param {string} globalAppsMessagesCol mongo collection name
+ * @param {string} globalAppsInformationCol mongo collection name
+ * @param {string} localAppsInformationCol mongo collection name
+ * @param {number} scannedHeight current height as scanned by the block explorer
+ * @returns {Promise<Array<string>} Any local apps that need to be removed (expired)
+ */
+async function reindexGlobalAppsInformation(
+  appsGlobalDb,
+  appsLocalDb,
+  globalAppsMessagesCol,
+  globalAppsInformationCol,
+  localAppsInformationCol,
+  scannedHeight,
+) {
+  const dropped = await dropCollection(appsGlobalDb, globalAppsInformationCol)
+    .catch((error) => {
+      if (error.message !== 'ns not found') {
+        log.error('reindexGlobalAppsInformation - Unable to drop db. '
+          + `Error: ${error}`);
+        return false;
+      }
+      return true;
+    });
+
+  if (!dropped) return [];
+
+  // These index names are ridiculous
+  await appsGlobalDb
+    .collection(globalAppsInformationCol)
+    .createIndex(
+      { name: 1 },
+      { name: 'query for getting zelapp based on zelapp specs name' },
+    );
+
+  await appsGlobalDb
+    .collection(globalAppsInformationCol)
+    .createIndex(
+      { owner: 1 },
+      { name: 'query for getting zelapp based on zelapp specs owner' },
+    );
+
+  await appsGlobalDb
+    .collection(globalAppsInformationCol)
+    .createIndex(
+      { repotag: 1 },
+      { name: 'query for getting zelapp based on image' },
+    );
+
+  await appsGlobalDb
+    .collection(globalAppsInformationCol)
+    .createIndex(
+      { height: 1 },
+      { name: 'query for getting zelapp based on last height update' },
+    );
+
+  await appsGlobalDb
+    .collection(globalAppsInformationCol)
+    .createIndex(
+      { hash: 1 },
+      { name: 'query for getting zelapp based on last hash' },
+    );
+
+  const pipeline = [
+    { $sort: { 'appSpecifications.name': 1, height: -1 } },
+    {
+      $group: {
+        _id: '$appSpecifications.name',
+        maxHeightMsg: { $first: '$$ROOT' },
+      },
+    },
+    {
+      $match: {
+        $expr: {
+          $gte: [
+            {
+              $add: [
+                '$maxHeightMsg.height',
+                { $ifNull: ['$maxHeightMsg.appSpecifications.expire', 22000] },
+              ],
+            },
+            scannedHeight,
+          ],
+        },
+      },
+    },
+    {
+      $replaceWith: {
+        $mergeObjects: [
+          '$maxHeightMsg.appSpecifications',
+          {
+            hash: '$maxHeightMsg.hash',
+            height: '$maxHeightMsg.height',
+          },
+        ],
+      },
+    },
+  ];
+
+  const resultCursor = aggregateInDatabase(
+    appsGlobalDb,
+    globalAppsMessagesCol,
+    pipeline,
+  );
+
+  const appsToRemove = await syncAppsInformationCollection(
+    resultCursor,
+    appsGlobalDb,
+    appsLocalDb,
+    globalAppsInformationCol,
+    localAppsInformationCol,
+  );
+  log.info(
+    `Reindexing of global applications finished. Local apps to be removed: ${JSON.stringify(
+      appsToRemove,
+    )}`,
+  );
+
+  return appsToRemove;
+}
+
+/**
+ * Verifies the app count based on an aggregation from appsmessages and compares it to the
+ * app count in appsinformation. If they differ - the appsinformation collection is dropped and
+ * rebuilt from the appsmessages. The entire process takes about 500-700ms.
+ * @returns {Promise<{validated: boolean, reindexed: boolean, appsToRemove: Array<string>}>}
+ */
+async function validateAppsInformation() {
+  const response = { validated: false, reindexed: false, appsToRemove: [] };
+
+  const {
+    database: {
+      appsglobal: {
+        database: appsGlobalDbName,
+        collections: {
+          appsInformation: globalAppsInformationCol,
+          appsMessages: globalAppsMessagesCol,
+        },
+      },
+      appslocal: {
+        database: appsLocalDbName,
+        collections: {
+          appsInformation: localAppsInformationCol,
+        },
+      },
+      daemon: {
+        database: daemonDbName,
+        collections: { scannedHeight: scannedHeightCol },
+      },
+    },
+  } = config;
+
+  const client = databaseConnection();
+
+  if (!client) {
+    log.warning('Unable to validate apps information collection, no client');
+    return response;
+  }
+
+  try {
+    const appsGlobalDb = client.db(appsGlobalDbName);
+    const appsLocalDb = client.db(appsLocalDbName);
+    const daemonDb = client.db(daemonDbName);
+
+    const scannedHeightResult = await findOneInDatabase(
+      daemonDb,
+      scannedHeightCol,
+    );
+    const { generalScannedHeight: scannedHeight = null } = scannedHeightResult;
+
+    if (!scannedHeight) return response;
+
+    const reindexRequired = await isReindexAppsInformationRequired(
+      appsGlobalDb,
+      globalAppsMessagesCol,
+      globalAppsInformationCol,
+      scannedHeight,
+    );
+
+    if (!reindexRequired) {
+      response.validated = true;
+      return response;
+    }
+
+    const appsToRemove = await reindexGlobalAppsInformation(
+      appsGlobalDb,
+      appsLocalDb,
+      globalAppsMessagesCol,
+      globalAppsInformationCol,
+      localAppsInformationCol,
+      scannedHeight,
+    );
+
+    response.reindexed = true;
+    response.appsToRemove = appsToRemove;
+  } catch (err) {
+    log.error('Unable to validate apps information. Error: {err}');
+  }
+  return response;
+}
+
+/**
+ *
+ * @param {string} command
+ * @returns {Promise<void>}
+ */
+async function main(command) {
+  const initiated = await initiateDB().catch(() => false);
+
+  if (!initiated) return;
+
+  if (command === 'validateInfoCol') {
+    await validateAppsInformation();
+  } else if (command === 'repairMessagesCol') {
+    await repairNanInAppsMessagesDb();
+  }
+
+  const client = databaseConnection();
+
+  await client.close();
+}
+
+if (require.main === module) {
+  // eslint-disable-next-line global-require
+  const { parseArgs } = require('node:util');
+
+  const { positionals } = parseArgs({
+    allowPositionals: true,
+    strict: true,
+  });
+
+  const validCommands = ['validateInfoCol', 'repairMessagesCol'];
+  const command = positionals[0];
+
+  if (!command || !validCommands.includes(command)) {
+    console.error(`Error: Invalid command. Expected one of: ${validCommands.join(', ')}`);
+    process.exit(1);
+  }
+
+  main(command);
+}
+
 module.exports = {
-  databaseConnection,
-  connectMongoDb,
-  initiateDB,
-  distinctDatabase,
-  findInDatabase,
-  findOneInDatabase,
-  findOneAndUpdateInDatabase,
-  findOneAndDeleteInDatabase,
-  insertOneToDatabase,
-  updateOneInDatabase,
-  updateInDatabase,
-  removeDocumentsFromCollection,
-  dropCollection,
-  collectionStats,
-  closeDbConnection,
-  insertManyToDatabase,
   aggregateInDatabase,
-  countInDatabase,
   bulkWriteInDatabase,
+  closeDbConnection,
+  collectionStats,
+  connectMongoDb,
+  countInDatabase,
+  databaseConnection,
+  distinctDatabase,
+  dropCollection,
+  findInDatabase,
+  findOneAndDeleteInDatabase,
+  findOneAndUpdateInDatabase,
+  findOneInDatabase,
+  initiateDB,
+  insertManyToDatabase,
+  insertOneToDatabase,
+  removeDocumentsFromCollection,
+  repairNanInAppsMessagesDb,
+  updateInDatabase,
+  updateOneInDatabase,
+  validateAppsInformation,
 };

--- a/ZelBack/src/services/dbHelper.js
+++ b/ZelBack/src/services/dbHelper.js
@@ -667,10 +667,11 @@ async function reindexGlobalAppsInformation(
     },
   ];
 
-  const resultCursor = aggregateInDatabase(
+  const resultCursor = await aggregateInDatabase(
     appsGlobalDb,
     globalAppsMessagesCol,
     pipeline,
+    { returnArray: false },
   );
 
   const appsToRemove = await syncAppsInformationCollection(

--- a/ZelBack/src/services/dbHelper.js
+++ b/ZelBack/src/services/dbHelper.js
@@ -431,7 +431,7 @@ async function isReindexAppsInformationRequired(
     {
       $match: {
         $expr: {
-          $gte: [
+          $gt: [
             {
               $add: [
                 '$maxHeightMsg.height',
@@ -456,7 +456,7 @@ async function isReindexAppsInformationRequired(
     },
     {
       $match: {
-        expireHeight: { $gte: scannedHeight },
+        expireHeight: { $gt: scannedHeight },
       },
     },
     {
@@ -642,7 +642,7 @@ async function reindexGlobalAppsInformation(
     {
       $match: {
         $expr: {
-          $gte: [
+          $gt: [
             {
               $add: [
                 '$maxHeightMsg.height',

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -129,7 +129,7 @@ async function startFluxFunctions() {
     const appRemover = async () => {
       // eslint-disable-next-line no-restricted-syntax
       for (const appName of appsToRemove) {
-        log.warning(`Application ${appName} is expired, removing`);
+        log.warn(`Application ${appName} is expired, removing`);
         // eslint-disable-next-line no-await-in-loop
         await appsService.removeAppLocally(appName, null, false, true, true);
         // eslint-disable-next-line no-await-in-loop

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -27,112 +27,6 @@ const apiPort = userconfig.initial.apiport || config.server.apiport;
 const development = userconfig.initial.development || false;
 const fluxTransactionCollection = config.database.daemon.collections.fluxTransactions;
 
-async function findValueSatNanInAppsMessages() {
-  const {
-    database: {
-      appsglobal: {
-        database: dbName, collections: { appsMessages: collectionName },
-      },
-    },
-  } = config;
-
-  const client = dbHelper.databaseConnection();
-  const db = client.db(dbName);
-  const query = { valueSat: NaN };
-  const options = { projection: { _id: 0, hash: 1 } };
-
-  const result = await dbHelper.findInDatabase(db, collectionName, query, options);
-
-  // ToDo: Fix the db helper so this is configurable
-  const brokenMessageHashes = result.map((item) => item.hash);
-
-  return brokenMessageHashes;
-}
-
-async function findValueSatInAppsHashes() {
-  const {
-    database: {
-      daemon: {
-        database: dbName, collections: { appsHashes: collectionName },
-      },
-    },
-  } = config;
-
-  const client = dbHelper.databaseConnection();
-  const db = client.db(dbName);
-  const query = {};
-  const options = { projection: { _id: 0, hash: 1, value: 1 } };
-
-  const results = await dbHelper.findInDatabase(db, collectionName, query, options);
-
-  const hashToValueMap = new Map();
-
-  results.forEach((result) => {
-    hashToValueMap.set(result.hash, result.value);
-  });
-
-  return hashToValueMap;
-}
-
-async function updateValueSatInAppsMessages(brokenHashes, hashMap) {
-  const {
-    database: {
-      appsglobal: {
-        database: dbName, collections: { appsMessages: collectionName },
-      },
-    },
-  } = config;
-
-  const client = dbHelper.databaseConnection();
-  const db = client.db(dbName);
-
-  const updateChunk = async (hashes) => {
-    const operations = [];
-
-    hashes.forEach((hash) => {
-      const valueSat = hashMap.get(hash);
-
-      if (valueSat) {
-        const operation = {
-          updateOne: {
-            filter: { hash },
-            update: { $set: { valueSat } },
-            upsert: true,
-          },
-        };
-
-        operations.push(operation);
-      }
-    });
-
-    await dbHelper.bulkWriteInDatabase(db, collectionName, operations);
-  };
-
-  const hashCount = brokenHashes.length;
-  const chunkSize = 5000;
-  let startIndex = 0;
-  let endIndex = Math.min(chunkSize, hashCount);
-
-  while (startIndex < hashCount) {
-    const chunk = brokenHashes.slice(startIndex, endIndex);
-    // eslint-disable-next-line no-await-in-loop
-    await updateChunk(chunk);
-
-    startIndex = endIndex;
-    endIndex += chunk.length;
-  }
-}
-
-async function repairNanInAppsMessagesDb() {
-  const brokenHashes = await findValueSatNanInAppsMessages();
-
-  if (!brokenHashes.length) return;
-
-  const hashMap = await findValueSatInAppsHashes();
-
-  await updateValueSatInAppsMessages(brokenHashes, hashMap);
-}
-
 /**
  * To start FluxOS. A series of checks are performed on port and UPnP (Universal Plug and Play) support and mapping. Database connections are established. The other relevant functions required to start FluxOS services are called.
  */
@@ -227,9 +121,23 @@ async function startFluxFunctions() {
     await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingErrorsLocations).createIndex({ name: 1, hash: 1, ip: 1 }, { name: 'query for getting flux app install errors location based on specs name and hash and node ip' });
 
     // This fixes an issue where the appsMessage db has NaN for valueSat. Once db is repaired on all nodes,
-    // we can remove this. If this is the first run, there will be no index, but also, there will be no broken
-    // records
-    await repairNanInAppsMessagesDb();
+    // we can remove this.
+    await dbHelper.repairNanInAppsMessagesDb();
+
+    const { appsToRemove } = await dbHelper.validateAppsInformation();
+
+    const appRemover = async () => {
+      // eslint-disable-next-line no-restricted-syntax
+      for (const appName of appsToRemove) {
+        log.warning(`Application ${appName} is expired, removing`);
+        // eslint-disable-next-line no-await-in-loop
+        await appsService.removeAppLocally(appName, null, false, true, true);
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise((r) => { setTimeout(r, 60_000); });
+      }
+    };
+
+    if (appsToRemove.length) setImmediate(appRemover);
 
     log.info('Flux Apps installing locations prepared');
     fluxNetworkHelper.adjustFirewall();


### PR DESCRIPTION
## Problem

Each fluxnode maintains a network state of applications in the `zelappsinformation` database. This db is based on apps messages that are received by the node. Due to prior? bugs, it seems this database is corrupted on many nodes.

For example, at this point in time, there were 648 apps on the network. As you can see below (sample of Arcane nodes) many have incorrect values.

<img width="658" height="1084" alt="Screenshot 2025-08-24 at 8 51 10 PM" src="https://github.com/user-attachments/assets/3bf5bbff-7d5b-4dcc-9d50-60d8e57f006d" />

It is critical that each node has the same view of the network, having different network state representations breaks many assumptions, i.e. for the loadbalancers etc.

## Solution

Rebuild the apps information colleciton off the app messages collection. 

Using mongo aggreations, we can do this quite easily. From node testing - it takes about 300ms to build the entire collection. The main function then returns any local apps that need removing.

We use some optomized db aggreations to do the work instead of doing it in javascript. We also use a dbCursor and iterate the apps on the go, instead of dumping them into memory.

The actual work is all done in the `dbHelper` module. (This module needs a lot of work in the short to medium term) and is ran once per Gravity application start. 

Apps information is only reindexes if the app count doesn't match what is in apps messages. I.e. in the following instance no reindex would occur:

<img width="1348" height="48" alt="Screenshot 2025-08-25 at 9 22 41 AM" src="https://github.com/user-attachments/assets/939c1e51-868b-4ac4-af82-b5a1c912abf6" />

It is also possible to now run the reindexing manually (if you want to test) like the following:

___Here I dropped the global zelappsinformation prior:___

<img width="2018" height="350" alt="Screenshot 2025-08-26 at 10 36 59 AM" src="https://github.com/user-attachments/assets/d4a54a2f-d393-47f3-9d2b-6fac10ad38b9" />

Here you can the collection being reindexed in about 300ms on a live node - this node was missing about 50 apps:

<img width="1870" height="234" alt="Screenshot 2025-08-26 at 10 48 43 AM" src="https://github.com/user-attachments/assets/feaf23e8-baf9-4e64-b1b9-f9407c8ff30d" />

Here is a view from mongo:

<img width="1496" height="450" alt="Screenshot 2025-08-26 at 10 48 24 AM" src="https://github.com/user-attachments/assets/f6316162-5abf-4889-83d6-8d9763519367" />

## Notes

This doesn't effect any of the existing logic. However, we should look at the way apps are expired as this should be done per app, not globally. (Put the apps in a map with blockHeight, then each block, expire the apps on that block height and remove from the map)

We need to keep an eye on this, after db's have been synced, make sure they don't drift - if they do, then we have a bug
