### PR TITLE
[FIX] Delete dir contents incl. hidden files, keep dir

### DIFF
--- a/ZelBack/src/services/IOUtils.js
+++ b/ZelBack/src/services/IOUtils.js
@@ -375,7 +375,7 @@ async function removeDirectory(rpath, directory = false) {
     if (directory === false) {
       execFinal = `sudo rm -rf "${rpath}"`;
     } else {
-      execFinal = `sudo rm -rf "${rpath}/*"`;
+      execFinal = `sudo find "${rpath}" -mindepth 1 -exec rm -rf {} +`;
     }
     await exec(execFinal, { maxBuffer: 1024 * 1024 * 10 });
     return true;


### PR DESCRIPTION
`removeDirectory(dir, true)` used `rm -rf dir/*`, which skips dot-files and fails on empty dirs. Replace with
`find dir -mindepth 1 -exec rm -rf {} +` so every entry inside the directory is removed while the directory itself is preserved.
