### PR TITLE
Bugfix - missing port info in deploymentinformation api

### DIFF
--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -12882,13 +12882,13 @@ async function deploymentInformation(req, res) {
     }
     // search in chainparams db for chainmessages of p version
     const appPrices = await getChainParamsPriceUpdates();
-    const { fluxapps: { minPort, maxPort } } = config;
+    const { fluxapps: { portMin, portMax } } = config;
     const information = {
       price: appPrices,
       appSpecsEnforcementHeights: config.fluxapps.appSpecsEnforcementHeights,
       address: deployAddr,
-      portMin: minPort,
-      portMax: maxPort,
+      portMin,
+      portMax,
       enterprisePorts: config.fluxapps.enterprisePorts,
       bannedPorts: config.fluxapps.bannedPorts,
       maxImageSize: config.fluxapps.maxImageSize,


### PR DESCRIPTION
As above. Variable was named around the wrong way.

Before:

<img width="3554" height="586" alt="Screenshot 2025-09-12 at 6 35 18 PM" src="https://github.com/user-attachments/assets/0902fe80-7e93-453d-a4e4-af42f39a3d5b" />

After:

<img width="3526" height="560" alt="Screenshot 2025-09-12 at 6 39 21 PM" src="https://github.com/user-attachments/assets/6acb53d9-891c-4450-ab1e-c7b362d7503b" />
