### PR TITLE
Fix for mising appvolumes dir as seen in installingerrorslocations

### DIFF
--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -285,6 +285,8 @@ async function createAppVolume(appSpecifications, appName, isComponent, res) {
 
     let execDD = `sudo fallocate -l ${appSpecifications.hdd}G ${useThisVolume.mount}/${appId}FLUXFSVOL`; // eg /mnt/sthMounted
     if (useThisVolume.mount === '/') {
+      const execMkdir = `sudo mkdir -p ${fluxDirPath}appvolumes`;
+      await cmdAsync(execMkdir);
       execDD = `sudo fallocate -l ${appSpecifications.hdd}G ${fluxDirPath}appvolumes/${appId}FLUXFSVOL`; // if root mount then temp file is /flu/appvolumes
     }
 
@@ -1767,6 +1769,8 @@ async function testAppMount() {
 
     let volumePath = `${useThisVolume.mount}/${appId}FLUXFSVOL`; // eg /mnt/sthMounted/
     if (useThisVolume.mount === '/') {
+      const execMkdir = `sudo mkdir -p ${fluxDirPath}appvolumes`;
+      await cmdAsync(execMkdir);
       volumePath = `${fluxDirPath}appvolumes/${appId}FLUXFSVOL`;// if root mount then temp file is in flux folder/appvolumes
     }
 


### PR DESCRIPTION
This bug has existed for quite some time.

<img width="3460" height="1688" alt="Screenshot 2025-10-10 at 10 56 26 AM" src="https://github.com/user-attachments/assets/24ea6f99-08a0-46da-9e0e-011e86c233cb" />

When the root mount is "/" (non Arcane) we aren't creating the appvolumes dir. (We could just do this once at startup) Harmless to do this on every volume creation (and could be deleted by the user anyway) 