### PR TITLE
Improve trySpawningGlobalApplication

### DIFF
--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -3435,8 +3435,8 @@ module.exports = {
       log.info(`trySpawningGlobalApplication - Found ${numberOfGlobalApps} apps that are missing instances on the network.`);
 
       // If there are multiple apps to process, use shorter delays
-      const delayTime = numberOfGlobalApps > 1 ? 5 * 1000 : 30 * 60 * 1000;
-      const shortDelayTime = numberOfGlobalApps > 1 ? 5 * 1000 : 5 * 60 * 1000;
+      const delayTime = numberOfGlobalApps > 1 ? 60 * 1000 : 30 * 60 * 1000;
+      const shortDelayTime = numberOfGlobalApps > 1 ? 60 * 1000 : 5 * 60 * 1000;
 
       let appToRun = null;
       let appToRunAux = null;


### PR DESCRIPTION
## Description

  Optimize app installation delays when multiple apps are waiting to be spawned on FluxNodes. Make apps try to install even if they are on appinstallingerrors database.

  ## Problem

  Previously, the `trySpawningGlobalApplication` function used fixed delays (5-30 minutes) between retry attempts, regardless of how many apps were waiting to
   be installed. This caused significant delays when multiple applications needed instances, as the function would wait 5-30 minutes before moving to the next
   app in the queue.

  For example, if 10 apps were missing instances, it could take hours to cycle through all of them, even when many apps couldn't be installed immediately on
  the current node.

  ## Solution

  Implemented dynamic delay logic based on the number of apps waiting for installation:

  - **When `numberOfGlobalApps > 1`**: Use 60-second delays to quickly cycle through the queue
  - **When `numberOfGlobalApps <= 1`**: Use original delays (5-30 minutes) to avoid unnecessary network load

  ### Changes Made

  1. **Added dynamic delay variables** (line 3438-3439):
     ```javascript
     const delayTime = numberOfGlobalApps > 1 ? 60 * 1000 : 30 * 60 * 1000;
     const shortDelayTime = numberOfGlobalApps > 1 ? 60 * 1000 : 5 * 60 * 1000;

  2. Updated 16 delay locations throughout trySpawningGlobalApplication():
    - Line 3487: No app to process
    - Line 3509: App already spawned/installing
    - Line 3517: ArcaneOS-only app
    - Line 3538: Already running on this IP
    - Line 3544: Already installing on this IP
    - Line 3573: Already installed locally
    - Line 3612: Ports not publicly available
    - Line 3622: Double-check instances
    - Line 3641: Syncthing same IP range
    - Line 3664: Syncthing connectivity check
    - Line 3735: Delayed app processing
    - Line 3761: Triple-check instances
    - Line 3804: Installing instance validation
    - Line 3820: Register app error
    - Line 3853: Success, reinitiate
    - Line 3858: Catch block (with fallback)
  3. Added safety fallback for catch block to handle errors before variables are initialized

  Impact

  Before

  - 10 apps waiting → could take 50-300 minutes to process all apps
  - Network cycles slowly through app queue
  - Apps that need immediate spawning are delayed

  After

  - 10 apps waiting → cycles through all apps in ~10 minutes
  - Rapid identification of installable apps
  - Much faster network response to missing instances
  - Original delays maintained when only 1 app is pending (no unnecessary load)

  Testing

  - Verify behavior when numberOfGlobalApps > 1: delays should be 5 seconds
  - Verify behavior when numberOfGlobalApps <= 1: delays should be original (5-30 minutes)
  - Verify catch block fallback works correctly
  - Monitor network for proper app distribution

  Related Issues

  Addresses the issue where multiple apps waiting for instances would experience long delays before being processed.