### PR TITLE
Fix syncthing checks starting g: apps

### DIFF
--- a/ZelBack/src/services/appsService.js
+++ b/ZelBack/src/services/appsService.js
@@ -1368,7 +1368,7 @@ async function syncthingApps() {
                     cache.restarted = false;
                     cache.numberOfExecutions = 1;
                     receiveOnlySyncthingAppsCache.set(appId, cache);
-                  } else if (!containerRunning) {
+                  } else if (!containerRunning && containerDataFlags.includes('r')) {
                     log.info(`syncthingApps - Container not running, starting app ${appId}`);
                     try {
                       // eslint-disable-next-line no-await-in-loop
@@ -1457,7 +1457,7 @@ async function syncthingApps() {
               } else {
                 try {
                   const containerInspect = await dockerService.dockerContainerInspect(id);
-                  if (!containerInspect.State.Running) {
+                  if (!containerInspect.State.Running && containerDataFlags.includes('r')) {
                     log.info(`syncthingApps - App ${appId} is not running, starting it`);
                     // eslint-disable-next-line no-await-in-loop
                     await dockerService.appDockerStart(id);
@@ -1596,7 +1596,7 @@ async function syncthingApps() {
                       cache.restarted = false;
                       cache.numberOfExecutions = 1;
                       receiveOnlySyncthingAppsCache.set(appId, cache);
-                    } else if (!containerRunning) {
+                    } else if (!containerRunning && containerDataFlags.includes('r')) {
                       log.info(`syncthingApps - Container not running, starting component ${appId}`);
                       try {
                         // eslint-disable-next-line no-await-in-loop
@@ -1686,7 +1686,7 @@ async function syncthingApps() {
                 } else {
                   try {
                     const containerInspect = await dockerService.dockerContainerInspect(id);
-                    if (!containerInspect.State.Running) {
+                    if (!containerInspect.State.Running && containerDataFlags.includes('r')) {
                       log.info(`syncthingApps - Component ${appId} is not running, starting it`);
                       // eslint-disable-next-line no-await-in-loop
                       await dockerService.appDockerStart(id);


### PR DESCRIPTION
Summary

  Fixes an issue where the Syncthing synchronization process was incorrectly starting global (:g) apps, which should
  only be handled by the master-slave function.

  Problem

  The syncthingApps() function was attempting to start containers regardless of their data flags. This caused the
  function to start global apps (marked with :g flag) even though these apps should only be managed by the
  master-slave functionality.

  Solution

  Added checks for the 'r' flag in containerDataFlags before attempting to start containers. This ensures that only
  receive-only apps are started by the Syncthing process, while global apps remain the responsibility of the
  master-slave function.

  Changes

  - Modified 4 locations in ZelBack/src/services/appsService.js where container start logic is invoked
  - Added condition containerDataFlags.includes('r') to each container start check
  - Applies to both single apps and multi-component apps
  - Locations: appsService.js:1371, appsService.js:1460, appsService.js:1599, appsService.js:1689

  Impact

  - Prevents inappropriate starting of global apps by the Syncthing process
  - Ensures proper separation of concerns between Syncthing and master-slave functionality
  - Reduces potential conflicts in app lifecycle management

  Testing

  - Verify that receive-only apps (:r flag) are still properly started by syncthingApps()
  - Confirm that global apps (:g flag) are no longer started by syncthingApps()
  - Ensure master-slave function continues to manage global apps correctly