### PR TITLE
Update to syncthing 2.0.10

### DIFF
--- a/ZelBack/src/services/systemService.js
+++ b/ZelBack/src/services/systemService.js
@@ -14,7 +14,6 @@ const log = require('../lib/log');
 const serviceHelper = require('./serviceHelper');
 const fifoQueue = require('./utils/fifoQueue');
 const daemonServiceUtils = require('./daemonService/daemonServiceUtils');
-const syncthingService = require('./syncthingService');
 
 const isArcane = Boolean(process.env.FLUXOS_PATH);
 


### PR DESCRIPTION
This PR updates the syncthing sources on legacy nodes from `stable` to `stable-v2`

This won't actually do anything until we change the min version on stats.

We are already using the double dash cmd line parameters. (That is the main breaking change)

Syncthing v2 is protocol backwards compatible with v1, so we can have v.1.30.0 nodes and v2.0.10 nodes coexisting. Will update Arcane on the next release.

I've only tested this on one node, so would be good to test on other legacy nodes

Once this is deployed (and enforced) we can change the minimum version on stats.

This is hugely beneficial, as the v2 releases have much better conflict resolution 