### PR TITLE
Increase network propagation delay for app installation messages

### DIFF
--- a/ZelBack/src/services/appLifecycle/appSpawner.js
+++ b/ZelBack/src/services/appLifecycle/appSpawner.js
@@ -523,7 +523,7 @@ async function trySpawningGlobalApplication() {
     await serviceHelper.delay(500);
     await fluxCommMessagesSender.broadcastMessageToIncoming(newAppInstallingMessage);
 
-    await serviceHelper.delay(30 * 1000); // give it time so messages are propagated on the network
+    await serviceHelper.delay(90 * 1000); // give it 1.5m so messages are propagated on the network
 
     // double check if app is installed in more of the instances requested
     runningAppList = await registryManager.appLocation(appToRun);


### PR DESCRIPTION
 ## Summary
  Increases the network propagation delay from 30 seconds to 90 seconds (1.5 minutes) when broadcasting app installation messages to allow sufficient time for messages to propagate across the Flux network before proceeding with global application spawning. This should lead to less app installs and uninstalls not needed.

  ## Changes
  - Modified delay in `trySpawningGlobalApplication()` function in `appSpawner.js:526`
  - Changed from 30 seconds to 90 seconds (1.5 minutes)

  ## Rationale
  The previous 30-second delay was insufficient to ensure that app installation messages (`fluxappinstalling`) fully propagate to all nodes in the network before the installation process continues. This could lead
  to race conditions where nodes attempt to install applications before receiving proper coordination messages from other nodes.

  ## Impact
  - Improves reliability of global application installations
  - Reduces potential race conditions during app deployment
  - Ensures better coordination across the Flux network
  - Trade-off: Slightly longer installation time, but more robust process