### PR TITLE
Increase message cache TTL to 5 minutes to reduce duplicate processing

### DIFF
--- a/ZelBack/src/services/utils/cacheManager.js
+++ b/ZelBack/src/services/utils/cacheManager.js
@@ -154,7 +154,7 @@ class FluxCacheManager {
     // every message, and check if it's in the cache. We should come up with a better algo here.
     messageCache: {
       max: 1_000,
-      ttl: FluxCacheManager.oneMinute,
+      ttl: 5 * FluxCacheManager.oneMinute,
     },
     wsPeerCache: {
       max: 100,


### PR DESCRIPTION
## Summary
  Increases the message cache TTL from 1 minute to 5 minutes in the FluxCommunication system to reduce
  redundant message processing across the network.

  ## Changes
  - Updated `messageCache.ttl` in `cacheManager.js` from 1 minute to 5 minutes

  ## Rationale
  The message cache handles `messageHashPresent` and `requestMessageHash` messages in the WebSocket
  peer-to-peer communication layer. With approximately 2.4k messages per minute across 26 peers (around
  135 unique messages), the previous 1-minute TTL was causing:
  - Redundant processing of the same messages
  - Increased network traffic as nodes re-broadcast messages that were already seen
  - Unnecessary CPU usage for hashing and cache lookups

  Extending the cache to 5 minutes will:
  - Reduce duplicate message processing
  - Lower bandwidth consumption between Flux nodes
  - Decrease CPU overhead from redundant hash calculations

  ## Impact
  - No breaking changes
  - Existing nodes will continue to function normally
  - Memory impact: Minimal (max 1,000 entries with 5-minute retention vs 1-minute)