### PR TITLE
Add decent NTP service for legacy nodes

### DIFF
--- a/ZelBack/src/services/systemService.js
+++ b/ZelBack/src/services/systemService.js
@@ -1056,17 +1056,21 @@ async function ensureChronyd() {
     // Disable and mask systemd-timesyncd to prevent it from running
     log.info('Disabling and masking systemd-timesyncd service...');
 
-    await serviceHelper.runCommand('systemctl', {
+    const { error: disableError } = await serviceHelper.runCommand('systemctl', {
       runAsRoot: true,
+      logError: false,
       params: ['disable', 'systemd-timesyncd'],
     });
 
-    await serviceHelper.runCommand('systemctl', {
-      runAsRoot: true,
-      params: ['mask', 'systemd-timesyncd'],
-    });
-
-    log.info('systemd-timesyncd disabled and masked');
+    if (!disableError) {
+      await serviceHelper.runCommand('systemctl', {
+        runAsRoot: true,
+        params: ['mask', 'systemd-timesyncd'],
+      });
+      log.info('systemd-timesyncd disabled and masked');
+    } else {
+      log.info('systemd-timesyncd service not found, skipping disable/mask');
+    }
     log.info('Chrony configured successfully');
     return true;
   } catch (error) {


### PR DESCRIPTION
Currently, there are some nodes on the network that transmit messages outside of the max 5 minute window. This causes a lot of spam on the network. It is suspected that a few nodes have incorrect system clocks / aren't syncing time via NTP.

3 nodes were found on Arcane that were using systemd-timesyncd that were not able to sync time. This was traced to upstream network providers blocking NTP when using an ephemeral source port (usually in the range 49152 to 65535) which is quite weird. However, they would accept it if both source and destination ports were 123 (default NTP port)

So now, the next Arcane image, we have dropped systemd-timesyncd and moved to Chrony.

This PR does the same for legacy nodes, hopefully, this should solve the timestamp issues on the network and the late messaging we have been seeing.

Tested on my Ubuntu 25.04 legacy node. However, Chrony is available for Debian buster 10 etc (we shouldn't have any nodes on 10 anymore hopefully) and is avaialble on Ubuntu. I think it might even be the default on some older systems.

FluxOS restart:

<img width="1350" height="708" alt="Screenshot 2025-11-04 at 4 12 20 PM" src="https://github.com/user-attachments/assets/e4eea8a3-b87e-400e-a4c1-589a88a3d758" />

Next Restart:

<img width="1364" height="192" alt="Screenshot 2025-11-04 at 4 14 22 PM" src="https://github.com/user-attachments/assets/de46ffa5-07d0-47b6-80b0-3a180b186f14" />
