### PR TITLE
Fix regression from eslint fix causing auth failures

### DIFF
--- a/ZelBack/src/services/registryAuth/services/authProviderFactory.js
+++ b/ZelBack/src/services/registryAuth/services/authProviderFactory.js
@@ -115,7 +115,7 @@ class AuthProviderFactory {
   static createProviderFromObject(registryUrl, authConfig, appName) {
     // Explicit provider type specified
     if (authConfig.type) {
-      return this.createExplicitProvider(authConfig.type, authConfig, registryUrl, appName);
+      return this.createExplicitProvider(authConfig.type, authConfig, appName, registryUrl);
     }
 
     // Auto-detect provider based on registry URL


### PR DESCRIPTION
Fixes a regression caused by an eslint fix eb19d3e (correctly) updating the function parameter order, however it didn't update the call location so auth was failing for token providers (Azure, Google, AWS)

Tested the fix registering an Azure container based app against this branch and is now able to auth properly