### PR TITLE
Fix syncthing not running errors

### DIFF
--- a/ZelBack/src/services/syncthingService.js
+++ b/ZelBack/src/services/syncthingService.js
@@ -25,10 +25,10 @@ const isArcane = Boolean(process.env.SYNCTHING_PATH);
 let syncthingBinaryPresent = false;
 
 /**
- * If syncthing is running okay. This does several checks. We optimistically set
- * this to true to avoid race conditions, as the webserver is started before the
- * syncthing checks. Also on Arcane, this is skipped entirely. If there is actually
- * a problem with syncthing, when the checks are run, this will be set to false.
+ * If syncthing is running okay. This does several checks. (See getDeviceId function)
+ * We optimistically set this to true to avoid race conditions, as the webserver
+ * is started before the syncthing checks. If there is actually a problem with
+ * syncthing, it will get set to false on the next iteration.
  */
 let syncthingStatusOk = true;
 


### PR DESCRIPTION
This has been an issue for quite some time.

There is a race condition where `getDeviceId()` is not called before `loginPhrase()` this can happen as the webserver is started before the syncthing stuff. This causes the `syncthingStatusOk` to be false and benchmarks can fail. (even though syncthing is actually running fine)

There are a few ways to fix this, but setting the value to `true` optimistically is the cleanest solution. If there is actually an error with syncthing... it will get picked up soon when the next syncthing checks run.

It causes the below error.

```
2025-11-21T14:05:49.299Z          Syncthing is not running properly
Error: Syncthing is not running properly
    at Object.loginPhrase (/dat/usr/lib/fluxos/ZelBack/src/services/idService.js:113:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
2025-11-21T14:05:49.338Z          Syncthing is not running properly
Error: Syncthing is not running properly
    at Object.loginPhrase (/dat/usr/lib/fluxos/ZelBack/src/services/idService.js:113:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
2025-11-21T14:05:49.394Z          Syncthing is not running properly
Error: Syncthing is not running properly
    at Object.loginPhrase (/dat/usr/lib/fluxos/ZelBack/src/services/idService.js:113:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
2025-11-21T14:05:49.497Z          Syncthing is not running properly
Error: Syncthing is not running properly
    at Object.loginPhrase (/dat/usr/lib/fluxos/ZelBack/src/services/idService.js:113:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
2025-11-21T14:05:49.526Z          Syncthing is not running properly
Error: Syncthing is not running properly
    at Object.loginPhrase (/dat/usr/lib/fluxos/ZelBack/src/services/idService.js:113:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
```