### PR TITLE
feat: Allow v8+ apps to run with minimum 1 instance instead of 3

### DIFF
--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -201,6 +201,7 @@ module.exports = {
     maxImageSize: 2000000000, // 2000mb
     minimumInstances: 3,
     minimumInstancesV8: 1,
+    minimumInstancesV8Block: 2176519, // block height where v8+ apps can have 1 instance - expected around December 19th 2025
     maximumInstances: 100,
     minOutgoing: 8,
     minUniqueIpsOutgoing: 7,

--- a/ZelBack/src/services/appRequirements/appValidator.js
+++ b/ZelBack/src/services/appRequirements/appValidator.js
@@ -787,7 +787,7 @@ function verifyRestrictionCorrectnessOfApp(appSpecifications, height) {
   }
 
   if (appSpecifications.version >= 3) {
-    const minInstances = appSpecifications.version >= 8
+    const minInstances = appSpecifications.version >= 8 && height >= config.fluxapps.minimumInstancesV8Block
       ? config.fluxapps.minimumInstancesV8
       : config.fluxapps.minimumInstances;
     if (appSpecifications.instances < minInstances) {

--- a/ZelBack/src/services/utils/appUtilities.js
+++ b/ZelBack/src/services/utils/appUtilities.js
@@ -28,7 +28,7 @@ async function appPricePerMonth(dataForAppRegistration, height, suppliedPrices) 
   const intervals = appPrices.filter((i) => i.height < height);
   const priceSpecifications = intervals[intervals.length - 1]; // filter does not change order
   let instancesAdditional = 0;
-  const isV8OrAbove = dataForAppRegistration.version >= 8;
+  const isV8OrAbove = dataForAppRegistration.version >= 8 && height >= config.fluxapps.minimumInstancesV8Block;
   const baseInstances = isV8OrAbove ? 1 : 3;
   if (dataForAppRegistration.instances) {
     // spec of version >= 3

--- a/tests/unit/globalconfig/default.js
+++ b/tests/unit/globalconfig/default.js
@@ -195,6 +195,7 @@ module.exports = {
     maxImageSize: 2000000000, // 2000mb
     minimumInstances: 3,
     minimumInstancesV8: 1,
+    minimumInstancesV8Block: 2176519, // block height where v8+ apps can have 1 instance - expected around December 19th 2025
     maximumInstances: 100,
     minOutgoing: 8,
     minUniqueIpsOutgoing: 7,


### PR DESCRIPTION
---
  PR Description

  ## Summary
  - Allow v8+ app specifications to have a minimum of 1 instance instead of the standard 3 instances required for v3-v7 apps
  - Adjust pricing calculation for v8+ apps to be per-instance based rather than the 3-instance base pricing

  ## Changes

  ### Configuration
  - Added new config `minimumInstancesV8: 1` to allow single-instance deployments for v8+ apps

  ### Validation
  - Updated `appValidator.js` to use version-aware minimum instance validation
  - Updated `appUtilities.js` (`specificationFormatter`) with the same version-aware validation

  ### Pricing
  - v8+ apps now calculate price per instance: base price is divided by 3, then multiplied by actual instance count
  - Extra instance pricing uses 1 as base for v8+ (vs 3 for v3-v7)
  - Minimum price of $0.99 USD remains enforced for all versions

  ## Pricing Behavior

  | Version | Min Instances | Base Price Calculation |
  |---------|--------------|------------------------|
  | v3-v7 | 3 | Standard (for 3 instances) |
  | v8+ | 1 | Per instance (÷3 then ×instances) |

  ## Files Changed
  - `ZelBack/config/default.js`
  - `ZelBack/src/services/appRequirements/appValidator.js`
  - `ZelBack/src/services/utils/appUtilities.js`
  - `tests/unit/globalconfig/default.js`

  ## Test Plan
  - [ ] Verify v8 app with 1 instance passes validation
  - [ ] Verify v7 app with 1 instance fails validation (min 3 required)
  - [ ] Verify v8 app pricing is calculated correctly (1/3 of previous 3-instance price)
  - [ ] Verify minimum $0.99 price is enforced for v8 apps with low resource requirements