### PR TITLE
Bugix: Fix memory leak in app monitoring

### DIFF
--- a/ZelBack/src/services/appManagement/appInspector.js
+++ b/ZelBack/src/services/appManagement/appInspector.js
@@ -439,6 +439,10 @@ function startAppMonitoring(appName, appsMonitored) {
 
   // eslint-disable-next-line no-param-reassign
   log.info('Initialize Monitoring...');
+  // Clear previous interval for this app to prevent multiple intervals
+  if (appsMonitored[appName] && appsMonitored[appName].oneMinuteInterval) {
+    clearInterval(appsMonitored[appName].oneMinuteInterval);
+  }
   // eslint-disable-next-line no-param-reassign
   appsMonitored[appName] = {}; // Initialize the app's monitoring object
   if (!appsMonitored[appName].statsStore) {
@@ -449,8 +453,6 @@ function startAppMonitoring(appName, appsMonitored) {
     // eslint-disable-next-line no-param-reassign
     appsMonitored[appName].lastHourstatsStore = [];
   }
-  // Clear previous interval for this app to prevent multiple intervals
-  clearInterval(appsMonitored[appName].oneMinuteInterval);
   // eslint-disable-next-line no-param-reassign
   appsMonitored[appName].run = 0;
   // eslint-disable-next-line no-param-reassign


### PR DESCRIPTION
Code was replacing `appsMonitored[appName].oneMinuteInterval` before clearing the interval. So the original reference was lost (and ran forever)

resulting in this:

<img width="1192" height="904" alt="Screenshot 2025-12-10 at 9 00 19 AM" src="https://github.com/user-attachments/assets/7ca67f81-1de0-491e-b908-314bcf68bdda" />
