### PR TITLE
Add benchmark data to host info service endpoint

### DIFF
--- a/ZelBack/src/services/fluxNodeService.js
+++ b/ZelBack/src/services/fluxNodeService.js
@@ -12,6 +12,7 @@ const geolocationService = require('./geolocationService');
 const fluxNetworkHelper = require('./fluxNetworkHelper');
 const generalService = require('./generalService');
 const dockerService = require('./dockerService');
+const benchmarkService = require('./benchmarkService');
 
 const express = require('express');
 
@@ -41,6 +42,22 @@ async function getHostInfo(req, res) {
         }
       } else {
         throw new Error('Host IP information not available at the moment');
+      }
+
+      const benchmarkResponse = await benchmarkService.getBenchmarks();
+      if (benchmarkResponse.status === 'success' && benchmarkResponse.data) {
+        const benchData = benchmarkResponse.data;
+        hostInfo.benchmark = {
+          vcores: benchData.cores,
+          ram: benchData.ram,
+          disk: benchData.disk,
+          diskwritespeed: benchData.diskwritespeed,
+          eps: benchData.eps,
+          download_speed: benchData.download_speed,
+          upload_speed: benchData.upload_speed,
+        };
+      } else {
+        throw new Error('Benchmark information is not available at the moment');
       }
 
       const message = messageHelper.createDataMessage(hostInfo);


### PR DESCRIPTION
## Summary
  - Extends the `/hostinfo` endpoint response to include node benchmark data
  - Adds a new `benchmark` object to the `getHostInfo` response with hardware performance metrics

  ## Changes
  - Added `benchmarkService` import to `fluxNodeService.js`
  - Extended `getHostInfo` to fetch and include benchmark data with the following properties:
    - `vcores` - Number of virtual CPU cores (mapped from `cores`)
    - `ram` - Available RAM in GB
    - `disk` - Disk space in GB
    - `diskwritespeed` - Disk write speed in MB/s
    - `eps` - Events per second benchmark score
    - `download_speed` - Network download speed in Mbps
    - `upload_speed` - Network upload speed in Mbps
  - Added error handling to throw an error if benchmark data is unavailable

  ## Response Example
  ```json
  {
    "status": "success",
    "data": {
      "appName": "...",
      "id": "...",
      "ip": "...",
      "geo": { ... },
      "benchmark": {
        "vcores": 32,
        "ram": 7,
        "disk": 220,
        "diskwritespeed": 498.38,
        "eps": 350,
        "download_speed": 923.44,
        "upload_speed": 932.25
      }
    }
  }