### PR TITLE
Fix Docker container permission issues by running all app containers as root (UID 0)

### DIFF
--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -878,6 +878,7 @@ async function appDockerCreate(appSpecifications, appName, isComponent, fullAppS
   const options = {
     Image: appSpecifications.repotag,
     name: getAppIdentifier(identifier),
+    User: '0:0', // Run as root to prevent UID mismatch permission issues on bind mounts
     Hostname: appSpecifications.name,
     AttachStdin: true,
     AttachStdout: true,


### PR DESCRIPTION
## Summary

  - Fix Docker container permission issues by running all app containers as root (UID 0)

  ## Problem

  Docker containers often run with different UIDs than the host system, causing permission conflicts on bind-mounted volumes. This occurs because:

  1. Dockerfiles define custom users (e.g., `USER node:node` with UID 1000)
  2. FluxOS creates bind mount directories owned by root on the host
  3. Even with `chmod 777`, the container process running as a non-root UID cannot reliably write to these mounts
  4. The UID inside the container doesn't match any UID on the host, leading to "permission denied" errors

  ### Example Failure Scenario

  Host: Creates /apps/myapp/appdata owned by root (UID 0)
  FluxOS: Applies chmod 777
  Container: Runs as node user (UID 1000)
  Result: Container cannot write to mount despite 777 permissions

  ## Solution

  Add `User: '0:0'` to Docker container creation options, forcing all containers to run as root inside the container. This ensures the container process has full access to bind-mounted volumes regardless of the Dockerfile's USER directive.

  ### Why This Is Safe

  FluxOS already implements multiple security layers that make running as container root acceptable:

  - **Isolated Docker networks**: Each app runs in its own network (`fluxDockerNetwork_${appName}`)
  - **Resource limits**: CPU, RAM, and storage quotas enforced via Docker
  - **No privileged mode**: `--privileged` flag is explicitly blocked
  - **No host namespace sharing**: Containers are isolated from host namespaces
  - **Platform consistency**: All FluxOS Gravity nodes run Ubuntu/Debian (no SELinux complications)

  Running as root inside an isolated, resource-limited container is a common and accepted pattern.

  ## Changes

  - `ZelBack/src/services/dockerService.js`: Added `User: '0:0'` to container creation options in `appDockerCreate()`

  ## Test Plan

  - [ ] Deploy a Flux app that uses a Dockerfile with a non-root USER directive
  - [ ] Verify the container can write to bind-mounted volumes without permission errors
  - [ ] Verify existing apps continue to function normally
  - [ ] Confirm container is running as root via `docker exec <container> id`