### PR TITLE
Fix incorrect $0.99 charge when updating component commands (compose order changes)

### DIFF
--- a/tests/unit/appSpecHelpers.test.js
+++ b/tests/unit/appSpecHelpers.test.js
@@ -258,6 +258,52 @@ describe('appSpecHelpers tests', () => {
       expect(result).to.be.true;
     });
 
+    it('should allow free update when components are reordered', async () => {
+      const daemonHeight = 100000;
+      const appSpecFormatted = {
+        name: 'TestApp',
+        instances: 5,
+        staticip: false,
+        nodes: [],
+        expire: 44000,
+        compose: [
+          {
+            name: 'B', cpu: 2, ram: 4000, hdd: 100,
+          },
+          {
+            name: 'A', cpu: 1, ram: 2000, hdd: 50,
+          },
+        ],
+      };
+
+      const appInfo = {
+        name: 'TestApp',
+        instances: 5,
+        staticip: false,
+        nodes: [],
+        expire: 44000,
+        height: daemonHeight + 44000 - appSpecFormatted.expire, // Height such that blocksToExtend = 0
+        compose: [
+          {
+            name: 'A', cpu: 1, ram: 2000, hdd: 50,
+          },
+          {
+            name: 'B', cpu: 2, ram: 4000, hdd: 100,
+          },
+        ],
+      };
+
+      sinon.stub(registryManager, 'getApplicationGlobalSpecifications').resolves(appInfo);
+      sinon.stub(dbHelper, 'databaseConnection').returns({
+        db: () => ({}),
+      });
+      sinon.stub(dbHelper, 'findInDatabase').resolves([]);
+
+      const result = await appSpecHelpers.checkFreeAppUpdate(appSpecFormatted, daemonHeight);
+
+      expect(result).to.be.true;
+    });
+
     it('should return false when CPU increased', async () => {
       const appSpecFormatted = {
         name: 'TestApp',


### PR DESCRIPTION
### Problem

  When users update a component’s commands, the UI can show a non‑zero price and enforce the $0.99 minimum charge, even though command-only updates should be free.

### Where the $0.99 comes from

  - Pricing is computed via /apps/calculatefiatandfluxprice → getAppFiatAndFluxPrice() in ZelBack/src/services/utils/appSpecHelpers.js:234.
  - getAppFiatAndFluxPrice() first calls checkFreeAppUpdate() (ZelBack/src/services/utils/appSpecHelpers.js:130):
      - If true: returns { usd: 0, flux: 0 } immediately.
      - If false: computes USD and clamps to minUSDPrice (0.99) from ZelBack/config/default.js:170.

### Root cause

  checkFreeAppUpdate() compared composed app components by array index (compose[0] vs compose[0], etc.).
  If compose[] order changes during an update request (likely when the UI re-serializes specs after editing commands), the index-based comparison can falsely detect a “resource increase”, causing the update to be considered not free and triggering the $0.99 clamp.

### Fix

  - Update checkFreeAppUpdate() to compare compose components by component name (order‑independent) when names are present and unique; fall back to index comparison for legacy/test data.
      - ZelBack/src/services/utils/appSpecHelpers.js:137
      
 ### Tests

  - Add regression coverage to ensure reordered components still qualify as a free update.
      - tests/unit/appSpecHelpers.test.js:261