### PR TITLE
fix: Add enterprise ports validation and increase block tolerance for free app updates

### DIFF
--- a/ZelBack/src/services/utils/appSpecHelpers.js
+++ b/ZelBack/src/services/utils/appSpecHelpers.js
@@ -11,6 +11,7 @@ const { getChainParamsPriceUpdates } = require('./chainUtilities');
 const registryManager = require('../appDatabase/registryManager');
 const cacheManager = require('./cacheManager').default;
 const hwRequirements = require('../appRequirements/hwRequirements');
+const fluxNetworkHelper = require('../fluxNetworkHelper');
 const log = require('../../lib/log');
 
 // Database collections
@@ -122,6 +123,16 @@ async function getAppFluxOnChainPrice(appSpecification) {
 }
 
 /**
+ * Count enterprise ports in a component's ports array
+ * @param {Array} ports - Array of port numbers
+ * @returns {number} Count of enterprise ports
+ */
+function countEnterprisePorts(ports) {
+  if (!Array.isArray(ports)) return 0;
+  return ports.filter((port) => fluxNetworkHelper.isPortEnterprise(port)).length;
+}
+
+/**
  * Check if app update is free
  * @param {object} appSpecFormatted - Formatted app specification
  * @param {number} daemonHeight - Current daemon height
@@ -133,7 +144,7 @@ async function checkFreeAppUpdate(appSpecFormatted, daemonHeight) {
   if (appInfo && appInfo.expire && appInfo.height && appSpecFormatted.expire) {
     const blocksToExtend = (appSpecFormatted.expire + Number(daemonHeight)) - appInfo.height - appInfo.expire;
     if (((!appSpecFormatted.nodes && !appInfo.nodes) || (appSpecFormatted.nodes && appInfo.nodes && appSpecFormatted.nodes.length === appInfo.nodes.length))
-      && appSpecFormatted.instances === appInfo.instances && appSpecFormatted.staticip === appInfo.staticip && blocksToExtend <= 2) { // free updates should not extend app subscription
+      && appSpecFormatted.instances === appInfo.instances && appSpecFormatted.staticip === appInfo.staticip && blocksToExtend <= 8) { // free updates should not extend app subscription
       if (Array.isArray(appSpecFormatted.compose) && Array.isArray(appInfo.compose) && appSpecFormatted.compose.length === appInfo.compose.length) {
         let changes = false;
         const appSpecComponentNames = appSpecFormatted.compose
@@ -149,7 +160,8 @@ async function checkFreeAppUpdate(appSpecFormatted, daemonHeight) {
           // eslint-disable-next-line no-restricted-syntax
           for (const compA of appSpecFormatted.compose) {
             const compB = appInfoComponentsByName.get(compA.name);
-            if (!compB || compA.cpu > compB.cpu || compA.ram > compB.ram || compA.hdd > compB.hdd) {
+            if (!compB || compA.cpu > compB.cpu || compA.ram > compB.ram || compA.hdd > compB.hdd
+              || countEnterprisePorts(compA.ports) > countEnterprisePorts(compB.ports)) {
               changes = true;
               break;
             }
@@ -159,7 +171,8 @@ async function checkFreeAppUpdate(appSpecFormatted, daemonHeight) {
           for (let i = 0; i < appSpecFormatted.compose.length; i += 1) {
             const compA = appSpecFormatted.compose[i];
             const compB = appInfo.compose[i];
-            if (compA.cpu > compB.cpu || compA.ram > compB.ram || compA.hdd > compB.hdd) {
+            if (compA.cpu > compB.cpu || compA.ram > compB.ram || compA.hdd > compB.hdd
+              || countEnterprisePorts(compA.ports) > countEnterprisePorts(compB.ports)) {
               changes = true;
               break;
             }


### PR DESCRIPTION
---
  PR Description

  ## Summary

  - Add enterprise ports validation to the free app update eligibility check to prevent price-affecting changes from bypassing payment
  - Increase block extension tolerance from 2 to 8 blocks to accommodate network latency and block timing variations

  ## Problem

  The `checkFreeAppUpdate` function was not validating enterprise port changes when determining if an app update qualifies as free. This allowed users to add enterprise ports (e.g., 443, 80) to their applications without paying, even though enterprise ports incur additional costs in the pricing model (`priceSpecifications.port` per enterprise port).

  Additionally, the previous 2-block tolerance for subscription extension was too strict, causing legitimate free updates to be rejected due to blocks being mined between validation and execution.

  ## Changes

  1. **Enterprise Ports Validation**: Added `countEnterprisePorts()` helper function that uses `fluxNetworkHelper.isPortEnterprise()` to count enterprise ports per component. The free update check now compares enterprise port counts between the new and existing specifications - if any component increases its enterprise port count, the update is no longer eligible for free.

  2. **Block Tolerance Increase**: Changed `blocksToExtend` threshold from `<= 2` to `<= 8` blocks to provide more tolerance for network timing variations while still preventing subscription extension abuse.

  ## Test Plan

  - [ ] Verify app update with added enterprise ports is correctly rejected as free update
  - [ ] Verify app update with same or fewer enterprise ports still qualifies for free update
  - [ ] Verify app updates within 8 blocks of current expiration qualify for free update
  - [ ] Verify app updates attempting to extend beyond 8 blocks are correctly charged