### PR TITLE
Improve app spawner delay system and add static IP node prioritization

### DIFF
--- a/ZelBack/src/services/appLifecycle/appSpawner.js
+++ b/ZelBack/src/services/appLifecycle/appSpawner.js
@@ -191,14 +191,14 @@ async function trySpawningGlobalApplication() {
       minInstances = appsToBeCheckedLater[appIndex].required;
       appsToBeCheckedLater.splice(appIndex, 1);
       appFromAppsToBeCheckedLater = true;
-      appsCountAvailableToInstallOnMyNode -= 1;
+      appsCountAvailableToInstallOnMyNode = Math.max(0, appsCountAvailableToInstallOnMyNode - 1);
     } else if (appSyncthingIndex >= 0) {
       appToRun = appsSyncthingToBeCheckedLater[appSyncthingIndex].appName;
       appHash = appsSyncthingToBeCheckedLater[appSyncthingIndex].hash;
       minInstances = appsSyncthingToBeCheckedLater[appSyncthingIndex].required;
       appsSyncthingToBeCheckedLater.splice(appSyncthingIndex, 1);
       appFromAppsSyncthingToBeCheckedLater = true;
-      appsCountAvailableToInstallOnMyNode -= 1;
+      appsCountAvailableToInstallOnMyNode = Math.max(0, appsCountAvailableToInstallOnMyNode - 1);
     } else {
       const myNodeLocation = await systemIntegration.nodeFullGeolocation();
 


### PR DESCRIPTION
## Summary
  - Add delay for static IP nodes when installing apps that don't require static IP
  - Reduce ArcaneOS non-enterprise app delay from ~27 minutes to 2 minutes as we start to have more arcaneOS nodes than legacy
  - Improve delay calculation accuracy by tracking apps actually installable on this node

  ## Changes

  ### 1. Static IP Node Prioritization
  Nodes with static IPs now defer apps that don't require static IP for ~27 minutes, giving non-static IP nodes priority to claim these apps first. This follows the same pattern as other tier-based prioritization (e.g., BAMF deferring cumulus-sized apps).

  ### 2. Faster ArcaneOS Non-Enterprise App Processing
  Reduced the delay for ArcaneOS nodes processing non-enterprise apps from ~27 minutes to 2 minutes. This speeds up app distribution while still giving non-ArcaneOS nodes a brief window to claim apps first.

  ### 3. Accurate Delay Calculation
  Previously, delay times were based on `numberOfGlobalApps` (all apps missing instances network-wide). Now delays are calculated based on the actual count of apps installable on **this specific node**, which includes:
  - Filtered `globalAppNamesLocation` (apps passing all node-specific filters)
  - `appsToBeCheckedLater` queue (deferred apps)
  - `appsSyncthingToBeCheckedLater` queue (deferred syncthing apps)

  This ensures:
  - Shorter delays (1 min) when the node has multiple apps queued
  - Longer delays (5-30 min) when only one app is available

  ## Test plan
  - [ ] Verify static IP nodes defer non-static-IP apps for ~27 minutes
  - [ ] Verify ArcaneOS nodes process non-enterprise apps after ~2 minute delay
  - [ ] Verify delay times adjust correctly based on number of installable apps
  - [ ] Monitor app distribution across different node types