### PR TITLE
fix: skip remote availability check when IP not in confirmed list

### DIFF
--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -1427,11 +1427,17 @@ async function checkDeterministicNodesCollisions() {
           }
         }
       }
-      // If this node is not CONFIRMED, remote nodes will reject the availability
-      // check (they verify confirmed status before probing ports). Skip to avoid
+      // If this node is not CONFIRMED, or our current IP isn't in the confirmed
+      // list (e.g. IP recently changed), remote nodes will reject the availability
+      // check via the confirmed-list gate in isFluxAvailable. Skip to avoid
       // spamming the network with requests that will always fail.
-      if (nodeStatus.data?.status !== 'CONFIRMED') {
-        log.warn(`Node status is ${nodeStatus.data?.status}. Skipping remote availability check.`);
+      const isConfirmed = nodeStatus.data?.status === 'CONFIRMED';
+      const inConfirmedList = await fluxCommunicationUtils.socketAddressInFluxList(myIP);
+      if (!isConfirmed || !inConfirmedList) {
+        const reason = !isConfirmed
+          ? `Node status is ${nodeStatus.data?.status}`
+          : `Our IP ${myIP} is not in the confirmed flux list`;
+        log.warn(`${reason}. Skipping remote availability check.`);
         setTimeout(() => {
           checkDeterministicNodesCollisions();
         }, 60 * 1000);

--- a/tests/unit/fluxNetworkHelper.test.js
+++ b/tests/unit/fluxNetworkHelper.test.js
@@ -1369,6 +1369,7 @@ describe('fluxNetworkHelper tests', () => {
       fluxNetworkHelper.setMyFluxIp('129.3.3.3');
       sinon.stub(daemonServiceWalletRpcs, 'createConfirmationTransaction').returns(true);
       sinon.stub(serviceHelper, 'delay').returns(true);
+      sinon.stub(fluxCommunicationUtils, 'socketAddressInFluxList').resolves(true);
       deterministicFluxnodeListResponse = [
         {
           collateral: 'COutPoint(38c04da72786b08adb309259cdd6d2128ea9059d0334afca127a5dc4e75bf174, 0)',
@@ -1448,6 +1449,34 @@ describe('fluxNetworkHelper tests', () => {
       await fluxNetworkHelper.checkDeterministicNodesCollisions();
 
       // Node is expired and not in list — availability check is skipped, no DOS penalty
+      expect(fluxNetworkHelper.getDosMessage()).to.be.null;
+      expect(fluxNetworkHelper.getDosStateValue()).to.equal(0);
+    });
+
+    it('should skip availability check when IP is not in confirmed flux list', async () => {
+      const ip = '127.0.0.1:5050';
+      const getBenchmarkResponseData = {
+        status: 'success',
+        data: { ipaddress: ip },
+      };
+      getBenchmarksStub.resolves(getBenchmarkResponseData);
+      isDaemonSyncedStub.returns({ data: { synced: true } });
+      deterministicFluxListStub.returns(deterministicFluxnodeListResponse);
+      getFluxNodeStatusStub.returns(
+        {
+          status: 'success',
+          data: {
+            status: 'CONFIRMED',
+            collateral: 'COutPoint(38c04da72786b08adb309259cdd6d2128ea9059d0334afca127a5dc4e75bf174, 0)',
+          },
+        },
+      );
+      // Our IP changed and is not in the confirmed list
+      fluxCommunicationUtils.socketAddressInFluxList.resolves(false);
+
+      await fluxNetworkHelper.checkDeterministicNodesCollisions();
+
+      // CONFIRMED but IP not in list — availability check is skipped, no DOS penalty
       expect(fluxNetworkHelper.getDosMessage()).to.be.null;
       expect(fluxNetworkHelper.getDosStateValue()).to.equal(0);
     });


### PR DESCRIPTION
## Summary
- Fixes a chicken-and-egg problem introduced by a367ec0db: when a node's IP changes, remote nodes reject the availability check because the new IP isn't in the confirmed list yet — but the node can't get confirmed at the new IP because the availability check always fails.
- Uses `socketAddressInFluxList` to detect the IP mismatch state and skip the remote probe, same pattern as the existing non-CONFIRMED skip (66882f75e).
- Adds test coverage for the new IP-not-in-list scenario.

## Test plan
- [x] Unit tests pass (`checkDeterministicNodesCollisions` — 8 passing)
- [x] Verified on live node: log shows `Our IP 47.206.56.185:16137 is not in the confirmed flux list. Skipping remote availability check.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)