### PR TITLE
Fix ghost fields in zelappsinformation from $set accumulation

### DIFF
--- a/ZelBack/src/services/appDatabase/registryManager.js
+++ b/ZelBack/src/services/appDatabase/registryManager.js
@@ -862,10 +862,10 @@ async function updateAppSpecsForRescanReindex(appSpecs) {
       // replaceOne instead of $set to avoid accumulating ghost fields
       // from prior spec versions (e.g. flat fields from v1-v3 lingering
       // after upgrade to v4+ compose format)
-      await database.collection(globalAppsInformation).replaceOne(query, appSpecs, options);
+      await dbHelper.replaceOneInDatabase(database, globalAppsInformation, query, appSpecs, options);
     }
   } else {
-    await database.collection(globalAppsInformation).replaceOne(query, appSpecs, options);
+    await dbHelper.replaceOneInDatabase(database, globalAppsInformation, query, appSpecs, options);
   }
   return true;
 }
@@ -1225,10 +1225,10 @@ async function updateAppSpecifications(appSpecs) {
         // replaceOne instead of $set to avoid accumulating ghost fields
         // from prior spec versions (e.g. flat fields from v1-v3 lingering
         // after upgrade to v4+ compose format)
-        await database.collection(globalAppsInformation).replaceOne(query, appSpecs, options);
+        await dbHelper.replaceOneInDatabase(database, globalAppsInformation, query, appSpecs, options);
       }
     } else {
-      await database.collection(globalAppsInformation).replaceOne(query, appSpecs, options);
+      await dbHelper.replaceOneInDatabase(database, globalAppsInformation, query, appSpecs, options);
     }
     const queryDeleteAppErrors = { name: appSpecs.name };
     await dbHelper.removeDocumentsFromCollection(database, globalAppsInstallingErrorsLocations, queryDeleteAppErrors);

--- a/ZelBack/src/services/appDatabase/registryManager.js
+++ b/ZelBack/src/services/appDatabase/registryManager.js
@@ -844,40 +844,10 @@ async function checkApplicationRegistrationNameConflicts(appSpecFormatted, hash)
  * @returns {Promise<boolean>} Update result
  */
 async function updateAppSpecsForRescanReindex(appSpecs) {
-  // appSpecs: {
-  //   version: 3,
-  //   name: 'FoldingAtHomeB',
-  //   description: 'Folding @ Home is cool :)',
-  //   repotag: 'yurinnick/folding-at-home:latest',
-  //   owner: '1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC',
-  //   ports: '[30001]',
-  //   containerPorts: '[7396]',
-  //   domains: '[""]',
-  //   enviromentParameters: '["USER=foldingUser", "TEAM=262156", "ENABLE_GPU=false", "ENABLE_SMP=true"]', // []
-  //   commands: '["--allow","0/0","--web-allow","0/0"]', // []
-  //   containerData: '/config',
-  //   cpu: 0.5,
-  //   ram: 500,
-  //   hdd: 5,
-  //   tiered: true,
-  //   cpubasic: 0.5,
-  //   rambasic: 500,
-  //   hddbasic: 5,
-  //   cpusuper: 1,
-  //   ramsuper: 1000,
-  //   hddsuper: 5,
-  //   cpubamf: 2,
-  //   rambamf: 2000,
-  //   hddbamf: 5,
-  //   instances: 10, // version 3 fork
-  //   hash: hash of message that has these paramenters,
-  //   height: height containing the message
-  // };
   const db = dbHelper.databaseConnection();
   const database = db.db(config.database.appsglobal.database);
 
   const query = { name: appSpecs.name };
-  const update = { $set: appSpecs };
   const options = {
     upsert: true,
   };
@@ -889,10 +859,13 @@ async function updateAppSpecsForRescanReindex(appSpecs) {
   const appInfo = await dbHelper.findOneInDatabase(database, globalAppsInformation, query, projection);
   if (appInfo) {
     if (appInfo.height < appSpecs.height) {
-      await dbHelper.updateOneInDatabase(database, globalAppsInformation, query, update, options);
+      // replaceOne instead of $set to avoid accumulating ghost fields
+      // from prior spec versions (e.g. flat fields from v1-v3 lingering
+      // after upgrade to v4+ compose format)
+      await database.collection(globalAppsInformation).replaceOne(query, appSpecs, options);
     }
   } else {
-    await dbHelper.updateOneInDatabase(database, globalAppsInformation, query, update, options);
+    await database.collection(globalAppsInformation).replaceOne(query, appSpecs, options);
   }
   return true;
 }
@@ -1234,73 +1207,10 @@ async function expireGlobalApplications() {
  */
 async function updateAppSpecifications(appSpecs) {
   try {
-    // appSpecs: {
-    //   version: 3,
-    //   name: 'FoldingAtHomeB',
-    //   description: 'Folding @ Home is cool :)',
-    //   repotag: 'yurinnick/folding-at-home:latest',
-    //   owner: '1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC',
-    //   ports: '[30001]',
-    //   containerPorts: '[7396]',
-    //   domains: '[""]',
-    //   enviromentParameters: '["USER=foldingUser", "TEAM=262156", "ENABLE_GPU=false", "ENABLE_SMP=true"]', // []
-    //   commands: '["--allow","0/0","--web-allow","0/0"]', // []
-    //   containerData: '/config',
-    //   cpu: 0.5,
-    //   ram: 500,
-    //   hdd: 5,
-    //   tiered: true,
-    //   cpubasic: 0.5,
-    //   rambasic: 500,
-    //   hddbasic: 5,
-    //   cpusuper: 1,
-    //   ramsuper: 1000,
-    //   hddsuper: 5,
-    //   cpubamf: 2,
-    //   rambamf: 2000,
-    //   hddbamf: 5,
-    //   instances: 10, // version 3 fork
-    //   hash: hash of message that has these paramenters,
-    //   height: height containing the message
-    // };
-    // const appSpecs = {
-    //   version: 4, // int
-    //   name: 'FoldingAtHomeB', // string
-    //   description: 'Folding @ Home is cool :)', // string
-    //   owner: '1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC', // string
-    //   compose: [ // array of max 5 objects of following specs
-    //     {
-    //       name: 'Daemon', // string
-    //       description: 'Main ddaemon for foldingAtHome', // string
-    //       repotag: 'yurinnick/folding-at-home:latest',
-    //       ports: '[30001]', // array of ints
-    //       containerPorts: '[7396]', // array of ints
-    //       domains: '[""]', // array of strings
-    //       environmentParameters: '["USER=foldingUser", "TEAM=262156", "ENABLE_GPU=false", "ENABLE_SMP=true"]', // array of strings
-    //       commands: '["--allow","0/0","--web-allow","0/0"]', // array of strings
-    //       containerData: '/config', // string
-    //       cpu: 0.5, // float
-    //       ram: 500, // int
-    //       hdd: 5, // int
-    //       tiered: true, // bool
-    //       cpubasic: 0.5, // float
-    //       rambasic: 500, // int
-    //       hddbasic: 5, // int
-    //       cpusuper: 1, // float
-    //       ramsuper: 1000, // int
-    //       hddsuper: 5, // int
-    //       cpubamf: 2, // float
-    //       rambamf: 2000, // int
-    //       hddbamf: 5, // int
-    //     },
-    //   ],
-    //   instances: 10, // int
-    // };
     const db = dbHelper.databaseConnection();
     const database = db.db(config.database.appsglobal.database);
 
     const query = { name: appSpecs.name };
-    const update = { $set: appSpecs };
     const options = {
       upsert: true,
     };
@@ -1312,10 +1222,13 @@ async function updateAppSpecifications(appSpecs) {
     const appInfo = await dbHelper.findOneInDatabase(database, globalAppsInformation, query, projection);
     if (appInfo) {
       if (appInfo.height < appSpecs.height) {
-        await dbHelper.updateOneInDatabase(database, globalAppsInformation, query, update, options);
+        // replaceOne instead of $set to avoid accumulating ghost fields
+        // from prior spec versions (e.g. flat fields from v1-v3 lingering
+        // after upgrade to v4+ compose format)
+        await database.collection(globalAppsInformation).replaceOne(query, appSpecs, options);
       }
     } else {
-      await dbHelper.updateOneInDatabase(database, globalAppsInformation, query, update, options);
+      await database.collection(globalAppsInformation).replaceOne(query, appSpecs, options);
     }
     const queryDeleteAppErrors = { name: appSpecs.name };
     await dbHelper.removeDocumentsFromCollection(database, globalAppsInstallingErrorsLocations, queryDeleteAppErrors);

--- a/ZelBack/src/services/dbHelper.js
+++ b/ZelBack/src/services/dbHelper.js
@@ -242,6 +242,24 @@ async function updateOneInDatabase(database, collection, query, update, options)
 }
 
 /**
+ * Replaces a single document in the collection. Unlike updateOne with $set,
+ * replaceOne completely replaces the document (except _id), preventing
+ * accumulation of stale fields from prior updates.
+ *
+ * @param {mongodb.Db} database
+ * @param {string} collection
+ * @param {object} query
+ * @param {object} replacement
+ * @param {object} [options]
+ * @returns {Promise<object>}
+ */
+async function replaceOneInDatabase(database, collection, query, replacement, options) {
+  const passedOptions = options || {};
+  const result = await database.collection(collection).replaceOne(query, replacement, passedOptions);
+  return result;
+}
+
+/**
  * Updates many documents in the collection
  *
  * @param {string} database
@@ -784,6 +802,7 @@ module.exports = {
   insertOneToDatabase,
   removeDocumentsFromCollection,
   repairNanInAppsMessagesDb,
+  replaceOneInDatabase,
   updateInDatabase,
   updateOneInDatabase,
   validateAppsInformation,

--- a/ZelBack/src/services/dbHelper.js
+++ b/ZelBack/src/services/dbHelper.js
@@ -566,9 +566,22 @@ async function isReindexAppsInformationRequired(
       + ` Found ${appsFromInformation.count} apps from appsInformation`,
     );
 
-    const reindexRequired = appsFromMessages.count !== appsFromInformation.count;
+    if (appsFromMessages.count !== appsFromInformation.count) {
+      return true;
+    }
 
-    return reindexRequired;
+    // Detect ghost flat fields on v4+ specs caused by $set accumulating
+    // fields from prior spec versions. Fixed by replaceOne in registryManager.
+    const ghostCount = await countInDatabase(appsGlobalDb, appsInformationCol, {
+      version: { $gte: 4 },
+      repotag: { $exists: true },
+    });
+    if (ghostCount > 0) {
+      log.info(`Found ${ghostCount} v4+ specs with ghost fields from prior versions, reindex required`);
+      return true;
+    }
+
+    return false;
   } catch (err) {
     log.error(`isReindexAppsInformationRequired - Mongodb Error: ${err}`);
     return false;

--- a/tests/unit/registryManager.test.js
+++ b/tests/unit/registryManager.test.js
@@ -432,6 +432,45 @@ describe('registryManager tests', () => {
       expect(result.height).to.equal(300);
       expect(result.hash).to.equal('hash1');
     });
+
+    it('should not accumulate ghost fields when spec version changes', async () => {
+      // Simulate a v3 flat spec registration
+      const v3Spec = {
+        version: 3,
+        name: 'GhostFieldTestApp',
+        description: 'Test',
+        owner: '1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC',
+        repotag: 'test/image:latest',
+        cpu: 0.5,
+        ram: 500,
+        hdd: 5,
+        height: 100,
+        hash: 'hash1',
+      };
+      await registryManager.updateAppSpecifications(v3Spec);
+
+      // Simulate a v4 compose update (no flat fields)
+      const v4Spec = {
+        version: 4,
+        name: 'GhostFieldTestApp',
+        description: 'Test',
+        owner: '1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC',
+        compose: [{ name: 'main', cpu: 0.5, ram: 500, hdd: 5 }],
+        instances: 3,
+        height: 200,
+        hash: 'hash2',
+      };
+      await registryManager.updateAppSpecifications(v4Spec);
+
+      const result = await registryManager.getApplicationSpecifications('GhostFieldTestApp');
+      expect(result.version).to.equal(4);
+      expect(result.compose).to.exist;
+      // Ghost flat fields from v3 should NOT exist
+      expect(result.repotag).to.be.undefined;
+      expect(result.cpu).to.be.undefined;
+      expect(result.ram).to.be.undefined;
+      expect(result.hdd).to.be.undefined;
+    });
   });
 
   describe('registrationInformation tests', () => {


### PR DESCRIPTION
## Summary

- `updateAppSpecifications` and `updateAppSpecsForRescanReindex` in `registryManager.js` used MongoDB `$set` to upsert into `zelappsinformation`. When an app upgraded across spec versions (e.g. v1→v4), `$set` only added new fields without removing old ones, leaving ghost flat fields (`repotag`, `cpu`, `ram`, `hdd`, `tiered`, etc.) on v4+ documents that should only have `compose`.
- Changed both functions to use `replaceOne` so the document always matches exactly what the latest message contains.
- Added ghost field detection to `isReindexAppsInformationRequired` in `dbHelper.js` — checks for v4+ docs with a `repotag` field. Triggers a one-time reindex on first startup after deploy, then never fires again.

## Impact

- 4 apps affected per node: `DiBiFetch`, `Minecraft`, `PokerTH`, `EthereumNodeLight`
- All ~8000 nodes have the same replicated data
- `zelappsmessages` (permanent messages) are unaffected — they were always clean

## Test plan

- [x] Verified on chud: ghost detection triggered reindex on startup
- [x] Reindex completed in ~34 seconds
- [x] 638 docs before and after — no data loss
- [x] Per-version counts identical
- [x] All 4 affected apps now have correct shape (ghost fields removed)
- [x] DiBiFetch v5 matches other v5 specs exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)