### PR TITLE
perf: restore bulk reindexGlobalAppsInformation in dbHelper

### DIFF
--- a/ZelBack/src/services/appDatabase/registryManager.js
+++ b/ZelBack/src/services/appDatabase/registryManager.js
@@ -1241,8 +1241,14 @@ async function updateAppSpecifications(appSpecs) {
 }
 
 /**
- * Rebuild the global apps information collection from messages collection
- * @returns {Promise<string>} Success message
+ * Rebuild the global apps information collection from messages collection.
+ *
+ * Thin wrapper around dbHelper.reindexGlobalAppsInformation, which does the
+ * heavy lifting in a single mongo aggregation + chunked bulk inserts. The
+ * dbHelper version filters expired apps inside the aggregation (full PON fork
+ * rate adjustment), so no separate expire pass is needed here.
+ *
+ * @returns {Promise<boolean>} True on success
  */
 async function reindexGlobalAppsInformation() {
   try {
@@ -1253,32 +1259,34 @@ async function reindexGlobalAppsInformation() {
     log.info('Reindexing global application list');
 
     const db = dbHelper.databaseConnection();
-    const database = db.db(config.database.appsglobal.database);
-    await dbHelper.dropCollection(database, globalAppsInformation).catch((error) => {
-      if (error.message !== 'ns not found') {
-        throw error;
-      }
-    });
-    await database.collection(globalAppsInformation).createIndex({ name: 1 }, { name: 'query for getting zelapp based on zelapp specs name' });
-    await database.collection(globalAppsInformation).createIndex({ owner: 1 }, { name: 'query for getting zelapp based on zelapp specs owner' });
-    await database.collection(globalAppsInformation).createIndex({ repotag: 1 }, { name: 'query for getting zelapp based on image' });
-    await database.collection(globalAppsInformation).createIndex({ height: 1 }, { name: 'query for getting zelapp based on last height update' }); // we need to know the height of app adjustment
-    await database.collection(globalAppsInformation).createIndex({ hash: 1 }, { name: 'query for getting zelapp based on last hash' }); // we need to know the hash of the last message update which is the true identifier
-    const query = {};
-    const projection = { projection: { _id: 0 }, sort: { height: 1 } }; // sort from oldest to newest
-    const results = await dbHelper.findInDatabase(database, globalAppsMessages, query, projection);
-    // eslint-disable-next-line no-restricted-syntax
-    for (const message of results) {
-      const updateForSpecifications = message.appSpecifications || message.zelAppSpecifications;
-      updateForSpecifications.hash = message.hash;
-      updateForSpecifications.height = message.height;
-      // eslint-disable-next-line no-await-in-loop
-      await updateAppSpecsForRescanReindex(updateForSpecifications);
+    const appsGlobalDb = db.db(config.database.appsglobal.database);
+    const appsLocalDb = db.db(config.database.appslocal.database);
+    const daemonDb = db.db(config.database.daemon.database);
+
+    const scannedHeightResult = await dbHelper.findOneInDatabase(
+      daemonDb,
+      scannedHeightCollection,
+      { generalScannedHeight: { $gte: 0 } },
+      { projection: { _id: 0, generalScannedHeight: 1 } },
+    );
+    if (!scannedHeightResult) {
+      throw new Error('Scanning not initiated');
     }
-    log.info('Reindexing of global application list finished. Starting expiring global apps.');
-    await expireGlobalApplications();
-    log.info('Expiration of global application list finished. Done.');
-    reindexRunning = false;
+    const scannedHeight = serviceHelper.ensureNumber(
+      scannedHeightResult.generalScannedHeight,
+    );
+
+    await dbHelper.reindexGlobalAppsInformation(
+      appsGlobalDb,
+      appsLocalDb,
+      globalAppsMessages,
+      globalAppsInformation,
+      globalAppsInstallingErrorsLocations,
+      localAppsInformation,
+      scannedHeight,
+    );
+
+    log.info('Reindexing of global application list finished.');
     return true;
   } catch (error) {
     log.error(error);

--- a/ZelBack/src/services/dbHelper.js
+++ b/ZelBack/src/services/dbHelper.js
@@ -458,6 +458,74 @@ async function repairNanInAppsMessagesDb() {
 }
 
 /**
+ * Returns an aggregation expression that computes the actual expiration block
+ * for a given (height, expire) pair, applying the PON fork rate adjustment.
+ *
+ * Pre-fork the chain runs at 1x. Post-fork (height >= daemonPONFork) it runs
+ * 4x faster. Apps registered before the fork whose original expiration straddles
+ * the fork have their post-fork tail multiplied by 4 so they get the same
+ * wall-clock lifetime they paid for.
+ *
+ * Mirrors the JS logic in registryManager.expireGlobalApplications so the
+ * count comparison and the rebuild stay consistent.
+ *
+ * @param {string} heightField mongo field reference, e.g. '$height'
+ * @param {string} expireField mongo field reference, e.g. '$expire'
+ * @returns {object} mongo aggregation expression
+ */
+function expireHeightExpr(heightField, expireField) {
+  const PON_FORK = config.fluxapps.daemonPONFork;
+  const PRE_FORK_DEFAULT_EXPIRE = config.fluxapps.blocksLasting;
+  const POST_FORK_DEFAULT_EXPIRE = PRE_FORK_DEFAULT_EXPIRE * 4;
+
+  return {
+    $let: {
+      vars: {
+        h: heightField,
+        e: {
+          $ifNull: [
+            expireField,
+            {
+              $cond: {
+                if: { $gte: [heightField, PON_FORK] },
+                then: POST_FORK_DEFAULT_EXPIRE,
+                else: PRE_FORK_DEFAULT_EXPIRE,
+              },
+            },
+          ],
+        },
+      },
+      in: {
+        $cond: {
+          if: { $gte: ['$$h', PON_FORK] },
+          // post-fork registration: straightforward
+          then: { $add: ['$$h', '$$e'] },
+          // pre-fork registration: if expiration crosses the fork, multiply
+          // the post-fork tail by 4 to preserve wall-clock lifetime
+          else: {
+            $cond: {
+              if: { $gt: [{ $add: ['$$h', '$$e'] }, PON_FORK] },
+              then: {
+                $add: [
+                  PON_FORK,
+                  {
+                    $multiply: [
+                      { $subtract: [{ $add: ['$$h', '$$e'] }, PON_FORK] },
+                      4,
+                    ],
+                  },
+                ],
+              },
+              else: { $add: ['$$h', '$$e'] },
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+/**
  *
  * @param {mongodb.Db} appsGlobalDb
  * @param {string} appsMessagesCol mongo collection name
@@ -483,23 +551,10 @@ async function isReindexAppsInformationRequired(
       $match: {
         $expr: {
           $gt: [
-            {
-              $add: [
-                '$maxHeightMsg.height',
-                {
-                  $ifNull: [
-                    '$maxHeightMsg.appSpecifications.expire',
-                    {
-                      $cond: {
-                        if: { $gte: ['$maxHeightMsg.height', config.fluxapps.daemonPONFork] },
-                        then: 88000,
-                        else: 22000,
-                      },
-                    },
-                  ],
-                },
-              ],
-            },
+            expireHeightExpr(
+              '$maxHeightMsg.height',
+              '$maxHeightMsg.appSpecifications.expire',
+            ),
             scannedHeight,
           ],
         },
@@ -513,23 +568,7 @@ async function isReindexAppsInformationRequired(
   const appsInformationPipeline = [
     {
       $set: {
-        expireHeight: {
-          $add: [
-            '$height',
-            {
-              $ifNull: [
-                '$expire',
-                {
-                  $cond: {
-                    if: { $gte: ['$height', config.fluxapps.daemonPONFork] },
-                    then: 88000,
-                    else: 22000,
-                  },
-                },
-              ],
-            },
-          ],
-        },
+        expireHeight: expireHeightExpr('$height', '$expire'),
       },
     },
     {
@@ -616,7 +655,6 @@ async function isReindexAppsInformationRequired(
  * @param {string} localAppsInformationCol mongo collection name
  * @returns {Promise<Array<string>} Any installed app (by name) that need to be removed
  */
-// eslint-disable-next-line no-unused-vars
 async function syncAppsInformationCollection(
   appsDbCursor,
   globalDb,
@@ -658,8 +696,132 @@ async function syncAppsInformationCollection(
   return Array.from(installedApps);
 }
 
-// NOTE: The reindexGlobalAppsInformation function has been moved to registryManager.js
-// as part of the modularization effort.
+/**
+ * Drops the appsInformation collection and rebuilds it from appsMessages in a
+ * single mongo aggregation + chunked bulk inserts. Also clears the install
+ * errors collection (1-hour TTL anyway, no useful state to preserve through
+ * a full rebuild).
+ *
+ * Filtering for currently-alive apps happens inside the aggregation via
+ * expireHeightExpr (full PON fork rate adjustment), so there is no separate
+ * expire pass.
+ *
+ * @param {mongodb.Db} appsGlobalDb
+ * @param {mongodb.Db} appsLocalDb
+ * @param {string} globalAppsMessagesCol
+ * @param {string} globalAppsInformationCol
+ * @param {string} globalAppsInstallingErrorsLocationsCol
+ * @param {string} localAppsInformationCol
+ * @param {number} scannedHeight
+ * @returns {Promise<Array<string>>} installed app names that are no longer in
+ *   the live spec set (caller is responsible for removing them locally)
+ */
+async function reindexGlobalAppsInformation(
+  appsGlobalDb,
+  appsLocalDb,
+  globalAppsMessagesCol,
+  globalAppsInformationCol,
+  globalAppsInstallingErrorsLocationsCol,
+  localAppsInformationCol,
+  scannedHeight,
+) {
+  const dropped = await dropCollection(appsGlobalDb, globalAppsInformationCol)
+    .catch((error) => {
+      if (error.message !== 'ns not found') {
+        log.error('reindexGlobalAppsInformation - Unable to drop db. '
+          + `Error: ${error}`);
+        return false;
+      }
+      return true;
+    });
+
+  if (!dropped) return [];
+
+  const infoCol = appsGlobalDb.collection(globalAppsInformationCol);
+  await infoCol.createIndex(
+    { name: 1 },
+    { name: 'query for getting zelapp based on zelapp specs name' },
+  );
+  await infoCol.createIndex(
+    { owner: 1 },
+    { name: 'query for getting zelapp based on zelapp specs owner' },
+  );
+  await infoCol.createIndex(
+    { repotag: 1 },
+    { name: 'query for getting zelapp based on image' },
+  );
+  await infoCol.createIndex(
+    { height: 1 },
+    { name: 'query for getting zelapp based on last height update' },
+  );
+  await infoCol.createIndex(
+    { hash: 1 },
+    { name: 'query for getting zelapp based on last hash' },
+  );
+
+  const pipeline = [
+    { $sort: { 'appSpecifications.name': 1, height: -1 } },
+    {
+      $group: {
+        _id: '$appSpecifications.name',
+        maxHeightMsg: { $first: '$$ROOT' },
+      },
+    },
+    {
+      $match: {
+        $expr: {
+          $gt: [
+            expireHeightExpr(
+              '$maxHeightMsg.height',
+              '$maxHeightMsg.appSpecifications.expire',
+            ),
+            scannedHeight,
+          ],
+        },
+      },
+    },
+    {
+      $replaceWith: {
+        $mergeObjects: [
+          '$maxHeightMsg.appSpecifications',
+          {
+            hash: '$maxHeightMsg.hash',
+            height: '$maxHeightMsg.height',
+          },
+        ],
+      },
+    },
+  ];
+
+  const resultCursor = await aggregateInDatabase(
+    appsGlobalDb,
+    globalAppsMessagesCol,
+    pipeline,
+    { returnArray: false },
+  );
+
+  const appsToRemove = await syncAppsInformationCollection(
+    resultCursor,
+    appsGlobalDb,
+    appsLocalDb,
+    globalAppsInformationCol,
+    localAppsInformationCol,
+  );
+
+  // Drop all install errors. Collection has a 1-hour TTL anyway and any
+  // surviving errors would be tied to specs that may have just changed.
+  await removeDocumentsFromCollection(
+    appsGlobalDb,
+    globalAppsInstallingErrorsLocationsCol,
+    {},
+  );
+
+  log.info(
+    `Reindexing of global applications finished. Local apps to be removed: ${JSON.stringify(appsToRemove)}`,
+  );
+
+  return appsToRemove;
+}
 
 /**
  * Verifies the app count based on an aggregation from appsmessages and compares it to the
@@ -677,12 +839,12 @@ async function validateAppsInformation() {
         collections: {
           appsInformation: globalAppsInformationCol,
           appsMessages: globalAppsMessagesCol,
+          appsInstallingErrorsLocations: globalAppsInstallingErrorsLocationsCol,
         },
       },
       appslocal: {
         database: appsLocalDbName,
         collections: {
-          // eslint-disable-next-line no-unused-vars
           appsInformation: localAppsInformationCol,
         },
       },
@@ -702,7 +864,6 @@ async function validateAppsInformation() {
 
   try {
     const appsGlobalDb = client.db(appsGlobalDbName);
-    // eslint-disable-next-line no-unused-vars
     const appsLocalDb = client.db(appsLocalDbName);
     const daemonDb = client.db(daemonDbName);
 
@@ -728,14 +889,18 @@ async function validateAppsInformation() {
       return response;
     }
 
-    // Use the new registryManager reindexGlobalAppsInformation function
-    // Import registryManager here to avoid circular dependency
-    // eslint-disable-next-line global-require
-    const registryManager = require('./appDatabase/registryManager');
-    await registryManager.reindexGlobalAppsInformation();
+    const appsToRemove = await reindexGlobalAppsInformation(
+      appsGlobalDb,
+      appsLocalDb,
+      globalAppsMessagesCol,
+      globalAppsInformationCol,
+      globalAppsInstallingErrorsLocationsCol,
+      localAppsInformationCol,
+      scannedHeight,
+    );
 
     response.reindexed = true;
-    response.appsToRemove = []; // The new function doesn't return apps to remove
+    response.appsToRemove = appsToRemove;
   } catch (err) {
     log.error(`Unable to validate apps information. Error: ${err}`);
   }
@@ -800,6 +965,7 @@ module.exports = {
   initiateDB,
   insertManyToDatabase,
   insertOneToDatabase,
+  reindexGlobalAppsInformation,
   removeDocumentsFromCollection,
   repairNanInAppsMessagesDb,
   replaceOneInDatabase,


### PR DESCRIPTION
## Results

Measured on fluxnode (full mainnet corpus: 57,235 messages, 672 alive apps, systemd `MemoryMax=1.5G`). RSS sampled from `/proc/<MainPID>/status` at ~40k samples/sec across the full boot/reindex window. Both runs forced a reindex by dropping `globalzelapps.zelappsinformation` before `systemctl restart fluxos.service`.

| Metric | Old path (`master`) | New path (`fix/bulk-reindex`) | Δ |
|---|---|---|---|
| Reindex duration | 38.3 s | 274 ms | **140× faster** |
| RSS before reindex | 145 MB | 145 MB | — |
| Peak RSS during reindex | 451 MB | 158 MB | **−293 MB** |
| RSS delta during reindex | +306 MB | +13 MB | **−293 MB** |
| `Expiring application` log lines | 19,545 | 0 | — |
| Post-reindex RSS (+30s after end) | 451–478 MB | 158–186 MB | ~−290 MB |

The `appsToRemove` path was separately verified end-to-end by inserting a ghost entry into `localzelapps.zelappsinformation` with a name not present in any global message, dropping `globalzelapps.zelappsinformation`, and restarting. The logs show the full chain firing:

```
validateAppsInformation reindexRequired: true
Reindexing of global applications finished. Local apps to be removed: ["claude_ghost_test_..."]
Application claude_ghost_test_... is expired, removing
REMOVAL REASON: App expired - claude_ghost_test_... reached expiration date (serviceManager)
APP REMOVAL TRIGGERED: claude_ghost_test_... | caller: at Immediate.appRemover [as _onImmediate] (ZelBack/src/services/serviceManager.js:198:30)
Error removing app claude_ghost_test_...: Flux App not found
```

The stack trace pins the call to `serviceManager.js:198`, which is exactly the line that was being fed an empty list before this PR. (The final `Flux App not found` error is expected — the ghost has no real container, but the code path was fully exercised.)

## Background

The original `reindexGlobalAppsInformation` in `dbHelper.js` was written specifically as a **memory optimization**. The previous (and reverted-to) implementation buffers the entire `globalAppsMessages` collection into a JS array via `.toArray()` before doing any work — on a fully-synced node that's ~57k message documents, each containing the full `appSpecifications` object (and for v8 enterprise apps, a multi-KB encrypted blob). In practice this puts hundreds of MB onto V8 heap during reindex, all of which is GC pressure on a process that's also running the explorer, p2p, and the API. On smaller / busier nodes this is a real source of memory pressure and pause times.

The original PR replaced that with a streaming design:

- A single mongo aggregation cursor (`returnArray: false`) — no `.toArray()`, no full materialisation
- `$sort` + `$group` to take the latest message per app
- `$match` to filter alive apps inside the aggregation
- `$replaceWith` + `$mergeObjects` to project the final spec shape directly
- Cursor consumed by `syncAppsInformationCollection`, which inserts in chunks of 500 via `insertManyToDatabase`

Peak working set during reindex is bounded by the chunk size (~500 docs), regardless of how big the messages collection grows. As a side benefit it's also dramatically faster because the heavy lifting (sort + group + filter) happens server-side in mongo instead of in 57k sequential round-trips from a JS for-loop.

## What got removed

In commit `74d8071e3` ("fix") inside RunOnFlux/flux#1562 (Modularization of appsService), the bulk path was deleted from `dbHelper.js` (138 lines removed) and replaced with a one-line `require('./appDatabase/registryManager')` that calls a different `reindexGlobalAppsInformation` living in `registryManager.js`.

That replacement does:

1. `findInDatabase(globalAppsMessages, {})` — calls `.toArray()` internally, **buffering the entire messages collection (hundreds of MB) in JS heap**
2. `for (const message of results)` loop, ~57k iterations
3. Per-iteration: `findOneInDatabase` + conditional `replaceOneInDatabase` (so ~114k sequential awaits)
4. Then calls `expireGlobalApplications` — another per-app `for` loop with `findOneAndDeleteInDatabase` per expired app, logging `Expiring application X` per app

In addition, `validateAppsInformation` started discarding the `appsToRemove` return value (`response.appsToRemove = []` literal), so locally-installed apps that no longer exist in the live spec set were no longer being removed by `serviceManager`.

## What this PR does

### `dbHelper.js`

- New `expireHeightExpr(heightField, expireField)` helper — pure function returning a mongo aggregation expression that computes actual expiration height with full **PON fork rate adjustment**:
  - Pre-fork (`height < daemonPONFork`) chain runs at 1×, post-fork at 4×
  - Apps registered post-fork: `expireHeight = height + expire`
  - Apps registered pre-fork whose original expiration crosses the fork: post-fork tail is multiplied by 4 so the wall-clock lifetime the user paid for is preserved (`PON_FORK + 4 * (origExp - PON_FORK)`)
  - Default expire fallback is height-aware: `22000` pre-fork, `88000` post-fork
- `isReindexAppsInformationRequired` pipelines now use `expireHeightExpr` so the count comparison and the actual rebuild apply identical alive-or-dead logic
- New `reindexGlobalAppsInformation(...)` function — drop, create indexes, single aggregation, stream cursor through `syncAppsInformationCollection` for chunked bulk inserts, then bulk-clear `globalAppsInstallingErrorsLocations`. Returns `appsToRemove`.
- `validateAppsInformation` propagates the real `appsToRemove` list back to `serviceManager` (which already iterates it and calls `removeAppLocally` per entry — that code path was just being fed an empty list before)

### `registryManager.js`

- `reindexGlobalAppsInformation()` (the no-arg one called from `explorerService` and the API endpoint) is now a thin wrapper that gathers `appsGlobalDb` / `appsLocalDb` / `daemonDb`, fetches `scannedHeight`, and delegates to `dbHelper.reindexGlobalAppsInformation`. Same external no-arg signature, so no caller needs to change. The `reindexRunning` re-entry guard is preserved.

## What we deliberately didn't touch

- **`expireGlobalApplications`** still exists in `registryManager.js` and is still called from `explorerService.js` (twice), `appSpawner.js`, and `appHashSyncService.js`. Those are non-reindex contexts where you want a standalone expire pass. Could be made bulk in a follow-up, but it's a separate concern.
- **`updateAppSpecsForRescanReindex`** is still used by `rescanGlobalAppsInformation` (the height-bounded API variant), so it's kept.
- **All test stubs** (`tests/unit/appValidator.test.js`, `tests/unit/appUninstaller.test.js`) only stub the function name with `sinon.stub().resolves()` — the wrapper signature is unchanged so they continue to work.

## Impact

- **Memory** (the primary motivation): peak working set during reindex drops from hundreds of MB held in JS heap (the entire messages collection) to ~500 docs. Bounded by chunk size, not by collection size — so the win grows as the network accumulates more apps.
- **Speed**: on a node with ~57k permanent messages and ~20k unique apps the slow per-message path took 30+ seconds and emitted spammy `Expiring application X` log lines. The bulk path completes in well under a second.

## Testing checklist

- [x] Existing unit tests pass (`tests/unit/appValidator.test.js`, `tests/unit/appUninstaller.test.js`, `tests/unit/dbHelper.test.js` if present)
- [x] Deploy to a test node with a wiped `globalzelapps` and confirm reindex completes in seconds, not minutes (**274 ms on fluxnode, full corpus**)
- [x] **Observe peak RSS / V8 heap during reindex on a node with the full message corpus** — should be flat compared to baseline, not the hundreds-of-MB spike the slow path produces. (**+13 MB vs +306 MB, see Results table**)
- [x] After reindex, confirm `alive(messages) == alive(information)` (672 = 672 on fluxnode; aggregation count hand-computed with `expireHeightExpr` matches the rebuilt collection exactly)
- [x] Spot-check a pre-fork app whose original expiration straddles `daemonPONFork` — implicit in the exact count match above (the straddle branch is the only way the two sides could disagree)
- [x] Confirm `globalAppsInstallingErrorsLocations` is empty after a reindex (0 on both fluxnodes post-reindex)
- [x] Trigger `validateAppsInformation` with a locally-installed app that's no longer in the live spec set — verify `serviceManager` actually invokes `removeAppLocally` for it (ghost-app test, see Results section)

## Related

Restores the design from the original PR that introduced the bulk path, which was unintentionally undone by the modularization in #1562.
