### PR TITLE
feat: opt-in enterprise network — gate app spawning and ownership split by node pubkey 

### DIFF
--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -306,6 +306,11 @@ module.exports = {
     '03cf1d8b708ca7f5979accb4d0dba35a90391e3dfc4422cf12670c929bb58d16ac',
     '03e29783936a36b396c28706494dbfd35f3d087f2addeb3df32e451f71bf9a53f3',
   ],
+  // Pubkeys of nodes that opt into the enterprise network. A node whose own
+  // fluxnode pubkey is in this list will only spawn/run apps owned by
+  // enterpriseAppOwners above and will uninstall any non-matching apps on boot.
+  enterpriseNodesPublicKeys: [
+  ],
   cpuBurst: {
     // Enables CFS CPU burst for enterprise app owners on cgroups-v2 + kernel >= 5.14 hosts.
     // The kernel rule (cgroup-v2: 0 <= cpu.max.burst <= cpu.max quota) lets a container

--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -310,6 +310,7 @@ module.exports = {
   // fluxnode pubkey is in this list will only spawn/run apps owned by
   // enterpriseAppOwners above and will uninstall any non-matching apps on boot.
   enterpriseNodesPublicKeys: [
+    '027595b0b8257d7b901fc024d7c5b66a7af68b64240dea0359dec3ffb1f2a33a8d',
   ],
   cpuBurst: {
     // Enables CFS CPU burst for enterprise app owners on cgroups-v2 + kernel >= 5.14 hosts.

--- a/ZelBack/src/services/appLifecycle/appSpawner.js
+++ b/ZelBack/src/services/appLifecycle/appSpawner.js
@@ -17,6 +17,7 @@ const portManager = require('../appNetwork/portManager');
 const appUtilities = require('../utils/appUtilities');
 const systemIntegration = require('../appSystem/systemIntegration');
 const globalState = require('../utils/globalState');
+const enterpriseNetwork = require('../utils/enterpriseNetwork');
 const { FluxCacheManager } = require('../utils/cacheManager');
 // const advancedWorkflows = require('./advancedWorkflows'); // Moved to dynamic require to avoid circular dependency
 
@@ -46,10 +47,18 @@ function initialize(deps) {
  * @returns {Promise<void>}
  */
 async function trySpawningGlobalApplication() {
+  let isEnterprise = false;
   let shortDelayTime = 5 * 60 * 1000; // Default 5 minutes
   let delayTime = 30 * 60 * 1000; // Default 30 minutes
   let appHash = null; // Declare outside try block to be accessible in catch
   try {
+    // Throws if fluxnode pubkey can't be resolved (daemon/benchmark down);
+    // the outer catch handles the retry so we never act on an unknown identity.
+    isEnterprise = await enterpriseNetwork.isEnterpriseNode();
+    if (isEnterprise) {
+      shortDelayTime = 30 * 1000;
+      delayTime = 60 * 1000;
+    }
     // how do we continue with this function?
     // we have globalapplication specifics list
     // check if we are synced
@@ -149,6 +158,7 @@ async function trySpawningGlobalApplication() {
           hash: '$hash',
           version: '$version',
           enterprise: '$enterprise',
+          owner: '$owner',
         },
       },
       { $sort: { name: 1 } },
@@ -211,9 +221,19 @@ async function trySpawningGlobalApplication() {
       globalAppNamesLocation = globalAppNamesLocation.filter((app) => (app.geolocation.length === 0 || app.geolocation.filter((loc) => loc.startsWith('a!c')).length === 0 || !app.geolocation.find((loc) => loc.startsWith('a!c') && `a!c${myNodeLocation}`.startsWith(loc.replace('_NONE', '')))));
       // filter apps that dont have geolocation or have and match my node geolocation
       globalAppNamesLocation = globalAppNamesLocation.filter((app) => (app.geolocation.length === 0 || app.geolocation.filter((loc) => loc.startsWith('ac')).length === 0 || app.geolocation.find((loc) => loc.startsWith('ac') && `ac${myNodeLocation}`.startsWith(loc))));
+      // enterprise network gating:
+      //   enterprise-network nodes install ONLY apps owned by enterpriseAppOwners
+      //   every other node NEVER installs apps owned by enterpriseAppOwners
+      if (isEnterprise) {
+        globalAppNamesLocation = globalAppNamesLocation.filter((app) => enterpriseNetwork.isEnterpriseAppOwner(app.owner));
+      } else {
+        globalAppNamesLocation = globalAppNamesLocation.filter((app) => !enterpriseNetwork.isEnterpriseAppOwner(app.owner));
+      }
 
       appsCountAvailableToInstallOnMyNode = globalAppNamesLocation.length + appsSyncthingToBeCheckedLater.length + appsToBeCheckedLater.length;
-      shortDelayTime = appsCountAvailableToInstallOnMyNode > 1 ? 60 * 1000 : 5 * 60 * 1000;
+      if (!isEnterprise) {
+        shortDelayTime = appsCountAvailableToInstallOnMyNode > 1 ? 60 * 1000 : 5 * 60 * 1000;
+      }
 
       if (globalAppNamesLocation.length === 0) {
         log.info('trySpawningGlobalApplication - No app currently to be processed');
@@ -254,8 +274,10 @@ async function trySpawningGlobalApplication() {
     }
 
     // If there are multiple apps to process, use shorter delays
-    delayTime = appsCountAvailableToInstallOnMyNode > 1 ? 60 * 1000 : 30 * 60 * 1000;
-    shortDelayTime = appsCountAvailableToInstallOnMyNode > 1 ? 60 * 1000 : 5 * 60 * 1000;
+    if (!isEnterprise) {
+      delayTime = appsCountAvailableToInstallOnMyNode > 1 ? 60 * 1000 : 30 * 60 * 1000;
+      shortDelayTime = appsCountAvailableToInstallOnMyNode > 1 ? 60 * 1000 : 5 * 60 * 1000;
+    }
 
     globalState.trySpawningGlobalAppCache.set(appHash, '');
     log.info(`trySpawningGlobalApplication - App ${appToRun} hash: ${appHash}`);
@@ -347,6 +369,10 @@ async function trySpawningGlobalApplication() {
 
     // verify requirements
     await hwRequirements.checkAppRequirements(appSpecifications);
+    // enterprise network nodes: reserve >4 vCores of burst headroom (automatic CPU burst)
+    if (isEnterprise) {
+      await hwRequirements.checkAppCpuBurstHeadroom(appSpecifications);
+    }
 
     // ensure ports unused
     // Get apps running specifically on this IP
@@ -697,7 +723,9 @@ async function trySpawningGlobalApplication() {
       }
     }
 
-    await serviceHelper.delay(delayTime);
+    if (!isEnterprise) {
+      await serviceHelper.delay(delayTime);
+    }
     log.info('trySpawningGlobalApplication - Reinitiating possible app installation');
     trySpawningGlobalApplication();
   } catch (error) {

--- a/ZelBack/src/services/appLifecycle/appSpawner.js
+++ b/ZelBack/src/services/appLifecycle/appSpawner.js
@@ -48,17 +48,13 @@ function initialize(deps) {
  */
 async function trySpawningGlobalApplication() {
   let isEnterprise = false;
-  let shortDelayTime = 5 * 60 * 1000; // Default 5 minutes
-  let delayTime = 30 * 60 * 1000; // Default 30 minutes
+  let { shortDelayTime, delayTime } = enterpriseNetwork.getSpawnDelays(false, 0);
   let appHash = null; // Declare outside try block to be accessible in catch
   try {
     // Throws if fluxnode pubkey can't be resolved (daemon/benchmark down);
     // the outer catch handles the retry so we never act on an unknown identity.
     isEnterprise = await enterpriseNetwork.isEnterpriseNode();
-    if (isEnterprise) {
-      shortDelayTime = 30 * 1000;
-      delayTime = 60 * 1000;
-    }
+    ({ shortDelayTime, delayTime } = enterpriseNetwork.getSpawnDelays(isEnterprise, 0));
     // how do we continue with this function?
     // we have globalapplication specifics list
     // check if we are synced
@@ -221,19 +217,10 @@ async function trySpawningGlobalApplication() {
       globalAppNamesLocation = globalAppNamesLocation.filter((app) => (app.geolocation.length === 0 || app.geolocation.filter((loc) => loc.startsWith('a!c')).length === 0 || !app.geolocation.find((loc) => loc.startsWith('a!c') && `a!c${myNodeLocation}`.startsWith(loc.replace('_NONE', '')))));
       // filter apps that dont have geolocation or have and match my node geolocation
       globalAppNamesLocation = globalAppNamesLocation.filter((app) => (app.geolocation.length === 0 || app.geolocation.filter((loc) => loc.startsWith('ac')).length === 0 || app.geolocation.find((loc) => loc.startsWith('ac') && `ac${myNodeLocation}`.startsWith(loc))));
-      // enterprise network gating:
-      //   enterprise-network nodes install ONLY apps owned by enterpriseAppOwners
-      //   every other node NEVER installs apps owned by enterpriseAppOwners
-      if (isEnterprise) {
-        globalAppNamesLocation = globalAppNamesLocation.filter((app) => enterpriseNetwork.isEnterpriseAppOwner(app.owner));
-      } else {
-        globalAppNamesLocation = globalAppNamesLocation.filter((app) => !enterpriseNetwork.isEnterpriseAppOwner(app.owner));
-      }
+      globalAppNamesLocation = enterpriseNetwork.filterAppsByOwnership(globalAppNamesLocation, isEnterprise);
 
       appsCountAvailableToInstallOnMyNode = globalAppNamesLocation.length + appsSyncthingToBeCheckedLater.length + appsToBeCheckedLater.length;
-      if (!isEnterprise) {
-        shortDelayTime = appsCountAvailableToInstallOnMyNode > 1 ? 60 * 1000 : 5 * 60 * 1000;
-      }
+      ({ shortDelayTime, delayTime } = enterpriseNetwork.getSpawnDelays(isEnterprise, appsCountAvailableToInstallOnMyNode));
 
       if (globalAppNamesLocation.length === 0) {
         log.info('trySpawningGlobalApplication - No app currently to be processed');
@@ -271,12 +258,6 @@ async function trySpawningGlobalApplication() {
         trySpawningGlobalApplication();
         return;
       }
-    }
-
-    // If there are multiple apps to process, use shorter delays
-    if (!isEnterprise) {
-      delayTime = appsCountAvailableToInstallOnMyNode > 1 ? 60 * 1000 : 30 * 60 * 1000;
-      shortDelayTime = appsCountAvailableToInstallOnMyNode > 1 ? 60 * 1000 : 5 * 60 * 1000;
     }
 
     globalState.trySpawningGlobalAppCache.set(appHash, '');

--- a/ZelBack/src/services/appLifecycle/appSpawner.js
+++ b/ZelBack/src/services/appLifecycle/appSpawner.js
@@ -47,14 +47,19 @@ function initialize(deps) {
  * @returns {Promise<void>}
  */
 async function trySpawningGlobalApplication() {
-  let isEnterprise = false;
-  let { shortDelayTime, delayTime } = enterpriseNetwork.getSpawnDelays(false, 0);
+  // Identity is resolved once at boot by scheduleIdentityResolution() in
+  // serviceManager. Until that lands we defer the spawn attempt, mirroring
+  // the synced / isNodeConfirmed branches below — no exception-for-retry.
+  const isEnterprise = enterpriseNetwork.getCachedEnterpriseIdentity();
+  if (isEnterprise === null) {
+    log.info('Flux enterprise identity not yet resolved');
+    await serviceHelper.delay(config.fluxapps.installation.delay * 1000);
+    trySpawningGlobalApplication();
+    return;
+  }
+  let { shortDelayTime, delayTime } = enterpriseNetwork.getSpawnDelays(isEnterprise, 0);
   let appHash = null; // Declare outside try block to be accessible in catch
   try {
-    // Throws if fluxnode pubkey can't be resolved (daemon/benchmark down);
-    // the outer catch handles the retry so we never act on an unknown identity.
-    isEnterprise = await enterpriseNetwork.isEnterpriseNode();
-    ({ shortDelayTime, delayTime } = enterpriseNetwork.getSpawnDelays(isEnterprise, 0));
     // how do we continue with this function?
     // we have globalapplication specifics list
     // check if we are synced

--- a/ZelBack/src/services/appRequirements/hwRequirements.js
+++ b/ZelBack/src/services/appRequirements/hwRequirements.js
@@ -420,6 +420,35 @@ async function checkAppHWRequirements(appSpecs) {
 }
 
 /**
+ * Reject apps that would leave <= 4 free vCores on the node once their CPU
+ * reservation is added to everything currently locked. The headroom is needed
+ * because FluxOS offers automatic CPU burst for enterprise apps, and burst
+ * needs spare capacity to draw from.
+ *
+ * @param {object} appSpecs App specifications.
+ * @returns {Promise<boolean>} True if enough burst headroom remains.
+ * @throws if remaining free cores would be <= 4.
+ */
+async function checkAppCpuBurstHeadroom(appSpecs) {
+  const tier = await generalService.nodeTier();
+  const resourcesLocked = await appsResources();
+  if (resourcesLocked.status !== 'success') {
+    throw new Error('Unable to obtain locked system resources by Flux Apps. Aborting.');
+  }
+  const appHWrequirements = totalAppHWRequirements(appSpecs, tier);
+  const specs = await getNodeSpecs();
+  const systemReservedCores = config.lockedSystemResources.cpu / 10;
+  const freeCoresAfterInstall = specs.cpuCores
+    - systemReservedCores
+    - resourcesLocked.data.appsCpusLocked
+    - appHWrequirements.cpu;
+  if (freeCoresAfterInstall <= 4) {
+    throw new Error('Insufficient CPU burst headroom on Flux Node to spawn an application');
+  }
+  return true;
+}
+
+/**
  * To check app requirements to include HDD space, CPU power, RAM and GEO for a node
  * @param {object} appSpecs App specifications.
  * @returns {boolean} True if all checks passed.
@@ -441,6 +470,7 @@ module.exports = {
   returnNodeSpecs,
   totalAppHWRequirements,
   checkAppHWRequirements,
+  checkAppCpuBurstHeadroom,
   checkAppRequirements,
   nodeFullGeolocation,
   checkAppStaticIpRequirements,

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -33,6 +33,7 @@ const containerMountRecovery = require('./appLifecycle/containerMountRecovery');
 const stoppedAppsRecovery = require('./appLifecycle/stoppedAppsRecovery');
 const hardwareValidationService = require('./appLifecycle/hardwareValidationService');
 const globalState = require('./utils/globalState');
+const enterpriseNetwork = require('./utils/enterpriseNetwork');
 const appQueryService = require('./appQuery/appQueryService');
 const daemonServiceMiscRpcs = require('./daemonService/daemonServiceMiscRpcs');
 const daemonServiceUtils = require('./daemonService/daemonServiceUtils');
@@ -313,6 +314,26 @@ async function startFluxFunctions() {
       // Check for enterprise apps on non-arcaneOS nodes and remove them
       advancedWorkflows.checkAndRemoveEnterpriseAppsOnNonArcane();
     }, 2 * 60 * 1000); // 2 minutes after startup
+    // Enforce the enterprise-network ownership split: enterprise nodes drop
+    // any app whose owner isn't in enterpriseAppOwners; every other node
+    // drops any app whose owner IS in enterpriseAppOwners. Broadcasts
+    // fluxappremoved so peers update appLocations.
+    //
+    // Retries every 5 minutes until a run completes without throwing, so we
+    // never act on a stale/unknown identity (pubkey can't resolve while the
+    // daemon or benchmark is still coming up).
+    const scheduleEnterpriseCleanup = () => {
+      setTimeout(async () => {
+        try {
+          await enterpriseNetwork.cleanupOwnershipViolations();
+          log.info('Enterprise network cleanup completed');
+        } catch (error) {
+          log.warn(`Enterprise network cleanup failed, retrying in 5 min: ${error.message || error}`);
+          scheduleEnterpriseCleanup();
+        }
+      }, 5 * 60 * 1000);
+    };
+    scheduleEnterpriseCleanup();
     setInterval(() => {
       portManager.restorePortsSupport(); // restore fluxos and apps ports/upnp
     }, 10 * 60 * 1000); // every 10 minutes

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -314,26 +314,25 @@ async function startFluxFunctions() {
       // Check for enterprise apps on non-arcaneOS nodes and remove them
       advancedWorkflows.checkAndRemoveEnterpriseAppsOnNonArcane();
     }, 2 * 60 * 1000); // 2 minutes after startup
-    // Enforce the enterprise-network ownership split: enterprise nodes drop
-    // any app whose owner isn't in enterpriseAppOwners; every other node
-    // drops any app whose owner IS in enterpriseAppOwners. Broadcasts
-    // fluxappremoved so peers update appLocations.
+    // Resolve this node's enterprise identity once, up front. Self-reschedules
+    // every 5 minutes until the pubkey resolves (daemon/benchmark may still be
+    // coming up). Once cached, hot paths (spawn loop) read it synchronously
+    // via getCachedEnterpriseIdentity() with no network call and no throws.
     //
-    // Retries every 5 minutes until a run completes without throwing, so we
-    // never act on a stale/unknown identity (pubkey can't resolve while the
-    // daemon or benchmark is still coming up).
-    const scheduleEnterpriseCleanup = () => {
+    // After identity is known, run the ownership-split cleanup once at T+5min:
+    // enterprise nodes drop any app whose owner isn't in enterpriseAppOwners;
+    // every other node drops any app whose owner IS in enterpriseAppOwners.
+    // Broadcasts fluxappremoved so peers update appLocations.
+    enterpriseNetwork.scheduleIdentityResolution().then(() => {
       setTimeout(async () => {
         try {
           await enterpriseNetwork.cleanupOwnershipViolations();
           log.info('Enterprise network cleanup completed');
         } catch (error) {
-          log.warn(`Enterprise network cleanup failed, retrying in 5 min: ${error.message || error}`);
-          scheduleEnterpriseCleanup();
+          log.error(`Enterprise network cleanup failed: ${error.message || error}`);
         }
       }, 5 * 60 * 1000);
-    };
-    scheduleEnterpriseCleanup();
+    });
     setInterval(() => {
       portManager.restorePortsSupport(); // restore fluxos and apps ports/upnp
     }, 10 * 60 * 1000); // every 10 minutes

--- a/ZelBack/src/services/utils/enterpriseNetwork.js
+++ b/ZelBack/src/services/utils/enterpriseNetwork.js
@@ -1,0 +1,109 @@
+const config = require('config');
+const dbHelper = require('../dbHelper');
+const fluxNetworkHelper = require('../fluxNetworkHelper');
+const appConstants = require('./appConstants');
+const log = require('../../lib/log');
+
+let cachedIsEnterpriseNode = null;
+
+function getEnterpriseAppOwners() {
+  return config.enterpriseAppOwners || [];
+}
+
+function getEnterpriseNodesPublicKeys() {
+  return config.enterpriseNodesPublicKeys || [];
+}
+
+function isEnterpriseAppOwner(owner) {
+  if (!owner) return false;
+  return getEnterpriseAppOwners().includes(owner);
+}
+
+/**
+ * Returns true if this fluxnode's own pubkey is listed in
+ * config.enterpriseNodesPublicKeys. Result is cached for the lifetime of the
+ * process after a successful resolution; call resetEnterpriseNodeCache() if
+ * the config is hot-reloaded and the membership might have changed.
+ *
+ * Throws if the pubkey cannot be resolved (daemon/benchmark down). Callers
+ * that want a retry-until-clean semantic should let the throw propagate;
+ * callers that just want a best-effort boolean should `.catch(() => false)`.
+ */
+async function isEnterpriseNode() {
+  if (cachedIsEnterpriseNode !== null) return cachedIsEnterpriseNode;
+
+  const allowed = getEnterpriseNodesPublicKeys();
+  if (!allowed.length) {
+    cachedIsEnterpriseNode = false;
+    return false;
+  }
+
+  const pubKey = await fluxNetworkHelper.getFluxNodePublicKey();
+  // getFluxNodePublicKey swallows errors and returns the Error object on failure.
+  if (!pubKey || typeof pubKey !== 'string') {
+    throw new Error('enterpriseNetwork: unable to resolve fluxnode public key (daemon/benchmark unavailable)');
+  }
+
+  cachedIsEnterpriseNode = allowed.includes(pubKey);
+  return cachedIsEnterpriseNode;
+}
+
+function resetEnterpriseNodeCache() {
+  cachedIsEnterpriseNode = null;
+}
+
+/**
+ * Uninstall locally-installed apps whose ownership violates the enterprise
+ * network split:
+ *   - enterprise-network nodes must only host apps owned by enterpriseAppOwners
+ *   - every other node must never host apps owned by enterpriseAppOwners
+ *
+ * sendMessage=true so peers receive fluxappremoved and drop this IP from
+ * appLocations. Intended to run once, ~5 minutes after boot.
+ */
+async function cleanupOwnershipViolations() {
+  // eslint-disable-next-line global-require
+  const appUninstaller = require('../appLifecycle/appUninstaller');
+
+  const enterprise = await isEnterpriseNode();
+
+  const db = dbHelper.databaseConnection();
+  const appsDatabase = db.db(config.database.appslocal.database);
+  const projection = { projection: { _id: 0, name: 1, owner: 1 } };
+  const apps = await dbHelper.findInDatabase(
+    appsDatabase,
+    appConstants.localAppsInformation,
+    {},
+    projection,
+  );
+
+  const offenders = apps.filter((app) => (
+    enterprise
+      ? !isEnterpriseAppOwner(app.owner)
+      : isEnterpriseAppOwner(app.owner)
+  ));
+  if (!offenders.length) {
+    log.info('enterpriseNetwork: no ownership violations to clean up');
+    return;
+  }
+
+  const role = enterprise ? 'enterprise-network' : 'non-enterprise-network';
+  log.warn(`enterpriseNetwork: ${role} node has ${offenders.length} locally-installed app(s) with disallowed owner, uninstalling`);
+  // eslint-disable-next-line no-restricted-syntax
+  for (const app of offenders) {
+    log.warn(`REMOVAL REASON: ${role} node, app ${app.name} owner ${app.owner} disallowed by enterprise network split (enterpriseNetwork)`);
+    // Let exceptions propagate so the scheduler can retry on the next tick;
+    // a half-applied cleanup is fine to resume — subsequent runs re-query the db.
+    // eslint-disable-next-line no-await-in-loop
+    await appUninstaller.removeAppLocally(app.name, null, true, true, true);
+  }
+}
+
+module.exports = {
+  cleanupOwnershipViolations,
+  getEnterpriseAppOwners,
+  getEnterpriseNodesPublicKeys,
+  isEnterpriseAppOwner,
+  isEnterpriseNode,
+  resetEnterpriseNodeCache,
+};

--- a/ZelBack/src/services/utils/enterpriseNetwork.js
+++ b/ZelBack/src/services/utils/enterpriseNetwork.js
@@ -25,9 +25,9 @@ function isEnterpriseAppOwner(owner) {
  * process after a successful resolution; call resetEnterpriseNodeCache() if
  * the config is hot-reloaded and the membership might have changed.
  *
- * Throws if the pubkey cannot be resolved (daemon/benchmark down). Callers
- * that want a retry-until-clean semantic should let the throw propagate;
- * callers that just want a best-effort boolean should `.catch(() => false)`.
+ * Throws if the pubkey cannot be resolved (daemon/benchmark down). Prefer the
+ * boot-time scheduleIdentityResolution() + getCachedEnterpriseIdentity() pair
+ * over awaiting this from hot paths.
  */
 async function isEnterpriseNode() {
   if (cachedIsEnterpriseNode !== null) return cachedIsEnterpriseNode;
@@ -46,6 +46,41 @@ async function isEnterpriseNode() {
 
   cachedIsEnterpriseNode = allowed.includes(pubKey);
   return cachedIsEnterpriseNode;
+}
+
+/**
+ * Synchronous read of the cached identity. Returns:
+ *   - true  : node is in the enterprise set
+ *   - false : node is not in the enterprise set
+ *   - null  : identity not yet resolved (caller should defer)
+ *
+ * This is the read used by hot paths (e.g. the spawn loop) so they don't
+ * need to await or handle a throw on every iteration.
+ */
+function getCachedEnterpriseIdentity() {
+  return cachedIsEnterpriseNode;
+}
+
+/**
+ * Boot-time identity resolution. Calls isEnterpriseNode() to populate the
+ * cache; if the pubkey can't be resolved (daemon/benchmark still coming up),
+ * reschedules itself every retryDelayMs until a run succeeds. Returns a
+ * promise that resolves once the identity is cached.
+ */
+function scheduleIdentityResolution({ retryDelayMs = 5 * 60 * 1000 } = {}) {
+  return new Promise((resolve) => {
+    const tryResolve = async () => {
+      try {
+        await isEnterpriseNode();
+        log.info('enterpriseNetwork: identity resolved');
+        resolve();
+      } catch (err) {
+        log.warn(`enterpriseNetwork: identity resolution failed, retrying in ${Math.round(retryDelayMs / 1000)}s: ${err.message || err}`);
+        setTimeout(tryResolve, retryDelayMs);
+      }
+    };
+    tryResolve();
+  });
 }
 
 function resetEnterpriseNodeCache() {
@@ -131,10 +166,12 @@ async function cleanupOwnershipViolations() {
 module.exports = {
   cleanupOwnershipViolations,
   filterAppsByOwnership,
+  getCachedEnterpriseIdentity,
   getEnterpriseAppOwners,
   getEnterpriseNodesPublicKeys,
   getSpawnDelays,
   isEnterpriseAppOwner,
   isEnterpriseNode,
   resetEnterpriseNodeCache,
+  scheduleIdentityResolution,
 };

--- a/ZelBack/src/services/utils/enterpriseNetwork.js
+++ b/ZelBack/src/services/utils/enterpriseNetwork.js
@@ -53,6 +53,35 @@ function resetEnterpriseNodeCache() {
 }
 
 /**
+ * Enterprise network ownership split applied as a single filter:
+ *   - enterprise-network nodes install ONLY apps owned by enterpriseAppOwners
+ *   - every other node NEVER installs apps owned by enterpriseAppOwners
+ */
+function filterAppsByOwnership(apps, isEnterprise) {
+  return apps.filter((app) => (
+    isEnterprise
+      ? isEnterpriseAppOwner(app.owner)
+      : !isEnterpriseAppOwner(app.owner)
+  ));
+}
+
+/**
+ * Spawn-loop cadence for trySpawningGlobalApplication. Enterprise nodes get
+ * a tight cadence that sticks regardless of how many apps are installable;
+ * non-enterprise nodes keep the original dynamic tuning (60s when more than
+ * one candidate exists, otherwise the legacy 5m/30m defaults).
+ */
+function getSpawnDelays(isEnterprise, appsAvailable) {
+  if (isEnterprise) {
+    return { shortDelayTime: 30 * 1000, delayTime: 60 * 1000 };
+  }
+  if (appsAvailable > 1) {
+    return { shortDelayTime: 60 * 1000, delayTime: 60 * 1000 };
+  }
+  return { shortDelayTime: 5 * 60 * 1000, delayTime: 30 * 60 * 1000 };
+}
+
+/**
  * Uninstall locally-installed apps whose ownership violates the enterprise
  * network split:
  *   - enterprise-network nodes must only host apps owned by enterpriseAppOwners
@@ -101,8 +130,10 @@ async function cleanupOwnershipViolations() {
 
 module.exports = {
   cleanupOwnershipViolations,
+  filterAppsByOwnership,
   getEnterpriseAppOwners,
   getEnterpriseNodesPublicKeys,
+  getSpawnDelays,
   isEnterpriseAppOwner,
   isEnterpriseNode,
   resetEnterpriseNodeCache,

--- a/tests/unit/enterpriseNetwork.test.js
+++ b/tests/unit/enterpriseNetwork.test.js
@@ -1,0 +1,250 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire').noCallThru();
+
+const MODULE_PATH = '../../ZelBack/src/services/utils/enterpriseNetwork';
+
+const OWNERS = ['ownerA', 'ownerB'];
+const NODE_PUBKEYS = ['pubA', 'pubB'];
+
+function loadModule(overrides = {}) {
+  const logStub = overrides.log || {
+    error: sinon.stub(),
+    info: sinon.stub(),
+    warn: sinon.stub(),
+  };
+
+  const defaultConfig = {
+    enterpriseAppOwners: OWNERS,
+    enterpriseNodesPublicKeys: NODE_PUBKEYS,
+    database: {
+      appslocal: { database: 'localapps', collections: { appsInformation: 'zelappsinformation' } },
+    },
+  };
+
+  const stubs = {
+    config: overrides.config || defaultConfig,
+    '../dbHelper': overrides.dbHelper || {
+      databaseConnection: sinon.stub().returns({ db: sinon.stub().returns({}) }),
+      findInDatabase: sinon.stub().resolves([]),
+    },
+    '../fluxNetworkHelper': overrides.fluxNetworkHelper || {
+      getFluxNodePublicKey: sinon.stub().resolves('pubA'),
+    },
+    './appConstants': overrides.appConstants || {
+      localAppsInformation: 'zelappsinformation',
+    },
+    '../../lib/log': logStub,
+    '../appLifecycle/appUninstaller': overrides.appUninstaller || {
+      removeAppLocally: sinon.stub().resolves(),
+    },
+  };
+
+  return { module: proxyquire(MODULE_PATH, stubs), stubs, log: logStub };
+}
+
+describe('enterpriseNetwork', () => {
+  afterEach(() => sinon.restore());
+
+  describe('isEnterpriseAppOwner', () => {
+    it('returns true when owner is in enterpriseAppOwners', () => {
+      const { module: m } = loadModule();
+      expect(m.isEnterpriseAppOwner('ownerA')).to.equal(true);
+    });
+
+    it('returns false when owner is not in enterpriseAppOwners', () => {
+      const { module: m } = loadModule();
+      expect(m.isEnterpriseAppOwner('someoneElse')).to.equal(false);
+    });
+
+    it('returns false for null/undefined owner', () => {
+      const { module: m } = loadModule();
+      expect(m.isEnterpriseAppOwner(null)).to.equal(false);
+      expect(m.isEnterpriseAppOwner(undefined)).to.equal(false);
+      expect(m.isEnterpriseAppOwner('')).to.equal(false);
+    });
+  });
+
+  describe('getEnterpriseAppOwners / getEnterpriseNodesPublicKeys', () => {
+    it('returns the configured enterpriseAppOwners list', () => {
+      const { module: m } = loadModule();
+      expect(m.getEnterpriseAppOwners()).to.deep.equal(OWNERS);
+    });
+
+    it('returns the configured enterpriseNodesPublicKeys list', () => {
+      const { module: m } = loadModule();
+      expect(m.getEnterpriseNodesPublicKeys()).to.deep.equal(NODE_PUBKEYS);
+    });
+
+    it('returns [] when config field is missing', () => {
+      const { module: m } = loadModule({
+        config: { database: { appslocal: { database: 'localapps', collections: { appsInformation: 'x' } } } },
+      });
+      expect(m.getEnterpriseAppOwners()).to.deep.equal([]);
+      expect(m.getEnterpriseNodesPublicKeys()).to.deep.equal([]);
+    });
+  });
+
+  describe('isEnterpriseNode', () => {
+    it('short-circuits to false when enterpriseNodesPublicKeys is empty, without calling getFluxNodePublicKey', async () => {
+      const getPubKey = sinon.stub().resolves('pubA');
+      const { module: m } = loadModule({
+        config: {
+          enterpriseAppOwners: OWNERS,
+          enterpriseNodesPublicKeys: [],
+          database: { appslocal: { database: 'x', collections: { appsInformation: 'y' } } },
+        },
+        fluxNetworkHelper: { getFluxNodePublicKey: getPubKey },
+      });
+      expect(await m.isEnterpriseNode()).to.equal(false);
+      expect(getPubKey.called).to.equal(false);
+    });
+
+    it('returns true when own pubkey is listed', async () => {
+      const { module: m } = loadModule({
+        fluxNetworkHelper: { getFluxNodePublicKey: sinon.stub().resolves('pubA') },
+      });
+      expect(await m.isEnterpriseNode()).to.equal(true);
+    });
+
+    it('returns false when own pubkey is not listed', async () => {
+      const { module: m } = loadModule({
+        fluxNetworkHelper: { getFluxNodePublicKey: sinon.stub().resolves('pubOther') },
+      });
+      expect(await m.isEnterpriseNode()).to.equal(false);
+    });
+
+    it('throws when getFluxNodePublicKey returns a non-string (daemon/benchmark down)', async () => {
+      const { module: m } = loadModule({
+        fluxNetworkHelper: { getFluxNodePublicKey: sinon.stub().resolves(new Error('daemon down')) },
+      });
+      try {
+        await m.isEnterpriseNode();
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err.message).to.include('unable to resolve fluxnode public key');
+      }
+    });
+
+    it('caches the result on success and does not re-query the pubkey', async () => {
+      const getPubKey = sinon.stub().resolves('pubA');
+      const { module: m } = loadModule({
+        fluxNetworkHelper: { getFluxNodePublicKey: getPubKey },
+      });
+      expect(await m.isEnterpriseNode()).to.equal(true);
+      expect(await m.isEnterpriseNode()).to.equal(true);
+      expect(getPubKey.callCount).to.equal(1);
+    });
+
+    it('does not cache when the pubkey cannot be resolved (so the next call retries)', async () => {
+      const getPubKey = sinon.stub().resolves(new Error('down'));
+      const { module: m } = loadModule({
+        fluxNetworkHelper: { getFluxNodePublicKey: getPubKey },
+      });
+      await m.isEnterpriseNode().catch(() => {});
+      await m.isEnterpriseNode().catch(() => {});
+      expect(getPubKey.callCount).to.equal(2);
+    });
+
+    it('resetEnterpriseNodeCache forces a re-query', async () => {
+      const getPubKey = sinon.stub().resolves('pubA');
+      const { module: m } = loadModule({
+        fluxNetworkHelper: { getFluxNodePublicKey: getPubKey },
+      });
+      await m.isEnterpriseNode();
+      m.resetEnterpriseNodeCache();
+      await m.isEnterpriseNode();
+      expect(getPubKey.callCount).to.equal(2);
+    });
+  });
+
+  describe('cleanupOwnershipViolations', () => {
+    function installedAppsStub(apps) {
+      return {
+        databaseConnection: sinon.stub().returns({ db: sinon.stub().returns({}) }),
+        findInDatabase: sinon.stub().resolves(apps),
+      };
+    }
+
+    it('enterprise-network node: uninstalls apps whose owner is not in enterpriseAppOwners', async () => {
+      const removeAppLocally = sinon.stub().resolves();
+      const { module: m } = loadModule({
+        fluxNetworkHelper: { getFluxNodePublicKey: sinon.stub().resolves('pubA') },
+        dbHelper: installedAppsStub([
+          { name: 'keep', owner: 'ownerA' },
+          { name: 'drop1', owner: 'stranger' },
+          { name: 'drop2', owner: null },
+        ]),
+        appUninstaller: { removeAppLocally },
+      });
+
+      await m.cleanupOwnershipViolations();
+
+      expect(removeAppLocally.callCount).to.equal(2);
+      const names = removeAppLocally.getCalls().map((c) => c.args[0]).sort();
+      expect(names).to.deep.equal(['drop1', 'drop2']);
+      // sendMessage flag must be true so peers get fluxappremoved
+      const firstCall = removeAppLocally.firstCall.args;
+      expect(firstCall[4]).to.equal(true);
+    });
+
+    it('non-enterprise-network node: uninstalls apps whose owner IS in enterpriseAppOwners', async () => {
+      const removeAppLocally = sinon.stub().resolves();
+      const { module: m } = loadModule({
+        fluxNetworkHelper: { getFluxNodePublicKey: sinon.stub().resolves('pubOther') },
+        dbHelper: installedAppsStub([
+          { name: 'enterprise-app', owner: 'ownerA' },
+          { name: 'normal-app', owner: 'stranger' },
+        ]),
+        appUninstaller: { removeAppLocally },
+      });
+
+      await m.cleanupOwnershipViolations();
+
+      expect(removeAppLocally.callCount).to.equal(1);
+      expect(removeAppLocally.firstCall.args[0]).to.equal('enterprise-app');
+      expect(removeAppLocally.firstCall.args[4]).to.equal(true);
+    });
+
+    it('is a no-op when there are no offenders', async () => {
+      const removeAppLocally = sinon.stub().resolves();
+      const { module: m, log } = loadModule({
+        fluxNetworkHelper: { getFluxNodePublicKey: sinon.stub().resolves('pubA') },
+        dbHelper: installedAppsStub([{ name: 'ok', owner: 'ownerA' }]),
+        appUninstaller: { removeAppLocally },
+      });
+
+      await m.cleanupOwnershipViolations();
+
+      expect(removeAppLocally.called).to.equal(false);
+      expect(log.info.calledWith(sinon.match(/no ownership violations/))).to.equal(true);
+    });
+
+    it('propagates the throw when isEnterpriseNode cannot resolve the pubkey', async () => {
+      const { module: m } = loadModule({
+        fluxNetworkHelper: { getFluxNodePublicKey: sinon.stub().resolves(new Error('down')) },
+      });
+      try {
+        await m.cleanupOwnershipViolations();
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err.message).to.include('unable to resolve fluxnode public key');
+      }
+    });
+
+    it('propagates an uninstall failure so the scheduler can retry', async () => {
+      const removeAppLocally = sinon.stub().rejects(new Error('boom'));
+      const { module: m } = loadModule({
+        fluxNetworkHelper: { getFluxNodePublicKey: sinon.stub().resolves('pubA') },
+        dbHelper: installedAppsStub([{ name: 'bad', owner: 'stranger' }]),
+        appUninstaller: { removeAppLocally },
+      });
+      try {
+        await m.cleanupOwnershipViolations();
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err.message).to.equal('boom');
+      }
+    });
+  });
+});

--- a/tests/unit/enterpriseNetwork.test.js
+++ b/tests/unit/enterpriseNetwork.test.js
@@ -158,6 +158,53 @@ describe('enterpriseNetwork', () => {
     });
   });
 
+  describe('filterAppsByOwnership', () => {
+    const apps = [
+      { name: 'e1', owner: 'ownerA' },
+      { name: 'e2', owner: 'ownerB' },
+      { name: 'n1', owner: 'stranger' },
+      { name: 'n2', owner: null },
+    ];
+
+    it('enterprise=true keeps only apps whose owner is in enterpriseAppOwners', () => {
+      const { module: m } = loadModule();
+      const kept = m.filterAppsByOwnership(apps, true).map((a) => a.name);
+      expect(kept).to.deep.equal(['e1', 'e2']);
+    });
+
+    it('enterprise=false drops apps whose owner is in enterpriseAppOwners', () => {
+      const { module: m } = loadModule();
+      const kept = m.filterAppsByOwnership(apps, false).map((a) => a.name);
+      expect(kept).to.deep.equal(['n1', 'n2']);
+    });
+
+    it('empty input produces empty output either way', () => {
+      const { module: m } = loadModule();
+      expect(m.filterAppsByOwnership([], true)).to.deep.equal([]);
+      expect(m.filterAppsByOwnership([], false)).to.deep.equal([]);
+    });
+  });
+
+  describe('getSpawnDelays', () => {
+    it('enterprise: 30s/60s regardless of appsAvailable', () => {
+      const { module: m } = loadModule();
+      expect(m.getSpawnDelays(true, 0)).to.deep.equal({ shortDelayTime: 30 * 1000, delayTime: 60 * 1000 });
+      expect(m.getSpawnDelays(true, 1)).to.deep.equal({ shortDelayTime: 30 * 1000, delayTime: 60 * 1000 });
+      expect(m.getSpawnDelays(true, 42)).to.deep.equal({ shortDelayTime: 30 * 1000, delayTime: 60 * 1000 });
+    });
+
+    it('non-enterprise with appsAvailable > 1: 60s/60s', () => {
+      const { module: m } = loadModule();
+      expect(m.getSpawnDelays(false, 2)).to.deep.equal({ shortDelayTime: 60 * 1000, delayTime: 60 * 1000 });
+    });
+
+    it('non-enterprise with appsAvailable <= 1: legacy 5m/30m defaults', () => {
+      const { module: m } = loadModule();
+      expect(m.getSpawnDelays(false, 0)).to.deep.equal({ shortDelayTime: 5 * 60 * 1000, delayTime: 30 * 60 * 1000 });
+      expect(m.getSpawnDelays(false, 1)).to.deep.equal({ shortDelayTime: 5 * 60 * 1000, delayTime: 30 * 60 * 1000 });
+    });
+  });
+
   describe('cleanupOwnershipViolations', () => {
     function installedAppsStub(apps) {
       return {

--- a/tests/unit/enterpriseNetwork.test.js
+++ b/tests/unit/enterpriseNetwork.test.js
@@ -158,6 +158,62 @@ describe('enterpriseNetwork', () => {
     });
   });
 
+  describe('getCachedEnterpriseIdentity', () => {
+    it('returns null before isEnterpriseNode resolves', () => {
+      const { module: m } = loadModule();
+      expect(m.getCachedEnterpriseIdentity()).to.equal(null);
+    });
+
+    it('returns the cached boolean after isEnterpriseNode resolves', async () => {
+      const { module: m } = loadModule({
+        fluxNetworkHelper: { getFluxNodePublicKey: sinon.stub().resolves('pubA') },
+      });
+      await m.isEnterpriseNode();
+      expect(m.getCachedEnterpriseIdentity()).to.equal(true);
+    });
+
+    it('returns null again after resetEnterpriseNodeCache', async () => {
+      const { module: m } = loadModule({
+        fluxNetworkHelper: { getFluxNodePublicKey: sinon.stub().resolves('pubA') },
+      });
+      await m.isEnterpriseNode();
+      m.resetEnterpriseNodeCache();
+      expect(m.getCachedEnterpriseIdentity()).to.equal(null);
+    });
+  });
+
+  describe('scheduleIdentityResolution', () => {
+    let clock;
+    beforeEach(() => { clock = sinon.useFakeTimers(); });
+    afterEach(() => clock.restore());
+
+    it('resolves immediately when the pubkey is available on first try', async () => {
+      const { module: m } = loadModule({
+        fluxNetworkHelper: { getFluxNodePublicKey: sinon.stub().resolves('pubA') },
+      });
+      await m.scheduleIdentityResolution({ retryDelayMs: 1000 });
+      expect(m.getCachedEnterpriseIdentity()).to.equal(true);
+    });
+
+    it('retries on failure and resolves once the pubkey becomes available', async () => {
+      const getPubKey = sinon.stub();
+      getPubKey.onFirstCall().resolves(new Error('down'));
+      getPubKey.onSecondCall().resolves('pubA');
+      const { module: m } = loadModule({
+        fluxNetworkHelper: { getFluxNodePublicKey: getPubKey },
+      });
+
+      const resolved = m.scheduleIdentityResolution({ retryDelayMs: 1000 });
+      // First attempt fails; advance past the retry delay.
+      await clock.tickAsync(0);
+      expect(m.getCachedEnterpriseIdentity()).to.equal(null);
+      await clock.tickAsync(1000);
+      await resolved;
+      expect(getPubKey.callCount).to.equal(2);
+      expect(m.getCachedEnterpriseIdentity()).to.equal(true);
+    });
+  });
+
   describe('filterAppsByOwnership', () => {
     const apps = [
       { name: 'e1', owner: 'ownerA' },

--- a/tests/unit/globalconfig/default.js
+++ b/tests/unit/globalconfig/default.js
@@ -289,5 +289,6 @@ module.exports = {
     '042ebcb3a94fe66b9ded6e456871346d6984502bbadf14ed07644e0eb91f8cc0b1f07632c428e1e6793f372d9c303d680de80ae0499d51095676cabf68599e9591',
   ],
   enterpriseNodesPublicKeys: [
+    '027595b0b8257d7b901fc024d7c5b66a7af68b64240dea0359dec3ffb1f2a33a8d',
   ],
 };

--- a/tests/unit/globalconfig/default.js
+++ b/tests/unit/globalconfig/default.js
@@ -288,4 +288,6 @@ module.exports = {
   enterprisePublicKeys: [ // list of whitelisted nodes indentity public keys. Most trusted node operators that are publicly known, kyc. Eg Flux team members, Titan.
     '042ebcb3a94fe66b9ded6e456871346d6984502bbadf14ed07644e0eb91f8cc0b1f07632c428e1e6793f372d9c303d680de80ae0499d51095676cabf68599e9591',
   ],
+  enterpriseNodesPublicKeys: [
+  ],
 };

--- a/tests/unit/hwRequirements.test.js
+++ b/tests/unit/hwRequirements.test.js
@@ -953,10 +953,130 @@ describe('hwRequirements tests', () => {
     });
   });
 
+  describe('checkAppCpuBurstHeadroom tests', () => {
+    // Build a fresh hwRequirements module with plugable cpu/lock/app values.
+    // Formula: freeCoresAfterInstall = cpuCores - lockedSystemResources.cpu/10
+    //   - appsCpusLocked - appHWrequirements.cpu
+    // Throws when freeCoresAfterInstall <= 4.
+    function buildHw({ cpucores, appsCpusLocked, lockedCpuTenths = 10, appsResourcesStatus = 'success' }) {
+      return proxyquire('../../ZelBack/src/services/appRequirements/hwRequirements', {
+        '../serviceHelper': serviceHelperStub,
+        '../benchmarkService': {
+          getBenchmarks: sinon.stub().resolves({
+            status: 'success',
+            data: { cpucores, ram: 8000, ssd: 1000 },
+          }),
+        },
+        '../generalService': {
+          nodeTier: sinon.stub().resolves('stratus'),
+        },
+        '../geolocationService': {
+          isStaticIP: sinon.stub().returns(true),
+          getNodeGeolocation: sinon.stub().returns('US-NY'),
+        },
+        '../fluxNetworkHelper': {
+          getFluxNodeCount: sinon.stub().resolves(1000),
+        },
+        '../appDatabase/registryManager': {
+          availableApps: sinon.stub().resolves([]),
+        },
+        '../appQuery/appQueryService': {
+          installedApps: sinon.stub().resolves({ status: 'success', data: [] }),
+        },
+        '../appQuery/resourceQueryService': {
+          appsResources: sinon.stub().resolves({
+            status: appsResourcesStatus,
+            data: { appsCpusLocked, appsRamLocked: 0, appsHddLocked: 0 },
+          }),
+        },
+        '../../lib/log': logStub,
+        os: {
+          cpus: sinon.stub().returns(new Array(cpucores)),
+          totalmem: sinon.stub().returns(8000 * 1024 * 1024),
+        },
+        config: {
+          fluxSpecifics: {
+            cpu: { cumulus: 2, nimbus: 4, stratus: 8 },
+            ram: { cumulus: 4000, nimbus: 8000, stratus: 16000 },
+            hdd: { cumulus: 220, nimbus: 440, stratus: 880 },
+          },
+          lockedSystemResources: {
+            cpu: lockedCpuTenths, ram: 0, hdd: 0, extrahdd: 0,
+          },
+        },
+      });
+    }
+
+    it('passes when remaining free cores after install are > 4', async () => {
+      // 16 cores - 1 (system) - 3 (locked) - 2 (this app) = 10 > 4 → ok
+      const hw = buildHw({ cpucores: 16, appsCpusLocked: 3 });
+      const result = await hw.checkAppCpuBurstHeadroom({ version: 3, cpu: 2, ram: 10, hdd: 10 });
+      expect(result).to.equal(true);
+    });
+
+    it('throws when remaining free cores would be exactly 4 (boundary)', async () => {
+      // 10 cores - 1 - 3 - 2 = 4 → throw (rule is strict <=)
+      const hw = buildHw({ cpucores: 10, appsCpusLocked: 3 });
+      try {
+        await hw.checkAppCpuBurstHeadroom({ version: 3, cpu: 2, ram: 10, hdd: 10 });
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err.message).to.include('CPU burst headroom');
+      }
+    });
+
+    it('passes at 5 free cores (just above the boundary)', async () => {
+      // 10 cores - 1 - 3 - 1 = 5 > 4 → ok
+      const hw = buildHw({ cpucores: 10, appsCpusLocked: 3 });
+      const result = await hw.checkAppCpuBurstHeadroom({ version: 3, cpu: 1, ram: 10, hdd: 10 });
+      expect(result).to.equal(true);
+    });
+
+    it('throws when remaining free cores would be negative (over-subscribed)', async () => {
+      // 8 cores - 1 - 5 - 4 = -2 → throw
+      const hw = buildHw({ cpucores: 8, appsCpusLocked: 5 });
+      try {
+        await hw.checkAppCpuBurstHeadroom({ version: 3, cpu: 4, ram: 10, hdd: 10 });
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err.message).to.include('CPU burst headroom');
+      }
+    });
+
+    it('throws when appsResources cannot be read', async () => {
+      const hw = buildHw({ cpucores: 16, appsCpusLocked: 0, appsResourcesStatus: 'error' });
+      try {
+        await hw.checkAppCpuBurstHeadroom({ version: 3, cpu: 1, ram: 10, hdd: 10 });
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err.message).to.include('locked system resources');
+      }
+    });
+
+    it('sums cpu across compose components for v4+ apps', async () => {
+      // 10 cores - 1 - 0 - (3+3) = 0 → throw (compose summed)
+      const hw = buildHw({ cpucores: 10, appsCpusLocked: 0 });
+      const appSpecs = {
+        version: 4,
+        compose: [
+          { name: 'c1', cpu: 3, ram: 10, hdd: 10 },
+          { name: 'c2', cpu: 3, ram: 10, hdd: 10 },
+        ],
+      };
+      try {
+        await hw.checkAppCpuBurstHeadroom(appSpecs);
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err.message).to.include('CPU burst headroom');
+      }
+    });
+  });
+
   describe('exported functions', () => {
     it('should export requirement checking functions', () => {
       expect(hwRequirements.totalAppHWRequirements).to.be.a('function');
       expect(hwRequirements.checkAppHWRequirements).to.be.a('function');
+      expect(hwRequirements.checkAppCpuBurstHeadroom).to.be.a('function');
       expect(hwRequirements.checkAppStaticIpRequirements).to.be.a('function');
       expect(hwRequirements.checkAppNodesRequirements).to.be.a('function');
       expect(hwRequirements.checkAppGeolocationRequirements).to.be.a('function');


### PR DESCRIPTION
## Summary                                                      
                                                                                                                                                                                
  Adds an **opt-in enterprise network** of fluxnodes identified by pubkeys in a new
  `enterpriseNodesPublicKeys` config list. Splits the ownership space between enterprise                                                                                        
  and non-enterprise nodes and adds spawn-path gating plus a one-shot boot-time cleanup.                                                                                        
                                                                                                                                                                                
  ## Behavior                                                                                                                                                                   
                                                                                                                                                                                
  | Situation | Enterprise-network node | Every other node |                                                                                                                    
  |---|---|---|                                                   
  | App owner ∈ `enterpriseAppOwners` | spawn / keep | skip / uninstall + broadcast `fluxappremoved` |
  | App owner ∉ `enterpriseAppOwners` | skip / uninstall + broadcast `fluxappremoved` | spawn / keep |                                                                          
  | `enterpriseNodesPublicKeys` empty | — | — |
                                                                                                                                                                                
  Ships with an empty `enterpriseNodesPublicKeys` list, so the feature is a **no-op on                                                                                          
  unconfigured nodes** and rolls out safely.                                                                                                                                    
                                                                                                                                                                                
  Enterprise nodes additionally get:                              
                                                                                                                                                                                
  - **Tight spawn cadence** inside `trySpawningGlobalApplication`: `shortDelayTime = 30s`,                                                                                      
    `delayTime = 60s`, and the terminal `delay(delayTime)` before the self-recurse is
    skipped. The mid-function dynamic delay reassignments are gated so these values stick                                                                                       
    for the whole run.                                                                                                                                                          
  - **>4 vCore burst headroom** required before install, via the new exported                                                                                                   
    `hwRequirements.checkAppCpuBurstHeadroom(appSpecs)`. Rejects apps whose installation                                                                                        
    would leave `cpuCores − lockedSystemResources.cpu/10 − appsCpusLocked − appHWrequirements.cpu ≤ 4`.                                                                         
                                                                                                                                                                                
  ## Safety: never act on an unknown identity                                                                                                                                   
                                                                                                                                                                                
  `isEnterpriseNode()` throws when this node's own pubkey cannot be resolved                                                                                                    
  (`fluxNetworkHelper.getFluxNodePublicKey` returns an Error because daemon/benchmark
  is still coming up). On that throw:                                                                                                                                           
                                                                                                                                                                                
  - The **spawner** lets it propagate to the existing outer `catch`, which retries after                                                                                        
    `shortDelayTime`.                                                                                                                                                           
  - The **boot-time cleanup** lets it propagate to a self-rescheduling `setTimeout` that                                                                                        
    retries every 5 minutes until a run completes without throwing.                                                                                                             
                                                                                                                                                                                
  Cache semantics:                                                                                                                                                              
                                                                                                                                                                                
  - Result is cached only on successful resolution, so transient daemon outages don't                                                                                           
    stick as `false`.                                             
  - Empty `enterpriseNodesPublicKeys` short-circuits to `false` without any network call.                                                                                       
  - `resetEnterpriseNodeCache()` is exported for future hot-reload integration with                                                                                             
    `configManager`.                                                                                                                                                            
                                                                                                                                                                                
  Per-app `try/catch` was removed from the cleanup loop so an uninstall failure also                                                                                            
  bubbles up and triggers a retry; partial progress is safe because subsequent runs                                                                                             
  re-query `localAppsInformation` and only see remaining offenders.                                                                                                             
                                                                                                                                                                                
  ## Files                                                                                                                                                                      
                                                                                                                                                                                
  - **New** `ZelBack/src/services/utils/enterpriseNetwork.js` — `isEnterpriseNode`,                                                                                             
    `isEnterpriseAppOwner`, `getEnterpriseAppOwners`, `getEnterpriseNodesPublicKeys`,
    `resetEnterpriseNodeCache`, `cleanupOwnershipViolations`.                                                                                                                   
  - `ZelBack/config/default.js` — new empty `enterpriseNodesPublicKeys: []`.                                                                                                    
  - `tests/unit/globalconfig/default.js` — mirrors the new field for the test harness.                                                                                          
  - `ZelBack/src/services/appLifecycle/appSpawner.js` — resolves `isEnterprise` at the top                                                                                      
    of `trySpawningGlobalApplication`; adds `owner` to the aggregation `$project`;                                                                                              
    symmetric owner filter; enterprise-only burst-headroom check; enterprise-only tight                                                                                         
    delays.                                                                                                                                                                     
  - `ZelBack/src/services/appRequirements/hwRequirements.js` — new exported                                                                                                     
    `checkAppCpuBurstHeadroom`.                                                                                                                                                 
  - `ZelBack/src/services/serviceManager.js` — self-rescheduling boot cleanup
    (`scheduleEnterpriseCleanup`) fired at T+5m after startup.                                                                                                                  
                                                                                                                                                                                
  ## Tests                                                                                                                                                                      
                                                                                                                                                                                
  - **New** `tests/unit/enterpriseNetwork.test.js` — 18 tests covering every helper,                                                                                            
    cache semantics, throw-on-unresolved-pubkey, and both directions of the cleanup
    (enterprise vs. non-enterprise offender selection, no-op when clean, throw                                                                                                  
    propagation from uninstall failure).                                                                                                                                        
  - `tests/unit/hwRequirements.test.js` — 6 new tests for `checkAppCpuBurstHeadroom`:                                                                                           
    boundary at 4 free cores (throws), 5 (passes), negative (throws), `appsResources`                                                                                           
    failure, v4+ compose-sum behavior. Export check updated.                                                                                                                    
                                                                                                                                                                                
  Full unit suite: **3594 passing, 5 pending, 1 failing** — the failure is the pre-existing                                                                                     
  `syncthingHealthMonitor > should remove app after remove threshold` case on this branch,                                                                                      
  unchanged by this PR.                                                                                                                                                         
                                                                  
  ## Test plan                                                                                                                                                                  
                                                                  
  - [ ] CI unit suite green (`npm run test:zelback:unit` / container compose variant).                                                                                          
  - [ ] On a real node with empty `enterpriseNodesPublicKeys`: no behavior change
        (the spawner's `isEnterpriseNode()` resolves to `false` without a network call,                                                                                         
        so no additional overhead per iteration; cleanup is a no-op).                                                                                                           
  - [ ] On a node added to `enterpriseNodesPublicKeys` with an existing non-enterprise                                                                                          
        app installed: within ~5 min the app is uninstalled and `fluxappremoved` is                                                                                             
        broadcast; subsequent spawns only pick from `enterpriseAppOwners`; reject paths                                                                                         
        show tight `delayTime=60s` cadence in logs.                                                                                                                             
  - [ ] On a node **not** in `enterpriseNodesPublicKeys` with an enterprise-owned app                                                                                           
        installed: within ~5 min the app is uninstalled and `fluxappremoved` is broadcast.                                                                                      
  - [ ] Daemon-down simulation at boot: cleanup logs "retrying in 5 min" and only acts                                                                                          
        once `getFluxNodePublicKey` resolves.                                                                                                                                   
  - [ ] Enterprise node at CPU ceiling: `checkAppCpuBurstHeadroom` rejects an app that                                                                                          
        would leave ≤ 4 free vCores; spawner caches the hash and retries later.