### PR TITLE
Faster enterprise-node spawn + host env vars injected into containers 

### DIFF
--- a/ZelBack/src/services/appLifecycle/appSpawner.js
+++ b/ZelBack/src/services/appLifecycle/appSpawner.js
@@ -464,7 +464,7 @@ async function trySpawningGlobalApplication() {
       }
     }
 
-    if (!appFromAppsToBeCheckedLater && !appFromAppsSyncthingToBeCheckedLater) {
+    if (!isEnterprise && !appFromAppsToBeCheckedLater && !appFromAppsSyncthingToBeCheckedLater) {
       const tier = await generalService.nodeTier();
       const appHWrequirements = hwRequirements.totalAppHWRequirements(appSpecifications, tier);
       let delay = false;
@@ -515,7 +515,7 @@ async function trySpawningGlobalApplication() {
         delay = true;
       } else if (appToRunAux.nodes.length > 0 && appToRunAux.nodes.find((ip) => ip === myIP)) {
         log.info(`trySpawningGlobalApplication - App ${appToRun} specs have this node as target ip`);
-      }else if (appToRunAux.nodes.length === 0 && tier === 'bamf' && appHWrequirements.cpu < 3 && appHWrequirements.ram < 6000 && appHWrequirements.hdd < 150) {
+      } else if (appToRunAux.nodes.length === 0 && tier === 'bamf' && appHWrequirements.cpu < 3 && appHWrequirements.ram < 6000 && appHWrequirements.hdd < 150) {
         const appToCheck = {
           timeToCheck: appToRunAux.enterprise ? Date.now() + 0.5 * 60 * 60 * 1000 : Date.now() + 1.95 * 60 * 60 * 1000,
           appName: appToRun,

--- a/ZelBack/src/services/appLifecycle/appSpawner.js
+++ b/ZelBack/src/services/appLifecycle/appSpawner.js
@@ -464,6 +464,22 @@ async function trySpawningGlobalApplication() {
       }
     }
 
+    if (!appFromAppsToBeCheckedLater && !appFromAppsSyncthingToBeCheckedLater
+      && appToRunAux.nodes.length > 0 && !appToRunAux.nodes.find((ip) => ip === myIP)) {
+      const appToCheck = {
+        timeToCheck: appToRunAux.enterprise ? Date.now() + 0.5 * 60 * 60 * 1000 : Date.now() + 0.95 * 60 * 60 * 1000,
+        appName: appToRun,
+        hash: appHash,
+        required: minInstances,
+      };
+      log.info(`trySpawningGlobalApplication - App ${appToRun} specs have target ips, will check in around 0.5h if instances are still missing`);
+      globalState.appsToBeCheckedLater.push(appToCheck);
+      globalState.trySpawningGlobalAppCache.delete(appHash);
+      await serviceHelper.delay(shortDelayTime);
+      trySpawningGlobalApplication();
+      return;
+    }
+
     if (!isEnterprise && !appFromAppsToBeCheckedLater && !appFromAppsSyncthingToBeCheckedLater) {
       const tier = await generalService.nodeTier();
       const appHWrequirements = hwRequirements.totalAppHWRequirements(appSpecifications, tier);
@@ -499,17 +515,6 @@ async function trySpawningGlobalApplication() {
           required: minInstances,
         };
         log.info(`trySpawningGlobalApplication - App ${appToRun} does not require datacenter but node is datacenter, will check in around 27m if instances are still missing`);
-        globalState.appsToBeCheckedLater.push(appToCheck);
-        globalState.trySpawningGlobalAppCache.delete(appHash);
-        delay = true;
-      } else if (appToRunAux.nodes.length > 0 && !appToRunAux.nodes.find((ip) => ip === myIP)) {
-        const appToCheck = {
-          timeToCheck: appToRunAux.enterprise ? Date.now() + 0.5 * 60 * 60 * 1000 : Date.now() + 0.95 * 60 * 60 * 1000,
-          appName: appToRun,
-          hash: appHash,
-          required: minInstances,
-        };
-        log.info(`trySpawningGlobalApplication - App ${appToRun} specs have target ips, will check in around 0.5h if instances are still missing`);
         globalState.appsToBeCheckedLater.push(appToCheck);
         globalState.trySpawningGlobalAppCache.delete(appHash);
         delay = true;

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -1011,6 +1011,20 @@ async function appDockerCreate(appSpecifications, appName, isComponent, fullAppS
     }
   }
 
+  // Template substitution: replace {{FLUX_NODE_IP}} in env values with the
+  // host's public IP. Runs after plain env, secrets, and F_S_ENV are merged
+  // so the token works from any source.
+  const nodeIpToken = '{{FLUX_NODE_IP}}';
+  if (options.Env.some((env) => typeof env === 'string' && env.includes(nodeIpToken))) {
+    const myFluxIp = await fluxNetworkHelper.getMyFluxIPandPort();
+    const resolvedIp = myFluxIp ? myFluxIp.split(':')[0] : null;
+    if (!resolvedIp) {
+      throw new Error(`Cannot resolve ${nodeIpToken}: node IP not available`);
+    }
+    options.Env = options.Env.map((env) => (typeof env === 'string' ? env.replaceAll(nodeIpToken, resolvedIp) : env));
+    log.info(`Substituted ${nodeIpToken} with ${resolvedIp} in env for ${identifier}`);
+  }
+
   // Ensure all required mount paths (files and directories) exist before creating container
   // This prevents Docker mount errors when files have been deleted or don't exist yet
   try {

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -1011,19 +1011,18 @@ async function appDockerCreate(appSpecifications, appName, isComponent, fullAppS
     }
   }
 
-  // Template substitution: replace {{FLUX_NODE_IP}} in env values with the
-  // host's public IP. Runs after plain env, secrets, and F_S_ENV are merged
-  // so the token works from any source.
-  const nodeIpToken = '{{FLUX_NODE_IP}}';
-  if (options.Env.some((env) => typeof env === 'string' && env.includes(nodeIpToken))) {
-    const myFluxIp = await fluxNetworkHelper.getMyFluxIPandPort();
-    const resolvedIp = myFluxIp ? myFluxIp.split(':')[0] : null;
-    if (!resolvedIp) {
-      throw new Error(`Cannot resolve ${nodeIpToken}: node IP not available`);
-    }
-    options.Env = options.Env.map((env) => (typeof env === 'string' ? env.replaceAll(nodeIpToken, resolvedIp) : env));
-    log.info(`Substituted ${nodeIpToken} with ${resolvedIp} in env for ${identifier}`);
+  // Inject Flux-provided env vars so apps can reference them directly or
+  // via ${VAR} expansion in their own config files (e.g. Datadog's
+  // DD_HOSTNAME=${FLUX_NODE_HOST_IP}). Appended last so they win over any
+  // identically-named values supplied by the operator.
+  const myFluxIp = await fluxNetworkHelper.getMyFluxIPandPort();
+  const nodeHostIp = myFluxIp ? myFluxIp.split(':')[0] : null;
+  if (nodeHostIp) {
+    options.Env.push(`FLUX_NODE_HOST_IP=${nodeHostIp}`);
+  } else {
+    log.warn(`FLUX_NODE_HOST_IP not injected for ${identifier}: node IP not available`);
   }
+  options.Env.push(`FLUX_APP_NAME=${appName}`);
 
   // Ensure all required mount paths (files and directories) exist before creating container
   // This prevents Docker mount errors when files have been deleted or don't exist yet

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -531,12 +531,30 @@ async function startFluxFunctions() {
       }, 30 * 60 * 1000);
       appHashSyncService.continuousFluxAppHashesCheck();
     }, (Math.floor(Math.random() * (30 - 15 + 1)) + 15) * 60 * 1000); // start between 15m and 30m after fluxOs start
-    setTimeout(() => {
-      // after 125 minutes of running ok and to make sure we are connected for enough time for receiving all apps running on other nodes
-      // 125 minutes should give enough time for node receive currently two times the apprunning messages
-      log.info('Starting to spawn applications');
-      appSpawner.trySpawningGlobalApplication();
-    }, (Math.floor(Math.random() * (135 - 125 + 1)) + 125) * 60 * 1000); // start between 125 and 135m after fluxos starts;
+    setTimeout(async () => {
+      // Enterprise-network nodes (pubkey in enterpriseNodesPublicKeys) start
+      // spawning at T+62m. Every other node keeps the legacy 125-135m window,
+      // which gives enough time to receive apprunning messages at least twice.
+      let isEnterprise = enterpriseNetwork.getCachedEnterpriseIdentity();
+      if (isEnterprise === null) {
+        try {
+          isEnterprise = await enterpriseNetwork.isEnterpriseNode();
+        } catch (err) {
+          log.warn(`Enterprise identity unresolved at spawn-gate, treating as non-enterprise: ${err.message || err}`);
+          isEnterprise = false;
+        }
+      }
+      if (isEnterprise) {
+        log.info('Starting to spawn applications (enterprise, 62m)');
+        appSpawner.trySpawningGlobalApplication();
+        return;
+      }
+      const remainingMs = (Math.floor(Math.random() * (135 - 125 + 1)) + 125 - 62) * 60 * 1000;
+      setTimeout(() => {
+        log.info('Starting to spawn applications');
+        appSpawner.trySpawningGlobalApplication();
+      }, remainingMs);
+    }, 62 * 60 * 1000);
     setInterval(() => {
       imageManager.checkApplicationsCompliance(appQueryService.installedApps, appUninstaller.removeAppLocally);
     }, 60 * 60 * 1000); //  every hour


### PR DESCRIPTION
## Summary

  Three related improvements to how FluxOS schedules app spawning and what every app container sees in its environment:                                                                                                                                                                                                
  
  1. **Enterprise-network nodes now start spawning apps at T+62m** instead of waiting the legacy 125–135m window. Non-enterprise nodes keep the original timing. Identity is read from the boot-time cache; unresolved nodes fall back to non-enterprise scheduling (safe default).                                    
  2. **Spawn-deferral paths in `trySpawningGlobalApplication` now behave correctly on enterprise nodes.** Tier-mismatch, static-IP, datacenter, and arcane-non-enterprise-app deferrals are skipped (enterprise nodes don't need them), but the **target-IP-mismatch** branch is preserved so enterprise nodes still
  honor specs that pin a concrete node list.                                                                                                                                                                                                                                                                           
  3. **Every app container now receives two Flux-provided env vars** — `FLUX_NODE_HOST_IP` (host's public IP) and `FLUX_APP_NAME`. Apps can reference them directly or via `${VAR}` expansion in config files that support it (e.g. Datadog's `DD_HOSTNAME=${FLUX_NODE_HOST_IP}`). Appended last, so they win over any
  identically-named operator-supplied values.                                                                                                                                                                                                                                                                          
                                                                             
  Taken together, these change how fast enterprise nodes come online with their assigned workloads, and give operators a standard, zero-spec way to pull host identity into their apps.                                                                                                                                
                                                                             
  ## Changes by file                                                                                                                                                                                                                                                                                                   
                                                                             
  - `ZelBack/src/services/serviceManager.js` — single 62-minute spawn-gate timer; enterprise nodes fire immediately, non-enterprise nodes schedule a second timer for the remaining 63–73m so they land in the original 125–135m window.                                                                               
  - `ZelBack/src/services/appLifecycle/appSpawner.js` — enterprise nodes bypass the `appsToBeCheckedLater` deferral block for tier / static-IP / datacenter / arcane-non-enterprise-app reasons, but still defer on target-IP mismatch.
  - `ZelBack/src/services/dockerService.js` — `appDockerCreate` unconditionally appends `FLUX_NODE_HOST_IP` and `FLUX_APP_NAME` to `options.Env` before container creation. If the node IP cannot be resolved, `FLUX_NODE_HOST_IP` is skipped with a warning rather than failing the container.                        
                                                                                                                                                                                                                                                                                                                       
  ## Behavior notes                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                       
  - **Non-enterprise nodes are unchanged** for spawn timing and deferral logic.                                                                                                                                                                                                                                        
  - **Existing apps that don't reference the new env vars are unaffected** — duplicate names (if any operator already sets `FLUX_NODE_HOST_IP` / `FLUX_APP_NAME`) are overridden by the platform injection because Docker keeps the last value for duplicate env entries.
  - **`target-IP` deferral on enterprise nodes** is intentional: enterprise app specs can still restrict installs to a listed IP set, and bypassing that would have installed on the wrong nodes.                                                                                                                      
                                                                                                                                                                                                                                                                                                                       
  ## Test plan                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                       
  - [ ] Boot a non-enterprise node and confirm `Starting to spawn applications` logs in the original 125–135m window.                                                                                                                                                                                                  
  - [ ] Boot an enterprise node (pubkey in `enterpriseNodesPublicKeys`) and confirm `Starting to spawn applications (enterprise, 62m)` at T+62m.
  - [ ] Install an app on a non-enterprise node whose spec targets a different IP list and confirm it still defers (no regression).                                                                                                                                                                                    
  - [ ] Install an app on an enterprise node whose spec targets a different IP list and confirm it defers (target-IP branch still effective).                                                                                                                                                                          
  - [ ] Install an app on an enterprise node with a tier / static-IP / datacenter / arcane-non-enterprise-app constraint that previously deferred and confirm it no longer defers.                                                                                                                                     
  - [ ] Exec into a newly-created container and confirm `env | grep FLUX_` shows `FLUX_NODE_HOST_IP=<host public IP>` and `FLUX_APP_NAME=<app name>`.                                                                                                                                                                  
  - [ ] Operator spec that references `${FLUX_NODE_HOST_IP}` in a config file (Datadog-style) resolves correctly at app startup.                                                                                                                                                                                       
  - [ ] Verify ESLint passes on the three touched files.