### PR TITLE
feat: event-driven app state sync & spawner startup

### DIFF
--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -56,6 +56,7 @@ module.exports = {
         appsInstallingLocations: 'appsinstallinglocations', // stores install location of flux apps as documents containing name, ip, obtainedAt
         appsInstallingErrorsLocations: 'appsInstallingErrorsLocations', // stores install errors location of flux apps as documents containing name, hash, ip, obtainedAt
         appsRunningBroadcasts: 'fluxapprunningbroadcasts', // stores signed apprunning broadcasts for sync
+        appsInstallingBroadcasts: 'fluxappinstallingbroadcasts', // stores signed appinstalling broadcasts for sync
       },
     },
     chainparams: {

--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -221,6 +221,7 @@ module.exports = {
     appSyncPeerThreshold: 12, // peers needed before starting app sync / spawning
     appSyncDegradedThreshold: 4, // below this, pause spawner — gossip unreliable
     appSyncMinPeerUptime: 60, // seconds a peer must have been running before we sync from it
+    appSyncMinCompletions: 1, // sync responses needed per type before spawner can start
     installation: {
       probability: 100, // 1%
       delay: 120, // in seconds

--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -220,6 +220,7 @@ module.exports = {
     minUpTime: 1800, // 30 mins
     appSyncPeerThreshold: 12, // peers needed before starting app sync / spawning
     appSyncDegradedThreshold: 4, // below this, pause spawner — gossip unreliable
+    appSyncMinPeerUptime: 60, // seconds a peer must have been running before we sync from it
     installation: {
       probability: 100, // 1%
       delay: 120, // in seconds

--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -57,6 +57,7 @@ module.exports = {
         appsInstallingErrorsLocations: 'appsInstallingErrorsLocations', // stores install errors location of flux apps as documents containing name, hash, ip, obtainedAt
         appsRunningBroadcasts: 'fluxapprunningbroadcasts', // stores signed apprunning broadcasts for sync
         appsInstallingBroadcasts: 'fluxappinstallingbroadcasts', // stores signed appinstalling broadcasts for sync
+        appsInstallingErrorsBroadcasts: 'fluxappinstallingerrorsbroadcasts', // stores signed appinstalling error broadcasts for sync
       },
     },
     chainparams: {

--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -215,6 +215,8 @@ module.exports = {
     minIncoming: 4,
     minUniqueIpsIncoming: 3,
     minUpTime: 1800, // 30 mins
+    appSyncPeerThreshold: 12, // peers needed before starting app sync / spawning
+    appSyncDegradedThreshold: 4, // below this, pause spawner — gossip unreliable
     installation: {
       probability: 100, // 1%
       delay: 120, // in seconds

--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -55,6 +55,7 @@ module.exports = {
         appsLocations: 'zelappslocation', // stores location of flux apps as documents containing name, hash, ip, obtainedAt
         appsInstallingLocations: 'appsinstallinglocations', // stores install location of flux apps as documents containing name, ip, obtainedAt
         appsInstallingErrorsLocations: 'appsInstallingErrorsLocations', // stores install errors location of flux apps as documents containing name, hash, ip, obtainedAt
+        appsRunningBroadcasts: 'fluxapprunningbroadcasts', // stores signed apprunning broadcasts for sync
       },
     },
     chainparams: {

--- a/ZelBack/src/lib/socketServer.js
+++ b/ZelBack/src/lib/socketServer.js
@@ -1,9 +1,7 @@
 const { match } = require('path-to-regexp');
 const WebSocketServer = require('ws').Server;
 const log = require('./log');
-const { FLUX_VERSION } = require('../services/utils/FluxPeerSocket');
-
-const LOCAL_CAPABILITIES = ['transmissionTimestamps', 'peerExchange', 'binaryMessages'];
+const { FLUX_VERSION, FLUX_CAPABILITIES } = require('../services/utils/FluxPeerSocket');
 
 class FluxWebsocketServer {
   static defautlErrorHandler = () => { };
@@ -51,8 +49,9 @@ class FluxWebsocketServer {
     // Add our capabilities and clock offset to every WS upgrade response header.
     // Old nodes silently ignore unknown headers.
     this.#socketServer.on('headers', (headers) => {
-      headers.push(`X-Flux-Capabilities: ${LOCAL_CAPABILITIES.join(',')}`);
+      headers.push(`X-Flux-Capabilities: ${FLUX_CAPABILITIES.join(',')}`);
       headers.push(`X-Flux-Version: ${FLUX_VERSION}`);
+      headers.push(`X-Flux-Uptime: ${Math.floor(process.uptime())}`);
       // Lazy require to avoid circular deps at module load time
       const fluxNetworkHelper = require('../services/fluxNetworkHelper');
       const offsetMs = fluxNetworkHelper.getLocalClockOffsetMs();

--- a/ZelBack/src/services/appDatabase/registryManager.js
+++ b/ZelBack/src/services/appDatabase/registryManager.js
@@ -116,6 +116,12 @@ async function appInstallingLocation(appname) {
  * @param {string} appname - Application name (optional)
  * @returns {Promise<Array>} Array of app installing error locations
  */
+async function countAppInstallingErrors(hash) {
+  const dbopen = dbHelper.databaseConnection();
+  const database = dbopen.db(config.database.appsglobal.database);
+  return dbHelper.countInDatabase(database, globalAppsInstallingErrorsLocations, { hash });
+}
+
 async function appInstallingErrorsLocation(appname) {
   const dbopen = dbHelper.databaseConnection();
   const database = dbopen.db(config.database.appsglobal.database);
@@ -131,8 +137,6 @@ async function appInstallingErrorsLocation(appname) {
       ip: 1,
       error: 1,
       broadcastedAt: 1,
-      cachedAt: 1,
-      expireAt: 1,
     },
   };
   const results = await dbHelper.findInDatabase(database, globalAppsInstallingErrorsLocations, query, projection);
@@ -1716,6 +1720,7 @@ module.exports = {
   appLocation,
   appInstallingLocation,
   appInstallingErrorsLocation,
+  countAppInstallingErrors,
   storeAppInstallingMessage,
   getAppsLocations,
   getAppsLocation,

--- a/ZelBack/src/services/appDatabase/registryManager.js
+++ b/ZelBack/src/services/appDatabase/registryManager.js
@@ -13,6 +13,7 @@ const {
   localAppsInformation,
   globalAppsMessages,
   globalAppsLocations,
+  globalAppsRunningBroadcasts,
   globalAppsInstallingLocations,
   globalAppsInstallingErrorsLocations,
   globalAppsInstallingErrorsBroadcasts,
@@ -84,6 +85,76 @@ async function appLocation(appname) {
     },
   };
   const results = await dbHelper.findInDatabase(database, globalAppsLocations, query, projection);
+  return results;
+}
+
+async function appLocationFromBroadcasts(appname) {
+  const dbopen = dbHelper.databaseConnection();
+  const database = dbopen.db(config.database.appsglobal.database);
+  const collection = database.collection(globalAppsRunningBroadcasts);
+
+  const nameMatch = appname ? new RegExp(`^${appname}$`, 'i') : null;
+
+  const pipeline = [
+    {
+      $facet: {
+        v2: [
+          { $match: { 'data.apps': { $exists: true } } },
+          { $unwind: '$data.apps' },
+          {
+            $project: {
+              _id: 0,
+              name: '$data.apps.name',
+              hash: '$data.apps.hash',
+              ip: '$data.ip',
+              broadcastedAt: '$broadcastedAt',
+              runningSince: { $ifNull: ['$data.apps.runningSince', '$data.runningSince'] },
+              osUptime: '$data.osUptime',
+              staticIp: '$data.staticIp',
+            },
+          },
+        ],
+        v1: [
+          { $match: { 'data.name': { $exists: true } } },
+          {
+            $project: {
+              _id: 0,
+              name: '$data.name',
+              hash: '$data.hash',
+              ip: '$data.ip',
+              broadcastedAt: '$broadcastedAt',
+              runningSince: '$data.runningSince',
+              osUptime: '$data.osUptime',
+              staticIp: '$data.staticIp',
+            },
+          },
+        ],
+      },
+    },
+    { $project: { all: { $concatArrays: ['$v2', '$v1'] } } },
+    { $unwind: '$all' },
+    { $replaceRoot: { newRoot: '$all' } },
+    { $sort: { broadcastedAt: -1 } },
+    {
+      $group: {
+        _id: { name: '$name', ip: '$ip' },
+        name: { $first: '$name' },
+        hash: { $first: '$hash' },
+        ip: { $first: '$ip' },
+        broadcastedAt: { $first: '$broadcastedAt' },
+        runningSince: { $first: '$runningSince' },
+        osUptime: { $first: '$osUptime' },
+        staticIp: { $first: '$staticIp' },
+      },
+    },
+    { $project: { _id: 0 } },
+  ];
+
+  if (nameMatch) {
+    pipeline.push({ $match: { name: nameMatch } });
+  }
+
+  const results = await collection.aggregate(pipeline).toArray();
   return results;
 }
 
@@ -1721,6 +1792,7 @@ async function rescanGlobalAppsInformationAPI(req, res) {
 module.exports = {
   getAppHashes,
   appLocation,
+  appLocationFromBroadcasts,
   appInstallingLocation,
   appInstallingErrorsLocation,
   countAppInstallingErrors,

--- a/ZelBack/src/services/appDatabase/registryManager.js
+++ b/ZelBack/src/services/appDatabase/registryManager.js
@@ -15,6 +15,7 @@ const {
   globalAppsLocations,
   globalAppsInstallingLocations,
   globalAppsInstallingErrorsLocations,
+  globalAppsInstallingErrorsBroadcasts,
   appsHashesCollection,
   scannedHeightCollection,
 } = require('../utils/appConstants');
@@ -1138,6 +1139,8 @@ async function expireGlobalApplications() {
       const queryDeleteAppErrors = { name: app.name };
       // eslint-disable-next-line no-await-in-loop
       await dbHelper.removeDocumentsFromCollection(databaseApps, globalAppsInstallingErrorsLocations, queryDeleteAppErrors);
+      // eslint-disable-next-line no-await-in-loop
+      await dbHelper.removeDocumentsFromCollection(databaseApps, globalAppsInstallingErrorsBroadcasts, { 'data.name': app.name });
     }
 
     // get list of locally installed apps.
@@ -1236,6 +1239,7 @@ async function updateAppSpecifications(appSpecs) {
     }
     const queryDeleteAppErrors = { name: appSpecs.name };
     await dbHelper.removeDocumentsFromCollection(database, globalAppsInstallingErrorsLocations, queryDeleteAppErrors);
+    await dbHelper.removeDocumentsFromCollection(database, globalAppsInstallingErrorsBroadcasts, { 'data.name': appSpecs.name });
   } catch (error) {
     // retry
     log.error(error);
@@ -1285,7 +1289,6 @@ async function reindexGlobalAppsInformation() {
       appsLocalDb,
       globalAppsMessages,
       globalAppsInformation,
-      globalAppsInstallingErrorsLocations,
       localAppsInformation,
       scannedHeight,
     );

--- a/ZelBack/src/services/appDatabase/registryManager.js
+++ b/ZelBack/src/services/appDatabase/registryManager.js
@@ -101,6 +101,7 @@ async function appLocationFromBroadcasts(appname) {
         v2: [
           { $match: { 'data.apps': { $exists: true } } },
           { $unwind: '$data.apps' },
+          { $match: { $expr: { $not: { $in: ['$data.apps.name', { $ifNull: ['$excludedApps', []] }] } } } },
           {
             $project: {
               _id: 0,
@@ -1621,6 +1622,11 @@ async function reindexGlobalAppsLocation() {
     const db = dbHelper.databaseConnection();
     const database = db.db(config.database.appsglobal.database);
     await dbHelper.dropCollection(database, globalAppsLocations).catch((error) => {
+      if (error.message !== 'ns not found') {
+        throw error;
+      }
+    });
+    await dbHelper.dropCollection(database, globalAppsRunningBroadcasts).catch((error) => {
       if (error.message !== 'ns not found') {
         throw error;
       }

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -4043,75 +4043,6 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
  // eslint-disable-next-line global-require
  * @returns {Promise<void>}
  */
-async function getPeerAppsInstallingErrorMessages() {
-  try {
-    // Import peerManager dynamically to avoid circular dependency
-    // eslint-disable-next-line global-require
-    const { peerManager } = require('../utils/peerState');
-
-    if (peerManager.outboundCount === 0) {
-      log.info('getPeerAppsInstallingErrorMessages - No outgoing peers available');
-      return;
-    }
-
-    let finished = false;
-    let i = 0;
-    while (!finished && i <= 10) {
-      i += 1;
-      const peer = peerManager.getRandomPeer('outbound');
-      if (!peer) break;
-      const client = peer.toPeerInfo();
-      let axiosConfig = {
-        timeout: 5000,
-      };
-      log.info(`getPeerAppsInstallingErrorMessages - Getting fluxos uptime from ${client.ip}:${client.port}`);
-      // eslint-disable-next-line no-await-in-loop
-      const response = await serviceHelper.axiosGet(`http://${client.ip}:${client.port}/flux/uptime`, axiosConfig).catch((error) => log.error(error));
-      if (!response || !response.data || response.data.status !== 'success' || !response.data.data) {
-        log.info(`getPeerAppsInstallingErrorMessages - Failed to get fluxos uptime from ${client.ip}:${client.port}`);
-        // eslint-disable-next-line no-continue
-        continue;
-      }
-      const ut = process.uptime();
-      const measureUptime = Math.floor(ut);
-      // let's get information from a node that have higher fluxos uptime than me for at least one hour.
-      if (response.data.data < measureUptime + 3600) {
-        log.info(`getPeerAppsInstallingErrorMessages - Connected peer ${client.ip}:${client.port} doesn't have FluxOS uptime to be used`);
-        // eslint-disable-next-line no-continue
-        continue;
-      }
-      log.info(`getPeerAppsInstallingErrorMessages - FluxOS uptime is ok on ${client.ip}:${client.port}`);
-      axiosConfig = {
-        timeout: 30000,
-      };
-      log.info(`getPeerAppsInstallingErrorMessages - Getting app installing errors from ${client.ip}:${client.port}`);
-      const url = `http://${client.ip}:${client.port}/apps/installingerrorslocations`;
-      // eslint-disable-next-line no-await-in-loop
-      const appsResponse = await serviceHelper.axiosGet(url, axiosConfig).catch((error) => log.error(error));
-      if (!appsResponse || !appsResponse.data || appsResponse.data.status !== 'success' || !appsResponse.data.data) {
-        log.info(`getPeerAppsInstallingErrorMessages - Failed to get app installing error locations from ${client.ip}:${client.port}`);
-        // eslint-disable-next-line no-continue
-        continue;
-      }
-      const apps = appsResponse.data.data;
-      log.info(`getPeerAppsInstallingErrorMessages - Will process ${apps.length} apps installing errors locations messages`);
-      const operations = apps.map((message) => ({
-        updateOne: {
-          filter: { name: message.name, hash: message.hash, ip: message.ip },
-          update: { $set: message },
-          upsert: true,
-        },
-      }));
-      const dbopen = dbHelper.databaseConnection();
-      const database = dbopen.db(config.database.appsglobal.database);
-      // eslint-disable-next-line no-await-in-loop
-      await dbHelper.bulkWriteInDatabase(database, globalAppsInstallingErrorsLocations, operations);
-      finished = true;
-    }
-  } catch (error) {
-    log.error(error);
-  }
-}
 
 /**
  * Ensures all required local mount paths (files and directories) exist for a component.
@@ -4282,7 +4213,6 @@ module.exports = {
   checkAndRemoveEnterpriseAppsOnNonArcane,
   forceAppRemovals,
   masterSlaveApps,
-  getPeerAppsInstallingErrorMessages,
   ensureMountPathsExist,
   appDockerStart,
 };

--- a/ZelBack/src/services/appLifecycle/appInstaller.js
+++ b/ZelBack/src/services/appLifecycle/appInstaller.js
@@ -15,7 +15,12 @@ const geolocationService = require('../geolocationService');
 const appUninstaller = require('./appUninstaller');
 // const advancedWorkflows = require('./advancedWorkflows'); // Moved to dynamic require to avoid circular dependency
 const fluxCommunicationMessagesSender = require('../fluxCommunicationMessagesSender');
-const { storeAppRunningMessage, storeAppInstallingErrorMessage } = require('../appMessaging/messageStore');
+const { storeAppInstallingErrorMessage } = require('../appMessaging/messageStore');
+
+let onInstallComplete = null;
+function setOnInstallComplete(callback) {
+  onInstallComplete = callback;
+}
 const { systemArchitecture } = require('../appSystem/systemIntegration');
 const { checkApplicationImagesCompliance, verifyRepository } = require('../appSecurity/imageManager');
 const { startAppMonitoring } = require('../appManagement/appInspector');
@@ -639,25 +644,8 @@ async function registerAppLocally(appSpecs, componentSpecs, res, test = false, s
 
     log.info(`Flux App: ${appName} is test install: ${test}`);
 
-    if (!test) {
-      const broadcastedAt = Date.now();
-      const newAppRunningMessage = {
-        type: 'fluxapprunning',
-        version: 2,
-        apps: [{
-          name: appSpecifications.name,
-          hash: appSpecifications.hash,
-          runningSince: new Date(broadcastedAt).toISOString(),
-        }],
-        ip: myIP,
-        broadcastedAt,
-        osUptime: os.uptime(),
-        staticIp: geolocationService.isStaticIP(),
-      };
-
-      // eslint-disable-next-line no-await-in-loop, no-use-before-define
-      await storeAppRunningMessage(newAppRunningMessage);
-      await fluxCommunicationMessagesSender.broadcastMessageToAll(newAppRunningMessage);
+    if (!test && onInstallComplete) {
+      await onInstallComplete();
     }
 
     // all done message
@@ -1234,4 +1222,5 @@ module.exports = {
   installAppLocally,
   checkAppRequirements,
   testAppInstall,
+  setOnInstallComplete,
 };

--- a/ZelBack/src/services/appLifecycle/appInstaller.js
+++ b/ZelBack/src/services/appLifecycle/appInstaller.js
@@ -643,22 +643,21 @@ async function registerAppLocally(appSpecs, componentSpecs, res, test = false, s
       const broadcastedAt = Date.now();
       const newAppRunningMessage = {
         type: 'fluxapprunning',
-        version: 1,
-        name: appSpecifications.name,
-        hash: appSpecifications.hash, // hash of application specifics that are running
+        version: 2,
+        apps: [{
+          name: appSpecifications.name,
+          hash: appSpecifications.hash,
+          runningSince: new Date(broadcastedAt).toISOString(),
+        }],
         ip: myIP,
         broadcastedAt,
-        runningSince: new Date(broadcastedAt).toISOString(),
         osUptime: os.uptime(),
         staticIp: geolocationService.isStaticIP(),
       };
 
-      // store it in local database first
       // eslint-disable-next-line no-await-in-loop, no-use-before-define
       await storeAppRunningMessage(newAppRunningMessage);
-      // broadcast messages about running apps to all peers
       await fluxCommunicationMessagesSender.broadcastMessageToAll(newAppRunningMessage);
-      // broadcast messages about running apps to all peers
     }
 
     // all done message

--- a/ZelBack/src/services/appLifecycle/appSpawner.js
+++ b/ZelBack/src/services/appLifecycle/appSpawner.js
@@ -35,6 +35,17 @@ function initialize(deps) {
   appInstaller = deps.appInstaller;
   // eslint-disable-next-line prefer-destructuring
   appUninstaller = deps.appUninstaller;
+  if (deps.orchestrator) {
+    deps.orchestrator.on('spawnerReady', () => {
+      log.info('AppSyncOrchestrator signals ready, starting spawn loop');
+      globalState.spawnerPaused = false;
+      trySpawningGlobalApplication();
+    });
+    deps.orchestrator.on('readinessLost', () => {
+      log.warn('AppSyncOrchestrator signals readiness lost, spawner will pause on next iteration');
+      globalState.spawnerPaused = true;
+    });
+  }
 }
 
 // Note: Docker Hub error classification and caching is now handled by imageManager.js
@@ -48,9 +59,10 @@ function initialize(deps) {
  * @returns {Promise<void>}
  */
 async function trySpawningGlobalApplication() {
-  // Identity is resolved once at boot by scheduleIdentityResolution() in
-  // serviceManager. Until that lands we defer the spawn attempt, mirroring
-  // the synced / isNodeConfirmed branches below — no exception-for-retry.
+  if (globalState.spawnerPaused) {
+    log.info('Spawner paused by orchestrator, waiting for readiness');
+    return;
+  }
   const isEnterprise = enterpriseNetwork.getCachedEnterpriseIdentity();
   if (isEnterprise === null) {
     log.info('Flux enterprise identity not yet resolved');

--- a/ZelBack/src/services/appLifecycle/appSpawner.js
+++ b/ZelBack/src/services/appLifecycle/appSpawner.js
@@ -105,10 +105,6 @@ async function trySpawningGlobalApplication() {
       log.info('Explorer Synced, checking for expired apps');
       await registryManager.expireGlobalApplications();
       globalState.firstExecutionAfterItsSynced = false;
-      // Dynamic require to avoid circular dependency
-      // eslint-disable-next-line global-require
-      const advancedWorkflows = require('./advancedWorkflows');
-      await advancedWorkflows.getPeerAppsInstallingErrorMessages();
     }
 
     if (globalState.fluxNodeWasAlreadyConfirmed && globalState.fluxNodeWasNotConfirmedOnLastCheck) {
@@ -333,11 +329,11 @@ async function trySpawningGlobalApplication() {
     globalState.trySpawningGlobalAppCache.set(appHash, '');
     log.info(`trySpawningGlobalApplication - App ${appToRun} hash: ${appHash}`);
 
-    /* const installingAppErrorsList = await registryManager.appInstallingErrorsLocation(appToRun);
-    if (installingAppErrorsList.find((app) => !app.expireAt && app.hash === appHash)) {
+    const errorCount = await registryManager.countAppInstallingErrors(appHash);
+    if (errorCount >= 5) {
       globalState.spawnErrorsLongerAppCache.set(appHash, '');
-      throw new Error(`trySpawningGlobalApplication - App ${appToRun} is marked as having errors on app installing errors locations.`);
-    } */
+      throw new Error(`trySpawningGlobalApplication - App ${appToRun} hash ${appHash} has ${errorCount} network-wide install failures, skipping`);
+    }
 
     runningAppList = await registryManager.appLocation(appToRun);
 

--- a/ZelBack/src/services/appLifecycle/appSpawner.js
+++ b/ZelBack/src/services/appLifecycle/appSpawner.js
@@ -6,6 +6,7 @@ const generalService = require('../generalService');
 const benchmarkService = require('../benchmarkService');
 const fluxNetworkHelper = require('../fluxNetworkHelper');
 const geolocationService = require('../geolocationService');
+const daemonServiceMiscRpcs = require('../daemonService/daemonServiceMiscRpcs');
 const log = require('../../lib/log');
 
 // Import modular services
@@ -129,7 +130,59 @@ async function trySpawningGlobalApplication() {
     // get all the applications list names missing instances
     // eslint-disable-next-line global-require
     const { globalAppsInformation } = require('../utils/appConstants');
+    const syncStatus = daemonServiceMiscRpcs.isDaemonSynced();
+    const currentHeight = syncStatus.data.height;
+    const ponFork = config.fluxapps.daemonPONFork;
+    const blocksLasting = config.fluxapps.blocksLasting;
+    const minBlocksAllowance = config.fluxapps.newMinBlocksAllowance;
     const pipeline = [
+      // Filter out apps that are expired or expiring within minBlocksAllowance (100) blocks
+      {
+        $addFields: {
+          _expireIn: {
+            $ifNull: [
+              '$expire',
+              {
+                $cond: {
+                  if: { $gte: ['$height', ponFork] },
+                  then: blocksLasting * 4,
+                  else: blocksLasting,
+                },
+              },
+            ],
+          },
+        },
+      },
+      {
+        $addFields: {
+          _actualExpirationHeight: {
+            $cond: {
+              if: { $lt: ['$height', ponFork] },
+              then: {
+                $cond: {
+                  if: { $lte: [{ $add: ['$height', '$_expireIn'] }, ponFork] },
+                  then: { $add: ['$height', '$_expireIn'] },
+                  else: {
+                    $add: [
+                      ponFork,
+                      { $multiply: [
+                        { $subtract: [{ $add: ['$height', '$_expireIn'] }, ponFork] },
+                        4,
+                      ] },
+                    ],
+                  },
+                },
+              },
+              else: { $add: ['$height', '$_expireIn'] },
+            },
+          },
+        },
+      },
+      {
+        $match: {
+          _actualExpirationHeight: { $gt: currentHeight + minBlocksAllowance },
+        },
+      },
       {
         $lookup: {
           from: 'zelappslocation',
@@ -184,8 +237,8 @@ async function trySpawningGlobalApplication() {
     let appFromAppsToBeCheckedLater = false;
     let appFromAppsSyncthingToBeCheckedLater = false;
     const { appsToBeCheckedLater, appsSyncthingToBeCheckedLater } = globalState;
-    const appIndex = appsToBeCheckedLater.findIndex((app) => app.timeToCheck >= Date.now());
-    const appSyncthingIndex = appsSyncthingToBeCheckedLater.findIndex((app) => app.timeToCheck >= Date.now());
+    const appIndex = appsToBeCheckedLater.findIndex((app) => app.timeToCheck <= Date.now());
+    const appSyncthingIndex = appsSyncthingToBeCheckedLater.findIndex((app) => app.timeToCheck <= Date.now());
     let runningAppList = [];
     let installingAppList = [];
 
@@ -215,7 +268,7 @@ async function trySpawningGlobalApplication() {
       globalAppNamesLocation = globalAppNamesLocation.filter((app) => !runningApps.data.find((appsRunning) => appsRunning.Names[0].slice(5) === app.name)
         && !globalState.spawnErrorsLongerAppCache.has(app.hash)
         && !globalState.trySpawningGlobalAppCache.has(app.hash)
-        && !appsToBeCheckedLater.includes((appAux) => appAux.appName === app.name));
+        && !appsToBeCheckedLater.some((appAux) => appAux.appName === app.name));
       // filter apps that are non enterprise or are marked to install on my node
       globalAppNamesLocation = globalAppNamesLocation.filter((app) => app.nodes.length === 0 || app.nodes.find((ip) => ip === myIP) || app.version >= 8);
       // filter apps that dont have geolocation or that are forbidden to spawn on my node geolocation

--- a/ZelBack/src/services/appLifecycle/stoppedAppsRecovery.js
+++ b/ZelBack/src/services/appLifecycle/stoppedAppsRecovery.js
@@ -13,9 +13,16 @@ const dbHelper = require('../dbHelper');
 const dockerService = require('../dockerService');
 const serviceHelper = require('../serviceHelper');
 const fluxNetworkHelper = require('../fluxNetworkHelper');
+const generalService = require('../generalService');
 const registryManager = require('../appDatabase/registryManager');
 const advancedWorkflows = require('./advancedWorkflows');
+const appInstaller = require('./appInstaller');
 const appUninstaller = require('./appUninstaller');
+const appInspector = require('../appManagement/appInspector');
+const appTamperingDetectionService = require('../appTamperingDetectionService');
+const globalState = require('../utils/globalState');
+const cacheManager = require('../utils/cacheManager').default;
+const { decryptEnterpriseApps } = require('../appQuery/appQueryService');
 const { localAppsInformation } = require('../utils/appConstants');
 
 const globalAppsLocations = config.database.appsglobal.collections.appsLocations;
@@ -315,10 +322,217 @@ async function startStoppedAppsOnBoot() {
   }
 }
 
+async function recreateMissingContainers(componentIdentifier) {
+  const mainAppName = componentIdentifier.split('_')[1] || componentIdentifier;
+  const dbopen = dbHelper.databaseConnection();
+  const appsDatabase = dbopen.db(config.database.appslocal.database);
+
+  const appsQuery = { name: mainAppName };
+  const appsProjection = { projection: { _id: 0 } };
+  let appSpec = await dbHelper.findOneInDatabase(appsDatabase, localAppsInformation, appsQuery, appsProjection);
+
+  if (!appSpec) {
+    throw new Error(`App ${mainAppName} not found in local database`);
+  }
+
+  appSpec = await decryptEnterpriseApps([appSpec], { formatSpecs: false });
+  // eslint-disable-next-line prefer-destructuring
+  appSpec = appSpec[0];
+
+  if (!appSpec.compose || appSpec.compose.length === 0) {
+    throw new Error(`App ${mainAppName} has no components to install`);
+  }
+
+  const tier = await generalService.nodeTier();
+  const isComponent = componentIdentifier.includes('_');
+
+  if (isComponent) {
+    const componentName = componentIdentifier.split('_')[0];
+    const componentSpec = appSpec.compose.find((c) => c.name === componentName);
+    if (!componentSpec) {
+      throw new Error(`Component ${componentName} not found in app ${mainAppName}`);
+    }
+    const hddTier = `hdd${tier}`;
+    const ramTier = `ram${tier}`;
+    const cpuTier = `cpu${tier}`;
+    componentSpec.cpu = componentSpec[cpuTier] || componentSpec.cpu;
+    componentSpec.ram = componentSpec[ramTier] || componentSpec.ram;
+    componentSpec.hdd = componentSpec[hddTier] || componentSpec.hdd;
+    await appInstaller.installApplicationHard(componentSpec, mainAppName, true, null, appSpec);
+  } else {
+    for (const componentSpec of appSpec.compose) {
+      const hddTier = `hdd${tier}`;
+      const ramTier = `ram${tier}`;
+      const cpuTier = `cpu${tier}`;
+      componentSpec.cpu = componentSpec[cpuTier] || componentSpec.cpu;
+      componentSpec.ram = componentSpec[ramTier] || componentSpec.ram;
+      componentSpec.hdd = componentSpec[hddTier] || componentSpec.hdd;
+      // eslint-disable-next-line no-await-in-loop
+      await appInstaller.installApplicationHard(componentSpec, mainAppName, true, null, appSpec);
+    }
+  }
+
+  log.info(`Successfully recreated missing containers for ${componentIdentifier}`);
+}
+
+async function handleMissingMasterSlaveContainer(stoppedApp, mainAppName) {
+  const containerExists = await dockerService.getDockerContainerOnly(stoppedApp);
+  if (containerExists) return;
+
+  log.warn(`Container for master/slave app ${stoppedApp} doesn't exist, recreating...`);
+  try {
+    await recreateMissingContainers(stoppedApp);
+    log.info(`Successfully recreated master/slave app container ${stoppedApp}`);
+    appInspector.startAppMonitoring(stoppedApp, globalState.appsMonitored);
+  } catch (recreateErr) {
+    const containerExistsNow = await dockerService.getDockerContainerOnly(stoppedApp);
+    if (containerExistsNow) {
+      log.info(`Container for ${stoppedApp} was created by another process, skipping removal`);
+      return;
+    }
+    log.error(`Failed to recreate master/slave app ${stoppedApp}: ${recreateErr.message}`);
+    log.warn(`REMOVAL REASON: Master/slave container recreation failure - ${mainAppName} (stoppedAppsRecovery)`);
+    await appTamperingDetectionService.recordEvent(mainAppName, 'recreation_failed', `Master/slave container recreation failure: ${recreateErr.message}`);
+    if (appTamperingDetectionService.isNetworkMissingError(recreateErr.message)) {
+      await appTamperingDetectionService.recordEvent(mainAppName, 'network_pruned', `Docker network missing during recreation: ${recreateErr.message}`);
+    }
+    await appUninstaller.removeAppLocally(mainAppName, null, false, true, true, () => {},
+      () => globalState, (name, deleteData) => appInspector.stopAppMonitoring(name, deleteData, globalState.appsMonitored));
+  }
+}
+
+/**
+ * Check for stopped apps and recover them. Returns list of master/slave apps
+ * that have syncthing containers (needed by the broadcast to include them even
+ * if some containers are stopped).
+ * @param {string} myIP - This node's IP
+ * @param {Array} appsInstalled - Installed app specs
+ * @param {Array} runningAppsNames - Names of running containers
+ * @returns {Promise<Array>} masterSlaveAppsInstalled
+ */
+async function checkStoppedApps(myIP, appsInstalled, runningAppsNames) {
+  const masterSlaveAppsInstalled = [];
+  const installedAppComponentNames = [];
+  appsInstalled.forEach((app) => {
+    if (app.version >= 4) {
+      app.compose.forEach((appComponent) => {
+        installedAppComponentNames.push(`${appComponent.name}_${app.name}`);
+      });
+    } else {
+      installedAppComponentNames.push(app.name);
+    }
+  });
+  const runningSet = new Set(runningAppsNames);
+  const stoppedApps = installedAppComponentNames.filter((installedApp) => !runningSet.has(installedApp));
+
+  const backupInProgress = globalState.backupInProgress || [];
+  const restoreInProgress = globalState.restoreInProgress || [];
+  const appsStoppedCache = cacheManager.stoppedAppsCache;
+
+  if (globalState.removalInProgress || globalState.installationInProgress || globalState.softRedeployInProgress || globalState.hardRedeployInProgress || globalState.reinstallationOfOldAppsInProgress) {
+    log.warn('Stopped application checks not running, some removal or installation is in progress');
+    return masterSlaveAppsInstalled;
+  }
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const stoppedApp of stoppedApps) {
+    try {
+      const mainAppName = stoppedApp.split('_')[1] || stoppedApp;
+      // eslint-disable-next-line no-await-in-loop
+      const appDetails = await registryManager.getApplicationGlobalSpecifications(mainAppName);
+      const appInstalledMasterSlave = appsInstalled.find((app) => app.name === mainAppName);
+      const appInstalledSyncthing = appInstalledMasterSlave.compose.find((comp) => comp.containerData.includes('g:') || comp.containerData.includes('r:'));
+      const appInstalledMasterSlaveCheck = appInstalledMasterSlave.compose.find((comp) => comp.containerData.includes('g:'));
+      if (appInstalledSyncthing) {
+        masterSlaveAppsInstalled.push(appInstalledMasterSlave);
+      }
+      if (appInstalledMasterSlaveCheck && appDetails) {
+        const backupSkip = backupInProgress.some((backupItem) => stoppedApp === backupItem);
+        const restoreSkip = restoreInProgress.some((backupItem) => stoppedApp === backupItem);
+        if (!backupSkip && !restoreSkip) {
+          // eslint-disable-next-line no-await-in-loop
+          await handleMissingMasterSlaveContainer(stoppedApp, mainAppName);
+        }
+      } else if (appDetails) {
+        log.warn(`${stoppedApp} is stopped but should be running. Starting...`);
+        const backupSkip = backupInProgress.some((backupItem) => stoppedApp === backupItem);
+        const restoreSkip = restoreInProgress.some((backupItem) => stoppedApp === backupItem);
+        if (backupSkip || restoreSkip) {
+          log.warn(`Application ${stoppedApp} backup/restore is in progress...`);
+        }
+        if (!globalState.removalInProgress && !globalState.installationInProgress && !globalState.softRedeployInProgress && !globalState.hardRedeployInProgress && !globalState.reinstallationOfOldAppsInProgress && !restoreSkip && !backupSkip) {
+          // eslint-disable-next-line no-await-in-loop
+          const containerExists = await dockerService.getDockerContainerOnly(stoppedApp);
+
+          if (containerExists && appInstalledSyncthing) {
+            const db = dbHelper.databaseConnection();
+            const database = db.db(config.database.appsglobal.database);
+            const queryFind = { name: mainAppName, ip: myIP };
+            const projection = { _id: 0, runningSince: 1 };
+            // eslint-disable-next-line no-await-in-loop
+            const result = await dbHelper.findOneInDatabase(database, globalAppsLocations, queryFind, projection);
+            if (!result || !result.runningSince || Date.parse(result.runningSince) + 30 * 60 * 1000 > Date.now()) {
+              log.info(`Application ${stoppedApp} uses r syncthing and container exists but is stopped. Haven't started yet because was installed less than 30m ago.`);
+              // eslint-disable-next-line no-continue
+              continue;
+            }
+          }
+
+          if (!containerExists) {
+            log.warn(`Container for ${stoppedApp} doesn't exist, recreating immediately...`);
+            // eslint-disable-next-line no-await-in-loop
+            await appTamperingDetectionService.recordEvent(mainAppName, 'container_vanished', `Container ${stoppedApp} missing, not found in Docker`);
+            try {
+              // eslint-disable-next-line no-await-in-loop
+              await recreateMissingContainers(stoppedApp);
+              log.info(`Successfully recreated ${stoppedApp}`);
+              appInspector.startAppMonitoring(stoppedApp, globalState.appsMonitored);
+            } catch (recreateErr) {
+              log.error(`Failed to recreate containers for ${stoppedApp}: ${recreateErr.message}`);
+              log.warn(`REMOVAL REASON: Container recreation failure - ${mainAppName} failed to recreate with error: ${recreateErr.message} (stoppedAppsRecovery)`);
+              // eslint-disable-next-line no-await-in-loop
+              await appTamperingDetectionService.recordEvent(mainAppName, 'recreation_failed', `Container recreation failure: ${recreateErr.message}`);
+              if (appTamperingDetectionService.isNetworkMissingError(recreateErr.message)) {
+                // eslint-disable-next-line no-await-in-loop
+                await appTamperingDetectionService.recordEvent(mainAppName, 'network_pruned', `Docker network missing during recreation: ${recreateErr.message}`);
+              }
+              // eslint-disable-next-line no-await-in-loop
+              await appUninstaller.removeAppLocally(mainAppName, null, false, true, true, () => {
+              }, () => globalState, (name, deleteData) => appInspector.stopAppMonitoring(name, deleteData, globalState.appsMonitored));
+            }
+          } else {
+            log.warn(`${stoppedApp} is stopped, starting`);
+            if (!appsStoppedCache.has(stoppedApp)) {
+              appsStoppedCache.set(stoppedApp, '');
+            } else {
+              // eslint-disable-next-line no-await-in-loop
+              await dockerService.appDockerStart(stoppedApp);
+              appInspector.startAppMonitoring(stoppedApp, globalState.appsMonitored);
+            }
+          }
+        } else {
+          log.warn(`Not starting ${stoppedApp} as application removal or installation or backup/restore is in progress`);
+        }
+      }
+    } catch (err) {
+      log.error(err);
+      const mainAppName = stoppedApp.split('_')[1] || stoppedApp;
+      if (!globalState.removalInProgress && !globalState.installationInProgress && !globalState.softRedeployInProgress && !globalState.hardRedeployInProgress && !globalState.reinstallationOfOldAppsInProgress) {
+        log.warn(`REMOVAL REASON: App start failure - ${mainAppName} failed to start with error: ${err.message} (stoppedAppsRecovery)`);
+        // eslint-disable-next-line no-await-in-loop
+        await appUninstaller.removeAppLocally(mainAppName, null, false, true, true, () => {
+        }, () => globalState, (name, deleteData) => appInspector.stopAppMonitoring(name, deleteData, globalState.appsMonitored));
+      }
+    }
+  }
+  return masterSlaveAppsInstalled;
+}
+
 module.exports = {
   startStoppedAppsOnBoot,
   getStoppedFluxContainers,
   appUsesGSyncthingMode,
   appHasValidLocationOnNode,
+  checkStoppedApps,
   parseContainerName,
 };

--- a/ZelBack/src/services/appLifecycle/stoppedAppsRecovery.js
+++ b/ZelBack/src/services/appLifecycle/stoppedAppsRecovery.js
@@ -535,4 +535,5 @@ module.exports = {
   appHasValidLocationOnNode,
   checkStoppedApps,
   parseContainerName,
+  handleMissingMasterSlaveContainer,
 };

--- a/ZelBack/src/services/appMessaging/appHashSyncService.js
+++ b/ZelBack/src/services/appMessaging/appHashSyncService.js
@@ -1,283 +1,231 @@
-// App Hash Sync Service - Manages synchronization of application hashes across the network
 const config = require('config');
 const dbHelper = require('../dbHelper');
 const messageHelper = require('../messageHelper');
 const verificationHelper = require('../verificationHelper');
 const serviceHelper = require('../serviceHelper');
-const generalService = require('../generalService');
-const fluxNetworkHelper = require('../fluxNetworkHelper');
 const messageStore = require('./messageStore');
 const messageVerifier = require('./messageVerifier');
-const registryManager = require('../appDatabase/registryManager');
 const log = require('../../lib/log');
 const { invalidMessages } = require('../invalidMessages');
-const globalState = require('../utils/globalState');
 
-// Database collections
-const scannedHeightCollection = config.database.daemon.collections.scannedHeight;
 const appsHashesCollection = config.database.daemon.collections.appsHashes;
+const globalAppsMessages = config.database.appsglobal.collections.appsMessages;
 
-// Module-level state variables
-let checkAndSyncAppHashesRunning = false;
-let continuousFluxAppHashesCheckRunning = false;
-let firstContinuousFluxAppHashesCheckRun = true;
-const hashesNumberOfSearchs = new Map();
+let syncRunning = false;
 
-/**
- * Check and sync app hashes from other nodes
- */
-async function checkAndSyncAppHashes() {
+async function getMissingHashes(options = {}) {
+  const { force = false } = options;
+  const db = dbHelper.databaseConnection();
+  const database = db.db(config.database.daemon.database);
+  const query = { message: false };
+  if (!force) {
+    query.messageNotFound = { $ne: true };
+  }
+  const projection = {
+    projection: {
+      _id: 0, txid: 1, hash: 1, height: 1, value: 1, message: 1, messageNotFound: 1,
+    },
+  };
+  const results = await dbHelper.findInDatabase(database, appsHashesCollection, query, projection);
+  results.sort((a, b) => a.height - b.height);
+  return results.filter((r) => {
+    if (force) return true;
+    return !invalidMessages.find((m) => m.hash === r.hash && m.txid === r.txid);
+  });
+}
+
+async function bulkFetchFromPeer(peerIp, peerPort) {
+  log.info(`syncMissingHashes - Checking explorer sync on ${peerIp}:${peerPort}`);
+  const syncResponse = await serviceHelper.axiosGet(
+    `http://${peerIp}:${peerPort}/explorer/issynced`,
+    { timeout: 5000 },
+  ).catch((error) => { log.error(error); return null; });
+  if (!syncResponse || !syncResponse.data || syncResponse.data.status !== 'success' || !syncResponse.data.data) {
+    return null;
+  }
+  log.info(`syncMissingHashes - Fetching permanent messages from ${peerIp}:${peerPort}`);
+  const response = await serviceHelper.axiosGet(
+    `http://${peerIp}:${peerPort}/apps/permanentmessages`,
+    { timeout: 120000 },
+  ).catch((error) => { log.error(error); return null; });
+  if (!response || !response.data || response.data.status !== 'success' || !response.data.data) {
+    return null;
+  }
+  return response.data.data;
+}
+
+async function processMessages(messages, onProgress) {
+  const db = dbHelper.databaseConnection();
+  const database = db.db(config.database.appsglobal.database);
+  let processed = 0;
+  let skipped = 0;
+
+  messages.sort((a, b) => a.height - b.height);
+  const filtered = messages.filter((app) => app.valueSat !== null);
+
+  for (const appMessage of filtered) {
+    try {
+      const existingPerm = await dbHelper.findOneInDatabase(
+        database, globalAppsMessages, { hash: appMessage.hash }, { projection: { _id: 0, hash: 1 } },
+      );
+      if (existingPerm) {
+        skipped += 1;
+        await messageVerifier.appHashHasMessage(appMessage.hash);
+        continue;
+      }
+
+      const cleanMessage = {
+        type: appMessage.type,
+        version: appMessage.version,
+        appSpecifications: appMessage.appSpecifications,
+        hash: appMessage.hash,
+        timestamp: appMessage.timestamp,
+        signature: appMessage.signature,
+      };
+      if (appMessage.zelAppSpecifications) {
+        cleanMessage.zelAppSpecifications = appMessage.zelAppSpecifications;
+      }
+      await messageStore.storeAppTemporaryMessage(cleanMessage);
+      await messageVerifier.checkAndRequestApp(appMessage.hash, appMessage.txid, appMessage.height, appMessage.valueSat, 2);
+      processed += 1;
+    } catch (error) {
+      log.error(error);
+    }
+    if ((processed + skipped) % 500 === 0) {
+      log.info(`syncMissingHashes - ${processed} processed, ${skipped} skipped of ${filtered.length}`);
+    }
+    if (onProgress && (processed + skipped) % 100 === 0) {
+      onProgress({ processed, skipped, total: filtered.length });
+    }
+  }
+  return { processed, skipped, total: filtered.length };
+}
+
+async function syncMissingHashes(options = {}) {
+  const { maxConcurrentPeers = 5, onProgress = null, force = false } = options;
+
+  if (syncRunning) {
+    log.info('syncMissingHashes - Already running, skipping');
+    return { resolved: 0, missing: 0, unreachable: 0 };
+  }
+
+  syncRunning = true;
   try {
-    checkAndSyncAppHashesRunning = true;
     // eslint-disable-next-line global-require
     const { peerManager } = require('../utils/peerState');
-    const dbopen = dbHelper.databaseConnection();
-    const database = dbopen.db(config.database.daemon.database);
-    // get flux app hashes that do not have a message;
-    const query = {};
-    const projection = {
-      projection: {
-        _id: 0,
-        message: 1,
-      },
-    };
-    const results = await dbHelper.findInDatabase(database, appsHashesCollection, query, projection);
-    const numberOfMissingApps = results.filter((app) => app.message === false).length;
-    if (numberOfMissingApps > results.length * 0.95) {
-      let finished = false;
-      let i = 0;
-      while (!finished && i <= 5) {
-        i += 1;
+
+    const missingHashes = await getMissingHashes({ force });
+    log.info(`syncMissingHashes - Found ${missingHashes.length} missing hashes`);
+
+    if (missingHashes.length === 0) {
+      return { resolved: 0, missing: 0, unreachable: 0 };
+    }
+
+    let resolved = 0;
+
+    if (missingHashes.length > 1000) {
+      log.info(`syncMissingHashes - ${missingHashes.length} missing, using bulk fetch`);
+      const peersToTry = [];
+      for (let i = 0; i < Math.min(maxConcurrentPeers, 3); i += 1) {
         const peer = peerManager.getRandomPeer('outbound');
-        if (!peer) break;
-        const client = peer.toPeerInfo();
-        let axiosConfig = {
-          timeout: 5000,
-        };
-        log.info(`checkAndSyncAppHashes - Getting explorer sync status from ${client.ip}:${client.port}`);
-        // eslint-disable-next-line no-await-in-loop
-        const response = await serviceHelper.axiosGet(`http://${client.ip}:${client.port}/explorer/issynced`, axiosConfig).catch((error) => log.error(error));
-        if (!response || !response.data || response.data.status !== 'success') {
-          log.info(`checkAndSyncAppHashes - Failed to get explorer sync status from ${client.ip}:${client.port}`);
-          // eslint-disable-next-line no-continue
-          continue;
-        }
-        if (!response.data.data) {
-          log.info(`checkAndSyncAppHashes - Explorer is not synced on ${client.ip}:${client.port}`);
-          // eslint-disable-next-line no-continue
-          continue;
-        }
-        log.info(`checkAndSyncAppHashes - Explorer is synced on ${client.ip}:${client.port}`);
-        axiosConfig = {
-          timeout: 120000,
-        };
-        log.info(`checkAndSyncAppHashes - Getting permanent app messages from ${client.ip}:${client.port}`);
-        // eslint-disable-next-line no-await-in-loop
-        const appsResponse = await serviceHelper.axiosGet(`http://${client.ip}:${client.port}/apps/permanentmessages`, axiosConfig).catch((error) => log.error(error));
-        if (!appsResponse || !appsResponse.data || appsResponse.data.status !== 'success' || !appsResponse.data.data) {
-          log.info(`checkAndSyncAppHashes - Failed to get permanent app messages from ${client.ip}:${client.port}`);
-          // eslint-disable-next-line no-continue
-          continue;
-        }
-        const apps = appsResponse.data.data;
-        log.info(`checkAndSyncAppHashes - Will process ${apps.length} apps messages`);
-        // sort it by height, so we process oldest messages first
-        apps.sort((a, b) => a.height - b.height);
+        if (peer) peersToTry.push(peer.toPeerInfo());
+      }
 
-        // because there are broken nodes on the network, we need to temporarily skip
-        // any apps that have null for valueSat.
-        const filteredApps = apps.filter((app) => app.valueSat !== null);
+      const fetchPromises = peersToTry.map((p) => bulkFetchFromPeer(p.ip, p.port));
+      const results = await Promise.allSettled(fetchPromises);
 
-        let y = 0;
-        // eslint-disable-next-line no-restricted-syntax
-        for (const appMessage of filteredApps) {
-          y += 1;
-          try {
-            // Clean the permanent message to only include fields used in signature verification
-            // Permanent messages have extra fields (txid, height, valueSat) that aren't part of the original signature
-            const cleanMessage = {
-              type: appMessage.type,
-              version: appMessage.version,
-              appSpecifications: appMessage.appSpecifications,
-              hash: appMessage.hash,
-              timestamp: appMessage.timestamp,
-              signature: appMessage.signature,
-            };
-            // Support legacy field name if present
-            if (appMessage.zelAppSpecifications) {
-              cleanMessage.zelAppSpecifications = appMessage.zelAppSpecifications;
-            }
-            // eslint-disable-next-line no-await-in-loop
-            await messageStore.storeAppTemporaryMessage(cleanMessage);
-            // eslint-disable-next-line no-await-in-loop
-            await messageVerifier.checkAndRequestApp(appMessage.hash, appMessage.txid, appMessage.height, appMessage.valueSat, 2);
-            // eslint-disable-next-line no-await-in-loop
-            await serviceHelper.delay(50);
-          } catch (error) {
-            log.error(error);
-          }
-          if (y % 500 === 0) {
-            log.info(`checkAndSyncAppHashes - ${y} were already processed`);
+      let bestResult = null;
+      for (const result of results) {
+        if (result.status === 'fulfilled' && result.value) {
+          if (!bestResult || result.value.length > bestResult.length) {
+            bestResult = result.value;
           }
         }
-        finished = true;
-        // eslint-disable-next-line no-await-in-loop
-        await registryManager.expireGlobalApplications();
-        log.info('checkAndSyncAppHashes - Process finished');
+      }
+
+      if (bestResult) {
+        log.info(`syncMissingHashes - Bulk fetched ${bestResult.length} messages, processing`);
+        const stats = await processMessages(bestResult, onProgress);
+        resolved += stats.processed;
+        log.info(`syncMissingHashes - Bulk: ${stats.processed} processed, ${stats.skipped} skipped`);
       }
     }
-    globalState.checkAndSyncAppHashesWasEverExecuted = true;
-    checkAndSyncAppHashesRunning = false;
+
+    // Request any still-missing hashes from multiple peers
+    const stillMissing = await getMissingHashes({ force });
+    if (stillMissing.length > 0) {
+      log.info(`syncMissingHashes - ${stillMissing.length} still missing, requesting from peers`);
+
+      const maxRounds = 3;
+      for (let round = 0; round < maxRounds; round += 1) {
+        const currentMissing = await getMissingHashes({ force });
+        if (currentMissing.length === 0) break;
+
+        log.info(`syncMissingHashes - Round ${round + 1}: ${currentMissing.length} missing`);
+        const appsToRequest = currentMissing.map((h) => ({
+          hash: h.hash, txid: h.txid, height: h.height, value: h.value,
+        }));
+
+        const requestPromises = [];
+        for (let i = 0; i < Math.min(maxConcurrentPeers, 5); i += 1) {
+          const incoming = i % 2 === 0;
+          requestPromises.push(
+            messageVerifier.checkAndRequestMultipleApps(appsToRequest, incoming),
+          );
+        }
+        await Promise.allSettled(requestPromises);
+
+        const afterRound = await getMissingHashes({ force });
+        const resolvedThisRound = currentMissing.length - afterRound.length;
+        resolved += resolvedThisRound;
+        log.info(`syncMissingHashes - Round ${round + 1}: resolved ${resolvedThisRound}`);
+
+        if (resolvedThisRound === 0) break;
+        if (onProgress) onProgress({ resolved, missing: afterRound.length });
+      }
+    }
+
+    const finalMissing = await getMissingHashes({ force: false });
+    const maxExpireBlocks = config.fluxapps.blocksLasting * 12;
+    const db = dbHelper.databaseConnection();
+    const database = db.db(config.database.daemon.database);
+    const scannedHeight = await dbHelper.findOneInDatabase(
+      database,
+      config.database.daemon.collections.scannedHeight,
+      { generalScannedHeight: { $gte: 0 } },
+      { projection: { _id: 0, generalScannedHeight: 1 } },
+    );
+    const currentHeight = scannedHeight ? scannedHeight.generalScannedHeight : 0;
+
+    let unreachable = 0;
+    for (const hash of finalMissing) {
+      if (currentHeight - hash.height > maxExpireBlocks) {
+        await messageVerifier.appHashHasMessageNotFound(hash.hash);
+        unreachable += 1;
+      }
+    }
+
+    const remaining = finalMissing.length - unreachable;
+    log.info(`syncMissingHashes - Complete: ${resolved} resolved, ${remaining} missing, ${unreachable} unreachable`);
+    return { resolved, missing: remaining, unreachable };
   } catch (error) {
     log.error(error);
-    globalState.checkAndSyncAppHashesWasEverExecuted = false;
-    checkAndSyncAppHashesRunning = false;
+    return { resolved: 0, missing: -1, unreachable: 0 };
+  } finally {
+    syncRunning = false;
   }
 }
 
-/**
- * Continuously check and request missing flux app hashes
- * @param {boolean} force - Force the check even if conditions aren't met
- */
-async function continuousFluxAppHashesCheck(force = false) {
-  try {
-    if (continuousFluxAppHashesCheckRunning) {
-      return;
-    }
-
-    // Check if checkAndSyncAppHashes is currently running
-    if (checkAndSyncAppHashesRunning) {
-      log.info('continuousFluxAppHashesCheck: checkAndSyncAppHashes is currently running, skipping this execution');
-      return;
-    }
-
-    log.info('Requesting missing Flux App messages');
-    continuousFluxAppHashesCheckRunning = true;
-    const numberOfPeers = fluxNetworkHelper.getNumberOfPeers();
-    if (numberOfPeers < 12) {
-      log.info('Not enough connected peers to request missing Flux App messages');
-      continuousFluxAppHashesCheckRunning = false;
-      return;
-    }
-
-    const synced = await generalService.checkSynced();
-    if (synced !== true) {
-      log.info('Flux not yet synced');
-      continuousFluxAppHashesCheckRunning = false;
-      return;
-    }
-
-    if (firstContinuousFluxAppHashesCheckRun && !globalState.checkAndSyncAppHashesWasEverExecuted) {
-      await checkAndSyncAppHashes();
-    }
-
-    const dbopen = dbHelper.databaseConnection();
-    const database = dbopen.db(config.database.daemon.database);
-    const queryHeight = { generalScannedHeight: { $gte: 0 } };
-    const projectionHeight = {
-      projection: {
-        _id: 0,
-        generalScannedHeight: 1,
-      },
-    };
-    const scanHeight = await dbHelper.findOneInDatabase(database, scannedHeightCollection, queryHeight, projectionHeight);
-    if (!scanHeight) {
-      throw new Error('Scanning not initiated');
-    }
-    const explorerHeight = serviceHelper.ensureNumber(scanHeight.generalScannedHeight);
-
-    // get flux app hashes that do not have a message
-    const query = { message: false };
-    const projection = {
-      projection: {
-        _id: 0,
-        txid: 1,
-        hash: 1,
-        height: 1,
-        value: 1,
-        message: 1,
-        messageNotFound: 1,
-      },
-    };
-    const results = await dbHelper.findInDatabase(database, appsHashesCollection, query, projection);
-    // sort it by height, so we request oldest messages first
-    results.sort((a, b) => a.height - b.height);
-    let appsMessagesMissing = [];
-    // eslint-disable-next-line no-restricted-syntax
-    for (const result of results) {
-      if (!result.messageNotFound || force || firstContinuousFluxAppHashesCheckRun) { // most likely wrong data, if no message found. This attribute is cleaned every reconstructAppMessagesHashPeriod blocks so all nodes search again for missing messages
-        let heightDifference = explorerHeight - result.height;
-        if (heightDifference < 0) {
-          heightDifference = 0;
-        }
-        let maturity = Math.round(heightDifference / config.fluxapps.blocksLasting);
-        if (maturity > 12) {
-          maturity = 16; // maturity of max 16 representing its older than 1 year. Old messages will only be searched 3 times, newer messages more oftenly
-        }
-        if (invalidMessages.find((message) => message.hash === result.hash && message.txid === result.txid)) {
-          if (!force) {
-            maturity = 30; // do not request known invalid messages.
-          }
-        }
-        // every config.fluxapps.blocksLasting increment maturity by 2;
-        let numberOfSearches = maturity;
-        if (hashesNumberOfSearchs.has(result.hash)) {
-          numberOfSearches = hashesNumberOfSearchs.get(result.hash) + 2; // max 10 tries
-        }
-        hashesNumberOfSearchs.set(result.hash, numberOfSearches);
-        log.info(`Requesting missing Flux App message: ${result.hash}, ${result.txid}, ${result.height}`);
-        if (numberOfSearches <= 20) { // up to 10 searches
-          const appMessageInformation = {
-            hash: result.hash,
-            txid: result.txid,
-            height: result.height,
-            value: result.value,
-          };
-          appsMessagesMissing.push(appMessageInformation);
-          if (appsMessagesMissing.length === 500) {
-            log.info('Requesting 500 app messages');
-            messageVerifier.checkAndRequestMultipleApps(appsMessagesMissing);
-            // eslint-disable-next-line no-await-in-loop
-            await serviceHelper.delay(2 * 60 * 1000); // delay 2 minutes to give enough time to process all messages received
-            appsMessagesMissing = [];
-          }
-        } else {
-          // eslint-disable-next-line no-await-in-loop
-          await messageVerifier.appHashHasMessageNotFound(result.hash); // mark message as not found
-          hashesNumberOfSearchs.delete(result.hash); // remove from our map
-        }
-      }
-    }
-    if (appsMessagesMissing.length > 0) {
-      log.info(`Requesting ${appsMessagesMissing.length} app messages`);
-      messageVerifier.checkAndRequestMultipleApps(appsMessagesMissing);
-    }
-    continuousFluxAppHashesCheckRunning = false;
-    firstContinuousFluxAppHashesCheckRun = false;
-  } catch (error) {
-    log.error(error);
-    continuousFluxAppHashesCheckRunning = false;
-    firstContinuousFluxAppHashesCheckRun = false;
-  }
-}
-
-/**
- * Trigger app hashes check API endpoint
- * @param {object} req Request.
- * @param {object} res Response.
- */
 async function triggerAppHashesCheckAPI(req, res) {
   try {
-    // only flux team and node owner can do this
     const authorized = await verificationHelper.verifyPrivilege('adminandfluxteam', req);
     if (!authorized) {
       const errMessage = messageHelper.errUnauthorizedMessage();
       res.json(errMessage);
       return;
     }
-
-    continuousFluxAppHashesCheck(true);
-    const resultsResponse = messageHelper.createSuccessMessage('Running check on missing application messages ');
+    syncMissingHashes({ force: true });
+    const resultsResponse = messageHelper.createSuccessMessage('Running sync on missing application messages');
     res.json(resultsResponse);
   } catch (error) {
     log.error(error);
@@ -287,7 +235,7 @@ async function triggerAppHashesCheckAPI(req, res) {
 }
 
 module.exports = {
-  checkAndSyncAppHashes,
-  continuousFluxAppHashesCheck,
+  syncMissingHashes,
+  getMissingHashes,
   triggerAppHashesCheckAPI,
 };

--- a/ZelBack/src/services/appMessaging/appSyncOrchestrator.js
+++ b/ZelBack/src/services/appMessaging/appSyncOrchestrator.js
@@ -16,7 +16,7 @@ const STATES = Object.freeze({
   RESYNCING: 'RESYNCING',
 });
 
-const MIN_SYNC_PEERS = 3;
+const MIN_SYNC_PEERS = config.fluxapps.appSyncMinCompletions || 3;
 const SYNC_TIMEOUT_MS = 2 * 60 * 1000;
 const MIN_UPTIME_SECONDS = config.fluxapps.appSyncMinPeerUptime || 7500;
 

--- a/ZelBack/src/services/appMessaging/appSyncOrchestrator.js
+++ b/ZelBack/src/services/appMessaging/appSyncOrchestrator.js
@@ -152,7 +152,7 @@ class AppSyncOrchestrator extends EventEmitter {
 
   async #fetchTempMessages() {
     try {
-      const eligible = this.#peerManager.getEligibleTempSyncPeers(7200);
+      const eligible = this.#peerManager.getEligibleTempSyncPeers(7500);
       if (eligible.length === 0) {
         log.info('AppSyncOrchestrator - No eligible peers for temp message catch-up');
         return;
@@ -173,7 +173,7 @@ class AppSyncOrchestrator extends EventEmitter {
 
   #fetchAppRunningMessages() {
     try {
-      const eligible = this.#peerManager.getEligibleAppRunningSyncPeers(7200);
+      const eligible = this.#peerManager.getEligibleAppRunningSyncPeers(7500);
       if (eligible.length === 0) {
         log.info('AppSyncOrchestrator - No eligible peers for apprunning sync');
         return;
@@ -194,7 +194,7 @@ class AppSyncOrchestrator extends EventEmitter {
 
   #fetchAppInstallingMessages() {
     try {
-      const eligible = this.#peerManager.getEligibleAppRunningSyncPeers(7200);
+      const eligible = this.#peerManager.getEligibleAppRunningSyncPeers(7500);
       if (eligible.length === 0) return;
       const peersToAsk = eligible.slice(0, 3);
       log.info(`AppSyncOrchestrator - Requesting appinstalling sync from ${peersToAsk.length} peers`);
@@ -212,7 +212,7 @@ class AppSyncOrchestrator extends EventEmitter {
 
   #fetchAppInstallingErrorMessages() {
     try {
-      const eligible = this.#peerManager.getEligibleAppRunningSyncPeers(7200);
+      const eligible = this.#peerManager.getEligibleAppRunningSyncPeers(7500);
       if (eligible.length === 0) return;
       const peersToAsk = eligible.slice(0, 3);
       log.info(`AppSyncOrchestrator - Requesting appinstalling errors sync from ${peersToAsk.length} peers`);

--- a/ZelBack/src/services/appMessaging/appSyncOrchestrator.js
+++ b/ZelBack/src/services/appMessaging/appSyncOrchestrator.js
@@ -69,6 +69,7 @@ class AppSyncOrchestrator extends EventEmitter {
     await this.#fetchTempMessages();
     this.#fetchAppRunningMessages();
     this.#fetchAppInstallingMessages();
+    this.#fetchAppInstallingErrorMessages();
 
     if (this.#state === STATES.RESYNCING) {
       if (this.#syncInProgress) return;
@@ -206,6 +207,24 @@ class AppSyncOrchestrator extends EventEmitter {
       }
     } catch (error) {
       log.error(`AppSyncOrchestrator - Appinstalling sync request failed: ${error.message}`);
+    }
+  }
+
+  #fetchAppInstallingErrorMessages() {
+    try {
+      const eligible = this.#peerManager.getEligibleAppRunningSyncPeers(60);
+      if (eligible.length === 0) return;
+      const peersToAsk = eligible.slice(0, 3);
+      log.info(`AppSyncOrchestrator - Requesting appinstalling errors sync from ${peersToAsk.length} peers`);
+      for (const peer of peersToAsk) {
+        try {
+          peer.send(peerCodec.encodeRequestAppInstallingErrors(0));
+        } catch (error) {
+          log.error(`AppSyncOrchestrator - Failed to request appinstalling errors from ${peer.key}: ${error.message}`);
+        }
+      }
+    } catch (error) {
+      log.error(`AppSyncOrchestrator - Appinstalling errors sync request failed: ${error.message}`);
     }
   }
 

--- a/ZelBack/src/services/appMessaging/appSyncOrchestrator.js
+++ b/ZelBack/src/services/appMessaging/appSyncOrchestrator.js
@@ -31,7 +31,7 @@ class AppSyncOrchestrator extends EventEmitter {
   #blocksSinceSyncStarted = 0;
   #blockThreshold = 0;
   #blockReceivedHandler = null;
-  #appRunningBroadcastInterval = null;
+  #broadcastStarted = null;
   #syncInProgress = false;
   #askedPeers = new Set();
   #syncCompletions = { apprunning: 0, appinstalling: 0, apperrors: 0 };
@@ -261,12 +261,9 @@ class AppSyncOrchestrator extends EventEmitter {
   }
 
   #startAppRunningBroadcast() {
-    if (this.#appRunningBroadcastInterval) return;
-
+    if (this.#broadcastStarted) return;
+    this.#broadcastStarted = true;
     peerNotification.checkAndNotifyPeersOfRunningApps();
-    this.#appRunningBroadcastInterval = setInterval(() => {
-      peerNotification.checkAndNotifyPeersOfRunningApps();
-    }, 60 * 60 * 1000);
     log.info('AppSyncOrchestrator - App running broadcast started');
   }
 
@@ -274,10 +271,8 @@ class AppSyncOrchestrator extends EventEmitter {
     if (this.#blockReceivedHandler) {
       this.#blockEmitter.removeListener('blockReceived', this.#blockReceivedHandler);
     }
-    if (this.#appRunningBroadcastInterval) {
-      clearInterval(this.#appRunningBroadcastInterval);
-      this.#appRunningBroadcastInterval = null;
-    }
+    peerNotification.stopBroadcastInterval();
+    this.#broadcastStarted = null;
     if (this.#syncTimeout) {
       clearTimeout(this.#syncTimeout);
       this.#syncTimeout = null;

--- a/ZelBack/src/services/appMessaging/appSyncOrchestrator.js
+++ b/ZelBack/src/services/appMessaging/appSyncOrchestrator.js
@@ -68,6 +68,7 @@ class AppSyncOrchestrator extends EventEmitter {
     this.#startAppRunningBroadcast();
     await this.#fetchTempMessages();
     this.#fetchAppRunningMessages();
+    this.#fetchAppInstallingMessages();
 
     if (this.#state === STATES.RESYNCING) {
       if (this.#syncInProgress) return;
@@ -190,9 +191,27 @@ class AppSyncOrchestrator extends EventEmitter {
     }
   }
 
+  #fetchAppInstallingMessages() {
+    try {
+      const eligible = this.#peerManager.getEligibleAppRunningSyncPeers(60);
+      if (eligible.length === 0) return;
+      const peersToAsk = eligible.slice(0, 3);
+      log.info(`AppSyncOrchestrator - Requesting appinstalling sync from ${peersToAsk.length} peers`);
+      for (const peer of peersToAsk) {
+        try {
+          peer.send(peerCodec.encodeRequestAppInstalling(0));
+        } catch (error) {
+          log.error(`AppSyncOrchestrator - Failed to request appinstalling from ${peer.key}: ${error.message}`);
+        }
+      }
+    } catch (error) {
+      log.error(`AppSyncOrchestrator - Appinstalling sync request failed: ${error.message}`);
+    }
+  }
+
   #isLocationReady() {
     if (globalState.appRunningSyncComplete) return true;
-    // Fallback for networks without appRunningSync peers
+    // Fallback for networks without appStateSync peers
     if (this.#locationBlockThreshold === 0) {
       const enterprise = this.#isEnterprise();
       const blocksPerMinute = 2;

--- a/ZelBack/src/services/appMessaging/appSyncOrchestrator.js
+++ b/ZelBack/src/services/appMessaging/appSyncOrchestrator.js
@@ -152,7 +152,7 @@ class AppSyncOrchestrator extends EventEmitter {
 
   async #fetchTempMessages() {
     try {
-      const eligible = this.#peerManager.getEligibleTempSyncPeers(60);
+      const eligible = this.#peerManager.getEligibleTempSyncPeers(7200);
       if (eligible.length === 0) {
         log.info('AppSyncOrchestrator - No eligible peers for temp message catch-up');
         return;
@@ -173,7 +173,7 @@ class AppSyncOrchestrator extends EventEmitter {
 
   #fetchAppRunningMessages() {
     try {
-      const eligible = this.#peerManager.getEligibleAppRunningSyncPeers(60);
+      const eligible = this.#peerManager.getEligibleAppRunningSyncPeers(7200);
       if (eligible.length === 0) {
         log.info('AppSyncOrchestrator - No eligible peers for apprunning sync');
         return;
@@ -194,7 +194,7 @@ class AppSyncOrchestrator extends EventEmitter {
 
   #fetchAppInstallingMessages() {
     try {
-      const eligible = this.#peerManager.getEligibleAppRunningSyncPeers(60);
+      const eligible = this.#peerManager.getEligibleAppRunningSyncPeers(7200);
       if (eligible.length === 0) return;
       const peersToAsk = eligible.slice(0, 3);
       log.info(`AppSyncOrchestrator - Requesting appinstalling sync from ${peersToAsk.length} peers`);
@@ -212,7 +212,7 @@ class AppSyncOrchestrator extends EventEmitter {
 
   #fetchAppInstallingErrorMessages() {
     try {
-      const eligible = this.#peerManager.getEligibleAppRunningSyncPeers(60);
+      const eligible = this.#peerManager.getEligibleAppRunningSyncPeers(7200);
       if (eligible.length === 0) return;
       const peersToAsk = eligible.slice(0, 3);
       log.info(`AppSyncOrchestrator - Requesting appinstalling errors sync from ${peersToAsk.length} peers`);

--- a/ZelBack/src/services/appMessaging/appSyncOrchestrator.js
+++ b/ZelBack/src/services/appMessaging/appSyncOrchestrator.js
@@ -1,3 +1,4 @@
+const config = require('config');
 const { EventEmitter } = require('events');
 const log = require('../../lib/log');
 const generalService = require('../generalService');
@@ -15,6 +16,10 @@ const STATES = Object.freeze({
   RESYNCING: 'RESYNCING',
 });
 
+const MIN_SYNC_PEERS = 3;
+const SYNC_TIMEOUT_MS = 2 * 60 * 1000;
+const MIN_UPTIME_SECONDS = config.fluxapps.appSyncMinPeerUptime || 7500;
+
 class AppSyncOrchestrator extends EventEmitter {
   #state = STATES.INITIALIZING;
   #blockEmitter = null;
@@ -24,10 +29,14 @@ class AppSyncOrchestrator extends EventEmitter {
   #hashSyncComplete = false;
   #dbRebuilt = false;
   #blocksSinceSyncStarted = 0;
-  #locationBlockThreshold = 0;
+  #blockThreshold = 0;
   #blockReceivedHandler = null;
   #appRunningBroadcastInterval = null;
   #syncInProgress = false;
+  #askedPeers = new Set();
+  #syncCompletions = { apprunning: 0, appinstalling: 0, apperrors: 0 };
+  #stateSyncComplete = false;
+  #syncTimeout = null;
 
   constructor(options = {}) {
     super();
@@ -59,6 +68,24 @@ class AppSyncOrchestrator extends EventEmitter {
     this.#blockEmitter.on('blockReceived', this.#blockReceivedHandler);
   }
 
+  onSyncComplete(syncType) {
+    if (this.#stateSyncComplete) return;
+    if (this.#syncCompletions[syncType] === undefined) return;
+    this.#syncCompletions[syncType] += 1;
+    log.info(`AppSyncOrchestrator - ${syncType} sync complete (${this.#syncCompletions[syncType]}/${MIN_SYNC_PEERS})`);
+    if (this.#syncCompletions.apprunning >= MIN_SYNC_PEERS
+      && this.#syncCompletions.appinstalling >= MIN_SYNC_PEERS
+      && this.#syncCompletions.apperrors >= MIN_SYNC_PEERS) {
+      this.#stateSyncComplete = true;
+      if (this.#syncTimeout) {
+        clearTimeout(this.#syncTimeout);
+        this.#syncTimeout = null;
+      }
+      log.info('AppSyncOrchestrator - All state syncs complete');
+      this.#checkReadiness();
+    }
+  }
+
   async #onPeersReady() {
     if (this.#state === STATES.DEGRADED) {
       this.#state = STATES.RESYNCING;
@@ -66,10 +93,7 @@ class AppSyncOrchestrator extends EventEmitter {
     }
 
     this.#startAppRunningBroadcast();
-    await this.#fetchTempMessages();
-    this.#fetchAppRunningMessages();
-    this.#fetchAppInstallingMessages();
-    this.#fetchAppInstallingErrorMessages();
+    this.#requestSyncs();
 
     if (this.#state === STATES.RESYNCING) {
       if (this.#syncInProgress) return;
@@ -78,14 +102,69 @@ class AppSyncOrchestrator extends EventEmitter {
     }
   }
 
+  #requestSyncs() {
+    const eligible = this.#peerManager.getEligibleSyncPeers(MIN_UPTIME_SECONDS);
+    const fresh = eligible.filter((p) => !this.#askedPeers.has(p.key));
+
+    if (fresh.length < MIN_SYNC_PEERS && this.#askedPeers.size === 0) {
+      log.info(`AppSyncOrchestrator - Only ${fresh.length} eligible sync peers (need ${MIN_SYNC_PEERS}), falling back to block timer`);
+      return;
+    }
+
+    if (fresh.length === 0) {
+      log.info('AppSyncOrchestrator - No new eligible sync peers to ask');
+      return;
+    }
+
+    const peersToAsk = fresh.slice(0, MIN_SYNC_PEERS);
+    for (const peer of peersToAsk) {
+      this.#askedPeers.add(peer.key);
+    }
+
+    this.#sendRequests(peersToAsk, 'temp messages', peerCodec.encodeRequestTempMessages());
+    this.#sendRequests(peersToAsk, 'apprunning', peerCodec.encodeRequestAppRunning(0));
+    this.#sendRequests(peersToAsk, 'appinstalling', peerCodec.encodeRequestAppInstalling(0));
+    this.#sendRequests(peersToAsk, 'apperrors', peerCodec.encodeRequestAppInstallingErrors(0));
+
+    if (!this.#syncTimeout && !this.#stateSyncComplete) {
+      this.#syncTimeout = setTimeout(() => {
+        this.#syncTimeout = null;
+        if (!this.#stateSyncComplete) {
+          log.warn(`AppSyncOrchestrator - Sync timeout, completions: apprunning=${this.#syncCompletions.apprunning} appinstalling=${this.#syncCompletions.appinstalling} apperrors=${this.#syncCompletions.apperrors}`);
+        }
+      }, SYNC_TIMEOUT_MS);
+    }
+  }
+
+  #sendRequests(peers, label, message) {
+    log.info(`AppSyncOrchestrator - Requesting ${label} sync from ${peers.length} peers`);
+    for (const peer of peers) {
+      try {
+        peer.send(message);
+      } catch (error) {
+        log.error(`AppSyncOrchestrator - Failed to request ${label} from ${peer.key}: ${error.message}`);
+      }
+    }
+  }
+
   #onPeersDegraded() {
     if (this.#state === STATES.READY) {
       this.#state = STATES.DEGRADED;
       this.#hashSyncComplete = false;
       this.#dbRebuilt = false;
-      globalState.appRunningSyncComplete = false;
+      this.#resetSyncState();
       log.warn('AppSyncOrchestrator - Degraded, pausing spawner');
       this.emit('readinessLost');
+    }
+  }
+
+  #resetSyncState() {
+    this.#askedPeers.clear();
+    this.#syncCompletions = { apprunning: 0, appinstalling: 0, apperrors: 0 };
+    this.#stateSyncComplete = false;
+    if (this.#syncTimeout) {
+      clearTimeout(this.#syncTimeout);
+      this.#syncTimeout = null;
     }
   }
 
@@ -100,7 +179,7 @@ class AppSyncOrchestrator extends EventEmitter {
     }
     if (this.#state === STATES.SYNCING || this.#state === STATES.READY) {
       this.#blocksSinceSyncStarted += 1;
-      if (!this.#isLocationReady() && this.#hashSyncComplete && this.#dbRebuilt) {
+      if (this.#hashSyncComplete && this.#dbRebuilt) {
         this.#checkReadiness();
       }
     }
@@ -150,95 +229,16 @@ class AppSyncOrchestrator extends EventEmitter {
     }
   }
 
-  async #fetchTempMessages() {
-    try {
-      const eligible = this.#peerManager.getEligibleTempSyncPeers(7500);
-      if (eligible.length === 0) {
-        log.info('AppSyncOrchestrator - No eligible peers for temp message catch-up');
-        return;
-      }
-      const peersToAsk = eligible.slice(0, 5);
-      log.info(`AppSyncOrchestrator - Requesting temp messages from ${peersToAsk.length} peers`);
-      for (const peer of peersToAsk) {
-        try {
-          peer.send(peerCodec.encodeRequestTempMessages());
-        } catch (error) {
-          log.error(`AppSyncOrchestrator - Failed to request temp messages from ${peer.key}: ${error.message}`);
-        }
-      }
-    } catch (error) {
-      log.error(`AppSyncOrchestrator - Temp message catch-up failed: ${error.message}`);
-    }
-  }
-
-  #fetchAppRunningMessages() {
-    try {
-      const eligible = this.#peerManager.getEligibleAppRunningSyncPeers(7500);
-      if (eligible.length === 0) {
-        log.info('AppSyncOrchestrator - No eligible peers for apprunning sync');
-        return;
-      }
-      const peersToAsk = eligible.slice(0, 3);
-      log.info(`AppSyncOrchestrator - Requesting apprunning sync from ${peersToAsk.length} peers`);
-      for (const peer of peersToAsk) {
-        try {
-          peer.send(peerCodec.encodeRequestAppRunning(0));
-        } catch (error) {
-          log.error(`AppSyncOrchestrator - Failed to request apprunning from ${peer.key}: ${error.message}`);
-        }
-      }
-    } catch (error) {
-      log.error(`AppSyncOrchestrator - Apprunning sync request failed: ${error.message}`);
-    }
-  }
-
-  #fetchAppInstallingMessages() {
-    try {
-      const eligible = this.#peerManager.getEligibleAppRunningSyncPeers(7500);
-      if (eligible.length === 0) return;
-      const peersToAsk = eligible.slice(0, 3);
-      log.info(`AppSyncOrchestrator - Requesting appinstalling sync from ${peersToAsk.length} peers`);
-      for (const peer of peersToAsk) {
-        try {
-          peer.send(peerCodec.encodeRequestAppInstalling(0));
-        } catch (error) {
-          log.error(`AppSyncOrchestrator - Failed to request appinstalling from ${peer.key}: ${error.message}`);
-        }
-      }
-    } catch (error) {
-      log.error(`AppSyncOrchestrator - Appinstalling sync request failed: ${error.message}`);
-    }
-  }
-
-  #fetchAppInstallingErrorMessages() {
-    try {
-      const eligible = this.#peerManager.getEligibleAppRunningSyncPeers(7500);
-      if (eligible.length === 0) return;
-      const peersToAsk = eligible.slice(0, 3);
-      log.info(`AppSyncOrchestrator - Requesting appinstalling errors sync from ${peersToAsk.length} peers`);
-      for (const peer of peersToAsk) {
-        try {
-          peer.send(peerCodec.encodeRequestAppInstallingErrors(0));
-        } catch (error) {
-          log.error(`AppSyncOrchestrator - Failed to request appinstalling errors from ${peer.key}: ${error.message}`);
-        }
-      }
-    } catch (error) {
-      log.error(`AppSyncOrchestrator - Appinstalling errors sync request failed: ${error.message}`);
-    }
-  }
-
-  #isLocationReady() {
-    if (globalState.appRunningSyncComplete) return true;
-    // Fallback for networks without appStateSync peers
-    if (this.#locationBlockThreshold === 0) {
+  #isStateSyncReady() {
+    if (this.#stateSyncComplete) return true;
+    if (this.#blockThreshold === 0) {
       const enterprise = this.#isEnterprise();
       const blocksPerMinute = 2;
-      this.#locationBlockThreshold = enterprise
+      this.#blockThreshold = enterprise
         ? 62 * blocksPerMinute
         : 125 * blocksPerMinute;
     }
-    return this.#blocksSinceSyncStarted >= this.#locationBlockThreshold;
+    return this.#blocksSinceSyncStarted >= this.#blockThreshold;
   }
 
   async #checkReadiness() {
@@ -246,7 +246,7 @@ class AppSyncOrchestrator extends EventEmitter {
     if (!this.#explorerSynced) return;
     if (!this.#hashSyncComplete) return;
     if (!this.#dbRebuilt) return;
-    if (!this.#isLocationReady()) return;
+    if (!this.#isStateSyncReady()) return;
 
     const isConfirmed = await generalService.isNodeStatusConfirmed().catch(() => null);
     if (!isConfirmed) {
@@ -277,6 +277,10 @@ class AppSyncOrchestrator extends EventEmitter {
     if (this.#appRunningBroadcastInterval) {
       clearInterval(this.#appRunningBroadcastInterval);
       this.#appRunningBroadcastInterval = null;
+    }
+    if (this.#syncTimeout) {
+      clearTimeout(this.#syncTimeout);
+      this.#syncTimeout = null;
     }
     this.removeAllListeners();
   }

--- a/ZelBack/src/services/appMessaging/appSyncOrchestrator.js
+++ b/ZelBack/src/services/appMessaging/appSyncOrchestrator.js
@@ -67,6 +67,7 @@ class AppSyncOrchestrator extends EventEmitter {
 
     this.#startAppRunningBroadcast();
     await this.#fetchTempMessages();
+    this.#fetchAppRunningMessages();
 
     if (this.#state === STATES.RESYNCING) {
       if (this.#syncInProgress) return;
@@ -80,6 +81,7 @@ class AppSyncOrchestrator extends EventEmitter {
       this.#state = STATES.DEGRADED;
       this.#hashSyncComplete = false;
       this.#dbRebuilt = false;
+      globalState.appRunningSyncComplete = false;
       log.warn('AppSyncOrchestrator - Degraded, pausing spawner');
       this.emit('readinessLost');
     }
@@ -167,7 +169,30 @@ class AppSyncOrchestrator extends EventEmitter {
     }
   }
 
+  #fetchAppRunningMessages() {
+    try {
+      const eligible = this.#peerManager.getEligibleAppRunningSyncPeers(60);
+      if (eligible.length === 0) {
+        log.info('AppSyncOrchestrator - No eligible peers for apprunning sync');
+        return;
+      }
+      const peersToAsk = eligible.slice(0, 3);
+      log.info(`AppSyncOrchestrator - Requesting apprunning sync from ${peersToAsk.length} peers`);
+      for (const peer of peersToAsk) {
+        try {
+          peer.send(peerCodec.encodeRequestAppRunning(0));
+        } catch (error) {
+          log.error(`AppSyncOrchestrator - Failed to request apprunning from ${peer.key}: ${error.message}`);
+        }
+      }
+    } catch (error) {
+      log.error(`AppSyncOrchestrator - Apprunning sync request failed: ${error.message}`);
+    }
+  }
+
   #isLocationReady() {
+    if (globalState.appRunningSyncComplete) return true;
+    // Fallback for networks without appRunningSync peers
     if (this.#locationBlockThreshold === 0) {
       const enterprise = this.#isEnterprise();
       const blocksPerMinute = 2;

--- a/ZelBack/src/services/appMessaging/appSyncOrchestrator.js
+++ b/ZelBack/src/services/appMessaging/appSyncOrchestrator.js
@@ -1,0 +1,220 @@
+const { EventEmitter } = require('events');
+const config = require('config');
+const log = require('../../lib/log');
+const generalService = require('../generalService');
+const appHashSyncService = require('./appHashSyncService');
+const peerNotification = require('./peerNotification');
+const registryManager = require('../appDatabase/registryManager');
+const globalState = require('../utils/globalState');
+const peerCodec = require('../utils/peerCodec');
+
+const STATES = Object.freeze({
+  INITIALIZING: 'INITIALIZING',
+  SYNCING: 'SYNCING',
+  READY: 'READY',
+  DEGRADED: 'DEGRADED',
+  RESYNCING: 'RESYNCING',
+});
+
+class AppSyncOrchestrator extends EventEmitter {
+  #state = STATES.INITIALIZING;
+  #blockEmitter = null;
+  #peerManager = null;
+  #isEnterprise = null;
+  #explorerSynced = false;
+  #hashSyncComplete = false;
+  #dbRebuilt = false;
+  #blocksSinceSyncStarted = 0;
+  #locationBlockThreshold = 0;
+  #blockReceivedHandler = null;
+  #appRunningBroadcastInterval = null;
+
+  constructor(options = {}) {
+    super();
+    this.#blockEmitter = options.blockEmitter;
+    this.#peerManager = options.peerManager;
+    this.#isEnterprise = options.isEnterprise || (() => false);
+  }
+
+  get state() {
+    return this.#state;
+  }
+
+  start() {
+    log.info(`AppSyncOrchestrator - Starting in state ${this.#state}`);
+
+    this.#peerManager.on('peerThresholdReached', (count) => {
+      log.info(`AppSyncOrchestrator - Peer threshold reached (${count} peers)`);
+      this.#onPeersReady();
+    });
+
+    this.#peerManager.on('peersBelowThreshold', (count) => {
+      log.info(`AppSyncOrchestrator - Peers below threshold (${count} peers)`);
+      this.#onPeersDegraded();
+    });
+
+    this.#blockReceivedHandler = (blockHeight) => {
+      this.#onBlockReceived(blockHeight);
+    };
+    this.#blockEmitter.on('blockReceived', this.#blockReceivedHandler);
+  }
+
+  async #onPeersReady() {
+    if (this.#state === STATES.DEGRADED) {
+      this.#state = STATES.RESYNCING;
+      log.info('AppSyncOrchestrator - Peers recovered, resyncing');
+    }
+
+    this.#startAppRunningBroadcast();
+    await this.#fetchTempMessages();
+
+    if (this.#state === STATES.RESYNCING) {
+      await this.#runHashSync();
+      this.#checkReadiness();
+    }
+  }
+
+  #onPeersDegraded() {
+    if (this.#state === STATES.READY) {
+      this.#state = STATES.DEGRADED;
+      this.#hashSyncComplete = false;
+      this.#dbRebuilt = false;
+      log.warn('AppSyncOrchestrator - Degraded, pausing spawner');
+      this.emit('readinessLost');
+    }
+  }
+
+  #onBlockReceived(blockHeight) {
+    if (!this.#explorerSynced) {
+      this.#explorerSynced = true;
+      log.info(`AppSyncOrchestrator - Explorer synced at block ${blockHeight}`);
+      if (this.#state === STATES.INITIALIZING) {
+        this.#state = STATES.SYNCING;
+        this.#runInitialSync();
+      }
+    }
+    if (this.#state === STATES.SYNCING || this.#state === STATES.READY) {
+      this.#blocksSinceSyncStarted += 1;
+      if (!this.#isLocationReady() && this.#hashSyncComplete && this.#dbRebuilt) {
+        this.#checkReadiness();
+      }
+    }
+  }
+
+  async #runInitialSync() {
+    log.info('AppSyncOrchestrator - Starting initial hash sync');
+    this.emit('syncStarted');
+    await this.#runHashSync();
+    this.#checkReadiness();
+  }
+
+  async #runHashSync() {
+    try {
+      const result = await appHashSyncService.syncMissingHashes({
+        onProgress: (progress) => this.emit('syncProgress', progress),
+      });
+      this.#hashSyncComplete = result.missing === 0;
+      if (this.#hashSyncComplete) {
+        log.info('AppSyncOrchestrator - Hash sync complete');
+        this.emit('syncComplete');
+        await this.#rebuildDb();
+      } else {
+        log.warn(`AppSyncOrchestrator - Hash sync incomplete, ${result.missing} still missing`);
+        this.#hashSyncComplete = true;
+        this.emit('syncComplete');
+        await this.#rebuildDb();
+      }
+      globalState.checkAndSyncAppHashesWasEverExecuted = true;
+    } catch (error) {
+      log.error(`AppSyncOrchestrator - Hash sync failed: ${error.message}`);
+    }
+  }
+
+  async #rebuildDb() {
+    try {
+      log.info('AppSyncOrchestrator - Rebuilding globalAppsInformation');
+      await registryManager.reindexGlobalAppsInformation();
+      log.info('AppSyncOrchestrator - Running expireGlobalApplications');
+      await registryManager.expireGlobalApplications();
+      this.#dbRebuilt = true;
+      this.emit('dbReady');
+    } catch (error) {
+      log.error(`AppSyncOrchestrator - DB rebuild failed: ${error.message}`);
+    }
+  }
+
+  async #fetchTempMessages() {
+    try {
+      const eligible = this.#peerManager.getEligibleTempSyncPeers(60);
+      if (eligible.length === 0) {
+        log.info('AppSyncOrchestrator - No eligible peers for temp message catch-up');
+        return;
+      }
+      const peersToAsk = eligible.slice(0, 5);
+      log.info(`AppSyncOrchestrator - Requesting temp messages from ${peersToAsk.length} peers`);
+      for (const peer of peersToAsk) {
+        try {
+          peer.send(peerCodec.encodeRequestTempMessages());
+        } catch (error) {
+          log.error(`AppSyncOrchestrator - Failed to request temp messages from ${peer.key}: ${error.message}`);
+        }
+      }
+    } catch (error) {
+      log.error(`AppSyncOrchestrator - Temp message catch-up failed: ${error.message}`);
+    }
+  }
+
+  #isLocationReady() {
+    if (this.#locationBlockThreshold === 0) {
+      const enterprise = this.#isEnterprise();
+      const ponFork = config.fluxapps.daemonPONFork;
+      const blocksPerMinute = 2;
+      this.#locationBlockThreshold = enterprise
+        ? 62 * blocksPerMinute
+        : 125 * blocksPerMinute;
+    }
+    return this.#blocksSinceSyncStarted >= this.#locationBlockThreshold;
+  }
+
+  async #checkReadiness() {
+    if (this.#state !== STATES.SYNCING && this.#state !== STATES.RESYNCING) return;
+    if (!this.#explorerSynced) return;
+    if (!this.#hashSyncComplete) return;
+    if (!this.#dbRebuilt) return;
+    if (!this.#isLocationReady()) return;
+
+    const isConfirmed = await generalService.isNodeStatusConfirmed().catch(() => null);
+    if (!isConfirmed) {
+      log.info('AppSyncOrchestrator - Node not confirmed, waiting');
+      setTimeout(() => this.#checkReadiness(), 60 * 1000);
+      return;
+    }
+
+    this.#state = STATES.READY;
+    log.info('AppSyncOrchestrator - All readiness conditions met');
+    this.emit('spawnerReady');
+  }
+
+  #startAppRunningBroadcast() {
+    if (this.#appRunningBroadcastInterval) return;
+
+    peerNotification.checkAndNotifyPeersOfRunningApps();
+    this.#appRunningBroadcastInterval = setInterval(() => {
+      peerNotification.checkAndNotifyPeersOfRunningApps();
+    }, 60 * 60 * 1000);
+    log.info('AppSyncOrchestrator - App running broadcast started');
+  }
+
+  stop() {
+    if (this.#blockReceivedHandler) {
+      this.#blockEmitter.removeListener('blockReceived', this.#blockReceivedHandler);
+    }
+    if (this.#appRunningBroadcastInterval) {
+      clearInterval(this.#appRunningBroadcastInterval);
+      this.#appRunningBroadcastInterval = null;
+    }
+    this.removeAllListeners();
+  }
+}
+
+module.exports = { AppSyncOrchestrator, STATES };

--- a/ZelBack/src/services/appMessaging/appSyncOrchestrator.js
+++ b/ZelBack/src/services/appMessaging/appSyncOrchestrator.js
@@ -1,5 +1,4 @@
 const { EventEmitter } = require('events');
-const config = require('config');
 const log = require('../../lib/log');
 const generalService = require('../generalService');
 const appHashSyncService = require('./appHashSyncService');
@@ -28,6 +27,7 @@ class AppSyncOrchestrator extends EventEmitter {
   #locationBlockThreshold = 0;
   #blockReceivedHandler = null;
   #appRunningBroadcastInterval = null;
+  #syncInProgress = false;
 
   constructor(options = {}) {
     super();
@@ -69,6 +69,7 @@ class AppSyncOrchestrator extends EventEmitter {
     await this.#fetchTempMessages();
 
     if (this.#state === STATES.RESYNCING) {
+      if (this.#syncInProgress) return;
       await this.#runHashSync();
       this.#checkReadiness();
     }
@@ -102,6 +103,7 @@ class AppSyncOrchestrator extends EventEmitter {
   }
 
   async #runInitialSync() {
+    if (this.#syncInProgress) return;
     log.info('AppSyncOrchestrator - Starting initial hash sync');
     this.emit('syncStarted');
     await this.#runHashSync();
@@ -109,24 +111,25 @@ class AppSyncOrchestrator extends EventEmitter {
   }
 
   async #runHashSync() {
+    if (this.#syncInProgress) return;
+    this.#syncInProgress = true;
     try {
       const result = await appHashSyncService.syncMissingHashes({
         onProgress: (progress) => this.emit('syncProgress', progress),
       });
-      this.#hashSyncComplete = result.missing === 0;
-      if (this.#hashSyncComplete) {
-        log.info('AppSyncOrchestrator - Hash sync complete');
-        this.emit('syncComplete');
-        await this.#rebuildDb();
+      if (result.missing > 0) {
+        log.warn(`AppSyncOrchestrator - Hash sync has ${result.missing} unresolvable hashes, proceeding`);
       } else {
-        log.warn(`AppSyncOrchestrator - Hash sync incomplete, ${result.missing} still missing`);
-        this.#hashSyncComplete = true;
-        this.emit('syncComplete');
-        await this.#rebuildDb();
+        log.info('AppSyncOrchestrator - Hash sync complete');
       }
+      this.#hashSyncComplete = true;
+      this.emit('syncComplete');
+      await this.#rebuildDb();
       globalState.checkAndSyncAppHashesWasEverExecuted = true;
     } catch (error) {
       log.error(`AppSyncOrchestrator - Hash sync failed: ${error.message}`);
+    } finally {
+      this.#syncInProgress = false;
     }
   }
 
@@ -167,7 +170,6 @@ class AppSyncOrchestrator extends EventEmitter {
   #isLocationReady() {
     if (this.#locationBlockThreshold === 0) {
       const enterprise = this.#isEnterprise();
-      const ponFork = config.fluxapps.daemonPONFork;
       const blocksPerMinute = 2;
       this.#locationBlockThreshold = enterprise
         ? 62 * blocksPerMinute

--- a/ZelBack/src/services/appMessaging/messageStore.js
+++ b/ZelBack/src/services/appMessaging/messageStore.js
@@ -678,7 +678,7 @@ const appsInstallingBroadcasts = config.database.appsglobal.collections.appsInst
 function storeSignedAppInstallingBroadcast(signedBroadcast) {
   const { data } = signedBroadcast;
   if (!data || !data.ip || !data.name || !data.broadcastedAt) return;
-  const validTill = data.broadcastedAt + (5 * 60 * 1000);
+  const validTill = data.broadcastedAt + (15 * 60 * 1000);
   if (validTill < Date.now()) return;
   const db = dbHelper.databaseConnection();
   const database = db.db(config.database.appsglobal.database);
@@ -709,7 +709,7 @@ async function storeBatchAppInstallingMessages(verifiedBroadcasts) {
 
   for (const broadcast of verifiedBroadcasts) {
     const { data } = broadcast;
-    const validTill = data.broadcastedAt + (5 * 60 * 1000);
+    const validTill = data.broadcastedAt + (15 * 60 * 1000);
     if (validTill < Date.now()) continue;
 
     signedOps.push({

--- a/ZelBack/src/services/appMessaging/messageStore.js
+++ b/ZelBack/src/services/appMessaging/messageStore.js
@@ -262,7 +262,7 @@ async function storeAppRunningMessage(message) {
     }
   }
 
-  const validTill = message.broadcastedAt + (125 * 60 * 1000); // 7500 seconds
+  const validTill = message.broadcastedAt + (5 * 60 * 1000);
   if (validTill < Date.now()) {
     log.warn(`Rejecting old/not valid Fluxapprunning message, message:${JSON.stringify(message)}`);
     // reject old message

--- a/ZelBack/src/services/appMessaging/messageStore.js
+++ b/ZelBack/src/services/appMessaging/messageStore.js
@@ -335,11 +335,6 @@ async function storeAppRunningMessage(message) {
     await dbHelper.removeDocumentsFromCollection(database, appsInstallingBroadcasts, { 'data.name': app.name, 'data.ip': message.ip });
   }
 
-  if (message.version === 2 && appsMessages.length > 0) {
-    const appNames = appsMessages.map((a) => a.name);
-    await dbHelper.removeDocumentsFromCollection(database, globalAppsLocations, { ip: message.ip, name: { $nin: appNames } });
-  }
-
   if (messageNotOk) {
     return false;
   }
@@ -587,19 +582,12 @@ function storeSignedAppRunningBroadcast(signedBroadcast) {
     expireAt: new Date(validTill),
   };
   const filter = data.apps ? { ip: data.ip } : { ip: data.ip, 'data.name': data.name };
-  const upsertPromise = dbHelper.updateOneInDatabase(
+  return dbHelper.updateOneInDatabase(
     database, appsRunningBroadcasts,
     filter,
     { $set: doc },
     { upsert: true },
   ).catch((err) => log.error(`storeSignedAppRunningBroadcast: ${err.message}`));
-  if (data.apps && data.apps.length > 0) {
-    const appNames = data.apps.map((a) => a.name);
-    dbHelper.removeDocumentsFromCollection(database, appsRunningBroadcasts, {
-      ip: data.ip, 'data.name': { $nin: [null, ...appNames] },
-    }).catch((err) => log.error(`storeSignedAppRunningBroadcast cleanup: ${err.message}`));
-  }
-  return upsertPromise;
 }
 
 async function storeBatchAppRunningMessages(verifiedBroadcasts) {
@@ -670,6 +658,20 @@ async function storeBatchAppRunningMessages(verifiedBroadcasts) {
     }
   }
 
+  for (const [ip, { names, broadcastedAt }] of v2AppsByIp) {
+    const cutoff = new Date(broadcastedAt);
+    locationOps.push({
+      deleteMany: {
+        filter: { ip, name: { $nin: names }, broadcastedAt: { $lte: cutoff } },
+      },
+    });
+    signedOps.push({
+      deleteMany: {
+        filter: { ip, 'data.name': { $nin: [null, ...names] }, broadcastedAt: { $lte: cutoff } },
+      },
+    });
+  }
+
   if (signedOps.length > 0) {
     await database.collection(appsRunningBroadcasts).bulkWrite(signedOps, { ordered: false })
       .catch((err) => log.error(`storeBatchAppRunningMessages signed: ${err.message}`));
@@ -677,29 +679,6 @@ async function storeBatchAppRunningMessages(verifiedBroadcasts) {
   if (locationOps.length > 0) {
     await database.collection(globalAppsLocations).bulkWrite(locationOps, { ordered: false })
       .catch((err) => log.error(`storeBatchAppRunningMessages locations: ${err.message}`));
-  }
-
-  const locationCleanupOps = [];
-  const signedCleanupOps = [];
-  for (const [ip, { names }] of v2AppsByIp) {
-    locationCleanupOps.push({
-      deleteMany: {
-        filter: { ip, name: { $nin: names } },
-      },
-    });
-    signedCleanupOps.push({
-      deleteMany: {
-        filter: { ip, 'data.name': { $nin: [null, ...names] } },
-      },
-    });
-  }
-  if (locationCleanupOps.length > 0) {
-    await database.collection(globalAppsLocations).bulkWrite(locationCleanupOps, { ordered: false })
-      .catch((err) => log.error(`storeBatchAppRunningMessages location cleanup: ${err.message}`));
-  }
-  if (signedCleanupOps.length > 0) {
-    await database.collection(appsRunningBroadcasts).bulkWrite(signedCleanupOps, { ordered: false })
-      .catch((err) => log.error(`storeBatchAppRunningMessages signed cleanup: ${err.message}`));
   }
 
   return { stored: signedOps.length };

--- a/ZelBack/src/services/appMessaging/messageStore.js
+++ b/ZelBack/src/services/appMessaging/messageStore.js
@@ -581,9 +581,10 @@ function storeSignedAppRunningBroadcast(signedBroadcast) {
     broadcastedAt: new Date(data.broadcastedAt),
     expireAt: new Date(validTill),
   };
+  const filter = data.apps ? { ip: data.ip } : { ip: data.ip, 'data.name': data.name };
   return dbHelper.updateOneInDatabase(
     database, appsRunningBroadcasts,
-    { ip: data.ip },
+    filter,
     { $set: doc },
     { upsert: true },
   ).catch((err) => log.error(`storeSignedAppRunningBroadcast: ${err.message}`));
@@ -602,9 +603,10 @@ async function storeBatchAppRunningMessages(verifiedBroadcasts) {
     const validTill = data.broadcastedAt + (125 * 60 * 1000);
     if (validTill < Date.now()) continue;
 
+    const filter = data.apps ? { ip: data.ip } : { ip: data.ip, 'data.name': data.name };
     signedOps.push({
       updateOne: {
-        filter: { ip: data.ip },
+        filter,
         update: {
           $set: {
             ip: data.ip,

--- a/ZelBack/src/services/appMessaging/messageStore.js
+++ b/ZelBack/src/services/appMessaging/messageStore.js
@@ -624,22 +624,27 @@ async function storeBatchAppRunningMessages(verifiedBroadcasts) {
     });
 
     const apps = data.version === 2 ? (data.apps || []) : [{ name: data.name, hash: data.hash }];
+    const incomingDate = new Date(data.broadcastedAt);
+    const incomingExpiry = new Date(validTill);
+    const isNewer = { $gt: [incomingDate, { $ifNull: ['$broadcastedAt', new Date(0)] }] };
     for (const app of apps) {
-      const locationDoc = {
+      const setFields = {
         name: app.name,
-        hash: app.hash,
         ip: data.ip,
-        broadcastedAt: new Date(data.broadcastedAt),
-        expireAt: new Date(validTill),
-        osUptime: data.osUptime,
-        staticIp: data.staticIp,
+        hash: { $cond: [isNewer, app.hash, { $ifNull: ['$hash', app.hash] }] },
+        broadcastedAt: { $cond: [isNewer, incomingDate, '$broadcastedAt'] },
+        expireAt: { $cond: [isNewer, incomingExpiry, '$expireAt'] },
+        osUptime: { $cond: [isNewer, data.osUptime, { $ifNull: ['$osUptime', data.osUptime] }] },
+        staticIp: { $cond: [isNewer, data.staticIp ?? null, { $ifNull: ['$staticIp', data.staticIp ?? null] }] },
       };
-      if (data.runningSince) locationDoc.runningSince = new Date(data.runningSince);
-      else if (app.runningSince) locationDoc.runningSince = new Date(app.runningSince);
+      const runningSince = data.runningSince ? new Date(data.runningSince) : (app.runningSince ? new Date(app.runningSince) : null);
+      if (runningSince) {
+        setFields.runningSince = { $cond: [isNewer, runningSince, { $ifNull: ['$runningSince', runningSince] }] };
+      }
       locationOps.push({
         updateOne: {
           filter: { name: app.name, ip: data.ip },
-          update: { $set: locationDoc },
+          update: [{ $set: setFields }],
           upsert: true,
         },
       });
@@ -714,17 +719,18 @@ async function storeBatchAppInstallingMessages(verifiedBroadcasts) {
       },
     });
 
+    const incomingDate = new Date(data.broadcastedAt);
+    const incomingExpiry = new Date(validTill);
+    const isNewer = { $gt: [incomingDate, { $ifNull: ['$broadcastedAt', new Date(0)] }] };
     locationOps.push({
       updateOne: {
         filter: { name: data.name, ip: data.ip },
-        update: {
-          $set: {
-            name: data.name,
-            ip: data.ip,
-            broadcastedAt: new Date(data.broadcastedAt),
-            expireAt: new Date(validTill),
-          },
-        },
+        update: [{ $set: {
+          name: data.name,
+          ip: data.ip,
+          broadcastedAt: { $cond: [isNewer, incomingDate, '$broadcastedAt'] },
+          expireAt: { $cond: [isNewer, incomingExpiry, '$expireAt'] },
+        } }],
         upsert: true,
       },
     });
@@ -794,18 +800,18 @@ async function storeBatchAppInstallingErrorMessages(verifiedBroadcasts) {
       },
     });
 
+    const incomingDate = new Date(data.broadcastedAt);
+    const isNewer = { $gt: [incomingDate, { $ifNull: ['$broadcastedAt', new Date(0)] }] };
     locationOps.push({
       updateOne: {
         filter: { name: data.name, hash: data.hash, ip: data.ip },
-        update: {
-          $set: {
-            name: data.name,
-            hash: data.hash,
-            ip: data.ip,
-            error: data.error,
-            broadcastedAt: new Date(data.broadcastedAt),
-          },
-        },
+        update: [{ $set: {
+          name: data.name,
+          hash: data.hash,
+          ip: data.ip,
+          error: { $cond: [isNewer, data.error, { $ifNull: ['$error', data.error] }] },
+          broadcastedAt: { $cond: [isNewer, incomingDate, '$broadcastedAt'] },
+        } }],
         upsert: true,
       },
     });

--- a/ZelBack/src/services/appMessaging/messageStore.js
+++ b/ZelBack/src/services/appMessaging/messageStore.js
@@ -478,10 +478,9 @@ async function storeAppInstallingErrorMessage(message) {
     return new Error(`Invalid Flux App Installing Error message for storing version ${message.version} not supported`);
   }
 
-  const validTill = message.broadcastedAt + (60 * 60 * 1000); // 60 minutes
+  const validTill = message.broadcastedAt + (5 * 60 * 1000);
   if (validTill < Date.now()) {
     log.warn(`Rejecting old/not valid fluxappinstallingerror message, message:${JSON.stringify(message)}`);
-    // reject old message
     return false;
   }
 
@@ -494,40 +493,22 @@ async function storeAppInstallingErrorMessage(message) {
     ip: message.ip,
     error: message.error,
     broadcastedAt: new Date(message.broadcastedAt),
-    startCacheAt: new Date(message.broadcastedAt),
-    expireAt: new Date(validTill),
   };
 
-  let queryFind = { name: newAppInstallingErrorMessage.name, hash: newAppInstallingErrorMessage.hash, ip: newAppInstallingErrorMessage.ip };
-  const projection = { _id: 0 };
-  // we already have the exact same data
-  // eslint-disable-next-line no-await-in-loop
+  const queryFind = { name: newAppInstallingErrorMessage.name, hash: newAppInstallingErrorMessage.hash, ip: newAppInstallingErrorMessage.ip };
+  const projection = { _id: 0, broadcastedAt: 1 };
   const result = await dbHelper.findOneInDatabase(database, globalAppsInstallingErrorsLocations, queryFind, projection);
   if (result && result.broadcastedAt && result.broadcastedAt >= newAppInstallingErrorMessage.broadcastedAt) {
-    // found a message that was already stored/probably from duplicated message processsed
     return false;
   }
 
-  let update = { $set: newAppInstallingErrorMessage };
-  const options = {
-    upsert: true,
-  };
-  await dbHelper.updateOneInDatabase(database, globalAppsInstallingErrorsLocations, queryFind, update, options);
+  const update = { $set: newAppInstallingErrorMessage };
+  await dbHelper.updateOneInDatabase(database, globalAppsInstallingErrorsLocations, queryFind, update, { upsert: true });
 
-  // clean up installing record since installation failed
   const installingQuery = { name: newAppInstallingErrorMessage.name, ip: newAppInstallingErrorMessage.ip };
   await dbHelper.removeDocumentsFromCollection(database, globalAppsInstallingLocations, installingQuery);
+  await dbHelper.removeDocumentsFromCollection(database, appsInstallingBroadcasts, { 'data.name': newAppInstallingErrorMessage.name, 'data.ip': newAppInstallingErrorMessage.ip });
 
-  queryFind = { name: newAppInstallingErrorMessage.name, hash: newAppInstallingErrorMessage.hash };
-  // we already have the exact same data
-  // eslint-disable-next-line no-await-in-loop
-  const results = await dbHelper.countInDatabase(database, globalAppsInstallingErrorsLocations, queryFind);
-  if (results >= 5) {
-    update = { $set: { startCacheAt: null, expireAt: null } };
-    // eslint-disable-next-line no-await-in-loop
-    await dbHelper.updateInDatabase(database, globalAppsInstallingErrorsLocations, queryFind, update);
-  }
-  // all stored, rebroadcast
   return true;
 }
 
@@ -757,6 +738,89 @@ async function storeBatchAppInstallingMessages(verifiedBroadcasts) {
   return { stored: signedOps.length };
 }
 
+const appsInstallingErrorsBroadcasts = config.database.appsglobal.collections.appsInstallingErrorsBroadcasts;
+
+function storeSignedAppInstallingErrorBroadcast(signedBroadcast) {
+  const { data } = signedBroadcast;
+  if (!data || !data.ip || !data.name || !data.hash || !data.broadcastedAt) return;
+  const validTill = data.broadcastedAt + (24 * 60 * 60 * 1000);
+  if (validTill < Date.now()) return;
+  const db = dbHelper.databaseConnection();
+  const database = db.db(config.database.appsglobal.database);
+  const doc = {
+    version: signedBroadcast.version,
+    timestamp: signedBroadcast.timestamp,
+    pubKey: signedBroadcast.pubKey,
+    signature: signedBroadcast.signature,
+    data,
+    broadcastedAt: new Date(data.broadcastedAt),
+  };
+  return dbHelper.updateOneInDatabase(
+    database, appsInstallingErrorsBroadcasts,
+    { 'data.name': data.name, 'data.hash': data.hash, 'data.ip': data.ip },
+    { $set: doc },
+    { upsert: true },
+  ).catch((err) => log.error(`storeSignedAppInstallingErrorBroadcast: ${err.message}`));
+}
+
+async function storeBatchAppInstallingErrorMessages(verifiedBroadcasts) {
+  if (verifiedBroadcasts.length === 0) return { stored: 0 };
+  const db = dbHelper.databaseConnection();
+  const database = db.db(config.database.appsglobal.database);
+
+  const signedOps = [];
+  const locationOps = [];
+
+  for (const broadcast of verifiedBroadcasts) {
+    const { data } = broadcast;
+    const validTill = data.broadcastedAt + (24 * 60 * 60 * 1000);
+    if (validTill < Date.now()) continue;
+
+    signedOps.push({
+      updateOne: {
+        filter: { 'data.name': data.name, 'data.hash': data.hash, 'data.ip': data.ip },
+        update: {
+          $set: {
+            version: broadcast.version,
+            timestamp: broadcast.timestamp,
+            pubKey: broadcast.pubKey,
+            signature: broadcast.signature,
+            data,
+            broadcastedAt: new Date(data.broadcastedAt),
+          },
+        },
+        upsert: true,
+      },
+    });
+
+    locationOps.push({
+      updateOne: {
+        filter: { name: data.name, hash: data.hash, ip: data.ip },
+        update: {
+          $set: {
+            name: data.name,
+            hash: data.hash,
+            ip: data.ip,
+            error: data.error,
+            broadcastedAt: new Date(data.broadcastedAt),
+          },
+        },
+        upsert: true,
+      },
+    });
+  }
+
+  if (signedOps.length > 0) {
+    await database.collection(appsInstallingErrorsBroadcasts).bulkWrite(signedOps, { ordered: false })
+      .catch((err) => log.error(`storeBatchAppInstallingErrorMessages signed: ${err.message}`));
+  }
+  if (locationOps.length > 0) {
+    await database.collection(globalAppsInstallingErrorsLocations).bulkWrite(locationOps, { ordered: false })
+      .catch((err) => log.error(`storeBatchAppInstallingErrorMessages locations: ${err.message}`));
+  }
+  return { stored: signedOps.length };
+}
+
 module.exports = {
   storeAppTemporaryMessage,
   storeAppPermanentMessage,
@@ -768,5 +832,7 @@ module.exports = {
   storeBatchAppInstallingMessages,
   storeAppRemovedMessage,
   storeAppInstallingErrorMessage,
+  storeSignedAppInstallingErrorBroadcast,
+  storeBatchAppInstallingErrorMessages,
   storeIPChangedMessage,
 };

--- a/ZelBack/src/services/appMessaging/messageStore.js
+++ b/ZelBack/src/services/appMessaging/messageStore.js
@@ -587,12 +587,19 @@ function storeSignedAppRunningBroadcast(signedBroadcast) {
     expireAt: new Date(validTill),
   };
   const filter = data.apps ? { ip: data.ip } : { ip: data.ip, 'data.name': data.name };
-  return dbHelper.updateOneInDatabase(
+  const upsertPromise = dbHelper.updateOneInDatabase(
     database, appsRunningBroadcasts,
     filter,
     { $set: doc },
     { upsert: true },
   ).catch((err) => log.error(`storeSignedAppRunningBroadcast: ${err.message}`));
+  if (data.apps && data.apps.length > 0) {
+    const appNames = data.apps.map((a) => a.name);
+    dbHelper.removeDocumentsFromCollection(database, appsRunningBroadcasts, {
+      ip: data.ip, 'data.name': { $nin: [null, ...appNames] },
+    }).catch((err) => log.error(`storeSignedAppRunningBroadcast cleanup: ${err.message}`));
+  }
+  return upsertPromise;
 }
 
 async function storeBatchAppRunningMessages(verifiedBroadcasts) {
@@ -672,17 +679,27 @@ async function storeBatchAppRunningMessages(verifiedBroadcasts) {
       .catch((err) => log.error(`storeBatchAppRunningMessages locations: ${err.message}`));
   }
 
-  const cleanupOps = [];
+  const locationCleanupOps = [];
+  const signedCleanupOps = [];
   for (const [ip, { names }] of v2AppsByIp) {
-    cleanupOps.push({
+    locationCleanupOps.push({
       deleteMany: {
         filter: { ip, name: { $nin: names } },
       },
     });
+    signedCleanupOps.push({
+      deleteMany: {
+        filter: { ip, 'data.name': { $nin: [null, ...names] } },
+      },
+    });
   }
-  if (cleanupOps.length > 0) {
-    await database.collection(globalAppsLocations).bulkWrite(cleanupOps, { ordered: false })
-      .catch((err) => log.error(`storeBatchAppRunningMessages cleanup: ${err.message}`));
+  if (locationCleanupOps.length > 0) {
+    await database.collection(globalAppsLocations).bulkWrite(locationCleanupOps, { ordered: false })
+      .catch((err) => log.error(`storeBatchAppRunningMessages location cleanup: ${err.message}`));
+  }
+  if (signedCleanupOps.length > 0) {
+    await database.collection(appsRunningBroadcasts).bulkWrite(signedCleanupOps, { ordered: false })
+      .catch((err) => log.error(`storeBatchAppRunningMessages signed cleanup: ${err.message}`));
   }
 
   return { stored: signedOps.length };

--- a/ZelBack/src/services/appMessaging/messageStore.js
+++ b/ZelBack/src/services/appMessaging/messageStore.js
@@ -579,10 +579,105 @@ async function storeIPChangedMessage(message) {
   return true;
 }
 
+const appsRunningBroadcasts = config.database.appsglobal.collections.appsRunningBroadcasts;
+
+function storeSignedAppRunningBroadcast(signedBroadcast) {
+  const { data } = signedBroadcast;
+  if (!data || !data.ip || !data.broadcastedAt) return;
+  const validTill = data.broadcastedAt + (125 * 60 * 1000);
+  if (validTill < Date.now()) return;
+  const db = dbHelper.databaseConnection();
+  const database = db.db(config.database.appsglobal.database);
+  const doc = {
+    ip: data.ip,
+    version: signedBroadcast.version,
+    timestamp: signedBroadcast.timestamp,
+    pubKey: signedBroadcast.pubKey,
+    signature: signedBroadcast.signature,
+    data,
+    broadcastedAt: new Date(data.broadcastedAt),
+    expireAt: new Date(validTill),
+  };
+  return dbHelper.updateOneInDatabase(
+    database, appsRunningBroadcasts,
+    { ip: data.ip },
+    { $set: doc },
+    { upsert: true },
+  ).catch((err) => log.error(`storeSignedAppRunningBroadcast: ${err.message}`));
+}
+
+async function storeBatchAppRunningMessages(verifiedBroadcasts) {
+  if (verifiedBroadcasts.length === 0) return { stored: 0 };
+  const db = dbHelper.databaseConnection();
+  const database = db.db(config.database.appsglobal.database);
+
+  const signedOps = [];
+  const locationOps = [];
+
+  for (const broadcast of verifiedBroadcasts) {
+    const { data } = broadcast;
+    const validTill = data.broadcastedAt + (125 * 60 * 1000);
+    if (validTill < Date.now()) continue;
+
+    signedOps.push({
+      updateOne: {
+        filter: { ip: data.ip },
+        update: {
+          $set: {
+            ip: data.ip,
+            version: broadcast.version,
+            timestamp: broadcast.timestamp,
+            pubKey: broadcast.pubKey,
+            signature: broadcast.signature,
+            data,
+            broadcastedAt: new Date(data.broadcastedAt),
+            expireAt: new Date(validTill),
+          },
+        },
+        upsert: true,
+      },
+    });
+
+    const apps = data.version === 2 ? (data.apps || []) : [{ name: data.name, hash: data.hash }];
+    for (const app of apps) {
+      const locationDoc = {
+        name: app.name,
+        hash: app.hash,
+        ip: data.ip,
+        broadcastedAt: new Date(data.broadcastedAt),
+        expireAt: new Date(validTill),
+        osUptime: data.osUptime,
+        staticIp: data.staticIp,
+      };
+      if (data.runningSince) locationDoc.runningSince = new Date(data.runningSince);
+      else if (app.runningSince) locationDoc.runningSince = new Date(app.runningSince);
+      locationOps.push({
+        updateOne: {
+          filter: { name: app.name, ip: data.ip },
+          update: { $set: locationDoc },
+          upsert: true,
+        },
+      });
+    }
+  }
+
+  if (signedOps.length > 0) {
+    await database.collection(appsRunningBroadcasts).bulkWrite(signedOps, { ordered: false })
+      .catch((err) => log.error(`storeBatchAppRunningMessages signed: ${err.message}`));
+  }
+  if (locationOps.length > 0) {
+    await database.collection(globalAppsLocations).bulkWrite(locationOps, { ordered: false })
+      .catch((err) => log.error(`storeBatchAppRunningMessages locations: ${err.message}`));
+  }
+  return { stored: signedOps.length };
+}
+
 module.exports = {
   storeAppTemporaryMessage,
   storeAppPermanentMessage,
   storeAppRunningMessage,
+  storeSignedAppRunningBroadcast,
+  storeBatchAppRunningMessages,
   storeAppInstallingMessage,
   storeAppRemovedMessage,
   storeAppInstallingErrorMessage,

--- a/ZelBack/src/services/appMessaging/messageStore.js
+++ b/ZelBack/src/services/appMessaging/messageStore.js
@@ -572,8 +572,8 @@ const appsRunningBroadcasts = config.database.appsglobal.collections.appsRunning
 function storeSignedAppRunningBroadcast(signedBroadcast) {
   const { data } = signedBroadcast;
   if (!data || !data.ip || !data.broadcastedAt) return;
+  if (data.broadcastedAt + (5 * 60 * 1000) < Date.now()) return;
   const validTill = data.broadcastedAt + (125 * 60 * 1000);
-  if (validTill < Date.now()) return;
   const db = dbHelper.databaseConnection();
   const database = db.db(config.database.appsglobal.database);
   const doc = {
@@ -710,8 +710,8 @@ const appsInstallingBroadcasts = config.database.appsglobal.collections.appsInst
 function storeSignedAppInstallingBroadcast(signedBroadcast) {
   const { data } = signedBroadcast;
   if (!data || !data.ip || !data.name || !data.broadcastedAt) return;
+  if (data.broadcastedAt + (5 * 60 * 1000) < Date.now()) return;
   const validTill = data.broadcastedAt + (15 * 60 * 1000);
-  if (validTill < Date.now()) return;
   const db = dbHelper.databaseConnection();
   const database = db.db(config.database.appsglobal.database);
   const doc = {
@@ -793,8 +793,8 @@ async function storeBatchAppInstallingMessages(verifiedBroadcasts) {
 function storeSignedAppInstallingErrorBroadcast(signedBroadcast) {
   const { data } = signedBroadcast;
   if (!data || !data.ip || !data.name || !data.hash || !data.broadcastedAt) return;
+  if (data.broadcastedAt + (5 * 60 * 1000) < Date.now()) return;
   const validTill = data.broadcastedAt + (24 * 60 * 60 * 1000);
-  if (validTill < Date.now()) return;
   const db = dbHelper.databaseConnection();
   const database = db.db(config.database.appsglobal.database);
   const doc = {

--- a/ZelBack/src/services/appMessaging/messageStore.js
+++ b/ZelBack/src/services/appMessaging/messageStore.js
@@ -335,6 +335,11 @@ async function storeAppRunningMessage(message) {
     await dbHelper.removeDocumentsFromCollection(database, appsInstallingBroadcasts, { 'data.name': app.name, 'data.ip': message.ip });
   }
 
+  if (message.version === 2 && appsMessages.length > 0) {
+    const appNames = appsMessages.map((a) => a.name);
+    await dbHelper.removeDocumentsFromCollection(database, globalAppsLocations, { ip: message.ip, name: { $nin: appNames } });
+  }
+
   if (messageNotOk) {
     return false;
   }
@@ -597,6 +602,7 @@ async function storeBatchAppRunningMessages(verifiedBroadcasts) {
 
   const signedOps = [];
   const locationOps = [];
+  const v2AppsByIp = new Map();
 
   for (const broadcast of verifiedBroadcasts) {
     const { data } = broadcast;
@@ -624,6 +630,12 @@ async function storeBatchAppRunningMessages(verifiedBroadcasts) {
     });
 
     const apps = data.version === 2 ? (data.apps || []) : [{ name: data.name, hash: data.hash }];
+    if (data.version === 2 && apps.length > 0) {
+      const existing = v2AppsByIp.get(data.ip);
+      if (!existing || data.broadcastedAt > existing.broadcastedAt) {
+        v2AppsByIp.set(data.ip, { names: apps.map((a) => a.name), broadcastedAt: data.broadcastedAt });
+      }
+    }
     const incomingDate = new Date(data.broadcastedAt);
     const incomingExpiry = new Date(validTill);
     const isNewer = { $gt: [incomingDate, { $ifNull: ['$broadcastedAt', new Date(0)] }] };
@@ -659,6 +671,20 @@ async function storeBatchAppRunningMessages(verifiedBroadcasts) {
     await database.collection(globalAppsLocations).bulkWrite(locationOps, { ordered: false })
       .catch((err) => log.error(`storeBatchAppRunningMessages locations: ${err.message}`));
   }
+
+  const cleanupOps = [];
+  for (const [ip, { names }] of v2AppsByIp) {
+    cleanupOps.push({
+      deleteMany: {
+        filter: { ip, name: { $nin: names } },
+      },
+    });
+  }
+  if (cleanupOps.length > 0) {
+    await database.collection(globalAppsLocations).bulkWrite(cleanupOps, { ordered: false })
+      .catch((err) => log.error(`storeBatchAppRunningMessages cleanup: ${err.message}`));
+  }
+
   return { stored: signedOps.length };
 }
 

--- a/ZelBack/src/services/appMessaging/messageStore.js
+++ b/ZelBack/src/services/appMessaging/messageStore.js
@@ -20,6 +20,11 @@ const {
 } = require('../utils/appConstants');
 const { specificationFormatter } = require('../utils/appSpecHelpers');
 
+const GOSSIP_VALIDITY_MS = 5 * 60 * 1000;
+const RUNNING_EXPIRY_MS = 125 * 60 * 1000;
+const INSTALLING_EXPIRY_MS = 15 * 60 * 1000;
+const INSTALLING_ERRORS_EXPIRY_MS = 24 * 60 * 60 * 1000;
+
 /**
  * Store temporary app message
  * @param {object} message - Message to store
@@ -263,14 +268,14 @@ async function storeAppRunningMessage(message) {
     }
   }
 
-  const validTill = message.broadcastedAt + (5 * 60 * 1000);
-  if (validTill < Date.now()) {
+  if (message.broadcastedAt + GOSSIP_VALIDITY_MS < Date.now()) {
     log.warn(`Rejecting old/not valid Fluxapprunning message, message:${JSON.stringify(message)}`);
     return { stored: false, rebroadcast: false };
   }
 
   const db = dbHelper.databaseConnection();
   const database = db.db(config.database.appsglobal.database);
+  const expireAt = new Date(message.broadcastedAt + RUNNING_EXPIRY_MS);
 
   let anyStored = false;
   for (let i = 0; i < appsMessages.length; i += 1) {
@@ -280,7 +285,7 @@ async function storeAppRunningMessage(message) {
       hash: app.hash, // hash of application specifics that are running
       ip: message.ip,
       broadcastedAt: new Date(message.broadcastedAt),
-      expireAt: new Date(validTill),
+      expireAt,
       osUptime: message.osUptime,
       staticIp: message.staticIp,
     };
@@ -312,12 +317,13 @@ async function storeAppRunningMessage(message) {
   }
 
   if (message.version === 2 && appsMessages.length === 0) {
-    const queryFind = { ip: message.ip };
-    const projection = { _id: 0, runningSince: 1 };
-    const result = await dbHelper.findInDatabase(database, globalAppsLocations, queryFind, projection);
+    const result = await dbHelper.findInDatabase(database, globalAppsLocations, { ip: message.ip }, { _id: 0, runningSince: 1 });
     if (result.length > 0) {
-      await dbHelper.removeDocumentsFromCollection(database, globalAppsLocations, queryFind);
-      await dbHelper.removeDocumentsFromCollection(database, globalAppsInstallingLocations, queryFind);
+      const broadcastDate = new Date(message.broadcastedAt);
+      const olderThanBroadcast = { ip: message.ip, broadcastedAt: { $lte: broadcastDate } };
+      await dbHelper.removeDocumentsFromCollection(database, globalAppsLocations, olderThanBroadcast);
+      await dbHelper.removeDocumentsFromCollection(database, appsRunningBroadcasts, olderThanBroadcast);
+      await dbHelper.removeDocumentsFromCollection(database, globalAppsInstallingLocations, { ip: message.ip });
       await dbHelper.removeDocumentsFromCollection(database, appsInstallingBroadcasts, { 'data.ip': message.ip });
       anyStored = true;
     } else {
@@ -358,10 +364,8 @@ async function storeAppInstallingMessage(message) {
     return new Error(`Invalid Flux App Installing message for storing version ${message.version} not supported`);
   }
 
-  const validTill = message.broadcastedAt + (5 * 60 * 1000); // 5 minutes
-  if (validTill < Date.now()) {
+  if (message.broadcastedAt + GOSSIP_VALIDITY_MS < Date.now()) {
     log.warn(`Rejecting old/not valid fluxappinstalling message, message:${JSON.stringify(message)}`);
-    // reject old message
     return false;
   }
 
@@ -372,7 +376,7 @@ async function storeAppInstallingMessage(message) {
     name: message.name,
     ip: message.ip,
     broadcastedAt: new Date(message.broadcastedAt),
-    expireAt: new Date(validTill),
+    expireAt: new Date(message.broadcastedAt + INSTALLING_EXPIRY_MS),
   };
 
   // indexes over name, hash, ip. Then name + ip and name + ip + broadcastedAt.
@@ -472,8 +476,7 @@ async function storeAppInstallingErrorMessage(message) {
     return new Error(`Invalid Flux App Installing Error message for storing version ${message.version} not supported`);
   }
 
-  const validTill = message.broadcastedAt + (5 * 60 * 1000);
-  if (validTill < Date.now()) {
+  if (message.broadcastedAt + GOSSIP_VALIDITY_MS < Date.now()) {
     log.warn(`Rejecting old/not valid fluxappinstallingerror message, message:${JSON.stringify(message)}`);
     return false;
   }
@@ -487,6 +490,7 @@ async function storeAppInstallingErrorMessage(message) {
     ip: message.ip,
     error: message.error,
     broadcastedAt: new Date(message.broadcastedAt),
+    expireAt: new Date(message.broadcastedAt + INSTALLING_ERRORS_EXPIRY_MS),
   };
 
   const queryFind = { name: newAppInstallingErrorMessage.name, hash: newAppInstallingErrorMessage.hash, ip: newAppInstallingErrorMessage.ip };
@@ -560,8 +564,7 @@ const appsRunningBroadcasts = config.database.appsglobal.collections.appsRunning
 function storeSignedAppRunningBroadcast(signedBroadcast) {
   const { data } = signedBroadcast;
   if (!data || !data.ip || !data.broadcastedAt) return;
-  const validTill = data.broadcastedAt + (125 * 60 * 1000);
-  if (validTill < Date.now()) return;
+  if (data.broadcastedAt + RUNNING_EXPIRY_MS < Date.now()) return;
   const db = dbHelper.databaseConnection();
   const database = db.db(config.database.appsglobal.database);
   const doc = {
@@ -572,7 +575,7 @@ function storeSignedAppRunningBroadcast(signedBroadcast) {
     signature: signedBroadcast.signature,
     data,
     broadcastedAt: new Date(data.broadcastedAt),
-    expireAt: new Date(validTill),
+    expireAt: new Date(data.broadcastedAt + RUNNING_EXPIRY_MS),
   };
   const filter = data.apps ? { ip: data.ip } : { ip: data.ip, 'data.name': data.name };
   return dbHelper.updateOneInDatabase(
@@ -594,7 +597,7 @@ async function storeBatchAppRunningMessages(verifiedBroadcasts) {
 
   for (const broadcast of verifiedBroadcasts) {
     const { data } = broadcast;
-    const validTill = data.broadcastedAt + (125 * 60 * 1000);
+    const validTill = data.broadcastedAt + RUNNING_EXPIRY_MS;
     if (validTill < Date.now()) continue;
 
     const filter = data.apps ? { ip: data.ip } : { ip: data.ip, 'data.name': data.name };
@@ -682,8 +685,7 @@ const appsInstallingBroadcasts = config.database.appsglobal.collections.appsInst
 function storeSignedAppInstallingBroadcast(signedBroadcast) {
   const { data } = signedBroadcast;
   if (!data || !data.ip || !data.name || !data.broadcastedAt) return;
-  if (data.broadcastedAt + (5 * 60 * 1000) < Date.now()) return;
-  const validTill = data.broadcastedAt + (15 * 60 * 1000);
+  if (data.broadcastedAt + INSTALLING_EXPIRY_MS < Date.now()) return;
   const db = dbHelper.databaseConnection();
   const database = db.db(config.database.appsglobal.database);
   const doc = {
@@ -693,7 +695,7 @@ function storeSignedAppInstallingBroadcast(signedBroadcast) {
     signature: signedBroadcast.signature,
     data,
     broadcastedAt: new Date(data.broadcastedAt),
-    expireAt: new Date(validTill),
+    expireAt: new Date(data.broadcastedAt + INSTALLING_EXPIRY_MS),
   };
   return dbHelper.updateOneInDatabase(
     database, appsInstallingBroadcasts,
@@ -713,7 +715,7 @@ async function storeBatchAppInstallingMessages(verifiedBroadcasts) {
 
   for (const broadcast of verifiedBroadcasts) {
     const { data } = broadcast;
-    const validTill = data.broadcastedAt + (15 * 60 * 1000);
+    const validTill = data.broadcastedAt + INSTALLING_EXPIRY_MS;
     if (validTill < Date.now()) continue;
 
     signedOps.push({
@@ -765,8 +767,7 @@ async function storeBatchAppInstallingMessages(verifiedBroadcasts) {
 function storeSignedAppInstallingErrorBroadcast(signedBroadcast) {
   const { data } = signedBroadcast;
   if (!data || !data.ip || !data.name || !data.hash || !data.broadcastedAt) return;
-  if (data.broadcastedAt + (5 * 60 * 1000) < Date.now()) return;
-  const validTill = data.broadcastedAt + (24 * 60 * 60 * 1000);
+  if (data.broadcastedAt + INSTALLING_ERRORS_EXPIRY_MS < Date.now()) return;
   const db = dbHelper.databaseConnection();
   const database = db.db(config.database.appsglobal.database);
   const doc = {
@@ -776,6 +777,7 @@ function storeSignedAppInstallingErrorBroadcast(signedBroadcast) {
     signature: signedBroadcast.signature,
     data,
     broadcastedAt: new Date(data.broadcastedAt),
+    expireAt: new Date(data.broadcastedAt + INSTALLING_ERRORS_EXPIRY_MS),
   };
   return dbHelper.updateOneInDatabase(
     database, globalAppsInstallingErrorsBroadcasts,
@@ -795,8 +797,11 @@ async function storeBatchAppInstallingErrorMessages(verifiedBroadcasts) {
 
   for (const broadcast of verifiedBroadcasts) {
     const { data } = broadcast;
-    const validTill = data.broadcastedAt + (24 * 60 * 60 * 1000);
+    const validTill = data.broadcastedAt + INSTALLING_ERRORS_EXPIRY_MS;
     if (validTill < Date.now()) continue;
+
+    const incomingDate = new Date(data.broadcastedAt);
+    const incomingExpiry = new Date(validTill);
 
     signedOps.push({
       updateOne: {
@@ -808,14 +813,14 @@ async function storeBatchAppInstallingErrorMessages(verifiedBroadcasts) {
             pubKey: broadcast.pubKey,
             signature: broadcast.signature,
             data,
-            broadcastedAt: new Date(data.broadcastedAt),
+            broadcastedAt: incomingDate,
+            expireAt: incomingExpiry,
           },
         },
         upsert: true,
       },
     });
 
-    const incomingDate = new Date(data.broadcastedAt);
     const isNewer = { $gt: [incomingDate, { $ifNull: ['$broadcastedAt', new Date(0)] }] };
     locationOps.push({
       updateOne: {
@@ -826,6 +831,7 @@ async function storeBatchAppInstallingErrorMessages(verifiedBroadcasts) {
           ip: data.ip,
           error: { $cond: [isNewer, data.error, { $ifNull: ['$error', data.error] }] },
           broadcastedAt: { $cond: [isNewer, incomingDate, '$broadcastedAt'] },
+          expireAt: { $cond: [isNewer, incomingExpiry, '$expireAt'] },
         } }],
         upsert: true,
       },

--- a/ZelBack/src/services/appMessaging/messageStore.js
+++ b/ZelBack/src/services/appMessaging/messageStore.js
@@ -71,6 +71,8 @@ async function storeAppTemporaryMessage(message, options = {}) {
       _id: 0,
       message: 1,
       height: 1,
+      txid: 1,
+      value: 1,
     },
   };
   let database = db.db(config.database.daemon.database);
@@ -166,7 +168,12 @@ async function storeAppTemporaryMessage(message, options = {}) {
   });
   // it is stored and rebroadcasted
   if (isAppRequested) {
-    // node received the message but it is coming from a requestappmessage we should not rebroadcast to all peers
+    if (result && result.txid && result.height) {
+      setImmediate(() => {
+        messageVerifier.checkAndRequestApp(message.hash, result.txid, result.height, result.value, 2)
+          .catch((err) => log.error(`Immediate promotion failed for ${message.hash}: ${err.message}`));
+      });
+    }
     return false;
   }
   return true;

--- a/ZelBack/src/services/appMessaging/messageStore.js
+++ b/ZelBack/src/services/appMessaging/messageStore.js
@@ -15,6 +15,7 @@ const {
   globalAppsLocations,
   globalAppsInstallingLocations,
   globalAppsInstallingErrorsLocations,
+  globalAppsInstallingErrorsBroadcasts,
   appsHashesCollection,
 } = require('../utils/appConstants');
 const { specificationFormatter } = require('../utils/appSpecHelpers');
@@ -738,8 +739,6 @@ async function storeBatchAppInstallingMessages(verifiedBroadcasts) {
   return { stored: signedOps.length };
 }
 
-const appsInstallingErrorsBroadcasts = config.database.appsglobal.collections.appsInstallingErrorsBroadcasts;
-
 function storeSignedAppInstallingErrorBroadcast(signedBroadcast) {
   const { data } = signedBroadcast;
   if (!data || !data.ip || !data.name || !data.hash || !data.broadcastedAt) return;
@@ -756,7 +755,7 @@ function storeSignedAppInstallingErrorBroadcast(signedBroadcast) {
     broadcastedAt: new Date(data.broadcastedAt),
   };
   return dbHelper.updateOneInDatabase(
-    database, appsInstallingErrorsBroadcasts,
+    database, globalAppsInstallingErrorsBroadcasts,
     { 'data.name': data.name, 'data.hash': data.hash, 'data.ip': data.ip },
     { $set: doc },
     { upsert: true },
@@ -811,7 +810,7 @@ async function storeBatchAppInstallingErrorMessages(verifiedBroadcasts) {
   }
 
   if (signedOps.length > 0) {
-    await database.collection(appsInstallingErrorsBroadcasts).bulkWrite(signedOps, { ordered: false })
+    await database.collection(globalAppsInstallingErrorsBroadcasts).bulkWrite(signedOps, { ordered: false })
       .catch((err) => log.error(`storeBatchAppInstallingErrorMessages signed: ${err.message}`));
   }
   if (locationOps.length > 0) {

--- a/ZelBack/src/services/appMessaging/messageStore.js
+++ b/ZelBack/src/services/appMessaging/messageStore.js
@@ -266,14 +266,13 @@ async function storeAppRunningMessage(message) {
   const validTill = message.broadcastedAt + (5 * 60 * 1000);
   if (validTill < Date.now()) {
     log.warn(`Rejecting old/not valid Fluxapprunning message, message:${JSON.stringify(message)}`);
-    // reject old message
-    return false;
+    return { stored: false, rebroadcast: false };
   }
 
   const db = dbHelper.databaseConnection();
   const database = db.db(config.database.appsglobal.database);
 
-  let messageNotOk = false;
+  let anyStored = false;
   for (let i = 0; i < appsMessages.length; i += 1) {
     const app = appsMessages[i];
     const newAppRunningMessage = {
@@ -289,13 +288,11 @@ async function storeAppRunningMessage(message) {
     // indexes over name, hash, ip. Then name + ip and name + ip + broadcastedAt.
     const queryFind = { name: newAppRunningMessage.name, ip: newAppRunningMessage.ip };
     const projection = { _id: 0, runningSince: 1, broadcastedAt: 1 };
-    // we already have the exact same data
     // eslint-disable-next-line no-await-in-loop
     const result = await dbHelper.findOneInDatabase(database, globalAppsLocations, queryFind, projection);
     if (result && result.broadcastedAt && result.broadcastedAt >= newAppRunningMessage.broadcastedAt) {
-      // found a message that was already stored/probably from duplicated message processsed
-      messageNotOk = true;
-      break;
+      // eslint-disable-next-line no-continue
+      continue;
     }
     if (message.runningSince) {
       newAppRunningMessage.runningSince = new Date(message.runningSince);
@@ -311,19 +308,20 @@ async function storeAppRunningMessage(message) {
     };
     // eslint-disable-next-line no-await-in-loop
     await dbHelper.updateOneInDatabase(database, globalAppsLocations, queryUpdate, update, options);
+    anyStored = true;
   }
 
   if (message.version === 2 && appsMessages.length === 0) {
     const queryFind = { ip: message.ip };
     const projection = { _id: 0, runningSince: 1 };
-    // we already have the exact same data
     const result = await dbHelper.findInDatabase(database, globalAppsLocations, queryFind, projection);
     if (result.length > 0) {
       await dbHelper.removeDocumentsFromCollection(database, globalAppsLocations, queryFind);
       await dbHelper.removeDocumentsFromCollection(database, globalAppsInstallingLocations, queryFind);
       await dbHelper.removeDocumentsFromCollection(database, appsInstallingBroadcasts, { 'data.ip': message.ip });
+      anyStored = true;
     } else {
-      return false;
+      return { stored: false, rebroadcast: false };
     }
   }
 
@@ -335,12 +333,7 @@ async function storeAppRunningMessage(message) {
     await dbHelper.removeDocumentsFromCollection(database, appsInstallingBroadcasts, { 'data.name': app.name, 'data.ip': message.ip });
   }
 
-  if (messageNotOk) {
-    return false;
-  }
-
-  // all stored, rebroadcast
-  return true;
+  return { stored: anyStored, rebroadcast: anyStored };
 }
 
 /**
@@ -567,8 +560,8 @@ const appsRunningBroadcasts = config.database.appsglobal.collections.appsRunning
 function storeSignedAppRunningBroadcast(signedBroadcast) {
   const { data } = signedBroadcast;
   if (!data || !data.ip || !data.broadcastedAt) return;
-  if (data.broadcastedAt + (5 * 60 * 1000) < Date.now()) return;
   const validTill = data.broadcastedAt + (125 * 60 * 1000);
+  if (validTill < Date.now()) return;
   const db = dbHelper.databaseConnection();
   const database = db.db(config.database.appsglobal.database);
   const doc = {

--- a/ZelBack/src/services/appMessaging/messageStore.js
+++ b/ZelBack/src/services/appMessaging/messageStore.js
@@ -672,6 +672,90 @@ async function storeBatchAppRunningMessages(verifiedBroadcasts) {
   return { stored: signedOps.length };
 }
 
+const appsInstallingBroadcasts = config.database.appsglobal.collections.appsInstallingBroadcasts;
+
+function storeSignedAppInstallingBroadcast(signedBroadcast) {
+  const { data } = signedBroadcast;
+  if (!data || !data.ip || !data.name || !data.broadcastedAt) return;
+  const validTill = data.broadcastedAt + (5 * 60 * 1000);
+  if (validTill < Date.now()) return;
+  const db = dbHelper.databaseConnection();
+  const database = db.db(config.database.appsglobal.database);
+  const doc = {
+    version: signedBroadcast.version,
+    timestamp: signedBroadcast.timestamp,
+    pubKey: signedBroadcast.pubKey,
+    signature: signedBroadcast.signature,
+    data,
+    broadcastedAt: new Date(data.broadcastedAt),
+    expireAt: new Date(validTill),
+  };
+  return dbHelper.updateOneInDatabase(
+    database, appsInstallingBroadcasts,
+    { 'data.name': data.name, 'data.ip': data.ip },
+    { $set: doc },
+    { upsert: true },
+  ).catch((err) => log.error(`storeSignedAppInstallingBroadcast: ${err.message}`));
+}
+
+async function storeBatchAppInstallingMessages(verifiedBroadcasts) {
+  if (verifiedBroadcasts.length === 0) return { stored: 0 };
+  const db = dbHelper.databaseConnection();
+  const database = db.db(config.database.appsglobal.database);
+
+  const signedOps = [];
+  const locationOps = [];
+
+  for (const broadcast of verifiedBroadcasts) {
+    const { data } = broadcast;
+    const validTill = data.broadcastedAt + (5 * 60 * 1000);
+    if (validTill < Date.now()) continue;
+
+    signedOps.push({
+      updateOne: {
+        filter: { 'data.name': data.name, 'data.ip': data.ip },
+        update: {
+          $set: {
+            version: broadcast.version,
+            timestamp: broadcast.timestamp,
+            pubKey: broadcast.pubKey,
+            signature: broadcast.signature,
+            data,
+            broadcastedAt: new Date(data.broadcastedAt),
+            expireAt: new Date(validTill),
+          },
+        },
+        upsert: true,
+      },
+    });
+
+    locationOps.push({
+      updateOne: {
+        filter: { name: data.name, ip: data.ip },
+        update: {
+          $set: {
+            name: data.name,
+            ip: data.ip,
+            broadcastedAt: new Date(data.broadcastedAt),
+            expireAt: new Date(validTill),
+          },
+        },
+        upsert: true,
+      },
+    });
+  }
+
+  if (signedOps.length > 0) {
+    await database.collection(appsInstallingBroadcasts).bulkWrite(signedOps, { ordered: false })
+      .catch((err) => log.error(`storeBatchAppInstallingMessages signed: ${err.message}`));
+  }
+  if (locationOps.length > 0) {
+    await database.collection(globalAppsInstallingLocations).bulkWrite(locationOps, { ordered: false })
+      .catch((err) => log.error(`storeBatchAppInstallingMessages locations: ${err.message}`));
+  }
+  return { stored: signedOps.length };
+}
+
 module.exports = {
   storeAppTemporaryMessage,
   storeAppPermanentMessage,
@@ -679,6 +763,8 @@ module.exports = {
   storeSignedAppRunningBroadcast,
   storeBatchAppRunningMessages,
   storeAppInstallingMessage,
+  storeSignedAppInstallingBroadcast,
+  storeBatchAppInstallingMessages,
   storeAppRemovedMessage,
   storeAppInstallingErrorMessage,
   storeIPChangedMessage,

--- a/ZelBack/src/services/appMessaging/messageStore.js
+++ b/ZelBack/src/services/appMessaging/messageStore.js
@@ -319,18 +319,19 @@ async function storeAppRunningMessage(message) {
     const result = await dbHelper.findInDatabase(database, globalAppsLocations, queryFind, projection);
     if (result.length > 0) {
       await dbHelper.removeDocumentsFromCollection(database, globalAppsLocations, queryFind);
-      // also clean up any installing records for this IP
       await dbHelper.removeDocumentsFromCollection(database, globalAppsInstallingLocations, queryFind);
+      await dbHelper.removeDocumentsFromCollection(database, appsInstallingBroadcasts, { 'data.ip': message.ip });
     } else {
       return false;
     }
   }
 
-  // clean up installing records for all apps that are now running
   for (const app of appsMessages) {
     const queryFind = { name: app.name, ip: message.ip };
     // eslint-disable-next-line no-await-in-loop
     await dbHelper.removeDocumentsFromCollection(database, globalAppsInstallingLocations, queryFind);
+    // eslint-disable-next-line no-await-in-loop
+    await dbHelper.removeDocumentsFromCollection(database, appsInstallingBroadcasts, { 'data.name': app.name, 'data.ip': message.ip });
   }
 
   if (messageNotOk) {

--- a/ZelBack/src/services/appMessaging/messageStore.js
+++ b/ZelBack/src/services/appMessaging/messageStore.js
@@ -448,10 +448,11 @@ async function storeAppRemovedMessage(message) {
   await dbHelper.findOneAndDeleteInDatabase(database, globalAppsLocations, query, projection);
 
   await dbHelper.removeDocumentsFromCollection(database, appsRunningBroadcasts, { ip: message.ip, 'data.name': message.appName });
-  const remaining = await dbHelper.countInDatabase(database, globalAppsLocations, { ip: message.ip });
-  if (remaining === 0) {
-    await dbHelper.removeDocumentsFromCollection(database, appsRunningBroadcasts, { ip: message.ip });
-  }
+  await dbHelper.updateOneInDatabase(
+    database, appsRunningBroadcasts,
+    { ip: message.ip, 'data.apps': { $exists: true } },
+    { $addToSet: { excludedApps: message.appName } },
+  ).catch(() => {});
 
   // all stored, rebroadcast
   return true;
@@ -587,7 +588,7 @@ function storeSignedAppRunningBroadcast(signedBroadcast) {
   return dbHelper.updateOneInDatabase(
     database, appsRunningBroadcasts,
     filter,
-    { $set: doc },
+    { $set: doc, $unset: { excludedApps: '' } },
     { upsert: true },
   ).catch((err) => log.error(`storeSignedAppRunningBroadcast: ${err.message}`));
 }
@@ -621,6 +622,7 @@ async function storeBatchAppRunningMessages(verifiedBroadcasts) {
             broadcastedAt: new Date(data.broadcastedAt),
             expireAt: new Date(validTill),
           },
+          $unset: { excludedApps: '' },
         },
         upsert: true,
       },

--- a/ZelBack/src/services/appMessaging/messageStore.js
+++ b/ZelBack/src/services/appMessaging/messageStore.js
@@ -447,6 +447,12 @@ async function storeAppRemovedMessage(message) {
   const projection = {};
   await dbHelper.findOneAndDeleteInDatabase(database, globalAppsLocations, query, projection);
 
+  await dbHelper.removeDocumentsFromCollection(database, appsRunningBroadcasts, { ip: message.ip, 'data.name': message.appName });
+  const remaining = await dbHelper.countInDatabase(database, globalAppsLocations, { ip: message.ip });
+  if (remaining === 0) {
+    await dbHelper.removeDocumentsFromCollection(database, appsRunningBroadcasts, { ip: message.ip });
+  }
+
   // all stored, rebroadcast
   return true;
 }

--- a/ZelBack/src/services/appMessaging/messageVerifier.js
+++ b/ZelBack/src/services/appMessaging/messageVerifier.js
@@ -26,13 +26,8 @@ const {
   globalAppsInformation,
   localAppsInformation,
 } = require('../utils/appConstants');
-const { invalidMessages } = require('../invalidMessages');
 const fluxNetworkHelper = require('../fluxNetworkHelper');
 const globalState = require('../utils/globalState');
-
-// Import hashesNumberOfSearchs from appsService - this should be shared state
-// For now, we'll create a local instance, but ideally this should be moved to globalState
-const hashesNumberOfSearchs = new Map();
 
 /**
  * Verify app hash against message content
@@ -862,11 +857,6 @@ async function checkAndRequestApp(hash, txid, height, valueSat, i = 0) {
       }
 
       if (i < 2) {
-      // request the message and broadcast the message further to our connected peers.
-      // rerun this after 1 min delay
-      // We ask to the connected nodes 2 times in 1 minute interval for the app message, if connected nodes don't
-      // have the app message we will ask for it again when continuousFluxAppHashesCheck executes again.
-      // in total we ask to the connected nodes 10 (30m interval) x 2 (1m interval) = 20 times before apphash is marked as not found
         await requestAppMessage(hash);
         await serviceHelper.delay(60 * 1000);
         return checkAndRequestApp(hash, txid, height, valueSat, i + 1);
@@ -919,159 +909,6 @@ async function checkAndRequestMultipleApps(apps, incoming = false, i = 1) {
   }
 }
 
-// Global variables for continuousFluxAppHashesCheck
-let continuousFluxAppHashesCheckRunning = false;
-let firstContinuousFluxAppHashesCheckRun = true;
-
-/**
- * Continuously checks for missing flux app hashes and requests missing messages
- * @param {boolean} force - Force check even if already running
- * @returns {Promise<void>}
- */
-async function continuousFluxAppHashesCheck(force = false) {
-  try {
-    if (continuousFluxAppHashesCheckRunning) {
-      return;
-    }
-    log.info('Requesting missing Flux App messages');
-    continuousFluxAppHashesCheckRunning = true;
-    const numberOfPeers = fluxNetworkHelper.getNumberOfPeers();
-    if (numberOfPeers < 12) {
-      log.info('Not enough connected peers to request missing Flux App messages');
-      continuousFluxAppHashesCheckRunning = false;
-      return;
-    }
-
-    const synced = await generalService.checkSynced();
-    if (synced !== true) {
-      log.info('Flux not yet synced');
-      continuousFluxAppHashesCheckRunning = false;
-      return;
-    }
-
-    if (firstContinuousFluxAppHashesCheckRun && !globalState.checkAndSyncAppHashesWasEverExecuted) {
-      // Import checkAndSyncAppHashes from appHashSyncService
-      // eslint-disable-next-line global-require
-      const appHashSyncService = require('./appHashSyncService');
-      await appHashSyncService.checkAndSyncAppHashes();
-    }
-
-    const dbopen = dbHelper.databaseConnection();
-    const database = dbopen.db(config.database.daemon.database);
-    const queryHeight = { generalScannedHeight: { $gte: 0 } };
-    const projectionHeight = {
-      projection: {
-        _id: 0,
-        generalScannedHeight: 1,
-      },
-    };
-    const scanHeight = await dbHelper.findOneInDatabase(database, scannedHeightCollection, queryHeight, projectionHeight);
-    if (!scanHeight) {
-      throw new Error('Scanning not initiated');
-    }
-    const explorerHeight = serviceHelper.ensureNumber(scanHeight.generalScannedHeight);
-
-    // get flux app hashes that do not have a message
-    const query = { message: false };
-    const projection = {
-      projection: {
-        _id: 0,
-        txid: 1,
-        hash: 1,
-        height: 1,
-        value: 1,
-        message: 1,
-        messageNotFound: 1,
-      },
-    };
-    const results = await dbHelper.findInDatabase(database, appsHashesCollection, query, projection);
-    // sort it by height, so we request oldest messages first
-    results.sort((a, b) => a.height - b.height);
-    let appsMessagesMissing = [];
-    // eslint-disable-next-line no-restricted-syntax
-    for (const result of results) {
-      if (!result.messageNotFound || force || firstContinuousFluxAppHashesCheckRun) { // most likely wrong data, if no message found. This attribute is cleaned every reconstructAppMessagesHashPeriod blocks so all nodes search again for missing messages
-        let heightDifference = explorerHeight - result.height;
-        if (heightDifference < 0) {
-          heightDifference = 0;
-        }
-        let maturity = Math.round(heightDifference / config.fluxapps.blocksLasting);
-        if (maturity > 12) {
-          maturity = 16; // maturity of max 16 representing its older than 1 year. Old messages will only be searched 3 times, newer messages more oftenly
-        }
-        if (invalidMessages.find((message) => message.hash === result.hash && message.txid === result.txid)) {
-          if (!force) {
-            maturity = 30; // do not request known invalid messages.
-          }
-        }
-        // every config.fluxapps.blocksLasting increment maturity by 2;
-        let numberOfSearches = maturity;
-        if (hashesNumberOfSearchs.has(result.hash)) {
-          numberOfSearches = hashesNumberOfSearchs.get(result.hash) + 2; // max 10 tries
-        }
-        hashesNumberOfSearchs.set(result.hash, numberOfSearches);
-        log.info(`Requesting missing Flux App message: ${result.hash}, ${result.txid}, ${result.height}`);
-        if (numberOfSearches <= 20) { // up to 10 searches
-          const appMessageInformation = {
-            hash: result.hash,
-            txid: result.txid,
-            height: result.height,
-            value: result.value,
-          };
-          appsMessagesMissing.push(appMessageInformation);
-          if (appsMessagesMissing.length === 500) {
-            log.info('Requesting 500 app messages');
-            checkAndRequestMultipleApps(appsMessagesMissing);
-            // eslint-disable-next-line no-await-in-loop
-            await serviceHelper.delay(2 * 60 * 1000); // delay 2 minutes to give enough time to process all messages received
-            appsMessagesMissing = [];
-          }
-        } else {
-          // eslint-disable-next-line no-await-in-loop
-          await appHashHasMessageNotFound(result.hash); // mark message as not found
-          hashesNumberOfSearchs.delete(result.hash); // remove from our map
-        }
-      }
-    }
-    if (appsMessagesMissing.length > 0) {
-      log.info(`Requesting ${appsMessagesMissing.length} app messages`);
-      checkAndRequestMultipleApps(appsMessagesMissing);
-    }
-    continuousFluxAppHashesCheckRunning = false;
-    firstContinuousFluxAppHashesCheckRun = false;
-  } catch (error) {
-    log.error(error);
-    continuousFluxAppHashesCheckRunning = false;
-    firstContinuousFluxAppHashesCheckRun = false;
-  }
-}
-
-/**
- * API endpoint to manually trigger app hashes check
- * @param {object} req - Request object
- * @param {object} res - Response object
- * @returns {Promise<void>}
- */
-async function triggerAppHashesCheckAPI(req, res) {
-  try {
-    // only flux team and node owner can do this
-    const authorized = await verificationHelper.verifyPrivilege('adminandfluxteam', req);
-    if (!authorized) {
-      const errMessage = messageHelper.errUnauthorizedMessage();
-      res.json(errMessage);
-      return;
-    }
-
-    continuousFluxAppHashesCheck(true);
-    const resultsResponse = messageHelper.createSuccessMessage('Running check on missing application messages ');
-    res.json(resultsResponse);
-  } catch (error) {
-    log.error(error);
-    const errMessage = messageHelper.createErrorMessage(error.message, error.name, error.code);
-    res.json(errMessage);
-  }
-}
-
 module.exports = {
   verifyAppHash,
   verifyAppMessageSignature,
@@ -1088,6 +925,4 @@ module.exports = {
   getAppsPermanentMessages,
   checkAndRequestApp,
   checkAndRequestMultipleApps,
-  continuousFluxAppHashesCheck,
-  triggerAppHashesCheckAPI,
 };

--- a/ZelBack/src/services/appMessaging/peerNotification.js
+++ b/ZelBack/src/services/appMessaging/peerNotification.js
@@ -322,77 +322,34 @@ async function checkAndNotifyPeersOfRunningApps() {
         const queryFind = { name: application.name, ip: myIP };
         const projection = { _id: 0, runningSince: 1 };
         let runningOnMyNodeSince = new Date().toISOString();
-        // we already have the exact same data
         // eslint-disable-next-line no-await-in-loop
         const result = await dbHelper.findOneInDatabase(database, globalAppsLocations, queryFind, projection);
         if (result && result.runningSince) {
           runningOnMyNodeSince = result.runningSince;
         }
         log.info(`${application.name} is running/installed properly. Broadcasting status.`);
-        // eslint-disable-next-line no-await-in-loop
-        // we can distinguish pure local apps from global with hash and height
-        const newAppRunningMessage = {
-          type: 'fluxapprunning',
-          version: 1,
-          name: application.name,
-          hash: application.hash, // hash of application specifics that are running
-          ip: myIP,
-          broadcastedAt: Date.now(),
-          runningSince: runningOnMyNodeSince,
-          osUptime: os.uptime(),
-          staticIp: geolocationService.isStaticIP(),
-        };
-        const app = {
+        apps.push({
           name: application.name,
           hash: application.hash,
           runningSince: runningOnMyNodeSince,
-        };
-        apps.push(app);
-        // store it in local database first
-        // eslint-disable-next-line no-await-in-loop
-        await messageStore.storeAppRunningMessage(newAppRunningMessage);
-        if (installedAndRunning.length === 1) {
-          // eslint-disable-next-line no-await-in-loop
-          await fluxCommunicationMessagesSender.broadcastMessageToAll(newAppRunningMessage);
-          // broadcast messages about running apps to all peers
-          log.info(`App Running Message broadcasted ${JSON.stringify(newAppRunningMessage)}`);
-        }
+        });
       }
-      if (installedAndRunning.length > 1) {
-        // send v2 unique message instead
-        const newAppRunningMessageV2 = {
-          type: 'fluxapprunning',
-          version: 2,
-          apps,
-          ip: myIP,
-          broadcastedAt: Date.now(),
-          osUptime: os.uptime(),
-          staticIp: geolocationService.isStaticIP(),
-        };
-        // eslint-disable-next-line no-await-in-loop
-        await fluxCommunicationMessagesSender.broadcastMessageToAll(newAppRunningMessageV2);
-        // broadcast messages about running apps to all peers
-        log.info(`App Running Message broadcasted ${JSON.stringify(newAppRunningMessageV2)}`);
-      } else if (installedAndRunning.length === 0 && checkAndNotifyPeersOfRunningAppsFirstRun) {
-        checkAndNotifyPeersOfRunningAppsFirstRun = false;
-        // we will broadcast a message that we are not running any app
-        // if multitoolbox option to reinstall fluxos or fix mongodb is executed all apps are removed from the node, once the node starts and it's confirmed
-        // should broadcast to the network what is running or not
-        // the nodes who receive the message will only rebroadcast if they had information about a app running on this node
-        const newAppRunningMessageV2 = {
-          type: 'fluxapprunning',
-          version: 2,
-          apps,
-          ip: myIP,
-          broadcastedAt: Date.now(),
-          osUptime: os.uptime(),
-          staticIp: geolocationService.isStaticIP(),
-        };
-        // eslint-disable-next-line no-await-in-loop
-        await fluxCommunicationMessagesSender.broadcastMessageToAll(newAppRunningMessageV2);
-        // broadcast messages about running apps to all peers
-        log.info(`No Apps Running Message broadcasted ${JSON.stringify(newAppRunningMessageV2)}`);
+      if (apps.length === 0 && !checkAndNotifyPeersOfRunningAppsFirstRun) {
+        return;
       }
+      checkAndNotifyPeersOfRunningAppsFirstRun = false;
+      const appRunningMessage = {
+        type: 'fluxapprunning',
+        version: 2,
+        apps,
+        ip: myIP,
+        broadcastedAt: Date.now(),
+        osUptime: os.uptime(),
+        staticIp: geolocationService.isStaticIP(),
+      };
+      await messageStore.storeAppRunningMessage(appRunningMessage);
+      await fluxCommunicationMessagesSender.broadcastMessageToAll(appRunningMessage);
+      log.info(`App Running Message broadcasted: ${apps.length} apps`);
     } catch (err) {
       log.error(err);
       // removeAppLocally(stoppedApp);

--- a/ZelBack/src/services/appMessaging/peerNotification.js
+++ b/ZelBack/src/services/appMessaging/peerNotification.js
@@ -1,147 +1,44 @@
-// Peer Notification Service - Manages broadcasting of running apps to network peers
 const os = require('os');
 const config = require('config');
 const dbHelper = require('../dbHelper');
-const dockerService = require('../dockerService');
-const serviceHelper = require('../serviceHelper');
 const generalService = require('../generalService');
 const benchmarkService = require('../benchmarkService');
 const geolocationService = require('../geolocationService');
 const fluxCommunicationMessagesSender = require('../fluxCommunicationMessagesSender');
 const messageStore = require('./messageStore');
-const registryManager = require('../appDatabase/registryManager');
-const appInspector = require('../appManagement/appInspector');
-const appUninstaller = require('../appLifecycle/appUninstaller');
-const appInstaller = require('../appLifecycle/appInstaller');
 const { decryptEnterpriseApps } = require('../appQuery/appQueryService');
-const { localAppsInformation } = require('../utils/appConstants');
 const log = require('../../lib/log');
 const globalState = require('../utils/globalState');
 const appQueryService = require('../appQuery/appQueryService');
-const cacheManager = require('../utils/cacheManager').default;
-const appTamperingDetectionService = require('../appTamperingDetectionService');
+const stoppedAppsRecovery = require('../appLifecycle/stoppedAppsRecovery');
 
-// Database collections
 const globalAppsLocations = config.database.appsglobal.collections.appsLocations;
 
-// Module-level state variable
 let checkAndNotifyPeersOfRunningAppsFirstRun = true;
+let broadcastInterval = null;
 
-/**
- * Recreate containers for app that exists in DB but has missing containers
- * @param {string} componentIdentifier - Component identifier (component_appname or appname)
- * @returns {Promise<void>}
- */
-async function recreateMissingContainers(componentIdentifier) {
-  const mainAppName = componentIdentifier.split('_')[1] || componentIdentifier;
-  const dbopen = dbHelper.databaseConnection();
-  const appsDatabase = dbopen.db(config.database.appslocal.database);
-
-  const appsQuery = { name: mainAppName };
-  const appsProjection = { projection: { _id: 0 } };
-  let appSpec = await dbHelper.findOneInDatabase(appsDatabase, localAppsInformation, appsQuery, appsProjection);
-
-  if (!appSpec) {
-    throw new Error(`App ${mainAppName} not found in local database`);
-  }
-
-  appSpec = await decryptEnterpriseApps([appSpec], { formatSpecs: false });
-  appSpec = appSpec[0];
-
-  if (!appSpec.compose || appSpec.compose.length === 0) {
-    throw new Error(`App ${mainAppName} has no components to install`);
-  }
-
-  const tier = await generalService.nodeTier();
-  const isComponent = componentIdentifier.includes('_');
-
-  if (isComponent) {
-    const componentName = componentIdentifier.split('_')[0];
-    const componentSpec = appSpec.compose.find((c) => c.name === componentName);
-    if (!componentSpec) {
-      throw new Error(`Component ${componentName} not found in app ${mainAppName}`);
-    }
-    const hddTier = `hdd${tier}`;
-    const ramTier = `ram${tier}`;
-    const cpuTier = `cpu${tier}`;
-    componentSpec.cpu = componentSpec[cpuTier] || componentSpec.cpu;
-    componentSpec.ram = componentSpec[ramTier] || componentSpec.ram;
-    componentSpec.hdd = componentSpec[hddTier] || componentSpec.hdd;
-    await appInstaller.installApplicationHard(componentSpec, mainAppName, true, null, appSpec);
-  } else {
-    for (const componentSpec of appSpec.compose) {
-      const hddTier = `hdd${tier}`;
-      const ramTier = `ram${tier}`;
-      const cpuTier = `cpu${tier}`;
-      componentSpec.cpu = componentSpec[cpuTier] || componentSpec.cpu;
-      componentSpec.ram = componentSpec[ramTier] || componentSpec.ram;
-      componentSpec.hdd = componentSpec[hddTier] || componentSpec.hdd;
-      await appInstaller.installApplicationHard(componentSpec, mainAppName, true, null, appSpec);
-    }
-  }
-
-  log.info(`Successfully recreated missing containers for ${componentIdentifier}`);
+function resetBroadcastInterval() {
+  if (broadcastInterval) clearInterval(broadcastInterval);
+  broadcastInterval = setInterval(() => {
+    checkAndNotifyPeersOfRunningApps();
+  }, 60 * 60 * 1000);
 }
 
-/**
- * Handle master/slave apps with missing containers.
- * Stopped containers are normal for master/slave apps. Missing containers need recovery.
- * @param {string} stoppedApp - Component identifier
- * @param {string} mainAppName - Main app name
- * @param {object} appsMonitored - Monitored apps object
- * @param {function} getGlobalState - Global state getter
- */
-async function handleMissingMasterSlaveContainer(stoppedApp, mainAppName) {
-  const containerExists = await dockerService.getDockerContainerOnly(stoppedApp);
-  if (containerExists) return;
-
-  log.warn(`Container for master/slave app ${stoppedApp} doesn't exist, recreating...`);
-  try {
-    await recreateMissingContainers(stoppedApp);
-    log.info(`Successfully recreated master/slave app container ${stoppedApp}`);
-    appInspector.startAppMonitoring(stoppedApp, globalState.appsMonitored);
-  } catch (recreateErr) {
-    // Check if container now exists — another process (e.g. masterSlaveApps) may have created it
-    const containerExistsNow = await dockerService.getDockerContainerOnly(stoppedApp);
-    if (containerExistsNow) {
-      log.info(`Container for ${stoppedApp} was created by another process, skipping removal`);
-      return;
-    }
-    log.error(`Failed to recreate master/slave app ${stoppedApp}: ${recreateErr.message}`);
-    log.warn(`REMOVAL REASON: Master/slave container recreation failure - ${mainAppName} (peerNotification)`);
-    await appTamperingDetectionService.recordEvent(mainAppName, 'recreation_failed', `Master/slave container recreation failure: ${recreateErr.message}`);
-    if (appTamperingDetectionService.isNetworkMissingError(recreateErr.message)) {
-      await appTamperingDetectionService.recordEvent(mainAppName, 'network_pruned', `Docker network missing during recreation: ${recreateErr.message}`);
-    }
-    await appUninstaller.removeAppLocally(mainAppName, null, false, true, true, () => {},
-      () => globalState, (name, deleteData) => appInspector.stopAppMonitoring(name, deleteData, globalState.appsMonitored));
+function stopBroadcastInterval() {
+  if (broadcastInterval) {
+    clearInterval(broadcastInterval);
+    broadcastInterval = null;
   }
 }
 
-/**
- * Check and notify peers of running applications
- * This function is called periodically to broadcast the status of running apps to the network
- * @param {function} installedApps - Function to get installed apps
- * @param {function} listRunningApps - Function to get running apps
- * @param {object} appsMonitored - Object tracking monitored apps
- * @param {boolean} removalInProgress - Whether app removal is in progress
- * @param {boolean} installationInProgress - Whether app installation is in progress
- * @param {boolean} softRedeployInProgress - Whether soft redeploy is in progress
- * @param {boolean} hardRedeployInProgress - Whether hard redeploy is in progress
- * @param {boolean} reinstallationOfOldAppsInProgress - Whether reinstallation is in progress
- * @param {function} getGlobalState - Function to get global state
- * @param {object} cacheManager - Cache manager instance with stoppedAppsCache
- */
 async function checkAndNotifyPeersOfRunningApps() {
   try {
-    let isNodeConfirmed = false;
-    isNodeConfirmed = await generalService.isNodeStatusConfirmed().catch(() => null);
+    const isNodeConfirmed = await generalService.isNodeStatusConfirmed().catch(() => null);
     if (!isNodeConfirmed) {
       log.info('checkAndNotifyPeersOfRunningApps - FluxNode is not Confirmed');
       return;
     }
 
-    // get my external IP and check that it is longer than 5 in length.
     const benchmarkResponse = await benchmarkService.getBenchmarks();
     let myIP = null;
     if (benchmarkResponse.status === 'success') {
@@ -154,8 +51,7 @@ async function checkAndNotifyPeersOfRunningApps() {
     if (myIP === null) {
       throw new Error('Unable to detect Flux IP address');
     }
-    // get list of locally installed apps. Store them in database as running and send info to our peers.
-    // check if they are running?
+
     const installedAppsRes = await appQueryService.installedApps();
     if (installedAppsRes.status !== 'success') {
       throw new Error('Failed to get installed Apps');
@@ -167,134 +63,15 @@ async function checkAndNotifyPeersOfRunningApps() {
     let appsInstalled = installedAppsRes.data;
     appsInstalled = await decryptEnterpriseApps(appsInstalled, { formatSpecs: false });
     const runningApps = runningAppsRes.data;
-    const installedAppComponentNames = [];
-    appsInstalled.forEach((app) => {
-      if (app.version >= 4) {
-        app.compose.forEach((appComponent) => {
-          installedAppComponentNames.push(`${appComponent.name}_${app.name}`);
-        });
-      } else {
-        installedAppComponentNames.push(app.name);
-      }
-    });
-    // kadena and folding is old naming scheme having /zel.  all global application start with /flux
     const runningAppsNames = runningApps.map((app) => {
       if (app.Names[0].startsWith('/zel')) {
         return app.Names[0].slice(4);
       }
       return app.Names[0].slice(5);
     });
-    // installed always is bigger array than running
-    const runningSet = new Set(runningAppsNames);
-    const stoppedApps = installedAppComponentNames.filter((installedApp) => !runningSet.has(installedApp));
-    const masterSlaveAppsInstalled = [];
 
-    const backupInProgress = globalState.backupInProgress || [];
-    const restoreInProgress = globalState.restoreInProgress || [];
-    const appsStopedCache = cacheManager.stoppedAppsCache;
+    const masterSlaveAppsInstalled = await stoppedAppsRecovery.checkStoppedApps(myIP, appsInstalled, runningAppsNames);
 
-    // check if stoppedApp is a global application present in specifics. If so, try to start it.
-    if (!globalState.removalInProgress && !globalState.installationInProgress && !globalState.softRedeployInProgress && !globalState.hardRedeployInProgress && !globalState.reinstallationOfOldAppsInProgress) {
-      // eslint-disable-next-line no-restricted-syntax
-      for (const stoppedApp of stoppedApps) { // will uninstall app if some component is missing
-        try {
-          // proceed ONLY if it's a global App
-          const mainAppName = stoppedApp.split('_')[1] || stoppedApp;
-          // eslint-disable-next-line no-await-in-loop
-          const appDetails = await registryManager.getApplicationGlobalSpecifications(mainAppName);
-          const appInstalledMasterSlave = appsInstalled.find((app) => app.name === mainAppName);
-          const appInstalledSyncthing = appInstalledMasterSlave.compose.find((comp) => comp.containerData.includes('g:') || comp.containerData.includes('r:'));
-          const appInstalledMasterSlaveCheck = appInstalledMasterSlave.compose.find((comp) => comp.containerData.includes('g:'));
-          if (appInstalledSyncthing) {
-            masterSlaveAppsInstalled.push(appInstalledMasterSlave);
-          }
-          if (appInstalledMasterSlaveCheck && appDetails) {
-            const backupSkip = backupInProgress.some((backupItem) => stoppedApp === backupItem);
-            const restoreSkip = restoreInProgress.some((backupItem) => stoppedApp === backupItem);
-            if (!backupSkip && !restoreSkip) {
-              // eslint-disable-next-line no-await-in-loop
-              await handleMissingMasterSlaveContainer(stoppedApp, mainAppName);
-            }
-          } else if (appDetails) {
-            log.warn(`${stoppedApp} is stopped but should be running. Starting...`);
-            // it is a stopped global app. Try to run it.
-            // check if some removal is in progress and if it is don't start it!
-            const backupSkip = backupInProgress.some((backupItem) => stoppedApp === backupItem);
-            const restoreSkip = restoreInProgress.some((backupItem) => stoppedApp === backupItem);
-            if (backupSkip || restoreSkip) {
-              log.warn(`Application ${stoppedApp} backup/restore is in progress...`);
-            }
-            if (!globalState.removalInProgress && !globalState.installationInProgress && !globalState.softRedeployInProgress && !globalState.hardRedeployInProgress && !globalState.reinstallationOfOldAppsInProgress && !restoreSkip && !backupSkip) {
-              // eslint-disable-next-line no-await-in-loop
-              const containerExists = await dockerService.getDockerContainerOnly(stoppedApp);
-
-              // Check if container exists before applying syncthing delay
-              if (containerExists && appInstalledSyncthing) {
-                const db = dbHelper.databaseConnection();
-                const database = db.db(config.database.appsglobal.database);
-                const queryFind = { name: mainAppName, ip: myIP };
-                const projection = { _id: 0, runningSince: 1 };
-                // we already have the exact same data
-                // eslint-disable-next-line no-await-in-loop
-                const result = await dbHelper.findOneInDatabase(database, globalAppsLocations, queryFind, projection);
-                if (!result || !result.runningSince || Date.parse(result.runningSince) + 30 * 60 * 1000 > Date.now()) {
-                  log.info(`Application ${stoppedApp} uses r syncthing and container exists but is stopped. Haven't started yet because was installed less than 30m ago.`);
-                  // eslint-disable-next-line no-continue
-                  continue;
-                }
-              }
-
-              if (!containerExists) {
-                log.warn(`Container for ${stoppedApp} doesn't exist, recreating immediately...`);
-                // eslint-disable-next-line no-await-in-loop
-                await appTamperingDetectionService.recordEvent(mainAppName, 'container_vanished', `Container ${stoppedApp} missing, not found in Docker`);
-                try {
-                  // eslint-disable-next-line no-await-in-loop
-                  await recreateMissingContainers(stoppedApp);
-                  log.info(`Successfully recreated ${stoppedApp}`);
-                  appInspector.startAppMonitoring(stoppedApp, globalState.appsMonitored);
-                } catch (recreateErr) {
-                  log.error(`Failed to recreate containers for ${stoppedApp}: ${recreateErr.message}`);
-                  log.warn(`REMOVAL REASON: Container recreation failure - ${mainAppName} failed to recreate with error: ${recreateErr.message} (peerNotification)`);
-                  // eslint-disable-next-line no-await-in-loop
-                  await appTamperingDetectionService.recordEvent(mainAppName, 'recreation_failed', `Container recreation failure: ${recreateErr.message}`);
-                  if (appTamperingDetectionService.isNetworkMissingError(recreateErr.message)) {
-                    // eslint-disable-next-line no-await-in-loop
-                    await appTamperingDetectionService.recordEvent(mainAppName, 'network_pruned', `Docker network missing during recreation: ${recreateErr.message}`);
-                  }
-                  // eslint-disable-next-line no-await-in-loop
-                  await appUninstaller.removeAppLocally(mainAppName, null, false, true, true, () => {
-                    // Handle response
-                  }, () => globalState, (name, deleteData) => appInspector.stopAppMonitoring(name, deleteData, globalState.appsMonitored));
-                }
-              } else {
-                log.warn(`${stoppedApp} is stopped, starting`);
-                if (!appsStopedCache.has(stoppedApp)) {
-                  appsStopedCache.set(stoppedApp, '');
-                } else {
-                  // eslint-disable-next-line no-await-in-loop
-                  await dockerService.appDockerStart(stoppedApp);
-                  appInspector.startAppMonitoring(stoppedApp, globalState.appsMonitored);
-                }
-              }
-            } else {
-              log.warn(`Not starting ${stoppedApp} as application removal or installation or backup/restore is in progress`);
-            }
-          }
-        } catch (err) {
-          log.error(err);
-          if (!globalState.removalInProgress && !globalState.installationInProgress && !globalState.softRedeployInProgress && !globalState.hardRedeployInProgress && !globalState.reinstallationOfOldAppsInProgress) {
-            log.warn(`REMOVAL REASON: App start failure - ${mainAppName} failed to start with error: ${err.message} (peerNotification)`);
-            // eslint-disable-next-line no-await-in-loop
-            await appUninstaller.removeAppLocally(mainAppName, null, false, true, true, () => {
-              // Handle response
-            }, () => globalState, (name, deleteData) => appInspector.stopAppMonitoring(name, deleteData, globalState.appsMonitored));
-          }
-        }
-      }
-    } else {
-      log.warn('Stopped application checks not running, some removal or installation is in progress');
-    }
     const installedAndRunning = [];
     appsInstalled.forEach((app) => {
       if (app.version >= 4) {
@@ -321,9 +98,9 @@ async function checkAndNotifyPeersOfRunningApps() {
       for (const application of applicationsToBroadcast) {
         const queryFind = { name: application.name, ip: myIP };
         const projection = { _id: 0, runningSince: 1 };
-        let runningOnMyNodeSince = new Date().toISOString();
         // eslint-disable-next-line no-await-in-loop
         const result = await dbHelper.findOneInDatabase(database, globalAppsLocations, queryFind, projection);
+        let runningOnMyNodeSince = new Date().toISOString();
         if (result && result.runningSince) {
           runningOnMyNodeSince = result.runningSince;
         }
@@ -352,9 +129,7 @@ async function checkAndNotifyPeersOfRunningApps() {
       log.info(`App Running Message broadcasted: ${apps.length} apps`);
     } catch (err) {
       log.error(err);
-      // removeAppLocally(stoppedApp);
     }
-    // Update the running apps cache with the current state
     const runningAppsCache = globalState.runningAppsCache;
     runningAppsCache.clear();
     apps.forEach((app) => {
@@ -364,10 +139,12 @@ async function checkAndNotifyPeersOfRunningApps() {
     log.info('Running Apps broadcasted');
   } catch (error) {
     log.error(error);
+  } finally {
+    resetBroadcastInterval();
   }
 }
 
 module.exports = {
   checkAndNotifyPeersOfRunningApps,
-  handleMissingMasterSlaveContainer,
+  stopBroadcastInterval,
 };

--- a/ZelBack/src/services/appMessaging/peerNotification.js
+++ b/ZelBack/src/services/appMessaging/peerNotification.js
@@ -125,7 +125,8 @@ async function checkAndNotifyPeersOfRunningApps() {
         staticIp: geolocationService.isStaticIP(),
       };
       await messageStore.storeAppRunningMessage(appRunningMessage);
-      await fluxCommunicationMessagesSender.broadcastMessageToAll(appRunningMessage);
+      const signed = await fluxCommunicationMessagesSender.broadcastMessageToAll(appRunningMessage);
+      messageStore.storeSignedAppRunningBroadcast(signed);
       log.info(`App Running Message broadcasted: ${apps.length} apps`);
     } catch (err) {
       log.error(err);

--- a/ZelBack/src/services/appMessaging/peerNotification.js
+++ b/ZelBack/src/services/appMessaging/peerNotification.js
@@ -17,6 +17,8 @@ const { decryptEnterpriseApps } = require('../appQuery/appQueryService');
 const { localAppsInformation } = require('../utils/appConstants');
 const log = require('../../lib/log');
 const globalState = require('../utils/globalState');
+const appQueryService = require('../appQuery/appQueryService');
+const cacheManager = require('../utils/cacheManager').default;
 const appTamperingDetectionService = require('../appTamperingDetectionService');
 
 // Database collections
@@ -89,7 +91,7 @@ async function recreateMissingContainers(componentIdentifier) {
  * @param {object} appsMonitored - Monitored apps object
  * @param {function} getGlobalState - Global state getter
  */
-async function handleMissingMasterSlaveContainer(stoppedApp, mainAppName, appsMonitored, getGlobalState) {
+async function handleMissingMasterSlaveContainer(stoppedApp, mainAppName) {
   const containerExists = await dockerService.getDockerContainerOnly(stoppedApp);
   if (containerExists) return;
 
@@ -97,7 +99,7 @@ async function handleMissingMasterSlaveContainer(stoppedApp, mainAppName, appsMo
   try {
     await recreateMissingContainers(stoppedApp);
     log.info(`Successfully recreated master/slave app container ${stoppedApp}`);
-    appInspector.startAppMonitoring(stoppedApp, appsMonitored);
+    appInspector.startAppMonitoring(stoppedApp, globalState.appsMonitored);
   } catch (recreateErr) {
     // Check if container now exists — another process (e.g. masterSlaveApps) may have created it
     const containerExistsNow = await dockerService.getDockerContainerOnly(stoppedApp);
@@ -112,7 +114,7 @@ async function handleMissingMasterSlaveContainer(stoppedApp, mainAppName, appsMo
       await appTamperingDetectionService.recordEvent(mainAppName, 'network_pruned', `Docker network missing during recreation: ${recreateErr.message}`);
     }
     await appUninstaller.removeAppLocally(mainAppName, null, false, true, true, () => {},
-      getGlobalState, (name, deleteData) => appInspector.stopAppMonitoring(name, deleteData, appsMonitored));
+      () => globalState, (name, deleteData) => appInspector.stopAppMonitoring(name, deleteData, globalState.appsMonitored));
   }
 }
 
@@ -130,21 +132,8 @@ async function handleMissingMasterSlaveContainer(stoppedApp, mainAppName, appsMo
  * @param {function} getGlobalState - Function to get global state
  * @param {object} cacheManager - Cache manager instance with stoppedAppsCache
  */
-async function checkAndNotifyPeersOfRunningApps(
-  installedApps,
-  listRunningApps,
-  appsMonitored,
-  removalInProgress,
-  installationInProgress,
-  softRedeployInProgress,
-  hardRedeployInProgress,
-  reinstallationOfOldAppsInProgress,
-  getGlobalState,
-  cacheManager,
-) {
+async function checkAndNotifyPeersOfRunningApps() {
   try {
-    // Sync global state before checking
-    getGlobalState();
     let isNodeConfirmed = false;
     isNodeConfirmed = await generalService.isNodeStatusConfirmed().catch(() => null);
     if (!isNodeConfirmed) {
@@ -167,11 +156,11 @@ async function checkAndNotifyPeersOfRunningApps(
     }
     // get list of locally installed apps. Store them in database as running and send info to our peers.
     // check if they are running?
-    const installedAppsRes = await installedApps();
+    const installedAppsRes = await appQueryService.installedApps();
     if (installedAppsRes.status !== 'success') {
       throw new Error('Failed to get installed Apps');
     }
-    const runningAppsRes = await listRunningApps();
+    const runningAppsRes = await appQueryService.listRunningApps();
     if (runningAppsRes.status !== 'success') {
       throw new Error('Unable to check running Apps');
     }
@@ -200,14 +189,12 @@ async function checkAndNotifyPeersOfRunningApps(
     const stoppedApps = installedAppComponentNames.filter((installedApp) => !runningSet.has(installedApp));
     const masterSlaveAppsInstalled = [];
 
-    // Get necessary references from global state
-    const globalState = getGlobalState();
     const backupInProgress = globalState.backupInProgress || [];
     const restoreInProgress = globalState.restoreInProgress || [];
     const appsStopedCache = cacheManager.stoppedAppsCache;
 
     // check if stoppedApp is a global application present in specifics. If so, try to start it.
-    if (!removalInProgress && !installationInProgress && !softRedeployInProgress && !hardRedeployInProgress && !reinstallationOfOldAppsInProgress) {
+    if (!globalState.removalInProgress && !globalState.installationInProgress && !globalState.softRedeployInProgress && !globalState.hardRedeployInProgress && !globalState.reinstallationOfOldAppsInProgress) {
       // eslint-disable-next-line no-restricted-syntax
       for (const stoppedApp of stoppedApps) { // will uninstall app if some component is missing
         try {
@@ -226,7 +213,7 @@ async function checkAndNotifyPeersOfRunningApps(
             const restoreSkip = restoreInProgress.some((backupItem) => stoppedApp === backupItem);
             if (!backupSkip && !restoreSkip) {
               // eslint-disable-next-line no-await-in-loop
-              await handleMissingMasterSlaveContainer(stoppedApp, mainAppName, appsMonitored, getGlobalState);
+              await handleMissingMasterSlaveContainer(stoppedApp, mainAppName);
             }
           } else if (appDetails) {
             log.warn(`${stoppedApp} is stopped but should be running. Starting...`);
@@ -237,7 +224,7 @@ async function checkAndNotifyPeersOfRunningApps(
             if (backupSkip || restoreSkip) {
               log.warn(`Application ${stoppedApp} backup/restore is in progress...`);
             }
-            if (!removalInProgress && !installationInProgress && !softRedeployInProgress && !hardRedeployInProgress && !reinstallationOfOldAppsInProgress && !restoreSkip && !backupSkip) {
+            if (!globalState.removalInProgress && !globalState.installationInProgress && !globalState.softRedeployInProgress && !globalState.hardRedeployInProgress && !globalState.reinstallationOfOldAppsInProgress && !restoreSkip && !backupSkip) {
               // eslint-disable-next-line no-await-in-loop
               const containerExists = await dockerService.getDockerContainerOnly(stoppedApp);
 
@@ -265,7 +252,7 @@ async function checkAndNotifyPeersOfRunningApps(
                   // eslint-disable-next-line no-await-in-loop
                   await recreateMissingContainers(stoppedApp);
                   log.info(`Successfully recreated ${stoppedApp}`);
-                  appInspector.startAppMonitoring(stoppedApp, appsMonitored);
+                  appInspector.startAppMonitoring(stoppedApp, globalState.appsMonitored);
                 } catch (recreateErr) {
                   log.error(`Failed to recreate containers for ${stoppedApp}: ${recreateErr.message}`);
                   log.warn(`REMOVAL REASON: Container recreation failure - ${mainAppName} failed to recreate with error: ${recreateErr.message} (peerNotification)`);
@@ -278,7 +265,7 @@ async function checkAndNotifyPeersOfRunningApps(
                   // eslint-disable-next-line no-await-in-loop
                   await appUninstaller.removeAppLocally(mainAppName, null, false, true, true, () => {
                     // Handle response
-                  }, getGlobalState, (name, deleteData) => appInspector.stopAppMonitoring(name, deleteData, appsMonitored));
+                  }, () => globalState, (name, deleteData) => appInspector.stopAppMonitoring(name, deleteData, globalState.appsMonitored));
                 }
               } else {
                 log.warn(`${stoppedApp} is stopped, starting`);
@@ -287,7 +274,7 @@ async function checkAndNotifyPeersOfRunningApps(
                 } else {
                   // eslint-disable-next-line no-await-in-loop
                   await dockerService.appDockerStart(stoppedApp);
-                  appInspector.startAppMonitoring(stoppedApp, appsMonitored);
+                  appInspector.startAppMonitoring(stoppedApp, globalState.appsMonitored);
                 }
               }
             } else {
@@ -296,12 +283,12 @@ async function checkAndNotifyPeersOfRunningApps(
           }
         } catch (err) {
           log.error(err);
-          if (!removalInProgress && !installationInProgress && !softRedeployInProgress && !hardRedeployInProgress && !reinstallationOfOldAppsInProgress) {
+          if (!globalState.removalInProgress && !globalState.installationInProgress && !globalState.softRedeployInProgress && !globalState.hardRedeployInProgress && !globalState.reinstallationOfOldAppsInProgress) {
             log.warn(`REMOVAL REASON: App start failure - ${mainAppName} failed to start with error: ${err.message} (peerNotification)`);
             // eslint-disable-next-line no-await-in-loop
             await appUninstaller.removeAppLocally(mainAppName, null, false, true, true, () => {
               // Handle response
-            }, getGlobalState, (name, deleteData) => appInspector.stopAppMonitoring(name, deleteData, appsMonitored));
+            }, () => globalState, (name, deleteData) => appInspector.stopAppMonitoring(name, deleteData, globalState.appsMonitored));
           }
         }
       }

--- a/ZelBack/src/services/appMonitoring/nodeStatusMonitor.js
+++ b/ZelBack/src/services/appMonitoring/nodeStatusMonitor.js
@@ -10,6 +10,7 @@ const log = require('../../lib/log');
 
 // Database collections
 const globalAppsLocations = config.database.appsglobal.collections.appsLocations;
+const appsRunningBroadcasts = config.database.appsglobal.collections.appsRunningBroadcasts;
 
 /**
  * Method responsible to monitor node status and uninstall apps if node is not confirmed
@@ -121,6 +122,8 @@ async function monitorNodeStatus(installedAppsFn, removeAppLocallyFn) {
           const query = { ip: location };
           // eslint-disable-next-line no-await-in-loop
           await dbHelper.removeDocumentsFromCollection(database, globalAppsLocations, query);
+          // eslint-disable-next-line no-await-in-loop
+          await dbHelper.removeDocumentsFromCollection(database, appsRunningBroadcasts, query);
         }
       }
     }

--- a/ZelBack/src/services/dbHelper.js
+++ b/ZelBack/src/services/dbHelper.js
@@ -721,7 +721,6 @@ async function reindexGlobalAppsInformation(
   appsLocalDb,
   globalAppsMessagesCol,
   globalAppsInformationCol,
-  globalAppsInstallingErrorsLocationsCol,
   localAppsInformationCol,
   scannedHeight,
 ) {
@@ -808,14 +807,6 @@ async function reindexGlobalAppsInformation(
     localAppsInformationCol,
   );
 
-  // Drop all install errors. Collection has a 1-hour TTL anyway and any
-  // surviving errors would be tied to specs that may have just changed.
-  await removeDocumentsFromCollection(
-    appsGlobalDb,
-    globalAppsInstallingErrorsLocationsCol,
-    {},
-  );
-
   log.info(
     `Reindexing of global applications finished. Local apps to be removed: ${JSON.stringify(appsToRemove)}`,
   );
@@ -839,7 +830,6 @@ async function validateAppsInformation() {
         collections: {
           appsInformation: globalAppsInformationCol,
           appsMessages: globalAppsMessagesCol,
-          appsInstallingErrorsLocations: globalAppsInstallingErrorsLocationsCol,
         },
       },
       appslocal: {
@@ -894,7 +884,6 @@ async function validateAppsInformation() {
       appsLocalDb,
       globalAppsMessagesCol,
       globalAppsInformationCol,
-      globalAppsInstallingErrorsLocationsCol,
       localAppsInformationCol,
       scannedHeight,
     );

--- a/ZelBack/src/services/explorerService.js
+++ b/ZelBack/src/services/explorerService.js
@@ -937,7 +937,12 @@ async function initiateBlockProcessor(restoreDatabase, deepRestore, reindexOrRes
             throw error;
           }
         });
-        log.info(resultE, resultF, resultG, resultH, resultI);
+        const resultJ = await dbHelper.dropCollection(databaseGlobal, config.database.appsglobal.collections.appsInstallingErrorsBroadcasts).catch((error) => {
+          if (error.message !== 'ns not found') {
+            throw error;
+          }
+        });
+        log.info(resultE, resultF, resultG, resultH, resultI, resultJ);
       }
       await databaseGlobal.collection(config.database.appsglobal.collections.appsMessages).createIndex({ hash: 1 }, { name: 'query for getting zelapp message based on hash', unique: true });
       await databaseGlobal.collection(config.database.appsglobal.collections.appsMessages).createIndex({ txid: 1 }, { name: 'query for getting zelapp message based on txid' });

--- a/ZelBack/src/services/explorerService.js
+++ b/ZelBack/src/services/explorerService.js
@@ -942,7 +942,17 @@ async function initiateBlockProcessor(restoreDatabase, deepRestore, reindexOrRes
             throw error;
           }
         });
-        log.info(resultE, resultF, resultG, resultH, resultI, resultJ);
+        const resultK = await dbHelper.dropCollection(databaseGlobal, config.database.appsglobal.collections.appsRunningBroadcasts).catch((error) => {
+          if (error.message !== 'ns not found') {
+            throw error;
+          }
+        });
+        const resultL = await dbHelper.dropCollection(databaseGlobal, config.database.appsglobal.collections.appsInstallingBroadcasts).catch((error) => {
+          if (error.message !== 'ns not found') {
+            throw error;
+          }
+        });
+        log.info(resultE, resultF, resultG, resultH, resultI, resultJ, resultK, resultL);
       }
       await databaseGlobal.collection(config.database.appsglobal.collections.appsMessages).createIndex({ hash: 1 }, { name: 'query for getting zelapp message based on hash', unique: true });
       await databaseGlobal.collection(config.database.appsglobal.collections.appsMessages).createIndex({ txid: 1 }, { name: 'query for getting zelapp message based on txid' });

--- a/ZelBack/src/services/fluxCommunication.js
+++ b/ZelBack/src/services/fluxCommunication.js
@@ -152,6 +152,37 @@ async function handleAppInstallingSyncResponse(message) {
   }
 }
 
+async function handleAppInstallingErrorsSyncResponse(message) {
+  try {
+    if (!message.data || message.data.type !== 'fluxappinstallingerrorssync') return;
+    const { messages, done } = message.data;
+    if (!Array.isArray(messages)) return;
+    log.info(`handleAppInstallingErrorsSyncResponse - Received ${messages.length} broadcasts (done: ${!!done})`);
+    const verified = [];
+    for (const broadcast of messages) {
+      try {
+        const result = await fluxCommunicationUtils.verifyFluxBroadcast(broadcast);
+        if (result === fluxCommunicationUtils.VerifyResult.OK) {
+          verified.push(broadcast);
+        } else {
+          log.warn(`handleAppInstallingErrorsSyncResponse - Broadcast from ${broadcast.data?.ip} failed: ${result}`);
+        }
+      } catch (err) {
+        log.error(`handleAppInstallingErrorsSyncResponse - Verification error: ${err.message}`);
+      }
+    }
+    if (verified.length > 0) {
+      const { stored } = await messageStore.storeBatchAppInstallingErrorMessages(verified);
+      log.info(`handleAppInstallingErrorsSyncResponse - Stored ${stored} of ${verified.length} verified broadcasts`);
+    }
+    if (done) {
+      log.info('handleAppInstallingErrorsSyncResponse - Sync complete');
+    }
+  } catch (error) {
+    log.error(error);
+  }
+}
+
 async function handleCheckMessageHashPresent(messageHash, fromIP, port) {
   try {
     if (!messageCache.has(messageHash)) {
@@ -246,10 +277,8 @@ async function handleAppInstallingMessage(message, fromIP, port) {
  */
 async function handleAppInstallingErrorMessage(message, fromIP, port) {
   try {
-    // check if we have it exactly like that in database and if not, update
-    // if not in database, rebroadcast to all connections
-    // do furtherVerification of message
     const rebroadcastToPeers = await messageStore.storeAppInstallingErrorMessage(message.data);
+    messageStore.storeSignedAppInstallingErrorBroadcast(message);
     const currentTimeStamp = Date.now();
     const timestampOK = fluxCommunicationUtils.verifyTimestampInFluxBroadcast(message, currentTimeStamp);
     if (rebroadcastToPeers === true && timestampOK) {
@@ -476,6 +505,8 @@ async function dispatchFluxMessage(msgObj, peerSocket) {
           setImmediate(() => handleAppRunningSyncResponse(msgObj));
         } else if (msgObj.data.type === 'fluxappinstallingsync') {
           setImmediate(() => handleAppInstallingSyncResponse(msgObj));
+        } else if (msgObj.data.type === 'fluxappinstallingerrorssync') {
+          setImmediate(() => handleAppInstallingErrorsSyncResponse(msgObj));
         } else {
           log.warn(`Unrecognised message type of ${msgObj.data.type}`);
         }
@@ -547,6 +578,13 @@ peerManager.hashHandlers = {
     if (now - last < 5 * 60 * 1000) return;
     peer.lastAppInstallingSyncResponse = now;
     setImmediate(() => fluxCommunicationMessagesSender.respondWithAppInstallingMessages(peer, sinceTimestamp));
+  },
+  handleAppInstallingErrorsRequest: (peer, sinceTimestamp) => {
+    const now = Date.now();
+    const last = peer.lastAppInstallingErrorsSyncResponse || 0;
+    if (now - last < 5 * 60 * 1000) return;
+    peer.lastAppInstallingErrorsSyncResponse = now;
+    setImmediate(() => fluxCommunicationMessagesSender.respondWithAppInstallingErrorsMessages(peer, sinceTimestamp));
   },
 };
 

--- a/ZelBack/src/services/fluxCommunication.js
+++ b/ZelBack/src/services/fluxCommunication.js
@@ -15,9 +15,12 @@ const dbHelper = require('./dbHelper');
 const { peerManager, PEER_SOURCE } = require('./utils/peerState');
 const cacheManager = require('./utils/cacheManager').default;
 const networkStateService = require('./networkStateService');
-const globalState = require('./utils/globalState');
-
 const globalAppsLocations = config.database.appsglobal.collections.appsLocations;
+
+let onSyncComplete = null;
+function setOnSyncComplete(callback) {
+  onSyncComplete = callback;
+}
 
 const { messageCache, wsPeerCache } = cacheManager;
 
@@ -113,7 +116,7 @@ async function handleAppRunningSyncResponse(message) {
       log.info(`handleAppRunningSyncResponse - Stored ${stored} of ${verified.length} verified broadcasts`);
     }
     if (done) {
-      globalState.appRunningSyncComplete = true;
+      if (onSyncComplete) onSyncComplete('apprunning');
       log.info('handleAppRunningSyncResponse - Sync complete');
     }
   } catch (error) {
@@ -145,6 +148,7 @@ async function handleAppInstallingSyncResponse(message) {
       log.info(`handleAppInstallingSyncResponse - Stored ${stored} of ${verified.length} verified broadcasts`);
     }
     if (done) {
+      if (onSyncComplete) onSyncComplete('appinstalling');
       log.info('handleAppInstallingSyncResponse - Sync complete');
     }
   } catch (error) {
@@ -176,6 +180,7 @@ async function handleAppInstallingErrorsSyncResponse(message) {
       log.info(`handleAppInstallingErrorsSyncResponse - Stored ${stored} of ${verified.length} verified broadcasts`);
     }
     if (done) {
+      if (onSyncComplete) onSyncComplete('apperrors');
       log.info('handleAppInstallingErrorsSyncResponse - Sync complete');
     }
   } catch (error) {
@@ -1320,4 +1325,5 @@ module.exports = {
   getPeerHistory,
   getTopology,
   getNetworkHealth,
+  setOnSyncComplete,
 };

--- a/ZelBack/src/services/fluxCommunication.js
+++ b/ZelBack/src/services/fluxCommunication.js
@@ -133,6 +133,8 @@ async function handleAppInstallingSyncResponse(message) {
         const result = await fluxCommunicationUtils.verifyFluxBroadcast(broadcast);
         if (result === fluxCommunicationUtils.VerifyResult.OK) {
           verified.push(broadcast);
+        } else {
+          log.warn(`handleAppInstallingSyncResponse - Broadcast from ${broadcast.data?.ip} failed: ${result}`);
         }
       } catch (err) {
         log.error(`handleAppInstallingSyncResponse - Verification error: ${err.message}`);

--- a/ZelBack/src/services/fluxCommunication.js
+++ b/ZelBack/src/services/fluxCommunication.js
@@ -16,6 +16,7 @@ const { peerManager, PEER_SOURCE } = require('./utils/peerState');
 const cacheManager = require('./utils/cacheManager').default;
 const networkStateService = require('./networkStateService');
 const globalAppsLocations = config.database.appsglobal.collections.appsLocations;
+const appsRunningBroadcasts = config.database.appsglobal.collections.appsRunningBroadcasts;
 
 let onSyncComplete = null;
 function setOnSyncComplete(callback) {
@@ -389,12 +390,10 @@ async function handleNodeSigtermMessage(message, fromIP, port) {
 
     log.info(`Found ${appsOnNode.length} apps for node ${ip}, updating expiration and rebroadcasting sigterm`);
 
-    // Update broadcastedAt to make records expire 7 minutes after the sigterm broadcastedAt
-    // TTL index is 7500 seconds, so set broadcastedAt = sigtermBroadcastedAt - (7500 - 420) seconds
-    const newBroadcastedAt = new Date(broadcastedAt - (7500 - 420) * 1000);
     const newExpireAt = new Date(broadcastedAt + (420 * 1000));
-    const update = { $set: { broadcastedAt: newBroadcastedAt, expireAt: newExpireAt } };
+    const update = { $set: { expireAt: newExpireAt } };
     await dbHelper.updateInDatabase(database, globalAppsLocations, query, update);
+    await dbHelper.updateInDatabase(database, appsRunningBroadcasts, query, update);
 
     // Rebroadcast to other peers
     const syncStatus = daemonServiceMiscRpcs.isDaemonSynced();

--- a/ZelBack/src/services/fluxCommunication.js
+++ b/ZelBack/src/services/fluxCommunication.js
@@ -121,6 +121,35 @@ async function handleAppRunningSyncResponse(message) {
   }
 }
 
+async function handleAppInstallingSyncResponse(message) {
+  try {
+    if (!message.data || message.data.type !== 'fluxappinstallingsync') return;
+    const { messages, done } = message.data;
+    if (!Array.isArray(messages)) return;
+    log.info(`handleAppInstallingSyncResponse - Received ${messages.length} broadcasts (done: ${!!done})`);
+    const verified = [];
+    for (const broadcast of messages) {
+      try {
+        const result = await fluxCommunicationUtils.verifyFluxBroadcast(broadcast);
+        if (result === fluxCommunicationUtils.VerifyResult.OK) {
+          verified.push(broadcast);
+        }
+      } catch (err) {
+        log.error(`handleAppInstallingSyncResponse - Verification error: ${err.message}`);
+      }
+    }
+    if (verified.length > 0) {
+      const { stored } = await messageStore.storeBatchAppInstallingMessages(verified);
+      log.info(`handleAppInstallingSyncResponse - Stored ${stored} of ${verified.length} verified broadcasts`);
+    }
+    if (done) {
+      log.info('handleAppInstallingSyncResponse - Sync complete');
+    }
+  } catch (error) {
+    log.error(error);
+  }
+}
+
 async function handleCheckMessageHashPresent(messageHash, fromIP, port) {
   try {
     if (!messageCache.has(messageHash)) {
@@ -189,10 +218,8 @@ async function handleAppRunningMessage(message, fromIP, port) {
  */
 async function handleAppInstallingMessage(message, fromIP, port) {
   try {
-    // check if we have it exactly like that in database and if not, update
-    // if not in database, rebroadcast to all connections
-    // do furtherVerification of message
     const rebroadcastToPeers = await messageStore.storeAppInstallingMessage(message.data);
+    messageStore.storeSignedAppInstallingBroadcast(message);
     const currentTimeStamp = Date.now();
     const timestampOK = fluxCommunicationUtils.verifyTimestampInFluxBroadcast(message, currentTimeStamp);
     if (rebroadcastToPeers === true && timestampOK) {
@@ -445,6 +472,8 @@ async function dispatchFluxMessage(msgObj, peerSocket) {
           setImmediate(() => handleTempSyncResponse(msgObj));
         } else if (msgObj.data.type === 'fluxapprunningsync') {
           setImmediate(() => handleAppRunningSyncResponse(msgObj));
+        } else if (msgObj.data.type === 'fluxappinstallingsync') {
+          setImmediate(() => handleAppInstallingSyncResponse(msgObj));
         } else {
           log.warn(`Unrecognised message type of ${msgObj.data.type}`);
         }
@@ -509,6 +538,13 @@ peerManager.hashHandlers = {
     if (now - last < 5 * 60 * 1000) return;
     peer.lastAppRunningSyncResponse = now;
     setImmediate(() => fluxCommunicationMessagesSender.respondWithAppRunningMessages(peer, sinceTimestamp));
+  },
+  handleAppInstallingRequest: (peer, sinceTimestamp) => {
+    const now = Date.now();
+    const last = peer.lastAppInstallingSyncResponse || 0;
+    if (now - last < 5 * 60 * 1000) return;
+    peer.lastAppInstallingSyncResponse = now;
+    setImmediate(() => fluxCommunicationMessagesSender.respondWithAppInstallingMessages(peer, sinceTimestamp));
   },
 };
 

--- a/ZelBack/src/services/fluxCommunication.js
+++ b/ZelBack/src/services/fluxCommunication.js
@@ -15,6 +15,7 @@ const dbHelper = require('./dbHelper');
 const { peerManager, PEER_SOURCE } = require('./utils/peerState');
 const cacheManager = require('./utils/cacheManager').default;
 const networkStateService = require('./networkStateService');
+const globalState = require('./utils/globalState');
 
 const globalAppsLocations = config.database.appsglobal.collections.appsLocations;
 
@@ -70,15 +71,11 @@ async function handleAppMessages(message, fromIP, port) {
 async function handleTempSyncResponse(message) {
   try {
     if (!message.data || message.data.type !== 'fluxapptempsync') return;
-    const { messages } = message.data;
+    const { messages, done } = message.data;
     if (!Array.isArray(messages)) return;
-    log.info(`handleTempSyncResponse - Received ${messages.length} temp messages`);
-    const toProcess = messages.slice(0, 500);
-    if (messages.length > 500) {
-      log.warn(`handleTempSyncResponse - Capped from ${messages.length} to 500`);
-    }
+    log.info(`handleTempSyncResponse - Received ${messages.length} temp messages (done: ${!!done})`);
     let stored = 0;
-    for (const msg of toProcess) {
+    for (const msg of messages) {
       try {
         const result = await messageStore.storeAppTemporaryMessage(msg, { furtherVerification: true });
         if (result === true || result === false) stored += 1;
@@ -86,7 +83,39 @@ async function handleTempSyncResponse(message) {
         log.error(`Temp sync message failed: ${err.message}`);
       }
     }
-    log.info(`handleTempSyncResponse - Processed ${stored} of ${toProcess.length} messages`);
+    log.info(`handleTempSyncResponse - Processed ${stored} of ${messages.length} messages`);
+  } catch (error) {
+    log.error(error);
+  }
+}
+
+async function handleAppRunningSyncResponse(message) {
+  try {
+    if (!message.data || message.data.type !== 'fluxapprunningsync') return;
+    const { messages, done } = message.data;
+    if (!Array.isArray(messages)) return;
+    log.info(`handleAppRunningSyncResponse - Received ${messages.length} broadcasts (done: ${!!done})`);
+    const verified = [];
+    for (const broadcast of messages) {
+      try {
+        const result = await fluxCommunicationUtils.verifyFluxBroadcast(broadcast);
+        if (result === fluxCommunicationUtils.VerifyResult.OK) {
+          verified.push(broadcast);
+        } else {
+          log.warn(`handleAppRunningSyncResponse - Broadcast from ${broadcast.data?.ip} failed verification: ${result}`);
+        }
+      } catch (err) {
+        log.error(`handleAppRunningSyncResponse - Verification error: ${err.message}`);
+      }
+    }
+    if (verified.length > 0) {
+      const { stored } = await messageStore.storeBatchAppRunningMessages(verified);
+      log.info(`handleAppRunningSyncResponse - Stored ${stored} of ${verified.length} verified broadcasts`);
+    }
+    if (done) {
+      globalState.appRunningSyncComplete = true;
+      log.info('handleAppRunningSyncResponse - Sync complete');
+    }
   } catch (error) {
     log.error(error);
   }
@@ -134,10 +163,8 @@ async function handleRequestMessageHash(messageHash, fromIP, port) {
  */
 async function handleAppRunningMessage(message, fromIP, port) {
   try {
-    // check if we have it exactly like that in database and if not, update
-    // if not in database, rebroadcast to all connections
-    // do furtherVerification of message
     const rebroadcastToPeers = await messageStore.storeAppRunningMessage(message.data);
+    messageStore.storeSignedAppRunningBroadcast(message);
     const currentTimeStamp = Date.now();
     const timestampOK = fluxCommunicationUtils.verifyTimestampInFluxBroadcast(message, currentTimeStamp, 240000);
     if (rebroadcastToPeers === true && timestampOK) {
@@ -416,6 +443,8 @@ async function dispatchFluxMessage(msgObj, peerSocket) {
           setImmediate(() => handleNodeSigtermMessage(msgObj, peerSocket.ip, peerSocket.port));
         } else if (msgObj.data.type === 'fluxapptempsync') {
           setImmediate(() => handleTempSyncResponse(msgObj));
+        } else if (msgObj.data.type === 'fluxapprunningsync') {
+          setImmediate(() => handleAppRunningSyncResponse(msgObj));
         } else {
           log.warn(`Unrecognised message type of ${msgObj.data.type}`);
         }
@@ -467,12 +496,19 @@ peerManager.hashHandlers = {
     peer.msgMap.set('requestHash', counter + 1);
     setImmediate(() => handleRequestMessageHash(hexHash, peer.ip, peer.port));
   },
-  handleTempMessagesRequest: (peer) => {
+  handleTempMessagesRequest: (peer, sinceTimestamp) => {
     const now = Date.now();
     const last = peer.lastTempSyncResponse || 0;
     if (now - last < 5 * 60 * 1000) return;
     peer.lastTempSyncResponse = now;
-    setImmediate(() => fluxCommunicationMessagesSender.respondWithTempMessages(peer));
+    setImmediate(() => fluxCommunicationMessagesSender.respondWithTempMessages(peer, sinceTimestamp));
+  },
+  handleAppRunningRequest: (peer, sinceTimestamp) => {
+    const now = Date.now();
+    const last = peer.lastAppRunningSyncResponse || 0;
+    if (now - last < 5 * 60 * 1000) return;
+    peer.lastAppRunningSyncResponse = now;
+    setImmediate(() => fluxCommunicationMessagesSender.respondWithAppRunningMessages(peer, sinceTimestamp));
   },
 };
 
@@ -695,7 +731,7 @@ async function initiateAndHandleConnection(connection, source = PEER_SOURCE.RAND
       // should not be compressed if context takeover is disabled.
       },
       headers: {
-        'X-Flux-Capabilities': 'transmissionTimestamps,peerExchange,binaryMessages,tempMessageSync',
+        'X-Flux-Capabilities': 'transmissionTimestamps,peerExchange,binaryMessages,tempMessageSync,appRunningSync',
         'X-Flux-Version': FLUX_VERSION,
         'X-Flux-Uptime': String(Math.floor(process.uptime())),
       },

--- a/ZelBack/src/services/fluxCommunication.js
+++ b/ZelBack/src/services/fluxCommunication.js
@@ -29,7 +29,7 @@ const { messageCache, wsPeerCache } = cacheManager;
 
 const testListCache = new LRUCache(LRUTest); */
 
-const { FluxPeerManager, DIRECTION, FLUX_VERSION } = require('./utils/FluxPeerManager');
+const { FluxPeerManager, DIRECTION, FLUX_VERSION, FLUX_CAPABILITIES } = require('./utils/FluxPeerManager');
 const { NAK_REASON } = require('./utils/peerCodec');
 const { networkHealthMonitor } = require('./utils/NetworkHealthMonitor');
 
@@ -731,7 +731,7 @@ async function initiateAndHandleConnection(connection, source = PEER_SOURCE.RAND
       // should not be compressed if context takeover is disabled.
       },
       headers: {
-        'X-Flux-Capabilities': 'transmissionTimestamps,peerExchange,binaryMessages,tempMessageSync,appRunningSync',
+        'X-Flux-Capabilities': FLUX_CAPABILITIES.join(','),
         'X-Flux-Version': FLUX_VERSION,
         'X-Flux-Uptime': String(Math.floor(process.uptime())),
       },

--- a/ZelBack/src/services/fluxCommunication.js
+++ b/ZelBack/src/services/fluxCommunication.js
@@ -230,11 +230,13 @@ async function handleRequestMessageHash(messageHash, fromIP, port) {
  */
 async function handleAppRunningMessage(message, fromIP, port) {
   try {
-    const rebroadcastToPeers = await messageStore.storeAppRunningMessage(message.data);
-    messageStore.storeSignedAppRunningBroadcast(message);
+    const result = await messageStore.storeAppRunningMessage(message.data);
+    if (result.stored) {
+      messageStore.storeSignedAppRunningBroadcast(message);
+    }
     const currentTimeStamp = Date.now();
     const timestampOK = fluxCommunicationUtils.verifyTimestampInFluxBroadcast(message, currentTimeStamp, 240000);
-    if (rebroadcastToPeers === true && timestampOK) {
+    if (result.rebroadcast && timestampOK) {
       const syncStatus = daemonServiceMiscRpcs.isDaemonSynced();
       const daemonHeight = syncStatus.data.height || 0;
       if (daemonHeight >= config.messagesBroadcastRefactorStart) {

--- a/ZelBack/src/services/fluxCommunication.js
+++ b/ZelBack/src/services/fluxCommunication.js
@@ -73,8 +73,12 @@ async function handleTempSyncResponse(message) {
     const { messages } = message.data;
     if (!Array.isArray(messages)) return;
     log.info(`handleTempSyncResponse - Received ${messages.length} temp messages`);
+    const toProcess = messages.slice(0, 500);
+    if (messages.length > 500) {
+      log.warn(`handleTempSyncResponse - Capped from ${messages.length} to 500`);
+    }
     let stored = 0;
-    for (const msg of messages) {
+    for (const msg of toProcess) {
       try {
         const result = await messageStore.storeAppTemporaryMessage(msg, { furtherVerification: true });
         if (result === true || result === false) stored += 1;
@@ -82,7 +86,7 @@ async function handleTempSyncResponse(message) {
         log.error(`Temp sync message failed: ${err.message}`);
       }
     }
-    log.info(`handleTempSyncResponse - Processed ${stored} of ${messages.length} messages`);
+    log.info(`handleTempSyncResponse - Processed ${stored} of ${toProcess.length} messages`);
   } catch (error) {
     log.error(error);
   }
@@ -464,6 +468,10 @@ peerManager.hashHandlers = {
     setImmediate(() => handleRequestMessageHash(hexHash, peer.ip, peer.port));
   },
   handleTempMessagesRequest: (peer) => {
+    const now = Date.now();
+    const last = peer.lastTempSyncResponse || 0;
+    if (now - last < 5 * 60 * 1000) return;
+    peer.lastTempSyncResponse = now;
     setImmediate(() => fluxCommunicationMessagesSender.respondWithTempMessages(peer));
   },
 };

--- a/ZelBack/src/services/fluxCommunication.js
+++ b/ZelBack/src/services/fluxCommunication.js
@@ -67,13 +67,27 @@ async function handleAppMessages(message, fromIP, port) {
   }
 }
 
-/**
- * To handle check if message hash is present, if node doesn't have that message hash will send to the client a message requesting for the message.
- * @param {string} messageHash Message hash.
- * @param {string} fromIP Sender's IP address.
- * @param {string} port Sender's node Api port.
- * @param {boolean} outgoingConnection says if ip/port is from incoming or outgoing connections.
- */
+async function handleTempSyncResponse(message) {
+  try {
+    if (!message.data || message.data.type !== 'fluxapptempsync') return;
+    const { messages } = message.data;
+    if (!Array.isArray(messages)) return;
+    log.info(`handleTempSyncResponse - Received ${messages.length} temp messages`);
+    let stored = 0;
+    for (const msg of messages) {
+      try {
+        const result = await messageStore.storeAppTemporaryMessage(msg, { furtherVerification: true });
+        if (result === true || result === false) stored += 1;
+      } catch (err) {
+        log.error(`Temp sync message failed: ${err.message}`);
+      }
+    }
+    log.info(`handleTempSyncResponse - Processed ${stored} of ${messages.length} messages`);
+  } catch (error) {
+    log.error(error);
+  }
+}
+
 async function handleCheckMessageHashPresent(messageHash, fromIP, port) {
   try {
     if (!messageCache.has(messageHash)) {
@@ -396,6 +410,8 @@ async function dispatchFluxMessage(msgObj, peerSocket) {
           setImmediate(() => handleAppInstallingErrorMessage(msgObj, peerSocket.ip, peerSocket.port));
         } else if (msgObj.data.type === 'fluxnodesigterm') {
           setImmediate(() => handleNodeSigtermMessage(msgObj, peerSocket.ip, peerSocket.port));
+        } else if (msgObj.data.type === 'fluxapptempsync') {
+          setImmediate(() => handleTempSyncResponse(msgObj));
         } else {
           log.warn(`Unrecognised message type of ${msgObj.data.type}`);
         }
@@ -446,6 +462,9 @@ peerManager.hashHandlers = {
     const counter = peer.msgMap.get('requestHash');
     peer.msgMap.set('requestHash', counter + 1);
     setImmediate(() => handleRequestMessageHash(hexHash, peer.ip, peer.port));
+  },
+  handleTempMessagesRequest: (peer) => {
+    setImmediate(() => fluxCommunicationMessagesSender.respondWithTempMessages(peer));
   },
 };
 
@@ -604,6 +623,7 @@ function onOutboundOpen() {
     remoteCapabilities: meta.remoteCapabilities,
     remoteClockOffsetMs: meta.remoteClockOffsetMs,
     remoteVersion: meta.remoteVersion,
+    remoteFluxUptime: meta.remoteFluxUptime,
   });
 }
 
@@ -619,6 +639,9 @@ function onOutboundUpgrade(response) {
   }
   if (response.headers['x-flux-version']) {
     meta.remoteVersion = response.headers['x-flux-version'];
+  }
+  if (response.headers['x-flux-uptime']) {
+    meta.remoteFluxUptime = Number(response.headers['x-flux-uptime']);
   }
 }
 
@@ -664,8 +687,9 @@ async function initiateAndHandleConnection(connection, source = PEER_SOURCE.RAND
       // should not be compressed if context takeover is disabled.
       },
       headers: {
-        'X-Flux-Capabilities': 'transmissionTimestamps,peerExchange,binaryMessages',
+        'X-Flux-Capabilities': 'transmissionTimestamps,peerExchange,binaryMessages,tempMessageSync',
         'X-Flux-Version': FLUX_VERSION,
+        'X-Flux-Uptime': String(Math.floor(process.uptime())),
       },
     };
     const offsetMs = fluxNetworkHelper.getLocalClockOffsetMs();

--- a/ZelBack/src/services/fluxCommunicationMessagesSender.js
+++ b/ZelBack/src/services/fluxCommunicationMessagesSender.js
@@ -1,9 +1,11 @@
 /* eslint-disable no-underscore-dangle */
+const config = require('config');
 const log = require('../lib/log');
 const serviceHelper = require('./serviceHelper');
 const fluxNetworkHelper = require('./fluxNetworkHelper');
 const verificationHelper = require('./verificationHelper');
 const messageHelper = require('./messageHelper');
+const dbHelper = require('./dbHelper');
 const { peerManager } = require('./utils/peerState');
 const cacheManager = require('./utils/cacheManager').default;
 
@@ -310,10 +312,36 @@ async function broadcastTemporaryAppMessage(message) {
   await broadcastMessageToAll(message);
 }
 
+async function respondWithTempMessages(peer) {
+  try {
+    const globalAppsTempMessages = config.database.appsglobal.collections.appsTemporaryMessages;
+    const db = dbHelper.databaseConnection();
+    const database = db.db(config.database.appsglobal.database);
+    const tempMessages = await dbHelper.findInDatabase(
+      database, globalAppsTempMessages, {}, { projection: { _id: 0, receivedAt: 0, expireAt: 0 } },
+    );
+    const messages = tempMessages.map((msg) => ({
+      type: msg.type,
+      version: msg.version,
+      appSpecifications: msg.appSpecifications,
+      hash: msg.hash,
+      timestamp: msg.timestamp,
+      signature: msg.signature,
+      arcaneSender: msg.arcaneSender,
+    }));
+    log.info(`respondWithTempMessages - Sending ${messages.length} temp messages to ${peer.key}`);
+    const response = { type: 'fluxapptempsync', version: 1, messages };
+    await sendSignedMessage(response, peer);
+  } catch (error) {
+    log.error(error);
+  }
+}
+
 module.exports = {
   relay,
   sendSignedMessage,
   respondWithAppMessage,
+  respondWithTempMessages,
   serialiseAndSignFluxBroadcast,
   getFluxMessageSignature,
   broadcastMessageToOutgoingFromUser,

--- a/ZelBack/src/services/fluxCommunicationMessagesSender.js
+++ b/ZelBack/src/services/fluxCommunicationMessagesSender.js
@@ -390,7 +390,7 @@ async function respondWithAppInstallingMessages(peer, sinceTimestamp = 0) {
     const adjustedTimestamp = sinceTimestamp > 0
       ? new Date(sinceTimestamp - (peer.remoteClockOffsetMs || 0))
       : new Date(0);
-    const validAfter = new Date(Date.now() - 5 * 60 * 1000);
+    const validAfter = new Date(Date.now() - 15 * 60 * 1000);
     const minTimestamp = adjustedTimestamp > validAfter ? adjustedTimestamp : validAfter;
     const cursor = database.collection(appsInstallingBroadcasts)
       .find({ broadcastedAt: { $gt: minTimestamp } }, { projection: { _id: 0, expireAt: 0 } })

--- a/ZelBack/src/services/fluxCommunicationMessagesSender.js
+++ b/ZelBack/src/services/fluxCommunicationMessagesSender.js
@@ -390,8 +390,10 @@ async function respondWithAppInstallingMessages(peer, sinceTimestamp = 0) {
     const adjustedTimestamp = sinceTimestamp > 0
       ? new Date(sinceTimestamp - (peer.remoteClockOffsetMs || 0))
       : new Date(0);
+    const validAfter = new Date(Date.now() - 5 * 60 * 1000);
+    const minTimestamp = adjustedTimestamp > validAfter ? adjustedTimestamp : validAfter;
     const cursor = database.collection(appsInstallingBroadcasts)
-      .find({ broadcastedAt: { $gt: adjustedTimestamp } }, { projection: { _id: 0, expireAt: 0 } })
+      .find({ broadcastedAt: { $gt: minTimestamp } }, { projection: { _id: 0, expireAt: 0 } })
       .sort({ broadcastedAt: 1 });
 
     const batchSize = 2000;

--- a/ZelBack/src/services/fluxCommunicationMessagesSender.js
+++ b/ZelBack/src/services/fluxCommunicationMessagesSender.js
@@ -415,6 +415,40 @@ async function respondWithAppInstallingMessages(peer, sinceTimestamp = 0) {
   }
 }
 
+async function respondWithAppInstallingErrorsMessages(peer, sinceTimestamp = 0) {
+  try {
+    const appsInstallingErrorsBroadcasts = config.database.appsglobal.collections.appsInstallingErrorsBroadcasts;
+    const db = dbHelper.databaseConnection();
+    const database = db.db(config.database.appsglobal.database);
+
+    const adjustedTimestamp = sinceTimestamp > 0
+      ? new Date(sinceTimestamp - (peer.remoteClockOffsetMs || 0))
+      : new Date(0);
+    const validAfter = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const minTimestamp = adjustedTimestamp > validAfter ? adjustedTimestamp : validAfter;
+    const cursor = database.collection(appsInstallingErrorsBroadcasts)
+      .find({ broadcastedAt: { $gt: minTimestamp } }, { projection: { _id: 0 } })
+      .sort({ broadcastedAt: 1 });
+
+    const batchSize = 2000;
+    let batch = [];
+    let total = 0;
+    for await (const doc of cursor) {
+      batch.push(doc);
+      if (batch.length >= batchSize) {
+        log.info(`respondWithAppInstallingErrorsMessages - Sending chunk of ${batch.length} to ${peer.key}`);
+        await sendSignedMessage({ type: 'fluxappinstallingerrorssync', messages: batch, done: false }, peer);
+        total += batch.length;
+        batch = [];
+      }
+    }
+    log.info(`respondWithAppInstallingErrorsMessages - Sending final ${batch.length} to ${peer.key} (total: ${total + batch.length})`);
+    await sendSignedMessage({ type: 'fluxappinstallingerrorssync', messages: batch, done: true }, peer);
+  } catch (error) {
+    log.error(error);
+  }
+}
+
 module.exports = {
   relay,
   sendSignedMessage,
@@ -422,6 +456,7 @@ module.exports = {
   respondWithTempMessages,
   respondWithAppRunningMessages,
   respondWithAppInstallingMessages,
+  respondWithAppInstallingErrorsMessages,
   serialiseAndSignFluxBroadcast,
   getFluxMessageSignature,
   broadcastMessageToOutgoingFromUser,

--- a/ZelBack/src/services/fluxCommunicationMessagesSender.js
+++ b/ZelBack/src/services/fluxCommunicationMessagesSender.js
@@ -312,26 +312,70 @@ async function broadcastTemporaryAppMessage(message) {
   await broadcastMessageToAll(message);
 }
 
-async function respondWithTempMessages(peer) {
+async function respondWithTempMessages(peer, sinceTimestamp = 0) {
   try {
     const globalAppsTempMessages = config.database.appsglobal.collections.appsTemporaryMessages;
     const db = dbHelper.databaseConnection();
     const database = db.db(config.database.appsglobal.database);
-    const tempMessages = await dbHelper.findInDatabase(
-      database, globalAppsTempMessages, {}, { projection: { _id: 0, receivedAt: 0, expireAt: 0 } },
-    );
-    const messages = tempMessages.map((msg) => ({
-      type: msg.type,
-      version: msg.version,
-      appSpecifications: msg.appSpecifications,
-      hash: msg.hash,
-      timestamp: msg.timestamp,
-      signature: msg.signature,
-      arcaneSender: msg.arcaneSender,
-    }));
-    log.info(`respondWithTempMessages - Sending ${messages.length} temp messages to ${peer.key}`);
-    const response = { type: 'fluxapptempsync', version: 1, messages };
-    await sendSignedMessage(response, peer);
+    const query = sinceTimestamp > 0 ? { receivedAt: { $gt: new Date(sinceTimestamp) } } : {};
+    const cursor = database.collection(globalAppsTempMessages)
+      .find(query, { projection: { _id: 0, receivedAt: 0, expireAt: 0 } })
+      .sort({ receivedAt: 1 });
+
+    const batchSize = 2000;
+    let batch = [];
+    let total = 0;
+    for await (const msg of cursor) {
+      batch.push({
+        type: msg.type,
+        version: msg.version,
+        appSpecifications: msg.appSpecifications,
+        hash: msg.hash,
+        timestamp: msg.timestamp,
+        signature: msg.signature,
+        arcaneSender: msg.arcaneSender,
+      });
+      if (batch.length >= batchSize) {
+        log.info(`respondWithTempMessages - Sending chunk of ${batch.length} to ${peer.key}`);
+        await sendSignedMessage({ type: 'fluxapptempsync', version: 1, messages: batch, done: false }, peer);
+        total += batch.length;
+        batch = [];
+      }
+    }
+    log.info(`respondWithTempMessages - Sending final ${batch.length} to ${peer.key} (total: ${total + batch.length})`);
+    await sendSignedMessage({ type: 'fluxapptempsync', version: 1, messages: batch, done: true }, peer);
+  } catch (error) {
+    log.error(error);
+  }
+}
+
+async function respondWithAppRunningMessages(peer, sinceTimestamp = 0) {
+  try {
+    const appsRunningBroadcasts = config.database.appsglobal.collections.appsRunningBroadcasts;
+    const db = dbHelper.databaseConnection();
+    const database = db.db(config.database.appsglobal.database);
+
+    const adjustedTimestamp = sinceTimestamp > 0
+      ? new Date(sinceTimestamp - (peer.remoteClockOffsetMs || 0))
+      : new Date(0);
+    const cursor = database.collection(appsRunningBroadcasts)
+      .find({ broadcastedAt: { $gt: adjustedTimestamp } }, { projection: { _id: 0, expireAt: 0 } })
+      .sort({ broadcastedAt: 1 });
+
+    const batchSize = 2000;
+    let batch = [];
+    let total = 0;
+    for await (const doc of cursor) {
+      batch.push(doc);
+      if (batch.length >= batchSize) {
+        log.info(`respondWithAppRunningMessages - Sending chunk of ${batch.length} to ${peer.key}`);
+        await sendSignedMessage({ type: 'fluxapprunningsync', messages: batch, done: false }, peer);
+        total += batch.length;
+        batch = [];
+      }
+    }
+    log.info(`respondWithAppRunningMessages - Sending final ${batch.length} to ${peer.key} (total: ${total + batch.length})`);
+    await sendSignedMessage({ type: 'fluxapprunningsync', messages: batch, done: true }, peer);
   } catch (error) {
     log.error(error);
   }
@@ -342,6 +386,7 @@ module.exports = {
   sendSignedMessage,
   respondWithAppMessage,
   respondWithTempMessages,
+  respondWithAppRunningMessages,
   serialiseAndSignFluxBroadcast,
   getFluxMessageSignature,
   broadcastMessageToOutgoingFromUser,

--- a/ZelBack/src/services/fluxCommunicationMessagesSender.js
+++ b/ZelBack/src/services/fluxCommunicationMessagesSender.js
@@ -381,12 +381,45 @@ async function respondWithAppRunningMessages(peer, sinceTimestamp = 0) {
   }
 }
 
+async function respondWithAppInstallingMessages(peer, sinceTimestamp = 0) {
+  try {
+    const appsInstallingBroadcasts = config.database.appsglobal.collections.appsInstallingBroadcasts;
+    const db = dbHelper.databaseConnection();
+    const database = db.db(config.database.appsglobal.database);
+
+    const adjustedTimestamp = sinceTimestamp > 0
+      ? new Date(sinceTimestamp - (peer.remoteClockOffsetMs || 0))
+      : new Date(0);
+    const cursor = database.collection(appsInstallingBroadcasts)
+      .find({ broadcastedAt: { $gt: adjustedTimestamp } }, { projection: { _id: 0, expireAt: 0 } })
+      .sort({ broadcastedAt: 1 });
+
+    const batchSize = 2000;
+    let batch = [];
+    let total = 0;
+    for await (const doc of cursor) {
+      batch.push(doc);
+      if (batch.length >= batchSize) {
+        log.info(`respondWithAppInstallingMessages - Sending chunk of ${batch.length} to ${peer.key}`);
+        await sendSignedMessage({ type: 'fluxappinstallingsync', messages: batch, done: false }, peer);
+        total += batch.length;
+        batch = [];
+      }
+    }
+    log.info(`respondWithAppInstallingMessages - Sending final ${batch.length} to ${peer.key} (total: ${total + batch.length})`);
+    await sendSignedMessage({ type: 'fluxappinstallingsync', messages: batch, done: true }, peer);
+  } catch (error) {
+    log.error(error);
+  }
+}
+
 module.exports = {
   relay,
   sendSignedMessage,
   respondWithAppMessage,
   respondWithTempMessages,
   respondWithAppRunningMessages,
+  respondWithAppInstallingMessages,
   serialiseAndSignFluxBroadcast,
   getFluxMessageSignature,
   broadcastMessageToOutgoingFromUser,

--- a/ZelBack/src/services/fluxCommunicationMessagesSender.js
+++ b/ZelBack/src/services/fluxCommunicationMessagesSender.js
@@ -163,6 +163,7 @@ async function relay(data, excludeKey) {
 async function broadcastMessageToAll(dataToBroadcast) {
   const serialisedData = await serialiseAndSignFluxBroadcast(dataToBroadcast);
   await relay(serialisedData);
+  return JSON.parse(serialisedData);
 }
 
 /**

--- a/ZelBack/src/services/fluxCommunicationMessagesSender.js
+++ b/ZelBack/src/services/fluxCommunicationMessagesSender.js
@@ -358,8 +358,10 @@ async function respondWithAppRunningMessages(peer, sinceTimestamp = 0) {
     const adjustedTimestamp = sinceTimestamp > 0
       ? new Date(sinceTimestamp - (peer.remoteClockOffsetMs || 0))
       : new Date(0);
+    const validAfter = new Date(Date.now() - 125 * 60 * 1000);
+    const minTimestamp = adjustedTimestamp > validAfter ? adjustedTimestamp : validAfter;
     const cursor = database.collection(appsRunningBroadcasts)
-      .find({ broadcastedAt: { $gt: adjustedTimestamp } }, { projection: { _id: 0, expireAt: 0 } })
+      .find({ broadcastedAt: { $gt: minTimestamp } }, { projection: { _id: 0, expireAt: 0 } })
       .sort({ broadcastedAt: 1 });
 
     const batchSize = 2000;

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -191,39 +191,39 @@ async function startFluxFunctions() {
     await databaseTemp.collection(config.database.appsglobal.collections.appsMessages).createIndex({ hash: 1 }, { name: 'query for getting zelapp message based on hash', unique: true });
     await databaseTemp.collection(config.database.appsglobal.collections.appsMessages).createIndex({ 'appSpecifications.version': 1 }, { name: 'query for getting app message based on version' });
     await databaseTemp.collection(config.database.appsglobal.collections.appsMessages).createIndex({ 'appSpecifications.nodes': 1 }, { name: 'query for getting app message based on nodes' });
-    // more than 2 hours and 5m. Meaning we have not received status message for a long time. So that node is no longer on a network or app is down.
-    await databaseTemp.collection(config.database.appsglobal.collections.appsLocations).createIndex({ broadcastedAt: 1 }, { expireAfterSeconds: 7500 });
+    // TTL is driven by expireAt (set per-document by store functions). Migrate from old broadcastedAt-based TTL.
+    await databaseTemp.collection(config.database.appsglobal.collections.appsLocations).dropIndex('broadcastedAt_1').catch(() => {});
+    await databaseTemp.collection(config.database.appsglobal.collections.appsLocations).createIndex({ expireAt: 1 }, { expireAfterSeconds: 0 });
     await databaseTemp.collection(config.database.appsglobal.collections.appsLocations).createIndex({ name: 1 }, { name: 'query for getting zelapp location based on zelapp specs name' });
     await databaseTemp.collection(config.database.appsglobal.collections.appsLocations).createIndex({ ip: 1, name: 1 });
     log.info('Flux Apps locations prepared');
-    await databaseTemp.collection(config.database.appsglobal.collections.appsRunningBroadcasts).createIndex({ broadcastedAt: 1 }, { expireAfterSeconds: 7500 });
+    await databaseTemp.collection(config.database.appsglobal.collections.appsRunningBroadcasts).dropIndex('broadcastedAt_1').catch(() => {});
+    await databaseTemp.collection(config.database.appsglobal.collections.appsRunningBroadcasts).createIndex({ expireAt: 1 }, { expireAfterSeconds: 0 });
+    await databaseTemp.collection(config.database.appsglobal.collections.appsRunningBroadcasts).createIndex({ broadcastedAt: 1 });
     await databaseTemp.collection(config.database.appsglobal.collections.appsRunningBroadcasts).dropIndex('ip_1').catch(() => {});
     await databaseTemp.collection(config.database.appsglobal.collections.appsRunningBroadcasts).createIndex({ ip: 1, 'data.name': 1 }, { unique: true });
     await databaseTemp.collection(config.database.appsglobal.collections.appsRunningBroadcasts).createIndex({ 'data.apps.name': 1 }, { name: 'query for app location from v2 broadcasts' });
     log.info('Signed apprunning broadcasts collection prepared');
-    await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingBroadcasts).createIndex({ broadcastedAt: 1 }, { expireAfterSeconds: 900 });
+    await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingBroadcasts).dropIndex('broadcastedAt_1').catch(() => {});
+    await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingBroadcasts).createIndex({ expireAt: 1 }, { expireAfterSeconds: 0 });
+    await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingBroadcasts).createIndex({ broadcastedAt: 1 });
     await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingBroadcasts).createIndex({ 'data.name': 1, 'data.ip': 1 }, { unique: true });
     log.info('Signed appinstalling broadcasts collection prepared');
-    // we just keep installing messages for 15 minutes
-    // Update existing TTL index if it exists (for nodes that already have it created with old value)
-    await databaseTemp.command({
-      collMod: config.database.appsglobal.collections.appsInstallingLocations,
-      index: {
-        keyPattern: { broadcastedAt: 1 },
-        expireAfterSeconds: 900,
-      },
-    }).catch(() => {}); // Ignore error if index doesn't exist yet
-    await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingLocations).createIndex({ broadcastedAt: 1 }, { expireAfterSeconds: 900 });
+    await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingLocations).dropIndex('broadcastedAt_1').catch(() => {});
+    await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingLocations).createIndex({ expireAt: 1 }, { expireAfterSeconds: 0 });
     await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingLocations).createIndex({ name: 1 }, { name: 'query for getting flux app install location based on specs name' });
     await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingLocations).createIndex({ name: 1, ip: 1 }, { name: 'query for getting flux app install location based on specs name and node ip' });
     log.info('Flux Apps installing locations prepared');
     await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingErrorsLocations).dropIndex('cachedAt_1').catch(() => {});
-    await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingErrorsLocations).createIndex({ broadcastedAt: 1 }, { expireAfterSeconds: 86400 });
+    await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingErrorsLocations).dropIndex('broadcastedAt_1').catch(() => {});
+    await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingErrorsLocations).createIndex({ expireAt: 1 }, { expireAfterSeconds: 0 });
     await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingErrorsLocations).createIndex({ name: 1 }, { name: 'query for getting flux app install errors location based on specs name' });
     await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingErrorsLocations).createIndex({ name: 1, hash: 1 }, { name: 'query for getting flux app install errors location based on specs name and hash' });
     await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingErrorsLocations).createIndex({ name: 1, hash: 1, ip: 1 }, { name: 'query for getting flux app install errors location based on specs name and hash and node ip' });
     log.info('App installing errors locations prepared');
-    await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingErrorsBroadcasts).createIndex({ broadcastedAt: 1 }, { expireAfterSeconds: 86400 });
+    await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingErrorsBroadcasts).dropIndex('broadcastedAt_1').catch(() => {});
+    await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingErrorsBroadcasts).createIndex({ expireAt: 1 }, { expireAfterSeconds: 0 });
+    await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingErrorsBroadcasts).createIndex({ broadcastedAt: 1 });
     await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingErrorsBroadcasts).createIndex({ 'data.name': 1, 'data.hash': 1, 'data.ip': 1 }, { unique: true });
     log.info('Signed app installing errors broadcasts collection prepared');
 

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -215,14 +215,15 @@ async function startFluxFunctions() {
     await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingLocations).createIndex({ name: 1 }, { name: 'query for getting flux app install location based on specs name' });
     await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingLocations).createIndex({ name: 1, ip: 1 }, { name: 'query for getting flux app install location based on specs name and node ip' });
     log.info('Flux Apps installing locations prepared');
-    // we keep installing error messages for 60 minutes
-    await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingErrorsLocations).createIndex({ cachedAt: 1 }, { expireAfterSeconds: 3600 });
+    await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingErrorsLocations).dropIndex('cachedAt_1').catch(() => {});
+    await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingErrorsLocations).createIndex({ broadcastedAt: 1 }, { expireAfterSeconds: 86400 });
     await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingErrorsLocations).createIndex({ name: 1 }, { name: 'query for getting flux app install errors location based on specs name' });
     await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingErrorsLocations).createIndex({ name: 1, hash: 1 }, { name: 'query for getting flux app install errors location based on specs name and hash' });
     await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingErrorsLocations).createIndex({ name: 1, hash: 1, ip: 1 }, { name: 'query for getting flux app install errors location based on specs name and hash and node ip' });
-    log.info('Clearing app installing errors from previous sessions...');
-    await dbHelper.removeDocumentsFromCollection(databaseTemp, config.database.appsglobal.collections.appsInstallingErrorsLocations, {});
-    log.info('App installing errors cleared');
+    log.info('App installing errors locations prepared');
+    await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingErrorsBroadcasts).createIndex({ broadcastedAt: 1 }, { expireAfterSeconds: 86400 });
+    await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingErrorsBroadcasts).createIndex({ 'data.name': 1, 'data.hash': 1, 'data.ip': 1 }, { unique: true });
+    log.info('Signed app installing errors broadcasts collection prepared');
 
     // This fixes an issue where the appsMessage db has NaN for valueSat. Once db is repaired on all nodes,
     // we can remove this.

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -194,7 +194,7 @@ async function startFluxFunctions() {
     // more than 2 hours and 5m. Meaning we have not received status message for a long time. So that node is no longer on a network or app is down.
     await databaseTemp.collection(config.database.appsglobal.collections.appsLocations).createIndex({ broadcastedAt: 1 }, { expireAfterSeconds: 7500 });
     await databaseTemp.collection(config.database.appsglobal.collections.appsLocations).createIndex({ name: 1 }, { name: 'query for getting zelapp location based on zelapp specs name' });
-    await databaseTemp.collection(config.database.appsglobal.collections.appsLocations).createIndex({ name: 1, ip: 1 });
+    await databaseTemp.collection(config.database.appsglobal.collections.appsLocations).createIndex({ ip: 1, name: 1 });
     log.info('Flux Apps locations prepared');
     await databaseTemp.collection(config.database.appsglobal.collections.appsRunningBroadcasts).createIndex({ broadcastedAt: 1 }, { expireAfterSeconds: 7500 });
     await databaseTemp.collection(config.database.appsglobal.collections.appsRunningBroadcasts).dropIndex('ip_1').catch(() => {});

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -194,6 +194,7 @@ async function startFluxFunctions() {
     // more than 2 hours and 5m. Meaning we have not received status message for a long time. So that node is no longer on a network or app is down.
     await databaseTemp.collection(config.database.appsglobal.collections.appsLocations).createIndex({ broadcastedAt: 1 }, { expireAfterSeconds: 7500 });
     await databaseTemp.collection(config.database.appsglobal.collections.appsLocations).createIndex({ name: 1 }, { name: 'query for getting zelapp location based on zelapp specs name' });
+    await databaseTemp.collection(config.database.appsglobal.collections.appsLocations).createIndex({ name: 1, ip: 1 });
     log.info('Flux Apps locations prepared');
     await databaseTemp.collection(config.database.appsglobal.collections.appsRunningBroadcasts).createIndex({ broadcastedAt: 1 }, { expireAfterSeconds: 7500 });
     await databaseTemp.collection(config.database.appsglobal.collections.appsRunningBroadcasts).dropIndex('ip_1').catch(() => {});

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -195,6 +195,10 @@ async function startFluxFunctions() {
     await databaseTemp.collection(config.database.appsglobal.collections.appsLocations).createIndex({ broadcastedAt: 1 }, { expireAfterSeconds: 7500 });
     await databaseTemp.collection(config.database.appsglobal.collections.appsLocations).createIndex({ name: 1 }, { name: 'query for getting zelapp location based on zelapp specs name' });
     log.info('Flux Apps locations prepared');
+    // Signed apprunning broadcasts for sync — one doc per IP, TTL matches location TTL
+    await databaseTemp.collection(config.database.appsglobal.collections.appsRunningBroadcasts).createIndex({ broadcastedAt: 1 }, { expireAfterSeconds: 7500 });
+    await databaseTemp.collection(config.database.appsglobal.collections.appsRunningBroadcasts).createIndex({ ip: 1 }, { unique: true });
+    log.info('Signed apprunning broadcasts collection prepared');
     // we just keep installing messages for 15 minutes
     // Update existing TTL index if it exists (for nodes that already have it created with old value)
     await databaseTemp.command({

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -195,9 +195,9 @@ async function startFluxFunctions() {
     await databaseTemp.collection(config.database.appsglobal.collections.appsLocations).createIndex({ broadcastedAt: 1 }, { expireAfterSeconds: 7500 });
     await databaseTemp.collection(config.database.appsglobal.collections.appsLocations).createIndex({ name: 1 }, { name: 'query for getting zelapp location based on zelapp specs name' });
     log.info('Flux Apps locations prepared');
-    // Signed apprunning broadcasts for sync — one doc per IP, TTL matches location TTL
     await databaseTemp.collection(config.database.appsglobal.collections.appsRunningBroadcasts).createIndex({ broadcastedAt: 1 }, { expireAfterSeconds: 7500 });
-    await databaseTemp.collection(config.database.appsglobal.collections.appsRunningBroadcasts).createIndex({ ip: 1 }, { unique: true });
+    await databaseTemp.collection(config.database.appsglobal.collections.appsRunningBroadcasts).dropIndex('ip_1').catch(() => {});
+    await databaseTemp.collection(config.database.appsglobal.collections.appsRunningBroadcasts).createIndex({ ip: 1, 'data.name': 1 }, { unique: true });
     log.info('Signed apprunning broadcasts collection prepared');
     await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingBroadcasts).createIndex({ broadcastedAt: 1 }, { expireAfterSeconds: 900 });
     await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingBroadcasts).createIndex({ 'data.name': 1, 'data.ip': 1 }, { unique: true });

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -199,6 +199,9 @@ async function startFluxFunctions() {
     await databaseTemp.collection(config.database.appsglobal.collections.appsRunningBroadcasts).createIndex({ broadcastedAt: 1 }, { expireAfterSeconds: 7500 });
     await databaseTemp.collection(config.database.appsglobal.collections.appsRunningBroadcasts).createIndex({ ip: 1 }, { unique: true });
     log.info('Signed apprunning broadcasts collection prepared');
+    await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingBroadcasts).createIndex({ broadcastedAt: 1 }, { expireAfterSeconds: 900 });
+    await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingBroadcasts).createIndex({ 'data.name': 1, 'data.ip': 1 }, { unique: true });
+    log.info('Signed appinstalling broadcasts collection prepared');
     // we just keep installing messages for 15 minutes
     // Update existing TTL index if it exists (for nodes that already have it created with old value)
     await databaseTemp.command({

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -279,6 +279,7 @@ async function startFluxFunctions() {
       isEnterprise: () => enterpriseNetwork.getCachedEnterpriseIdentity(),
     });
     appSpawner.initialize({ appInstaller, appUninstaller, orchestrator });
+    fluxCommunication.setOnSyncComplete((syncType) => orchestrator.onSyncComplete(syncType));
     log.info('App Spawner initialized');
 
     fluxNetworkHelper.adjustFirewall();

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -280,6 +280,7 @@ async function startFluxFunctions() {
       isEnterprise: () => enterpriseNetwork.getCachedEnterpriseIdentity(),
     });
     appSpawner.initialize({ appInstaller, appUninstaller, orchestrator });
+    appInstaller.setOnInstallComplete(() => peerNotification.checkAndNotifyPeersOfRunningApps());
     fluxCommunication.setOnSyncComplete((syncType) => orchestrator.onSyncComplete(syncType));
     log.info('App Spawner initialized');
 

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -25,9 +25,9 @@ const peerNotification = require('./appMessaging/peerNotification');
 const syncthingMonitor = require('./appMonitoring/syncthingMonitor');
 const daemonHealthMonitor = require('./appMonitoring/daemonHealthMonitor');
 const advancedWorkflows = require('./appLifecycle/advancedWorkflows');
-const appHashSyncService = require('./appMessaging/appHashSyncService');
 const imageManager = require('./appSecurity/imageManager');
 const appSpawner = require('./appLifecycle/appSpawner');
+const { AppSyncOrchestrator } = require('./appMessaging/appSyncOrchestrator');
 const crontabAndMountsCleanup = require('./appLifecycle/crontabAndMountsCleanup');
 const containerMountRecovery = require('./appLifecycle/containerMountRecovery');
 const stoppedAppsRecovery = require('./appLifecycle/stoppedAppsRecovery');
@@ -263,8 +263,14 @@ async function startFluxFunctions() {
 
     log.info('Flux Apps installing locations prepared');
 
-    // Initialize appSpawner with dependencies to avoid circular dependency
-    appSpawner.initialize({ appInstaller, appUninstaller });
+    // Initialize app sync orchestrator and spawner
+    const { peerManager } = require('./utils/peerState');
+    const orchestrator = new AppSyncOrchestrator({
+      blockEmitter: explorerService.getBlockEmitter(),
+      peerManager,
+      isEnterprise: () => enterpriseNetwork.getCachedEnterpriseIdentity(),
+    });
+    appSpawner.initialize({ appInstaller, appUninstaller, orchestrator });
     log.info('App Spawner initialized');
 
     fluxNetworkHelper.adjustFirewall();
@@ -473,34 +479,6 @@ async function startFluxFunctions() {
       nodeStatusMonitor.monitorNodeStatus(appQueryService.installedApps, appUninstaller.removeAppLocally);
     }, 1.5 * 60 * 1000);
     setTimeout(() => {
-      peerNotification.checkAndNotifyPeersOfRunningApps(
-        appQueryService.installedApps,
-        appQueryService.listRunningApps,
-        globalState.appsMonitored,
-        globalState.removalInProgress,
-        globalState.installationInProgress,
-        globalState.softRedeployInProgress,
-        globalState.hardRedeployInProgress,
-        globalState.reinstallationOfOldAppsInProgress,
-        () => globalState,
-        cacheManager,
-      ); // first broadcast after 1m of starting fluxos
-      setInterval(() => { // every 60 mins messages stay on db for 65m
-        peerNotification.checkAndNotifyPeersOfRunningApps(
-          appQueryService.installedApps,
-          appQueryService.listRunningApps,
-          globalState.appsMonitored,
-          globalState.removalInProgress,
-          globalState.installationInProgress,
-          globalState.softRedeployInProgress,
-          globalState.hardRedeployInProgress,
-          globalState.reinstallationOfOldAppsInProgress,
-          () => globalState,
-          cacheManager,
-        );
-      }, 60 * 60 * 1000);
-    }, 1 * 60 * 1000);
-    setTimeout(() => {
       syncthingMonitor.syncthingApps(
         globalState,
         appQueryService.installedApps,
@@ -525,36 +503,9 @@ async function startFluxFunctions() {
         appInspector.monitorSharedDBApps(appQueryService.installedApps, appUninstaller.removeAppLocally, globalState); // Monitor SharedDB Apps.
       }, 60 * 1000);
     }, 3 * 60 * 1000);
-    setTimeout(() => {
-      setInterval(() => { // every 30 mins (15 blocks)
-        appHashSyncService.continuousFluxAppHashesCheck();
-      }, 30 * 60 * 1000);
-      appHashSyncService.continuousFluxAppHashesCheck();
-    }, (Math.floor(Math.random() * (30 - 15 + 1)) + 15) * 60 * 1000); // start between 15m and 30m after fluxOs start
-    setTimeout(async () => {
-      // Enterprise-network nodes (pubkey in enterpriseNodesPublicKeys) start
-      // spawning at T+62m. Every other node keeps the legacy 125-135m window,
-      // which gives enough time to receive apprunning messages at least twice.
-      let isEnterprise = enterpriseNetwork.getCachedEnterpriseIdentity();
-      if (isEnterprise === null) {
-        try {
-          isEnterprise = await enterpriseNetwork.isEnterpriseNode();
-        } catch (err) {
-          log.warn(`Enterprise identity unresolved at spawn-gate, treating as non-enterprise: ${err.message || err}`);
-          isEnterprise = false;
-        }
-      }
-      if (isEnterprise) {
-        log.info('Starting to spawn applications (enterprise, 62m)');
-        appSpawner.trySpawningGlobalApplication();
-        return;
-      }
-      const remainingMs = (Math.floor(Math.random() * (135 - 125 + 1)) + 125 - 62) * 60 * 1000;
-      setTimeout(() => {
-        log.info('Starting to spawn applications');
-        appSpawner.trySpawningGlobalApplication();
-      }, remainingMs);
-    }, 62 * 60 * 1000);
+    // Hash sync and spawner startup are now managed by the AppSyncOrchestrator (event-driven)
+    orchestrator.start();
+    log.info('AppSyncOrchestrator started');
     setInterval(() => {
       imageManager.checkApplicationsCompliance(appQueryService.installedApps, appUninstaller.removeAppLocally);
     }, 60 * 60 * 1000); //  every hour

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -198,6 +198,7 @@ async function startFluxFunctions() {
     await databaseTemp.collection(config.database.appsglobal.collections.appsRunningBroadcasts).createIndex({ broadcastedAt: 1 }, { expireAfterSeconds: 7500 });
     await databaseTemp.collection(config.database.appsglobal.collections.appsRunningBroadcasts).dropIndex('ip_1').catch(() => {});
     await databaseTemp.collection(config.database.appsglobal.collections.appsRunningBroadcasts).createIndex({ ip: 1, 'data.name': 1 }, { unique: true });
+    await databaseTemp.collection(config.database.appsglobal.collections.appsRunningBroadcasts).createIndex({ 'data.apps.name': 1 }, { name: 'query for app location from v2 broadcasts' });
     log.info('Signed apprunning broadcasts collection prepared');
     await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingBroadcasts).createIndex({ broadcastedAt: 1 }, { expireAfterSeconds: 900 });
     await databaseTemp.collection(config.database.appsglobal.collections.appsInstallingBroadcasts).createIndex({ 'data.name': 1, 'data.ip': 1 }, { unique: true });

--- a/ZelBack/src/services/utils/FluxPeerManager.js
+++ b/ZelBack/src/services/utils/FluxPeerManager.js
@@ -370,26 +370,20 @@ class FluxPeerManager extends EventEmitter {
     return peer.remoteFluxUptime + (Date.now() - peer.connectedAt) / 1000;
   }
 
-  getEligibleTempSyncPeers(minUptimeSeconds) {
+  getEligibleSyncPeers(minUptimeSeconds, count) {
     const eligible = [];
     for (const peer of this.#peers.values()) {
+      if (peer.missedPongs !== 0) continue;
       if (!peer.remoteCapabilities.has('appStateSync')) continue;
       const uptime = this.getPeerFluxUptime(peer.key);
       if (uptime === null || uptime < minUptimeSeconds) continue;
       eligible.push(peer);
     }
-    return eligible;
-  }
-
-  getEligibleAppRunningSyncPeers(minUptimeSeconds) {
-    const eligible = [];
-    for (const peer of this.#peers.values()) {
-      if (!peer.remoteCapabilities.has('appStateSync')) continue;
-      const uptime = this.getPeerFluxUptime(peer.key);
-      if (uptime === null || uptime < minUptimeSeconds) continue;
-      eligible.push(peer);
+    for (let i = eligible.length - 1; i > 0; i -= 1) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [eligible[i], eligible[j]] = [eligible[j], eligible[i]];
     }
-    return eligible;
+    return count ? eligible.slice(0, count) : eligible;
   }
 
   // --- Liveness ---

--- a/ZelBack/src/services/utils/FluxPeerManager.js
+++ b/ZelBack/src/services/utils/FluxPeerManager.js
@@ -381,6 +381,17 @@ class FluxPeerManager extends EventEmitter {
     return eligible;
   }
 
+  getEligibleAppRunningSyncPeers(minUptimeSeconds) {
+    const eligible = [];
+    for (const peer of this.#peers.values()) {
+      if (!peer.remoteCapabilities.has('appRunningSync')) continue;
+      const uptime = this.getPeerFluxUptime(peer.key);
+      if (uptime === null || uptime < minUptimeSeconds) continue;
+      eligible.push(peer);
+    }
+    return eligible;
+  }
+
   // --- Liveness ---
 
   /**
@@ -978,7 +989,16 @@ class FluxPeerManager extends EventEmitter {
         }
         case peerCodec.MSG_TYPE.REQUEST_TEMP_MESSAGES: {
           if (this.hashHandlers && this.hashHandlers.handleTempMessagesRequest) {
-            this.hashHandlers.handleTempMessagesRequest(peer);
+            const sinceTimestamp = buf.length >= 9 ? peerCodec.decodeSyncTimestamp(buf) : 0;
+            this.hashHandlers.handleTempMessagesRequest(peer, sinceTimestamp);
+          }
+          break;
+        }
+        case peerCodec.MSG_TYPE.REQUEST_APP_RUNNING: {
+          if (buf.length < 9) break;
+          const sinceTimestamp = peerCodec.decodeSyncTimestamp(buf);
+          if (this.hashHandlers && this.hashHandlers.handleAppRunningRequest) {
+            this.hashHandlers.handleAppRunningRequest(peer, sinceTimestamp);
           }
           break;
         }

--- a/ZelBack/src/services/utils/FluxPeerManager.js
+++ b/ZelBack/src/services/utils/FluxPeerManager.js
@@ -2,7 +2,7 @@ const { EventEmitter } = require('events');
 const config = require('config');
 const log = require('../../lib/log');
 const serviceHelper = require('../serviceHelper');
-const { FluxPeerSocket, CLOSE_CODES, PEER_SOURCE, DIRECTION, FLUX_VERSION } = require('./FluxPeerSocket');
+const { FluxPeerSocket, CLOSE_CODES, PEER_SOURCE, DIRECTION, FLUX_VERSION, FLUX_CAPABILITIES } = require('./FluxPeerSocket');
 const peerCodec = require('./peerCodec');
 
 const UNSTABLE_DISCONNECT_THRESHOLD = 5;
@@ -1384,4 +1384,4 @@ class FluxPeerManager extends EventEmitter {
 // Singleton export
 const peerManager = new FluxPeerManager();
 
-module.exports = { FluxPeerManager, peerManager, CLOSE_CODES, PEER_SOURCE, DIRECTION, FLUX_VERSION };
+module.exports = { FluxPeerManager, peerManager, CLOSE_CODES, PEER_SOURCE, DIRECTION, FLUX_VERSION, FLUX_CAPABILITIES };

--- a/ZelBack/src/services/utils/FluxPeerManager.js
+++ b/ZelBack/src/services/utils/FluxPeerManager.js
@@ -1,3 +1,4 @@
+const { EventEmitter } = require('events');
 const config = require('config');
 const log = require('../../lib/log');
 const serviceHelper = require('../serviceHelper');
@@ -25,7 +26,7 @@ const CLOSE_CODE_NAMES = Object.freeze(
   Object.fromEntries(Object.entries(CLOSE_CODES).map(([name, code]) => [code, name])),
 );
 
-class FluxPeerManager {
+class FluxPeerManager extends EventEmitter {
   static CONNECTION_BACKOFF_MS = [2 * 60000, 5 * 60000, 10 * 60000, 15 * 60000];
 
   /** @type {Map<string, FluxPeerSocket>} */
@@ -48,6 +49,12 @@ class FluxPeerManager {
   #pendingConnections = new Set();
   /** @type {Map<string, number>} reconnect count per peer key, persists across connection cycles */
   #reconnectCounts = new Map();
+  /** @type {number} peer count threshold for app sync readiness */
+  #syncPeerThreshold;
+  /** @type {number} peer count threshold for degraded state */
+  #syncDegradedThreshold;
+  /** @type {boolean} true when peer count is above syncPeerThreshold */
+  #aboveThreshold;
   /** @type {Map<string, Set<string>>} reporter key → their peer keys */
   #peerTopology = new Map();
   /** @type {Array<function>} topology change listeners */
@@ -66,6 +73,12 @@ class FluxPeerManager {
   #historyCount = 0;
 
   constructor() {
+    super();
+
+    this.#syncPeerThreshold = config.fluxapps.appSyncPeerThreshold;
+    this.#syncDegradedThreshold = config.fluxapps.appSyncDegradedThreshold;
+    this.#aboveThreshold = false;
+
     /**
      * Hash message handlers — set by fluxCommunication.js to break circular dependency.
      * @type {{ handleHashPresent: function, handleHashRequest: function }|null}
@@ -128,6 +141,9 @@ class FluxPeerManager {
     if (typeof options.remoteVersion === 'string' && options.remoteVersion) {
       peer.remoteVersion = options.remoteVersion;
     }
+    if (typeof options.remoteFluxUptime === 'number' && !Number.isNaN(options.remoteFluxUptime)) {
+      peer.remoteFluxUptime = options.remoteFluxUptime;
+    }
     if (existing || options.source === PEER_SOURCE.RECONNECT) {
       this.#reconnectCounts.set(key, (this.#reconnectCounts.get(key) || 0) + 1);
     }
@@ -162,6 +178,10 @@ class FluxPeerManager {
     this.#pendingRemoves.delete(peer.key);
     this.#schedulePeerUpdate();
     if (this.networkHealthMonitor) this.networkHealthMonitor.recordConnect();
+    if (!this.#aboveThreshold && this.#peers.size >= this.#syncPeerThreshold) {
+      this.#aboveThreshold = true;
+      this.emit('peerThresholdReached', this.#peers.size);
+    }
     return peer;
   }
 
@@ -214,6 +234,10 @@ class FluxPeerManager {
     });
 
     log.info(`Connection ${key} removed from peerManager (${peer.direction}, code: ${closeCode})`);
+    if (this.#aboveThreshold && this.#peers.size < this.#syncDegradedThreshold) {
+      this.#aboveThreshold = false;
+      this.emit('peersBelowThreshold', this.#peers.size);
+    }
     return peer;
   }
 
@@ -338,6 +362,23 @@ class FluxPeerManager {
 
   getNumberOfPeers() {
     return this.#peers.size;
+  }
+
+  getPeerFluxUptime(key) {
+    const peer = this.#peers.get(key);
+    if (!peer || peer.remoteFluxUptime === null) return null;
+    return peer.remoteFluxUptime + (Date.now() - peer.connectedAt) / 1000;
+  }
+
+  getEligibleTempSyncPeers(minUptimeSeconds) {
+    const eligible = [];
+    for (const peer of this.#peers.values()) {
+      if (!peer.remoteCapabilities.has('tempMessageSync')) continue;
+      const uptime = this.getPeerFluxUptime(peer.key);
+      if (uptime === null || uptime < minUptimeSeconds) continue;
+      eligible.push(peer);
+    }
+    return eligible;
   }
 
   // --- Liveness ---
@@ -695,6 +736,9 @@ class FluxPeerManager {
         if (req.headers['x-flux-version']) {
           metadata.remoteVersion = req.headers['x-flux-version'];
         }
+        if (req.headers['x-flux-uptime']) {
+          metadata.remoteFluxUptime = Number(req.headers['x-flux-uptime']);
+        }
       }
       const maxPeers = 4 * config.fluxapps.minIncoming;
       const maxNumberOfConnections = this.numberOfFluxNodes / 160 < 9 * config.fluxapps.minIncoming
@@ -930,6 +974,12 @@ class FluxPeerManager {
           if (buf.length < 7) return;
           const { addOutbound, addInbound, rm } = peerCodec.decodePeerUpdate(buf);
           this.handlePeerUpdate(peer, addOutbound, addInbound, rm);
+          break;
+        }
+        case peerCodec.MSG_TYPE.REQUEST_TEMP_MESSAGES: {
+          if (this.hashHandlers && this.hashHandlers.handleTempMessagesRequest) {
+            this.hashHandlers.handleTempMessagesRequest(peer);
+          }
           break;
         }
         default:

--- a/ZelBack/src/services/utils/FluxPeerManager.js
+++ b/ZelBack/src/services/utils/FluxPeerManager.js
@@ -373,7 +373,7 @@ class FluxPeerManager extends EventEmitter {
   getEligibleTempSyncPeers(minUptimeSeconds) {
     const eligible = [];
     for (const peer of this.#peers.values()) {
-      if (!peer.remoteCapabilities.has('tempMessageSync')) continue;
+      if (!peer.remoteCapabilities.has('appStateSync')) continue;
       const uptime = this.getPeerFluxUptime(peer.key);
       if (uptime === null || uptime < minUptimeSeconds) continue;
       eligible.push(peer);
@@ -384,7 +384,7 @@ class FluxPeerManager extends EventEmitter {
   getEligibleAppRunningSyncPeers(minUptimeSeconds) {
     const eligible = [];
     for (const peer of this.#peers.values()) {
-      if (!peer.remoteCapabilities.has('appRunningSync')) continue;
+      if (!peer.remoteCapabilities.has('appStateSync')) continue;
       const uptime = this.getPeerFluxUptime(peer.key);
       if (uptime === null || uptime < minUptimeSeconds) continue;
       eligible.push(peer);
@@ -999,6 +999,14 @@ class FluxPeerManager extends EventEmitter {
           const sinceTimestamp = peerCodec.decodeSyncTimestamp(buf);
           if (this.hashHandlers && this.hashHandlers.handleAppRunningRequest) {
             this.hashHandlers.handleAppRunningRequest(peer, sinceTimestamp);
+          }
+          break;
+        }
+        case peerCodec.MSG_TYPE.REQUEST_APP_INSTALLING: {
+          if (buf.length < 9) break;
+          const sinceTimestamp = peerCodec.decodeSyncTimestamp(buf);
+          if (this.hashHandlers && this.hashHandlers.handleAppInstallingRequest) {
+            this.hashHandlers.handleAppInstallingRequest(peer, sinceTimestamp);
           }
           break;
         }

--- a/ZelBack/src/services/utils/FluxPeerManager.js
+++ b/ZelBack/src/services/utils/FluxPeerManager.js
@@ -1010,6 +1010,14 @@ class FluxPeerManager extends EventEmitter {
           }
           break;
         }
+        case peerCodec.MSG_TYPE.REQUEST_APP_INSTALLING_ERRORS: {
+          if (buf.length < 9) break;
+          const sinceTimestamp = peerCodec.decodeSyncTimestamp(buf);
+          if (this.hashHandlers && this.hashHandlers.handleAppInstallingErrorsRequest) {
+            this.hashHandlers.handleAppInstallingErrorsRequest(peer, sinceTimestamp);
+          }
+          break;
+        }
         default:
           // Unknown type — ignore for forward compatibility
           break;

--- a/ZelBack/src/services/utils/FluxPeerSocket.js
+++ b/ZelBack/src/services/utils/FluxPeerSocket.js
@@ -84,6 +84,7 @@ class FluxPeerSocket {
     this.remoteCapabilities = new Set();
     this.remoteClockOffsetMs = null;
     this.remoteVersion = null;
+    this.remoteFluxUptime = null;
     this.source = PEER_SOURCE.INBOUND;
     this.msgMap = new Map([['requestHash', 0], ['newHash', 0]]);
     this.messagesReceived = 0;

--- a/ZelBack/src/services/utils/FluxPeerSocket.js
+++ b/ZelBack/src/services/utils/FluxPeerSocket.js
@@ -339,4 +339,12 @@ class FluxPeerSocket {
   }
 }
 
-module.exports = { FluxPeerSocket, CLOSE_CODES, PEER_SOURCE, DIRECTION, FLUX_VERSION };
+const FLUX_CAPABILITIES = Object.freeze([
+  'transmissionTimestamps',
+  'peerExchange',
+  'binaryMessages',
+  'tempMessageSync',
+  'appRunningSync',
+]);
+
+module.exports = { FluxPeerSocket, CLOSE_CODES, PEER_SOURCE, DIRECTION, FLUX_VERSION, FLUX_CAPABILITIES };

--- a/ZelBack/src/services/utils/FluxPeerSocket.js
+++ b/ZelBack/src/services/utils/FluxPeerSocket.js
@@ -343,8 +343,7 @@ const FLUX_CAPABILITIES = Object.freeze([
   'transmissionTimestamps',
   'peerExchange',
   'binaryMessages',
-  'tempMessageSync',
-  'appRunningSync',
+  'appStateSync',
 ]);
 
 module.exports = { FluxPeerSocket, CLOSE_CODES, PEER_SOURCE, DIRECTION, FLUX_VERSION, FLUX_CAPABILITIES };

--- a/ZelBack/src/services/utils/appConstants.js
+++ b/ZelBack/src/services/utils/appConstants.js
@@ -20,6 +20,7 @@ const globalAppsTempMessages = config.database.appsglobal.collections.appsTempor
 const globalAppsLocations = config.database.appsglobal.collections.appsLocations;
 const globalAppsInstallingLocations = config.database.appsglobal.collections.appsInstallingLocations;
 const globalAppsInstallingErrorsLocations = config.database.appsglobal.collections.appsInstallingErrorsLocations;
+const globalAppsInstallingErrorsBroadcasts = config.database.appsglobal.collections.appsInstallingErrorsBroadcasts;
 
 // Supported architectures
 const supportedArchitectures = ['amd64', 'arm64'];
@@ -79,6 +80,7 @@ module.exports = {
   globalAppsLocations,
   globalAppsInstallingLocations,
   globalAppsInstallingErrorsLocations,
+  globalAppsInstallingErrorsBroadcasts,
 
   // Configuration
   supportedArchitectures,

--- a/ZelBack/src/services/utils/appConstants.js
+++ b/ZelBack/src/services/utils/appConstants.js
@@ -19,6 +19,7 @@ const globalAppsInformation = config.database.appsglobal.collections.appsInforma
 const globalAppsTempMessages = config.database.appsglobal.collections.appsTemporaryMessages;
 const globalAppsLocations = config.database.appsglobal.collections.appsLocations;
 const globalAppsInstallingLocations = config.database.appsglobal.collections.appsInstallingLocations;
+const globalAppsRunningBroadcasts = config.database.appsglobal.collections.appsRunningBroadcasts;
 const globalAppsInstallingErrorsLocations = config.database.appsglobal.collections.appsInstallingErrorsLocations;
 const globalAppsInstallingErrorsBroadcasts = config.database.appsglobal.collections.appsInstallingErrorsBroadcasts;
 
@@ -79,6 +80,7 @@ module.exports = {
   globalAppsTempMessages,
   globalAppsLocations,
   globalAppsInstallingLocations,
+  globalAppsRunningBroadcasts,
   globalAppsInstallingErrorsLocations,
   globalAppsInstallingErrorsBroadcasts,
 

--- a/ZelBack/src/services/utils/globalState.js
+++ b/ZelBack/src/services/utils/globalState.js
@@ -20,6 +20,7 @@ let appsMonitored = {};
 let fluxNodeWasNotConfirmedOnLastCheck = false;
 let firstExecutionAfterItsSynced = true;
 let fluxNodeWasAlreadyConfirmed = false;
+let spawnerPaused = false;
 
 // Cache and delay lists
 const appsToBeCheckedLater = [];
@@ -91,6 +92,9 @@ module.exports = {
 
   get fluxNodeWasAlreadyConfirmed() { return fluxNodeWasAlreadyConfirmed; },
   set fluxNodeWasAlreadyConfirmed(value) { fluxNodeWasAlreadyConfirmed = value; },
+
+  get spawnerPaused() { return spawnerPaused; },
+  set spawnerPaused(value) { spawnerPaused = value; },
 
   get appsToBeCheckedLater() { return appsToBeCheckedLater; },
   get appsSyncthingToBeCheckedLater() { return appsSyncthingToBeCheckedLater; },

--- a/ZelBack/src/services/utils/globalState.js
+++ b/ZelBack/src/services/utils/globalState.js
@@ -21,6 +21,7 @@ let fluxNodeWasNotConfirmedOnLastCheck = false;
 let firstExecutionAfterItsSynced = true;
 let fluxNodeWasAlreadyConfirmed = false;
 let spawnerPaused = false;
+let appRunningSyncComplete = false;
 
 // Cache and delay lists
 const appsToBeCheckedLater = [];
@@ -95,6 +96,9 @@ module.exports = {
 
   get spawnerPaused() { return spawnerPaused; },
   set spawnerPaused(value) { spawnerPaused = value; },
+
+  get appRunningSyncComplete() { return appRunningSyncComplete; },
+  set appRunningSyncComplete(value) { appRunningSyncComplete = value; },
 
   get appsToBeCheckedLater() { return appsToBeCheckedLater; },
   get appsSyncthingToBeCheckedLater() { return appsSyncthingToBeCheckedLater; },

--- a/ZelBack/src/services/utils/globalState.js
+++ b/ZelBack/src/services/utils/globalState.js
@@ -21,7 +21,6 @@ let fluxNodeWasNotConfirmedOnLastCheck = false;
 let firstExecutionAfterItsSynced = true;
 let fluxNodeWasAlreadyConfirmed = false;
 let spawnerPaused = false;
-let appRunningSyncComplete = false;
 
 // Cache and delay lists
 const appsToBeCheckedLater = [];
@@ -96,9 +95,6 @@ module.exports = {
 
   get spawnerPaused() { return spawnerPaused; },
   set spawnerPaused(value) { spawnerPaused = value; },
-
-  get appRunningSyncComplete() { return appRunningSyncComplete; },
-  set appRunningSyncComplete(value) { appRunningSyncComplete = value; },
 
   get appsToBeCheckedLater() { return appsToBeCheckedLater; },
   get appsSyncthingToBeCheckedLater() { return appsSyncthingToBeCheckedLater; },

--- a/ZelBack/src/services/utils/peerCodec.js
+++ b/ZelBack/src/services/utils/peerCodec.js
@@ -9,7 +9,8 @@
  * Type 0x03 — nak                 [type:1][hash:20][reason:1]  = 22 bytes
  * Type 0x10 — peerExchange        [type:1][count:2][peer:6]... = 3 + count*6
  * Type 0x11 — peerUpdate          [type:1][addCnt:2][rmCnt:2][peer:6]... = 5 + total*6
- * Type 0x20 — requestTempMessages [type:1]                    = 1 byte
+ * Type 0x20 — requestTempMessages  [type:1][sinceTs:8]          = 9 bytes
+ * Type 0x21 — requestAppRunning   [type:1][sinceTs:8]          = 9 bytes
  */
 
 const MSG_TYPE = Object.freeze({
@@ -19,6 +20,7 @@ const MSG_TYPE = Object.freeze({
   PEER_EXCHANGE: 0x10,
   PEER_UPDATE: 0x11,
   REQUEST_TEMP_MESSAGES: 0x20,
+  REQUEST_APP_RUNNING: 0x21,
 });
 
 const NAK_REASON = Object.freeze({
@@ -190,12 +192,25 @@ function decodePeerUpdate(buf) {
   return { addOutbound, addInbound, rm };
 }
 
-// --- Temp Message Sync ---
+// --- Sync Requests ---
 
-function encodeRequestTempMessages() {
-  const buf = Buffer.allocUnsafe(1);
+function encodeRequestTempMessages(sinceTimestamp = 0) {
+  const buf = Buffer.allocUnsafe(9);
   buf[0] = MSG_TYPE.REQUEST_TEMP_MESSAGES;
+  buf.writeBigUInt64BE(BigInt(sinceTimestamp), 1);
   return buf;
+}
+
+function encodeRequestAppRunning(sinceTimestamp = 0) {
+  const buf = Buffer.allocUnsafe(9);
+  buf[0] = MSG_TYPE.REQUEST_APP_RUNNING;
+  buf.writeBigUInt64BE(BigInt(sinceTimestamp), 1);
+  return buf;
+}
+
+function decodeSyncTimestamp(buf) {
+  if (buf.length < 9) return 0;
+  return Number(buf.readBigUInt64BE(1));
 }
 
 module.exports = {
@@ -214,4 +229,6 @@ module.exports = {
   encodePeerUpdate,
   decodePeerUpdate,
   encodeRequestTempMessages,
+  encodeRequestAppRunning,
+  decodeSyncTimestamp,
 };

--- a/ZelBack/src/services/utils/peerCodec.js
+++ b/ZelBack/src/services/utils/peerCodec.js
@@ -9,6 +9,7 @@
  * Type 0x03 — nak                 [type:1][hash:20][reason:1]  = 22 bytes
  * Type 0x10 — peerExchange        [type:1][count:2][peer:6]... = 3 + count*6
  * Type 0x11 — peerUpdate          [type:1][addCnt:2][rmCnt:2][peer:6]... = 5 + total*6
+ * Type 0x20 — requestTempMessages [type:1]                    = 1 byte
  */
 
 const MSG_TYPE = Object.freeze({
@@ -17,6 +18,7 @@ const MSG_TYPE = Object.freeze({
   NAK: 0x03,
   PEER_EXCHANGE: 0x10,
   PEER_UPDATE: 0x11,
+  REQUEST_TEMP_MESSAGES: 0x20,
 });
 
 const NAK_REASON = Object.freeze({
@@ -188,6 +190,14 @@ function decodePeerUpdate(buf) {
   return { addOutbound, addInbound, rm };
 }
 
+// --- Temp Message Sync ---
+
+function encodeRequestTempMessages() {
+  const buf = Buffer.allocUnsafe(1);
+  buf[0] = MSG_TYPE.REQUEST_TEMP_MESSAGES;
+  return buf;
+}
+
 module.exports = {
   MSG_TYPE,
   NAK_REASON,
@@ -203,4 +213,5 @@ module.exports = {
   decodePeerExchange,
   encodePeerUpdate,
   decodePeerUpdate,
+  encodeRequestTempMessages,
 };

--- a/ZelBack/src/services/utils/peerCodec.js
+++ b/ZelBack/src/services/utils/peerCodec.js
@@ -12,6 +12,7 @@
  * Type 0x20 — requestTempMessages  [type:1][sinceTs:8]          = 9 bytes
  * Type 0x21 — requestAppRunning   [type:1][sinceTs:8]          = 9 bytes
  * Type 0x22 — requestAppInstalling [type:1][sinceTs:8]         = 9 bytes
+ * Type 0x23 — requestAppInstallingErrors [type:1][sinceTs:8]  = 9 bytes
  */
 
 const MSG_TYPE = Object.freeze({
@@ -23,6 +24,7 @@ const MSG_TYPE = Object.freeze({
   REQUEST_TEMP_MESSAGES: 0x20,
   REQUEST_APP_RUNNING: 0x21,
   REQUEST_APP_INSTALLING: 0x22,
+  REQUEST_APP_INSTALLING_ERRORS: 0x23,
 });
 
 const NAK_REASON = Object.freeze({
@@ -217,6 +219,13 @@ function encodeRequestAppInstalling(sinceTimestamp = 0) {
   return buf;
 }
 
+function encodeRequestAppInstallingErrors(sinceTimestamp = 0) {
+  const buf = Buffer.allocUnsafe(9);
+  buf[0] = MSG_TYPE.REQUEST_APP_INSTALLING_ERRORS;
+  buf.writeBigUInt64BE(BigInt(sinceTimestamp), 1);
+  return buf;
+}
+
 function decodeSyncTimestamp(buf) {
   if (buf.length < 9) return 0;
   return Number(buf.readBigUInt64BE(1));
@@ -240,5 +249,6 @@ module.exports = {
   encodeRequestTempMessages,
   encodeRequestAppRunning,
   encodeRequestAppInstalling,
+  encodeRequestAppInstallingErrors,
   decodeSyncTimestamp,
 };

--- a/ZelBack/src/services/utils/peerCodec.js
+++ b/ZelBack/src/services/utils/peerCodec.js
@@ -11,6 +11,7 @@
  * Type 0x11 — peerUpdate          [type:1][addCnt:2][rmCnt:2][peer:6]... = 5 + total*6
  * Type 0x20 — requestTempMessages  [type:1][sinceTs:8]          = 9 bytes
  * Type 0x21 — requestAppRunning   [type:1][sinceTs:8]          = 9 bytes
+ * Type 0x22 — requestAppInstalling [type:1][sinceTs:8]         = 9 bytes
  */
 
 const MSG_TYPE = Object.freeze({
@@ -21,6 +22,7 @@ const MSG_TYPE = Object.freeze({
   PEER_UPDATE: 0x11,
   REQUEST_TEMP_MESSAGES: 0x20,
   REQUEST_APP_RUNNING: 0x21,
+  REQUEST_APP_INSTALLING: 0x22,
 });
 
 const NAK_REASON = Object.freeze({
@@ -208,6 +210,13 @@ function encodeRequestAppRunning(sinceTimestamp = 0) {
   return buf;
 }
 
+function encodeRequestAppInstalling(sinceTimestamp = 0) {
+  const buf = Buffer.allocUnsafe(9);
+  buf[0] = MSG_TYPE.REQUEST_APP_INSTALLING;
+  buf.writeBigUInt64BE(BigInt(sinceTimestamp), 1);
+  return buf;
+}
+
 function decodeSyncTimestamp(buf) {
   if (buf.length < 9) return 0;
   return Number(buf.readBigUInt64BE(1));
@@ -230,5 +239,6 @@ module.exports = {
   decodePeerUpdate,
   encodeRequestTempMessages,
   encodeRequestAppRunning,
+  encodeRequestAppInstalling,
   decodeSyncTimestamp,
 };

--- a/apiServer.js
+++ b/apiServer.js
@@ -398,21 +398,20 @@ async function handleSigterm() {
 
         await fluxCommunicationMessagesSender.broadcastMessageToAll(sigtermMessage);
 
-        // Update local DB to expire app location records in ~7 minutes,
-        // same manipulation that peers apply when receiving the sigterm.
-        // This keeps the local DB consistent with the network so that on
-        // reboot the TTL check correctly detects expired locations.
+        // Update local DB to expire app records in ~7 minutes.
+        // Peers apply the same expireAt update when receiving the sigterm.
         try {
           const db = dbHelper.databaseConnection();
           const database = db.db(config.database.appsglobal.database);
           const globalAppsLocations = config.database.appsglobal.collections.appsLocations;
-          const newBroadcastedAt = new Date(sigtermMessage.broadcastedAt - (7500 - 420) * 1000);
+          const appsRunningBroadcasts = config.database.appsglobal.collections.appsRunningBroadcasts;
           const newExpireAt = new Date(sigtermMessage.broadcastedAt + (420 * 1000));
-          const update = { $set: { broadcastedAt: newBroadcastedAt, expireAt: newExpireAt } };
+          const update = { $set: { expireAt: newExpireAt } };
           await dbHelper.updateInDatabase(database, globalAppsLocations, { ip }, update);
-          log.info('Local app location records updated to expire in ~7 minutes');
+          await dbHelper.updateInDatabase(database, appsRunningBroadcasts, { ip }, update);
+          log.info('Local app location and broadcast records updated to expire in ~7 minutes');
         } catch (dbError) {
-          log.warn(`Failed to update local app location expiration: ${dbError.message}`);
+          log.warn(`Failed to update local app expiration: ${dbError.message}`);
         }
 
         log.info('Shutdown notification broadcasted successfully');

--- a/tests/unit/appHashSyncService.test.js
+++ b/tests/unit/appHashSyncService.test.js
@@ -8,14 +8,12 @@ describe('appHashSyncService tests', () => {
   let messageHelperStub;
   let serviceHelperStub;
   let verificationHelperStub;
-  let fluxNetworkHelperStub;
-  let generalServiceStub;
-  let globalStateStub;
   let logStub;
   let configStub;
+  let messageVerifierStub;
+  let messageStoreStub;
 
   beforeEach(() => {
-    // Config stub
     configStub = {
       database: {
         daemon: {
@@ -25,53 +23,32 @@ describe('appHashSyncService tests', () => {
           },
           database: 'daemon',
         },
-        appslocal: {
-          collections: {
-            appsInformation: 'localAppsInformation',
-          },
-          database: 'localapps',
-        },
         appsglobal: {
           collections: {
             appsMessages: 'appsMessages',
-            appsInformation: 'globalAppsInformation',
-            appsTemporaryMessages: 'appsTemporaryMessages',
-            appsLocations: 'appsLocations',
-            appsInstallingLocations: 'appsInstallingLocations',
-            appsInstallingErrorsLocations: 'appsInstallingErrorsLocations',
           },
           database: 'globalapps',
         },
       },
       fluxapps: {
         blocksLasting: 22000,
-        latestAppSpecification: 1,
       },
     };
 
-    // Stubs
     dbHelperStub = {
       databaseConnection: sinon.stub(),
       findInDatabase: sinon.stub(),
       findOneInDatabase: sinon.stub(),
-      insertOneToDatabase: sinon.stub(),
-      updateOneInDatabase: sinon.stub(),
-      aggregateInDatabase: sinon.stub(),
     };
 
     messageHelperStub = {
-      createDataMessage: sinon.stub(),
       createErrorMessage: sinon.stub(),
       createSuccessMessage: sinon.stub(),
+      errUnauthorizedMessage: sinon.stub().returns({ status: 'error' }),
     };
 
     serviceHelperStub = {
-      axiosGet: sinon.stub().resolves({
-        data: {
-          status: 'success',
-          data: true,
-        },
-      }),
+      axiosGet: sinon.stub(),
       delay: sinon.stub().resolves(),
       ensureNumber: sinon.stub().returnsArg(0),
     };
@@ -80,16 +57,15 @@ describe('appHashSyncService tests', () => {
       verifyPrivilege: sinon.stub(),
     };
 
-    fluxNetworkHelperStub = {
-      getNumberOfPeers: sinon.stub(),
+    messageVerifierStub = {
+      checkAndRequestApp: sinon.stub().resolves(true),
+      appHashHasMessage: sinon.stub().resolves(),
+      appHashHasMessageNotFound: sinon.stub().resolves(),
+      checkAndRequestMultipleApps: sinon.stub().resolves(),
     };
 
-    generalServiceStub = {
-      checkSynced: sinon.stub(),
-    };
-
-    globalStateStub = {
-      checkAndSyncAppHashesWasEverExecuted: false,
+    messageStoreStub = {
+      storeAppTemporaryMessage: sinon.stub().resolves(true),
     };
 
     logStub = {
@@ -98,34 +74,16 @@ describe('appHashSyncService tests', () => {
       warn: sinon.stub(),
     };
 
-    // Proxy require
     appHashSyncService = proxyquire('../../ZelBack/src/services/appMessaging/appHashSyncService', {
       config: configStub,
       '../dbHelper': dbHelperStub,
       '../messageHelper': messageHelperStub,
       '../serviceHelper': serviceHelperStub,
       '../verificationHelper': verificationHelperStub,
-      '../generalService': generalServiceStub,
-      '../fluxNetworkHelper': fluxNetworkHelperStub,
-      '../utils/globalState': globalStateStub,
       '../../lib/log': logStub,
-      './messageStore': {
-        storeAppTemporaryMessage: sinon.stub().resolves(true),
-      },
-      './messageVerifier': {
-        checkAndRequestApp: sinon.stub().resolves(true),
-        appHashHasMessageNotFound: sinon.stub().resolves(true),
-        checkAndRequestMultipleApps: sinon.stub().resolves(),
-      },
-      '../appDatabase/registryManager': {
-        expireGlobalApplications: sinon.stub().resolves(),
-      },
-      '../invalidMessages': {
-        invalidMessages: [],
-      },
-      '../utils/appConstants': proxyquire('../../ZelBack/src/services/utils/appConstants', {
-        config: configStub,
-      }),
+      './messageStore': messageStoreStub,
+      './messageVerifier': messageVerifierStub,
+      '../invalidMessages': { invalidMessages: [] },
       '../utils/peerState': {
         peerManager: {
           getRandomPeer: () => ({
@@ -141,137 +99,175 @@ describe('appHashSyncService tests', () => {
   });
 
   describe('triggerAppHashesCheckAPI', () => {
-    it('should trigger hashes check when authorized', async () => {
+    it('should trigger sync when authorized', async () => {
       const req = {};
-      const res = {
-        json: sinon.stub(),
-      };
+      const res = { json: sinon.stub() };
 
       verificationHelperStub.verifyPrivilege.resolves(true);
-      messageHelperStub.createSuccessMessage.returns({ status: 'success', data: { message: 'Running check on missing application messages ' } });
+      messageHelperStub.createSuccessMessage.returns({ status: 'success' });
 
       await appHashSyncService.triggerAppHashesCheckAPI(req, res);
 
       expect(res.json.calledOnce).to.be.true;
       expect(verificationHelperStub.verifyPrivilege.calledWith('adminandfluxteam', req)).to.be.true;
-      expect(messageHelperStub.createSuccessMessage.calledOnce).to.be.true;
     });
 
     it('should deny unauthorized access', async () => {
       const req = {};
-      const res = {
-        json: sinon.stub(),
-      };
+      const res = { json: sinon.stub() };
 
       verificationHelperStub.verifyPrivilege.resolves(false);
-      messageHelperStub.errUnauthorizedMessage = sinon.stub().returns({ status: 'error', data: { message: 'Unauthorized' } });
 
       await appHashSyncService.triggerAppHashesCheckAPI(req, res);
 
       expect(res.json.calledOnce).to.be.true;
-      expect(verificationHelperStub.verifyPrivilege.calledOnce).to.be.true;
       expect(messageHelperStub.errUnauthorizedMessage.calledOnce).to.be.true;
     });
 
     it('should handle errors gracefully', async () => {
       const req = {};
-      const res = {
-        json: sinon.stub(),
-      };
+      const res = { json: sinon.stub() };
       const error = new Error('Test error');
 
       verificationHelperStub.verifyPrivilege.rejects(error);
-      messageHelperStub.createErrorMessage.returns({ status: 'error', data: { message: 'Test error' } });
+      messageHelperStub.createErrorMessage.returns({ status: 'error' });
 
       await appHashSyncService.triggerAppHashesCheckAPI(req, res);
 
       expect(res.json.calledOnce).to.be.true;
       expect(logStub.error.calledWith(error)).to.be.true;
-      expect(messageHelperStub.createErrorMessage.calledOnce).to.be.true;
     });
   });
 
-  describe('checkAndSyncAppHashes', () => {
-    it('should complete successfully with low percentage of missing apps', async () => {
+  describe('getMissingHashes', () => {
+    it('should return missing hashes sorted by height', async () => {
       const mockDb = { db: sinon.stub().returns('database') };
       dbHelperStub.databaseConnection.returns(mockDb);
-      // Return results where less than 95% are missing (e.g., 5 out of 100)
-      const results = Array(100).fill({ message: true });
-      for (let i = 0; i < 5; i += 1) {
-        results[i] = { message: false };
-      }
-      dbHelperStub.findInDatabase.resolves(results);
+      dbHelperStub.findInDatabase.resolves([
+        { hash: 'b', height: 200, message: false },
+        { hash: 'a', height: 100, message: false },
+      ]);
 
-      await appHashSyncService.checkAndSyncAppHashes();
+      const result = await appHashSyncService.getMissingHashes();
 
-      expect(dbHelperStub.findInDatabase.calledOnce).to.be.true;
-      expect(globalStateStub.checkAndSyncAppHashesWasEverExecuted).to.be.true;
+      expect(result).to.have.lengthOf(2);
+      expect(result[0].hash).to.equal('a');
+      expect(result[1].hash).to.equal('b');
     });
 
-    it('should handle errors and reset running flag', async () => {
-      const error = new Error('Database error');
-      // eslint-disable-next-line no-unused-vars
-      const mockDb = { db: sinon.stub().returns('database') };
-
-      dbHelperStub.databaseConnection.throws(error);
-      fluxNetworkHelperStub.getNumberOfPeers.returns(15);
-
-      await appHashSyncService.checkAndSyncAppHashes();
-
-      expect(logStub.error.calledWith(error)).to.be.true;
-      expect(globalStateStub.checkAndSyncAppHashesWasEverExecuted).to.be.false;
-    });
-  });
-
-  describe('continuousFluxAppHashesCheck', () => {
-    it('should skip if not enough peers', async () => {
-      fluxNetworkHelperStub.getNumberOfPeers.returns(5);
-
-      await appHashSyncService.continuousFluxAppHashesCheck();
-
-      expect(logStub.info.calledWith('Not enough connected peers to request missing Flux App messages')).to.be.true;
-      expect(dbHelperStub.findInDatabase.called).to.be.false;
-    });
-
-    it('should skip if not synced', async () => {
-      fluxNetworkHelperStub.getNumberOfPeers.returns(15);
-      generalServiceStub.checkSynced.resolves(false);
-
-      await appHashSyncService.continuousFluxAppHashesCheck();
-
-      expect(logStub.info.calledWith('Flux not yet synced')).to.be.true;
-      expect(dbHelperStub.findInDatabase.called).to.be.false;
-    });
-
-    it('should handle empty results gracefully', async () => {
-      fluxNetworkHelperStub.getNumberOfPeers.returns(15);
-      generalServiceStub.checkSynced.resolves(true);
-      globalStateStub.checkAndSyncAppHashesWasEverExecuted = true;
+    it('should exclude invalid messages when not forced', async () => {
+      const mod = proxyquire('../../ZelBack/src/services/appMessaging/appHashSyncService', {
+        config: configStub,
+        '../dbHelper': dbHelperStub,
+        '../messageHelper': messageHelperStub,
+        '../serviceHelper': serviceHelperStub,
+        '../verificationHelper': verificationHelperStub,
+        '../../lib/log': logStub,
+        './messageStore': messageStoreStub,
+        './messageVerifier': messageVerifierStub,
+        '../invalidMessages': {
+          invalidMessages: [{ hash: 'invalid1', txid: 'tx1' }],
+        },
+        '../utils/peerState': {
+          peerManager: { getRandomPeer: () => null },
+        },
+      });
 
       const mockDb = { db: sinon.stub().returns('database') };
       dbHelperStub.databaseConnection.returns(mockDb);
-      dbHelperStub.findOneInDatabase.resolves({ generalScannedHeight: 1000 });
+      dbHelperStub.findInDatabase.resolves([
+        { hash: 'invalid1', txid: 'tx1', height: 100, message: false },
+        { hash: 'valid1', txid: 'tx2', height: 200, message: false },
+      ]);
+
+      const result = await mod.getMissingHashes();
+      expect(result).to.have.lengthOf(1);
+      expect(result[0].hash).to.equal('valid1');
+    });
+
+    it('should return empty array when no hashes are missing', async () => {
+      const mockDb = { db: sinon.stub().returns('database') };
+      dbHelperStub.databaseConnection.returns(mockDb);
       dbHelperStub.findInDatabase.resolves([]);
 
-      await appHashSyncService.continuousFluxAppHashesCheck();
-
-      expect(dbHelperStub.findInDatabase.calledOnce).to.be.true;
-      expect(logStub.info.calledWith('Requesting missing Flux App messages')).to.be.true;
+      const result = await appHashSyncService.getMissingHashes();
+      expect(result).to.have.lengthOf(0);
     });
+  });
 
-    it('should handle database errors', async () => {
-      const error = new Error('Database error');
-      fluxNetworkHelperStub.getNumberOfPeers.returns(15);
-      generalServiceStub.checkSynced.resolves(true);
-      globalStateStub.checkAndSyncAppHashesWasEverExecuted = true;
-
+  describe('syncMissingHashes', () => {
+    it('should return immediately when no hashes are missing', async () => {
       const mockDb = { db: sinon.stub().returns('database') };
       dbHelperStub.databaseConnection.returns(mockDb);
-      dbHelperStub.findOneInDatabase.rejects(error);
+      dbHelperStub.findInDatabase.resolves([]);
 
-      await appHashSyncService.continuousFluxAppHashesCheck();
+      const result = await appHashSyncService.syncMissingHashes();
 
-      expect(logStub.error.calledWith(error)).to.be.true;
+      expect(result.resolved).to.equal(0);
+      expect(result.missing).to.equal(0);
+    });
+
+    it('should skip when already running', async () => {
+      const mockDb = { db: sinon.stub().returns('database') };
+      dbHelperStub.databaseConnection.returns(mockDb);
+
+      // Make findInDatabase slow so syncMissingHashes is still running when we call again
+      let resolveFirst;
+      const firstCallPromise = new Promise((r) => { resolveFirst = r; });
+      dbHelperStub.findInDatabase.onFirstCall().returns(firstCallPromise);
+      dbHelperStub.findInDatabase.onSecondCall().resolves([]);
+
+      const first = appHashSyncService.syncMissingHashes();
+      const second = await appHashSyncService.syncMissingHashes();
+
+      expect(second.resolved).to.equal(0);
+      expect(logStub.info.calledWith('syncMissingHashes - Already running, skipping')).to.be.true;
+
+      resolveFirst([]);
+      await first;
+    });
+
+    it('should use bulk fetch when many hashes are missing', async () => {
+      const mockDb = { db: sinon.stub().returns('database') };
+      dbHelperStub.databaseConnection.returns(mockDb);
+
+      const manyMissing = Array(1500).fill(null).map((_, i) => ({
+        hash: `hash${i}`, txid: `tx${i}`, height: 1000 + i, value: 100, message: false,
+      }));
+
+      // First call: getMissingHashes returns many
+      // Subsequent calls (after bulk fetch): return empty
+      dbHelperStub.findInDatabase.onFirstCall().resolves(manyMissing);
+      dbHelperStub.findInDatabase.resolves([]);
+      dbHelperStub.findOneInDatabase.resolves(null);
+
+      serviceHelperStub.axiosGet.resolves({
+        data: { status: 'success', data: true },
+      });
+
+      // Bulk fetch returns no messages (peer has nothing)
+      serviceHelperStub.axiosGet.onSecondCall().resolves({
+        data: { status: 'success', data: [] },
+      });
+
+      dbHelperStub.findOneInDatabase.resolves({ generalScannedHeight: 2555000 });
+
+      const result = await appHashSyncService.syncMissingHashes();
+
+      // Should have attempted bulk fetch (axiosGet called for explorer sync check + permanent messages)
+      expect(serviceHelperStub.axiosGet.called).to.be.true;
+      expect(logStub.info.calledWith(sinon.match('using bulk fetch'))).to.be.true;
+    });
+
+    it('should handle errors without crashing', async () => {
+      const mockDb = { db: sinon.stub().returns('database') };
+      dbHelperStub.databaseConnection.returns(mockDb);
+      dbHelperStub.findInDatabase.rejects(new Error('DB error'));
+
+      const result = await appHashSyncService.syncMissingHashes();
+
+      expect(result.missing).to.equal(-1);
+      expect(logStub.error.called).to.be.true;
     });
   });
 });

--- a/tests/unit/appSpawner.test.js
+++ b/tests/unit/appSpawner.test.js
@@ -6,44 +6,68 @@ describe('appSpawner tests', () => {
   let appSpawner;
   let logStub;
   let configStub;
+  let globalStateStub;
+  let aggregateStub;
+  let delayStub;
+  let daemonSyncStub;
 
-  beforeEach(() => {
-    // Config stub
-    configStub = {
+  function createConfigStub(overrides = {}) {
+    return {
       database: {
-        daemon: {
-          database: 'daemon',
-        },
-        appslocal: {
-          database: 'localapps',
-        },
-        appsglobal: {
-          database: 'globalapps',
-        },
+        daemon: { database: 'daemon' },
+        appslocal: { database: 'localapps' },
+        appsglobal: { database: 'globalapps' },
       },
       fluxapps: {
-        installation: {
-          delay: 300,
-        },
+        installation: { delay: 300 },
+        daemonPONFork: 2020000,
+        blocksLasting: 22000,
+        newMinBlocksAllowance: 100,
+        ...overrides,
       },
     };
+  }
 
-    logStub = {
-      error: sinon.stub(),
-      info: sinon.stub(),
-      warn: sinon.stub(),
+  function createGlobalStateStub() {
+    return {
+      checkAndSyncAppHashesWasEverExecuted: true,
+      fluxNodeWasNotConfirmedOnLastCheck: false,
+      fluxNodeWasAlreadyConfirmed: true,
+      firstExecutionAfterItsSynced: false,
+      spawnErrorsLongerAppCache: new Map(),
+      trySpawningGlobalAppCache: new Map(),
+      appsToBeCheckedLater: [],
+      appsSyncthingToBeCheckedLater: [],
     };
+  }
 
-    // Proxy require - note: we're NOT actually running trySpawningGlobalApplication in tests
+  function buildModule(opts = {}) {
+    configStub = createConfigStub(opts.configOverrides);
+    globalStateStub = createGlobalStateStub();
+    if (opts.globalStateOverrides) {
+      Object.assign(globalStateStub, opts.globalStateOverrides);
+    }
+
+    logStub = { error: sinon.stub(), info: sinon.stub(), warn: sinon.stub() };
+    aggregateStub = sinon.stub().resolves(opts.aggregateResult || []);
+    // First delay resolves normally, subsequent calls reject to break recursion
+    delayStub = sinon.stub();
+    delayStub.onFirstCall().resolves();
+    delayStub.onSecondCall().rejects(new Error('break recursion'));
+    delayStub.rejects(new Error('break recursion'));
+    daemonSyncStub = sinon.stub().returns({
+      data: { height: opts.daemonHeight || 2555563, synced: true },
+    });
+
     appSpawner = proxyquire('../../ZelBack/src/services/appLifecycle/appSpawner', {
       config: configStub,
       '../dbHelper': {
-        databaseConnection: sinon.stub(),
-        aggregateInDatabase: sinon.stub(),
-        findInDatabase: sinon.stub(),
+        databaseConnection: sinon.stub().returns({ db: sinon.stub().returns({}) }),
+        aggregateInDatabase: aggregateStub,
+        findInDatabase: sinon.stub().resolves([]),
       },
       '../serviceHelper': {
-        delay: sinon.stub().resolves(),
+        delay: delayStub,
         ensureNumber: sinon.stub().returnsArg(0),
       },
       '../generalService': {
@@ -61,6 +85,9 @@ describe('appSpawner tests', () => {
         isPortOpen: sinon.stub().resolves(true),
         isPortUserBlocked: sinon.stub().returns(false),
       },
+      '../daemonService/daemonServiceMiscRpcs': {
+        isDaemonSynced: daemonSyncStub,
+      },
       '../../lib/log': logStub,
       '../appQuery/appQueryService': {
         listRunningApps: sinon.stub().resolves({ status: 'success', data: [] }),
@@ -76,10 +103,12 @@ describe('appSpawner tests', () => {
       '../appSecurity/imageManager': {
         checkApplicationImagesCompliance: sinon.stub().resolves(),
         verifyRepository: sinon.stub().resolves(),
+        isAppVetted: sinon.stub().resolves(false),
       },
       '../appRequirements/hwRequirements': {
         checkAppRequirements: sinon.stub().resolves(),
         totalAppHWRequirements: sinon.stub().returns({ cpu: 1, ram: 1000, hdd: 10 }),
+        checkAppCpuBurstHeadroom: sinon.stub().resolves(),
       },
       '../appNetwork/portManager': {
         ensureApplicationPortsNotUsed: sinon.stub().resolves(),
@@ -92,15 +121,10 @@ describe('appSpawner tests', () => {
         systemArchitecture: sinon.stub().resolves('amd64'),
         nodeFullGeolocation: sinon.stub().returns('US-NY'),
       },
-      '../utils/globalState': {
-        checkAndSyncAppHashesWasEverExecuted: true,
-        fluxNodeWasNotConfirmedOnLastCheck: false,
-        fluxNodeWasAlreadyConfirmed: false,
-        firstExecutionAfterItsSynced: false,
-        spawnErrorsLongerAppCache: new Map(),
-        trySpawningGlobalAppCache: new Map(),
-        appsToBeCheckedLater: [],
-        appsSyncthingToBeCheckedLater: [],
+      '../utils/globalState': globalStateStub,
+      '../geolocationService': {
+        isStaticIP: sinon.stub().returns(false),
+        isDataCenter: sinon.stub().returns(false),
       },
       './advancedWorkflows': {
         getPeerAppsInstallingErrorMessages: sinon.stub().resolves(),
@@ -108,54 +132,278 @@ describe('appSpawner tests', () => {
       '../fluxCommunicationMessagesSender': {
         broadcastMessageToOutgoing: sinon.stub().resolves(),
         broadcastMessageToIncoming: sinon.stub().resolves(),
+        broadcastMessageToAll: sinon.stub().resolves(),
       },
       '../utils/appConstants': {
         globalAppsInformation: 'appsInformation',
         localAppsInformation: 'localAppsInformation',
       },
+      '../utils/enterpriseNetwork': {
+        getCachedEnterpriseIdentity: sinon.stub().returns(false),
+        getSpawnDelays: sinon.stub().returns({ shortDelayTime: 60000, delayTime: 60000 }),
+        filterAppsByOwnership: sinon.stub().callsFake((apps) => apps),
+      },
+      '../utils/cacheManager': {
+        FluxCacheManager: { oneHour: 3600000 },
+      },
     });
-  });
+  }
 
   afterEach(() => {
     sinon.restore();
   });
 
   describe('initialize', () => {
+    beforeEach(() => buildModule());
+
     it('should initialize appInstaller and appUninstaller dependencies', () => {
-      const mockAppInstaller = { registerAppLocally: sinon.stub() };
-      const mockAppUninstaller = { removeAppLocally: sinon.stub() };
-
       const deps = {
-        appInstaller: mockAppInstaller,
-        appUninstaller: mockAppUninstaller,
+        appInstaller: { registerAppLocally: sinon.stub() },
+        appUninstaller: { removeAppLocally: sinon.stub() },
       };
-
-      // Initialize should not throw
       appSpawner.initialize(deps);
-
-      // After initialization, the module should have stored these dependencies
-      // We can't easily test this without exposing them, but at least verify it doesn't throw
       expect(appSpawner.initialize).to.be.a('function');
     });
 
     it('should handle empty dependencies object', () => {
-      const deps = {};
-
-      // Should not throw even with empty deps
-      appSpawner.initialize(deps);
-
+      appSpawner.initialize({});
       expect(appSpawner.initialize).to.be.a('function');
     });
   });
 
   describe('trySpawningGlobalApplication', () => {
+    beforeEach(() => buildModule());
+
     it('should be exported as a function', () => {
       expect(appSpawner.trySpawningGlobalApplication).to.be.a('function');
     });
+  });
 
-    // Note: We don't actually call trySpawningGlobalApplication in these tests
-    // because it's a long-running recursive function with complex business logic.
-    // Testing it properly would require integration tests or significant mocking.
-    // The function is tested indirectly through integration tests.
+  describe('expiration filter pipeline', () => {
+    beforeEach(() => buildModule({ daemonHeight: 2555563 }));
+
+    function getPipelineFromCall() {
+      expect(aggregateStub.calledOnce).to.be.true;
+      return aggregateStub.firstCall.args[2];
+    }
+
+    function evaluateExpiration(height, expire, currentHeight) {
+      const ponFork = 2020000;
+      const blocksLasting = 22000;
+      const minBlocksAllowance = 100;
+
+      const expireIn = expire ?? (height >= ponFork ? blocksLasting * 4 : blocksLasting);
+      let actualExpirationHeight;
+      if (height < ponFork) {
+        const originalExpiration = height + expireIn;
+        if (originalExpiration <= ponFork) {
+          actualExpirationHeight = originalExpiration;
+        } else {
+          const blocksAfterFork = originalExpiration - ponFork;
+          actualExpirationHeight = ponFork + (blocksAfterFork * 4);
+        }
+      } else {
+        actualExpirationHeight = height + expireIn;
+      }
+      return {
+        actualExpirationHeight,
+        wouldInstall: actualExpirationHeight > currentHeight + minBlocksAllowance,
+      };
+    }
+
+    it('should include expiration filter stages before $lookup', async () => {
+      await appSpawner.trySpawningGlobalApplication();
+      const pipeline = getPipelineFromCall();
+
+      // First stage: $addFields for _expireIn
+      expect(pipeline[0]).to.have.property('$addFields');
+      expect(pipeline[0].$addFields).to.have.property('_expireIn');
+
+      // Second stage: $addFields for _actualExpirationHeight
+      expect(pipeline[1]).to.have.property('$addFields');
+      expect(pipeline[1].$addFields).to.have.property('_actualExpirationHeight');
+
+      // Third stage: $match on _actualExpirationHeight
+      expect(pipeline[2]).to.have.property('$match');
+      expect(pipeline[2].$match).to.have.property('_actualExpirationHeight');
+
+      // Fourth stage should be the $lookup (previously first)
+      expect(pipeline[3]).to.have.property('$lookup');
+    });
+
+    it('should use daemon height + newMinBlocksAllowance as threshold', async () => {
+      await appSpawner.trySpawningGlobalApplication();
+      const pipeline = getPipelineFromCall();
+
+      expect(pipeline[2].$match._actualExpirationHeight.$gt).to.equal(2555563 + 100);
+    });
+
+    it('should use correct post-PON default expire (blocksLasting * 4)', async () => {
+      await appSpawner.trySpawningGlobalApplication();
+      const pipeline = getPipelineFromCall();
+
+      // The $ifNull fallback for post-PON should be 88000
+      const expireField = pipeline[0].$addFields._expireIn;
+      const condThen = expireField.$ifNull[1].$cond.then;
+      expect(condThen).to.equal(22000 * 4);
+    });
+
+    it('should use correct pre-PON default expire (blocksLasting)', async () => {
+      await appSpawner.trySpawningGlobalApplication();
+      const pipeline = getPipelineFromCall();
+
+      const expireField = pipeline[0].$addFields._expireIn;
+      const condElse = expireField.$ifNull[1].$cond.else;
+      expect(condElse).to.equal(22000);
+    });
+
+    it('should not include _expireIn or _actualExpirationHeight in $project output', async () => {
+      await appSpawner.trySpawningGlobalApplication();
+      const pipeline = getPipelineFromCall();
+
+      const projectStage = pipeline.find((stage) => stage.$project);
+      expect(projectStage.$project).to.not.have.property('_expireIn');
+      expect(projectStage.$project).to.not.have.property('_actualExpirationHeight');
+    });
+
+    // Expiration math verification using the same logic as the pipeline
+    describe('expiration math', () => {
+      const currentHeight = 2555563;
+
+      it('should reject post-PON app with expire=100 (cancellation)', () => {
+        const result = evaluateExpiration(2555500, 100, currentHeight);
+        expect(result.wouldInstall).to.be.false;
+      });
+
+      it('should reject post-PON app with expire=85', () => {
+        const result = evaluateExpiration(2555500, 85, currentHeight);
+        expect(result.wouldInstall).to.be.false;
+      });
+
+      it('should accept post-PON app with 101+ blocks remaining', () => {
+        const result = evaluateExpiration(2555500, 164, currentHeight);
+        expect(result.wouldInstall).to.be.true;
+      });
+
+      it('should accept post-PON app with default expire (88000)', () => {
+        const result = evaluateExpiration(2550000, 88000, currentHeight);
+        expect(result.wouldInstall).to.be.true;
+      });
+
+      it('should accept post-PON app with no expire field (defaults to 88000)', () => {
+        const result = evaluateExpiration(2550000, undefined, currentHeight);
+        expect(result.actualExpirationHeight).to.equal(2550000 + 88000);
+        expect(result.wouldInstall).to.be.true;
+      });
+
+      it('should reject pre-PON app that expires before fork', () => {
+        const result = evaluateExpiration(2019000, 85, currentHeight);
+        expect(result.actualExpirationHeight).to.equal(2019085);
+        expect(result.wouldInstall).to.be.false;
+      });
+
+      it('should apply 4x multiplier to blocks after PON fork', () => {
+        // height=2000000, expire=22000 -> original=2022000
+        // blocksAfterFork = 2022000 - 2020000 = 2000
+        // adjusted = 2000 * 4 = 8000
+        // actual = 2020000 + 8000 = 2028000
+        const result = evaluateExpiration(2000000, 22000, currentHeight);
+        expect(result.actualExpirationHeight).to.equal(2028000);
+        expect(result.wouldInstall).to.be.false;
+      });
+
+      it('should handle pre-PON app close to threshold (under)', () => {
+        // Computed to have 49 blocks remaining after adjustment
+        const result = evaluateExpiration(2000000, 153903, currentHeight);
+        expect(result.actualExpirationHeight).to.equal(2555612);
+        expect(result.wouldInstall).to.be.false;
+      });
+
+      it('should handle pre-PON app close to threshold (over)', () => {
+        // Computed to have 249 blocks remaining after adjustment
+        const result = evaluateExpiration(2000000, 153953, currentHeight);
+        expect(result.actualExpirationHeight).to.equal(2555812);
+        expect(result.wouldInstall).to.be.true;
+      });
+
+      it('should accept pre-PON app with long lease (264000)', () => {
+        const result = evaluateExpiration(2000000, 264000, currentHeight);
+        expect(result.actualExpirationHeight).to.equal(2996000);
+        expect(result.wouldInstall).to.be.true;
+      });
+
+      it('should reject pre-PON app with no expire field (defaults to 22000)', () => {
+        const result = evaluateExpiration(2000000, undefined, currentHeight);
+        expect(result.actualExpirationHeight).to.equal(2028000);
+        expect(result.wouldInstall).to.be.false;
+      });
+
+      it('should reject post-PON app with exactly 100 blocks remaining', () => {
+        // height + expire - currentHeight = 100 exactly
+        const result = evaluateExpiration(2555414, 249, currentHeight);
+        expect(result.actualExpirationHeight - currentHeight).to.equal(100);
+        expect(result.wouldInstall).to.be.false;
+      });
+    });
+  });
+
+  describe('deferred queue fixes', () => {
+    it('findIndex should match apps whose timeToCheck is in the past (<=)', () => {
+      const now = Date.now();
+      const queue = [
+        { timeToCheck: now - 1000, appName: 'ready', hash: 'abc', required: 3 },
+        { timeToCheck: now + 60000, appName: 'notReady', hash: 'def', required: 3 },
+      ];
+      // Fixed: <= means we find apps whose time has passed
+      const index = queue.findIndex((app) => app.timeToCheck <= now);
+      expect(index).to.equal(0);
+      expect(queue[index].appName).to.equal('ready');
+    });
+
+    it('findIndex should not match apps whose timeToCheck is in the future', () => {
+      const now = Date.now();
+      const queue = [
+        { timeToCheck: now + 60000, appName: 'notReady', hash: 'abc', required: 3 },
+      ];
+      const index = queue.findIndex((app) => app.timeToCheck <= now);
+      expect(index).to.equal(-1);
+    });
+
+    it('findIndex with old bug (>=) would incorrectly match future apps', () => {
+      const now = Date.now();
+      const queue = [
+        { timeToCheck: now + 60000, appName: 'notReady', hash: 'abc', required: 3 },
+      ];
+      // Old buggy behavior: >= matches apps still waiting
+      const buggyIndex = queue.findIndex((app) => app.timeToCheck >= now);
+      expect(buggyIndex).to.equal(0); // Bug: would pop an app that should still be waiting
+    });
+
+    it('Array.some should correctly filter apps already in deferred queue', () => {
+      const queue = [
+        { appName: 'myApp', hash: 'abc', required: 3, timeToCheck: Date.now() + 60000 },
+      ];
+      const apps = [
+        { name: 'myApp', hash: 'abc' },
+        { name: 'otherApp', hash: 'def' },
+      ];
+      const filtered = apps.filter((app) => !queue.some((appAux) => appAux.appName === app.name));
+      expect(filtered).to.have.lengthOf(1);
+      expect(filtered[0].name).to.equal('otherApp');
+    });
+
+    it('Array.includes with callback (old bug) never filters anything', () => {
+      const queue = [
+        { appName: 'myApp', hash: 'abc', required: 3, timeToCheck: Date.now() + 60000 },
+      ];
+      const apps = [
+        { name: 'myApp', hash: 'abc' },
+        { name: 'otherApp', hash: 'def' },
+      ];
+      // Old buggy behavior: includes() with a function always returns false
+      // eslint-disable-next-line no-array-constructor
+      const filtered = apps.filter((app) => !queue.includes((appAux) => appAux.appName === app.name));
+      expect(filtered).to.have.lengthOf(2); // Bug: nothing filtered
+    });
   });
 });

--- a/tests/unit/appSyncOrchestrator.test.js
+++ b/tests/unit/appSyncOrchestrator.test.js
@@ -1,0 +1,222 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+const { EventEmitter } = require('events');
+const proxyquire = require('proxyquire').noCallThru();
+
+describe('AppSyncOrchestrator', () => {
+  let AppSyncOrchestrator;
+  let STATES;
+  let blockEmitter;
+  let peerManager;
+  let logStub;
+  let syncMissingHashesStub;
+  let reindexStub;
+  let expireStub;
+  let isNodeStatusConfirmedStub;
+  let globalStateStub;
+  let checkAndNotifyStub;
+
+  beforeEach(() => {
+    blockEmitter = new EventEmitter();
+    peerManager = new EventEmitter();
+    peerManager.getEligibleTempSyncPeers = sinon.stub().returns([]);
+
+    logStub = { info: sinon.stub(), warn: sinon.stub(), error: sinon.stub() };
+    syncMissingHashesStub = sinon.stub().resolves({ resolved: 0, missing: 0, unreachable: 0 });
+    reindexStub = sinon.stub().resolves();
+    expireStub = sinon.stub().resolves();
+    isNodeStatusConfirmedStub = sinon.stub().resolves(true);
+    globalStateStub = {
+      checkAndSyncAppHashesWasEverExecuted: false,
+    };
+    checkAndNotifyStub = sinon.stub().resolves();
+
+    const mod = proxyquire('../../ZelBack/src/services/appMessaging/appSyncOrchestrator', {
+      config: {
+        fluxapps: {
+          daemonPONFork: 2020000,
+          blocksLasting: 22000,
+          appSyncPeerThreshold: 12,
+          appSyncDegradedThreshold: 4,
+        },
+      },
+      '../../lib/log': logStub,
+      '../generalService': { isNodeStatusConfirmed: isNodeStatusConfirmedStub },
+      './appHashSyncService': { syncMissingHashes: syncMissingHashesStub },
+      './peerNotification': { checkAndNotifyPeersOfRunningApps: checkAndNotifyStub },
+      '../appDatabase/registryManager': {
+        reindexGlobalAppsInformation: reindexStub,
+        expireGlobalApplications: expireStub,
+      },
+      '../utils/globalState': globalStateStub,
+      '../utils/peerCodec': { encodeRequestTempMessages: sinon.stub().returns(Buffer.from([0x20])) },
+    });
+    AppSyncOrchestrator = mod.AppSyncOrchestrator;
+    STATES = mod.STATES;
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('state machine', () => {
+    it('should start in INITIALIZING state', () => {
+      const orchestrator = new AppSyncOrchestrator({ blockEmitter, peerManager });
+      expect(orchestrator.state).to.equal(STATES.INITIALIZING);
+    });
+
+    it('should transition to SYNCING on first blockReceived', async () => {
+      const orchestrator = new AppSyncOrchestrator({ blockEmitter, peerManager });
+      orchestrator.start();
+      blockEmitter.emit('blockReceived', 2555000);
+      await new Promise((r) => setImmediate(r));
+      expect(orchestrator.state).to.equal(STATES.SYNCING);
+    });
+
+    it('should emit syncStarted on first blockReceived', async () => {
+      const orchestrator = new AppSyncOrchestrator({ blockEmitter, peerManager });
+      orchestrator.start();
+      const spy = sinon.spy();
+      orchestrator.on('syncStarted', spy);
+      blockEmitter.emit('blockReceived', 2555000);
+      await new Promise((r) => setImmediate(r));
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should call syncMissingHashes on first blockReceived', async () => {
+      const orchestrator = new AppSyncOrchestrator({ blockEmitter, peerManager });
+      orchestrator.start();
+      blockEmitter.emit('blockReceived', 2555000);
+      await new Promise((r) => setTimeout(r, 50));
+      expect(syncMissingHashesStub.calledOnce).to.be.true;
+    });
+
+    it('should call reindexGlobalAppsInformation after sync', async () => {
+      const orchestrator = new AppSyncOrchestrator({ blockEmitter, peerManager });
+      orchestrator.start();
+      blockEmitter.emit('blockReceived', 2555000);
+      await new Promise((r) => setTimeout(r, 50));
+      expect(reindexStub.calledOnce).to.be.true;
+    });
+
+    it('should call expireGlobalApplications after reindex', async () => {
+      const orchestrator = new AppSyncOrchestrator({ blockEmitter, peerManager });
+      orchestrator.start();
+      blockEmitter.emit('blockReceived', 2555000);
+      await new Promise((r) => setTimeout(r, 50));
+      expect(expireStub.calledOnce).to.be.true;
+    });
+
+    it('should set checkAndSyncAppHashesWasEverExecuted after sync', async () => {
+      const orchestrator = new AppSyncOrchestrator({ blockEmitter, peerManager });
+      orchestrator.start();
+      blockEmitter.emit('blockReceived', 2555000);
+      await new Promise((r) => setTimeout(r, 50));
+      expect(globalStateStub.checkAndSyncAppHashesWasEverExecuted).to.be.true;
+    });
+
+    it('should emit dbReady after reindex', async () => {
+      const orchestrator = new AppSyncOrchestrator({ blockEmitter, peerManager });
+      orchestrator.start();
+      const spy = sinon.spy();
+      orchestrator.on('dbReady', spy);
+      blockEmitter.emit('blockReceived', 2555000);
+      await new Promise((r) => setTimeout(r, 50));
+      expect(spy.calledOnce).to.be.true;
+    });
+  });
+
+  describe('peer threshold events', () => {
+    it('should trigger temp message catch-up on peerThresholdReached', async () => {
+      const orchestrator = new AppSyncOrchestrator({ blockEmitter, peerManager });
+      orchestrator.start();
+      peerManager.emit('peerThresholdReached', 12);
+      await new Promise((r) => setTimeout(r, 50));
+      expect(peerManager.getEligibleTempSyncPeers.calledOnce).to.be.true;
+    });
+
+    it('should start apprunning broadcast on peerThresholdReached', async () => {
+      const orchestrator = new AppSyncOrchestrator({ blockEmitter, peerManager });
+      orchestrator.start();
+      peerManager.emit('peerThresholdReached', 12);
+      await new Promise((r) => setTimeout(r, 50));
+      expect(checkAndNotifyStub.calledOnce).to.be.true;
+    });
+
+    it('should transition to DEGRADED on peersBelowThreshold when READY', async () => {
+      const orchestrator = new AppSyncOrchestrator({
+        blockEmitter, peerManager, isEnterprise: () => true,
+      });
+      orchestrator.start();
+
+      // Get to READY state: sync completes + enough blocks + confirmed
+      blockEmitter.emit('blockReceived', 2555000);
+      await new Promise((r) => setTimeout(r, 50));
+      // Simulate enough blocks for location readiness (enterprise = 124 blocks)
+      for (let i = 0; i < 130; i += 1) {
+        blockEmitter.emit('blockReceived', 2555000 + i);
+      }
+      await new Promise((r) => setTimeout(r, 50));
+
+      if (orchestrator.state === STATES.READY) {
+        peerManager.emit('peersBelowThreshold', 3);
+        expect(orchestrator.state).to.equal(STATES.DEGRADED);
+      }
+    });
+
+    it('should emit readinessLost on degradation', async () => {
+      const orchestrator = new AppSyncOrchestrator({
+        blockEmitter, peerManager, isEnterprise: () => true,
+      });
+      orchestrator.start();
+      const spy = sinon.spy();
+      orchestrator.on('readinessLost', spy);
+
+      blockEmitter.emit('blockReceived', 2555000);
+      await new Promise((r) => setTimeout(r, 50));
+      for (let i = 0; i < 130; i += 1) {
+        blockEmitter.emit('blockReceived', 2555000 + i);
+      }
+      await new Promise((r) => setTimeout(r, 50));
+
+      if (orchestrator.state === STATES.READY) {
+        peerManager.emit('peersBelowThreshold', 3);
+        expect(spy.calledOnce).to.be.true;
+      }
+    });
+  });
+
+  describe('temp message catch-up', () => {
+    it('should send binary request to eligible peers', async () => {
+      const fakePeer = { key: '1.2.3.4:16127', send: sinon.stub() };
+      peerManager.getEligibleTempSyncPeers = sinon.stub().returns([fakePeer]);
+
+      const orchestrator = new AppSyncOrchestrator({ blockEmitter, peerManager });
+      orchestrator.start();
+      peerManager.emit('peerThresholdReached', 12);
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(fakePeer.send.calledOnce).to.be.true;
+    });
+
+    it('should not send requests when no eligible peers', async () => {
+      peerManager.getEligibleTempSyncPeers = sinon.stub().returns([]);
+
+      const orchestrator = new AppSyncOrchestrator({ blockEmitter, peerManager });
+      orchestrator.start();
+      peerManager.emit('peerThresholdReached', 12);
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(logStub.info.calledWith('AppSyncOrchestrator - No eligible peers for temp message catch-up')).to.be.true;
+    });
+  });
+
+  describe('stop', () => {
+    it('should remove all listeners and clear intervals', () => {
+      const orchestrator = new AppSyncOrchestrator({ blockEmitter, peerManager });
+      orchestrator.start();
+      orchestrator.stop();
+      expect(blockEmitter.listenerCount('blockReceived')).to.equal(0);
+    });
+  });
+});

--- a/tests/unit/appSyncOrchestrator.test.js
+++ b/tests/unit/appSyncOrchestrator.test.js
@@ -46,6 +46,8 @@ describe('AppSyncOrchestrator', () => {
       '../utils/peerCodec': {
         encodeRequestTempMessages: sinon.stub().returns(Buffer.alloc(9, 0x20)),
         encodeRequestAppRunning: sinon.stub().returns(Buffer.alloc(9, 0x21)),
+        encodeRequestAppInstalling: sinon.stub().returns(Buffer.alloc(9, 0x22)),
+        encodeRequestAppInstallingErrors: sinon.stub().returns(Buffer.alloc(9, 0x23)),
       },
     });
     AppSyncOrchestrator = mod.AppSyncOrchestrator;
@@ -206,6 +208,87 @@ describe('AppSyncOrchestrator', () => {
       await new Promise((r) => setTimeout(r, 50));
 
       expect(logStub.info.calledWith('AppSyncOrchestrator - No eligible peers for temp message catch-up')).to.be.true;
+    });
+  });
+
+  describe('apprunning sync', () => {
+    it('should request apprunning sync from eligible peers', async () => {
+      const fakePeer = { key: '1.2.3.4:16127', send: sinon.stub() };
+      peerManager.getEligibleTempSyncPeers = sinon.stub().returns([]);
+      peerManager.getEligibleAppRunningSyncPeers = sinon.stub().returns([fakePeer]);
+
+      const orchestrator = new AppSyncOrchestrator({ blockEmitter, peerManager });
+      orchestrator.start();
+      peerManager.emit('peerThresholdReached', 12);
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(peerManager.getEligibleAppRunningSyncPeers.called).to.be.true;
+      // send called for apprunning + appinstalling + appinstalling errors
+      expect(fakePeer.send.callCount).to.be.at.least(3);
+    });
+
+    it('should skip apprunning sync when no eligible peers', async () => {
+      peerManager.getEligibleTempSyncPeers = sinon.stub().returns([]);
+      peerManager.getEligibleAppRunningSyncPeers = sinon.stub().returns([]);
+
+      const orchestrator = new AppSyncOrchestrator({ blockEmitter, peerManager });
+      orchestrator.start();
+      peerManager.emit('peerThresholdReached', 12);
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(logStub.info.calledWith('AppSyncOrchestrator - No eligible peers for apprunning sync')).to.be.true;
+    });
+  });
+
+  describe('location readiness', () => {
+    it('should use appRunningSyncComplete when set', async () => {
+      globalStateStub.appRunningSyncComplete = true;
+      const orchestrator = new AppSyncOrchestrator({
+        blockEmitter, peerManager, isEnterprise: () => true,
+      });
+      orchestrator.start();
+      blockEmitter.emit('blockReceived', 2555000);
+      await new Promise((r) => setTimeout(r, 50));
+
+      // With appRunningSyncComplete=true, should reach READY without 124 blocks
+      if (orchestrator.state !== STATES.READY) {
+        // Need a couple more blocks for checkReadiness to trigger
+        blockEmitter.emit('blockReceived', 2555001);
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      expect(orchestrator.state).to.equal(STATES.READY);
+    });
+
+    it('should fall back to block count when appRunningSyncComplete is false', async () => {
+      globalStateStub.appRunningSyncComplete = false;
+      const orchestrator = new AppSyncOrchestrator({
+        blockEmitter, peerManager, isEnterprise: () => true,
+      });
+      orchestrator.start();
+      blockEmitter.emit('blockReceived', 2555000);
+      await new Promise((r) => setTimeout(r, 50));
+
+      // After sync but before enough blocks, should still be SYNCING
+      expect(orchestrator.state).to.equal(STATES.SYNCING);
+    });
+
+    it('should reset appRunningSyncComplete on degradation', async () => {
+      globalStateStub.appRunningSyncComplete = true;
+      const orchestrator = new AppSyncOrchestrator({
+        blockEmitter, peerManager, isEnterprise: () => true,
+      });
+      orchestrator.start();
+      blockEmitter.emit('blockReceived', 2555000);
+      await new Promise((r) => setTimeout(r, 50));
+      for (let i = 0; i < 130; i += 1) {
+        blockEmitter.emit('blockReceived', 2555000 + i);
+      }
+      await new Promise((r) => setTimeout(r, 50));
+
+      if (orchestrator.state === STATES.READY) {
+        peerManager.emit('peersBelowThreshold', 3);
+        expect(globalStateStub.appRunningSyncComplete).to.be.false;
+      }
     });
   });
 

--- a/tests/unit/appSyncOrchestrator.test.js
+++ b/tests/unit/appSyncOrchestrator.test.js
@@ -16,11 +16,22 @@ describe('AppSyncOrchestrator', () => {
   let globalStateStub;
   let checkAndNotifyStub;
 
+  function makePeer(key) {
+    return { key, send: sinon.stub(), missedPongs: 0 };
+  }
+
+  function makeEligiblePeers(count) {
+    const peers = [];
+    for (let i = 0; i < count; i += 1) {
+      peers.push(makePeer(`10.0.0.${i + 1}:16127`));
+    }
+    return peers;
+  }
+
   beforeEach(() => {
     blockEmitter = new EventEmitter();
     peerManager = new EventEmitter();
-    peerManager.getEligibleTempSyncPeers = sinon.stub().returns([]);
-    peerManager.getEligibleAppRunningSyncPeers = sinon.stub().returns([]);
+    peerManager.getEligibleSyncPeers = sinon.stub().returns([]);
 
     logStub = { info: sinon.stub(), warn: sinon.stub(), error: sinon.stub() };
     syncMissingHashesStub = sinon.stub().resolves({ resolved: 0, missing: 0, unreachable: 0 });
@@ -29,7 +40,6 @@ describe('AppSyncOrchestrator', () => {
     isNodeStatusConfirmedStub = sinon.stub().resolves(true);
     globalStateStub = {
       checkAndSyncAppHashesWasEverExecuted: false,
-      appRunningSyncComplete: false,
     };
     checkAndNotifyStub = sinon.stub().resolves();
 
@@ -126,12 +136,12 @@ describe('AppSyncOrchestrator', () => {
   });
 
   describe('peer threshold events', () => {
-    it('should trigger temp message catch-up on peerThresholdReached', async () => {
+    it('should call getEligibleSyncPeers on peerThresholdReached', async () => {
       const orchestrator = new AppSyncOrchestrator({ blockEmitter, peerManager });
       orchestrator.start();
       peerManager.emit('peerThresholdReached', 12);
       await new Promise((r) => setTimeout(r, 50));
-      expect(peerManager.getEligibleTempSyncPeers.calledOnce).to.be.true;
+      expect(peerManager.getEligibleSyncPeers.calledOnce).to.be.true;
     });
 
     it('should start apprunning broadcast on peerThresholdReached', async () => {
@@ -148,10 +158,8 @@ describe('AppSyncOrchestrator', () => {
       });
       orchestrator.start();
 
-      // Get to READY state: sync completes + enough blocks + confirmed
       blockEmitter.emit('blockReceived', 2555000);
       await new Promise((r) => setTimeout(r, 50));
-      // Simulate enough blocks for location readiness (enterprise = 124 blocks)
       for (let i = 0; i < 130; i += 1) {
         blockEmitter.emit('blockReceived', 2555000 + i);
       }
@@ -185,82 +193,142 @@ describe('AppSyncOrchestrator', () => {
     });
   });
 
-  describe('temp message catch-up', () => {
-    it('should send binary request to eligible peers', async () => {
-      const fakePeer = { key: '1.2.3.4:16127', send: sinon.stub() };
-      peerManager.getEligibleTempSyncPeers = sinon.stub().returns([fakePeer]);
+  describe('sync requests', () => {
+    it('should send all 4 request types to eligible peers', async () => {
+      const peers = makeEligiblePeers(3);
+      peerManager.getEligibleSyncPeers = sinon.stub().returns(peers);
 
       const orchestrator = new AppSyncOrchestrator({ blockEmitter, peerManager });
       orchestrator.start();
       peerManager.emit('peerThresholdReached', 12);
       await new Promise((r) => setTimeout(r, 50));
 
-      expect(fakePeer.send.calledOnce).to.be.true;
+      for (const peer of peers) {
+        expect(peer.send.callCount).to.equal(4);
+      }
     });
 
-    it('should not send requests when no eligible peers', async () => {
-      peerManager.getEligibleTempSyncPeers = sinon.stub().returns([]);
-    peerManager.getEligibleAppRunningSyncPeers = sinon.stub().returns([]);
+    it('should not send when fewer than 3 eligible peers on first attempt', async () => {
+      const peers = makeEligiblePeers(2);
+      peerManager.getEligibleSyncPeers = sinon.stub().returns(peers);
 
       const orchestrator = new AppSyncOrchestrator({ blockEmitter, peerManager });
       orchestrator.start();
       peerManager.emit('peerThresholdReached', 12);
       await new Promise((r) => setTimeout(r, 50));
 
-      expect(logStub.info.calledWith('AppSyncOrchestrator - No eligible peers for temp message catch-up')).to.be.true;
+      for (const peer of peers) {
+        expect(peer.send.called).to.be.false;
+      }
     });
-  });
 
-  describe('apprunning sync', () => {
-    it('should request apprunning sync from eligible peers', async () => {
-      const fakePeer = { key: '1.2.3.4:16127', send: sinon.stub() };
-      peerManager.getEligibleTempSyncPeers = sinon.stub().returns([]);
-      peerManager.getEligibleAppRunningSyncPeers = sinon.stub().returns([fakePeer]);
+    it('should not ask the same peer twice in the same cycle', async () => {
+      const peers = makeEligiblePeers(3);
+      peerManager.getEligibleSyncPeers = sinon.stub().returns(peers);
 
       const orchestrator = new AppSyncOrchestrator({ blockEmitter, peerManager });
       orchestrator.start();
       peerManager.emit('peerThresholdReached', 12);
       await new Promise((r) => setTimeout(r, 50));
 
-      expect(peerManager.getEligibleAppRunningSyncPeers.called).to.be.true;
-      // send called for apprunning + appinstalling + appinstalling errors
-      expect(fakePeer.send.callCount).to.be.at.least(3);
-    });
-
-    it('should skip apprunning sync when no eligible peers', async () => {
-      peerManager.getEligibleTempSyncPeers = sinon.stub().returns([]);
-      peerManager.getEligibleAppRunningSyncPeers = sinon.stub().returns([]);
-
-      const orchestrator = new AppSyncOrchestrator({ blockEmitter, peerManager });
-      orchestrator.start();
-      peerManager.emit('peerThresholdReached', 12);
+      // Second threshold event — same peers returned, but already asked
+      peerManager.emit('peerThresholdReached', 15);
       await new Promise((r) => setTimeout(r, 50));
 
-      expect(logStub.info.calledWith('AppSyncOrchestrator - No eligible peers for apprunning sync')).to.be.true;
+      for (const peer of peers) {
+        expect(peer.send.callCount).to.equal(4);
+      }
     });
-  });
 
-  describe('location readiness', () => {
-    it('should use appRunningSyncComplete when set', async () => {
-      globalStateStub.appRunningSyncComplete = true;
+    it('should reset asked peers on degradation', async () => {
+      const peers = makeEligiblePeers(3);
+      peerManager.getEligibleSyncPeers = sinon.stub().returns(peers);
+
       const orchestrator = new AppSyncOrchestrator({
         blockEmitter, peerManager, isEnterprise: () => true,
       });
       orchestrator.start();
+
+      // Get to READY via block-count fallback
+      blockEmitter.emit('blockReceived', 2555000);
+      await new Promise((r) => setTimeout(r, 50));
+      peerManager.emit('peerThresholdReached', 12);
+      await new Promise((r) => setTimeout(r, 50));
+      for (let i = 0; i < 130; i += 1) {
+        blockEmitter.emit('blockReceived', 2555000 + i);
+      }
+      await new Promise((r) => setTimeout(r, 50));
+
+      if (orchestrator.state === STATES.READY) {
+        // Degrade and recover — peers should be asked again
+        peerManager.emit('peersBelowThreshold', 3);
+        const sendCountBefore = peers[0].send.callCount;
+        peerManager.emit('peerThresholdReached', 12);
+        await new Promise((r) => setTimeout(r, 50));
+        expect(peers[0].send.callCount).to.be.greaterThan(sendCountBefore);
+      }
+    });
+  });
+
+  describe('state sync readiness', () => {
+    it('should reach READY when all 3 sync types complete from 3 peers', async () => {
+      const peers = makeEligiblePeers(3);
+      peerManager.getEligibleSyncPeers = sinon.stub().returns(peers);
+
+      const orchestrator = new AppSyncOrchestrator({
+        blockEmitter, peerManager, isEnterprise: () => true,
+      });
+      orchestrator.start();
+
+      // Start hash sync
       blockEmitter.emit('blockReceived', 2555000);
       await new Promise((r) => setTimeout(r, 50));
 
-      // With appRunningSyncComplete=true, should reach READY without 124 blocks
-      if (orchestrator.state !== STATES.READY) {
-        // Need a couple more blocks for checkReadiness to trigger
-        blockEmitter.emit('blockReceived', 2555001);
-        await new Promise((r) => setTimeout(r, 50));
+      // Send sync requests
+      peerManager.emit('peerThresholdReached', 12);
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Complete all syncs from 3 peers
+      for (let i = 0; i < 3; i += 1) {
+        orchestrator.onSyncComplete('apprunning');
+        orchestrator.onSyncComplete('appinstalling');
+        orchestrator.onSyncComplete('apperrors');
       }
+      await new Promise((r) => setTimeout(r, 50));
+
       expect(orchestrator.state).to.equal(STATES.READY);
     });
 
-    it('should fall back to block count when appRunningSyncComplete is false', async () => {
-      globalStateStub.appRunningSyncComplete = false;
+    it('should not reach READY when only 2 peers complete apprunning', async () => {
+      const peers = makeEligiblePeers(3);
+      peerManager.getEligibleSyncPeers = sinon.stub().returns(peers);
+
+      const orchestrator = new AppSyncOrchestrator({
+        blockEmitter, peerManager, isEnterprise: () => true,
+      });
+      orchestrator.start();
+
+      blockEmitter.emit('blockReceived', 2555000);
+      await new Promise((r) => setTimeout(r, 50));
+
+      peerManager.emit('peerThresholdReached', 12);
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Only 2 apprunning, but 3 of the others
+      orchestrator.onSyncComplete('apprunning');
+      orchestrator.onSyncComplete('apprunning');
+      for (let i = 0; i < 3; i += 1) {
+        orchestrator.onSyncComplete('appinstalling');
+        orchestrator.onSyncComplete('apperrors');
+      }
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(orchestrator.state).to.equal(STATES.SYNCING);
+    });
+
+    it('should fall back to block count when no sync peers available', async () => {
+      peerManager.getEligibleSyncPeers = sinon.stub().returns([]);
+
       const orchestrator = new AppSyncOrchestrator({
         blockEmitter, peerManager, isEnterprise: () => true,
       });
@@ -270,25 +338,46 @@ describe('AppSyncOrchestrator', () => {
 
       // After sync but before enough blocks, should still be SYNCING
       expect(orchestrator.state).to.equal(STATES.SYNCING);
-    });
 
-    it('should reset appRunningSyncComplete on degradation', async () => {
-      globalStateStub.appRunningSyncComplete = true;
-      const orchestrator = new AppSyncOrchestrator({
-        blockEmitter, peerManager, isEnterprise: () => true,
-      });
-      orchestrator.start();
-      blockEmitter.emit('blockReceived', 2555000);
-      await new Promise((r) => setTimeout(r, 50));
+      // After enough blocks (enterprise = 124), should reach READY
       for (let i = 0; i < 130; i += 1) {
         blockEmitter.emit('blockReceived', 2555000 + i);
       }
       await new Promise((r) => setTimeout(r, 50));
+      expect(orchestrator.state).to.equal(STATES.READY);
+    });
 
-      if (orchestrator.state === STATES.READY) {
-        peerManager.emit('peersBelowThreshold', 3);
-        expect(globalStateStub.appRunningSyncComplete).to.be.false;
+    it('should reset sync completions on degradation', async () => {
+      const peers = makeEligiblePeers(3);
+      peerManager.getEligibleSyncPeers = sinon.stub().returns(peers);
+
+      const orchestrator = new AppSyncOrchestrator({
+        blockEmitter, peerManager, isEnterprise: () => true,
+      });
+      orchestrator.start();
+
+      blockEmitter.emit('blockReceived', 2555000);
+      await new Promise((r) => setTimeout(r, 50));
+      peerManager.emit('peerThresholdReached', 12);
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Complete all syncs → READY
+      for (let i = 0; i < 3; i += 1) {
+        orchestrator.onSyncComplete('apprunning');
+        orchestrator.onSyncComplete('appinstalling');
+        orchestrator.onSyncComplete('apperrors');
       }
+      await new Promise((r) => setTimeout(r, 50));
+      expect(orchestrator.state).to.equal(STATES.READY);
+
+      // Degrade
+      peerManager.emit('peersBelowThreshold', 3);
+      expect(orchestrator.state).to.equal(STATES.DEGRADED);
+
+      // Recovery — need fresh syncs, previous completions reset
+      peerManager.emit('peerThresholdReached', 12);
+      await new Promise((r) => setTimeout(r, 50));
+      expect(orchestrator.state).to.equal(STATES.RESYNCING);
     });
   });
 

--- a/tests/unit/appSyncOrchestrator.test.js
+++ b/tests/unit/appSyncOrchestrator.test.js
@@ -20,6 +20,7 @@ describe('AppSyncOrchestrator', () => {
     blockEmitter = new EventEmitter();
     peerManager = new EventEmitter();
     peerManager.getEligibleTempSyncPeers = sinon.stub().returns([]);
+    peerManager.getEligibleAppRunningSyncPeers = sinon.stub().returns([]);
 
     logStub = { info: sinon.stub(), warn: sinon.stub(), error: sinon.stub() };
     syncMissingHashesStub = sinon.stub().resolves({ resolved: 0, missing: 0, unreachable: 0 });
@@ -28,6 +29,7 @@ describe('AppSyncOrchestrator', () => {
     isNodeStatusConfirmedStub = sinon.stub().resolves(true);
     globalStateStub = {
       checkAndSyncAppHashesWasEverExecuted: false,
+      appRunningSyncComplete: false,
     };
     checkAndNotifyStub = sinon.stub().resolves();
 
@@ -41,7 +43,10 @@ describe('AppSyncOrchestrator', () => {
         expireGlobalApplications: expireStub,
       },
       '../utils/globalState': globalStateStub,
-      '../utils/peerCodec': { encodeRequestTempMessages: sinon.stub().returns(Buffer.from([0x20])) },
+      '../utils/peerCodec': {
+        encodeRequestTempMessages: sinon.stub().returns(Buffer.alloc(9, 0x20)),
+        encodeRequestAppRunning: sinon.stub().returns(Buffer.alloc(9, 0x21)),
+      },
     });
     AppSyncOrchestrator = mod.AppSyncOrchestrator;
     STATES = mod.STATES;
@@ -193,6 +198,7 @@ describe('AppSyncOrchestrator', () => {
 
     it('should not send requests when no eligible peers', async () => {
       peerManager.getEligibleTempSyncPeers = sinon.stub().returns([]);
+    peerManager.getEligibleAppRunningSyncPeers = sinon.stub().returns([]);
 
       const orchestrator = new AppSyncOrchestrator({ blockEmitter, peerManager });
       orchestrator.start();

--- a/tests/unit/appSyncOrchestrator.test.js
+++ b/tests/unit/appSyncOrchestrator.test.js
@@ -32,14 +32,6 @@ describe('AppSyncOrchestrator', () => {
     checkAndNotifyStub = sinon.stub().resolves();
 
     const mod = proxyquire('../../ZelBack/src/services/appMessaging/appSyncOrchestrator', {
-      config: {
-        fluxapps: {
-          daemonPONFork: 2020000,
-          blocksLasting: 22000,
-          appSyncPeerThreshold: 12,
-          appSyncDegradedThreshold: 4,
-        },
-      },
       '../../lib/log': logStub,
       '../generalService': { isNodeStatusConfirmed: isNodeStatusConfirmedStub },
       './appHashSyncService': { syncMissingHashes: syncMissingHashesStub },

--- a/tests/unit/appSyncOrchestrator.test.js
+++ b/tests/unit/appSyncOrchestrator.test.js
@@ -47,7 +47,7 @@ describe('AppSyncOrchestrator', () => {
       '../../lib/log': logStub,
       '../generalService': { isNodeStatusConfirmed: isNodeStatusConfirmedStub },
       './appHashSyncService': { syncMissingHashes: syncMissingHashesStub },
-      './peerNotification': { checkAndNotifyPeersOfRunningApps: checkAndNotifyStub },
+      './peerNotification': { checkAndNotifyPeersOfRunningApps: checkAndNotifyStub, stopBroadcastInterval: sinon.stub() },
       '../appDatabase/registryManager': {
         reindexGlobalAppsInformation: reindexStub,
         expireGlobalApplications: expireStub,

--- a/tests/unit/fluxCommunication.test.js
+++ b/tests/unit/fluxCommunication.test.js
@@ -271,7 +271,9 @@ describe('fluxCommunication tests', () => {
     });
 
     it('should broadcast the app message if a proper data is given', async () => {
-      sinon.stub(messageStore, 'storeAppRunningMessage').returns(true);
+      sinon.stub(messageStore, 'storeAppRunningMessage').resolves({ stored: true, rebroadcast: true });
+      sinon.stub(messageStore, 'storeSignedAppRunningBroadcast');
+      sinon.stub(daemonServiceMiscRpcs, 'isDaemonSynced').returns({ data: { synced: true, height: 0 } });
       const fromIp = '127.0.0.5';
       const port = '16127';
       const type = 'fluxappregister';
@@ -1513,7 +1515,7 @@ describe('fluxCommunication tests', () => {
 
       sinon.assert.calledWith(logInfoSpy, sinon.match(/Received SIGTERM notification from node/));
       sinon.assert.calledWith(logInfoSpy, sinon.match(/Found 2 apps for node/));
-      sinon.assert.calledOnce(updateInDatabaseStub);
+      sinon.assert.calledTwice(updateInDatabaseStub);
       sinon.assert.calledOnce(relaySpy);
     }).timeout(10000);
 

--- a/tests/unit/globalconfig/default.js
+++ b/tests/unit/globalconfig/default.js
@@ -49,6 +49,9 @@ module.exports = {
         appsLocations: 'zelappslocation', // stores location of flux apps as documents containing name, hash, ip, obtainedAt
         appsInstallingLocations: 'appsInstallingLocations',
         appsInstallingErrorsLocations: 'appsInstallingErrorsLocations', // stores install errors location of flux apps as documents containing name, hash, ip, obtainedAt
+        appsRunningBroadcasts: 'fluxapprunningbroadcasts',
+        appsInstallingBroadcasts: 'fluxappinstallingbroadcasts',
+        appsInstallingErrorsBroadcasts: 'fluxappinstallingerrorsbroadcasts',
       },
     },
     chainparams: {

--- a/tests/unit/globalconfig/default.js
+++ b/tests/unit/globalconfig/default.js
@@ -206,6 +206,10 @@ module.exports = {
     minIncoming: 4,
     minUniqueIpsIncoming: 3,
     minUpTime: 1800, // 30 mins
+    appSyncPeerThreshold: 12,
+    appSyncDegradedThreshold: 4,
+    appSyncMinPeerUptime: 60,
+    appSyncMinCompletions: 3,
     installation: {
       probability: 100, // 1%
       delay: 120, // in seconds

--- a/tests/unit/messageStore.test.js
+++ b/tests/unit/messageStore.test.js
@@ -48,6 +48,9 @@ describe('messageStore tests', () => {
           database: 'appsdb',
           collections: {
             appsLocations: 'appsLocations',
+            appsRunningBroadcasts: 'appsRunningBroadcasts',
+            appsInstallingBroadcasts: 'appsInstallingBroadcasts',
+            appsInstallingErrorsBroadcasts: 'appsInstallingErrorsBroadcasts',
           },
         },
       },
@@ -82,6 +85,7 @@ describe('messageStore tests', () => {
         globalAppsLocations: 'appsLocations',
         globalAppsInstallingLocations: 'appsInstallingLocations',
         globalAppsInstallingErrorsLocations: 'appsInstallingErrorsLocations',
+        globalAppsInstallingErrorsBroadcasts: 'appsInstallingErrorsBroadcasts',
         appsHashesCollection: 'appsHashes',
       },
       '../utils/appSpecHelpers': {
@@ -403,8 +407,8 @@ describe('messageStore tests', () => {
       const result = await messageStore.storeAppRunningMessage(message);
 
       expect(result).to.deep.equal({ stored: true, rebroadcast: true });
-      // Called three times: locations, installing locations, installing broadcasts
-      expect(dbHelperStub.removeDocumentsFromCollection.callCount).to.equal(3);
+      // Called four times: locations, running broadcasts, installing locations, installing broadcasts
+      expect(dbHelperStub.removeDocumentsFromCollection.callCount).to.equal(4);
     });
   });
 
@@ -479,7 +483,7 @@ describe('messageStore tests', () => {
       expect(result.message).to.include('appName cannot be empty');
     });
 
-    it('should store valid removed message', async () => {
+    it('should store valid removed message and clean up broadcasts', async () => {
       const message = {
         type: 'fluxappremoved',
         version: 1,
@@ -491,11 +495,23 @@ describe('messageStore tests', () => {
       const mockDb = { db: sinon.stub().returns('database') };
       dbHelperStub.databaseConnection.returns(mockDb);
       dbHelperStub.findOneAndDeleteInDatabase.resolves();
+      dbHelperStub.removeDocumentsFromCollection.resolves();
+      dbHelperStub.updateOneInDatabase.resolves();
 
       const result = await messageStore.storeAppRemovedMessage(message);
 
       expect(result).to.be.true;
       expect(dbHelperStub.findOneAndDeleteInDatabase.calledOnce).to.be.true;
+      // Should delete v1 broadcast for this ip+name
+      expect(dbHelperStub.removeDocumentsFromCollection.calledOnce).to.be.true;
+      expect(dbHelperStub.removeDocumentsFromCollection.firstCall.args[2]).to.deep.equal({
+        ip: '192.168.1.1', 'data.name': 'testapp',
+      });
+      // Should add to excludedApps on v2 broadcast
+      expect(dbHelperStub.updateOneInDatabase.calledOnce).to.be.true;
+      const updateArgs = dbHelperStub.updateOneInDatabase.firstCall.args;
+      expect(updateArgs[2]).to.deep.equal({ ip: '192.168.1.1', 'data.apps': { $exists: true } });
+      expect(updateArgs[3]).to.deep.equal({ $addToSet: { excludedApps: 'testapp' } });
     });
   });
 
@@ -623,6 +639,32 @@ describe('messageStore tests', () => {
 
       expect(result).to.be.true;
       expect(dbHelperStub.updateInDatabase.calledOnce).to.be.true;
+    });
+  });
+
+  describe('storeSignedAppRunningBroadcast', () => {
+    it('should clear excludedApps when storing a broadcast', () => {
+      const signedBroadcast = {
+        version: 1,
+        timestamp: Date.now(),
+        pubKey: 'pubkey',
+        signature: 'sig',
+        data: {
+          ip: '192.168.1.1',
+          broadcastedAt: Date.now(),
+          apps: [{ name: 'app1', hash: 'h1' }],
+        },
+      };
+
+      const mockDb = { db: sinon.stub().returns('database') };
+      dbHelperStub.databaseConnection.returns(mockDb);
+      dbHelperStub.updateOneInDatabase.resolves();
+
+      messageStore.storeSignedAppRunningBroadcast(signedBroadcast);
+
+      expect(dbHelperStub.updateOneInDatabase.calledOnce).to.be.true;
+      const updateArg = dbHelperStub.updateOneInDatabase.firstCall.args[3];
+      expect(updateArg.$unset).to.deep.equal({ excludedApps: '' });
     });
   });
 });

--- a/tests/unit/messageStore.test.js
+++ b/tests/unit/messageStore.test.js
@@ -334,7 +334,7 @@ describe('messageStore tests', () => {
 
       const result = await messageStore.storeAppRunningMessage(message);
 
-      expect(result).to.be.false;
+      expect(result).to.deep.equal({ stored: false, rebroadcast: false });
       expect(logStub.warn.called).to.be.true;
     });
 
@@ -356,7 +356,7 @@ describe('messageStore tests', () => {
 
       const result = await messageStore.storeAppRunningMessage(message);
 
-      expect(result).to.be.true;
+      expect(result).to.deep.equal({ stored: true, rebroadcast: true });
       expect(dbHelperStub.updateOneInDatabase.calledOnce).to.be.true;
     });
 
@@ -380,10 +380,10 @@ describe('messageStore tests', () => {
 
       const result = await messageStore.storeAppRunningMessage(message);
 
-      expect(result).to.be.true;
+      expect(result).to.deep.equal({ stored: true, rebroadcast: true });
       expect(dbHelperStub.updateOneInDatabase.callCount).to.equal(2);
-      // Should clean up installing records for each app
-      expect(dbHelperStub.removeDocumentsFromCollection.callCount).to.equal(2);
+      // Should clean up installing records for each app (location + broadcast per app)
+      expect(dbHelperStub.removeDocumentsFromCollection.callCount).to.equal(4);
     });
 
     it('should handle version 2 message with empty apps array', async () => {
@@ -402,9 +402,9 @@ describe('messageStore tests', () => {
 
       const result = await messageStore.storeAppRunningMessage(message);
 
-      expect(result).to.be.true;
-      // Called twice: once for locations, once for installing locations
-      expect(dbHelperStub.removeDocumentsFromCollection.calledTwice).to.be.true;
+      expect(result).to.deep.equal({ stored: true, rebroadcast: true });
+      // Called three times: locations, installing locations, installing broadcasts
+      expect(dbHelperStub.removeDocumentsFromCollection.callCount).to.equal(3);
     });
   });
 
@@ -531,8 +531,8 @@ describe('messageStore tests', () => {
 
       expect(result).to.be.true;
       expect(dbHelperStub.updateOneInDatabase.calledOnce).to.be.true;
-      // Should clean up installing record since installation failed
-      expect(dbHelperStub.removeDocumentsFromCollection.calledOnce).to.be.true;
+      // Should clean up installing record since installation failed (location + broadcast)
+      expect(dbHelperStub.removeDocumentsFromCollection.callCount).to.equal(2);
       expect(dbHelperStub.removeDocumentsFromCollection.calledWith(
         'database',
         'appsInstallingLocations',
@@ -562,8 +562,7 @@ describe('messageStore tests', () => {
       const result = await messageStore.storeAppInstallingErrorMessage(message);
 
       expect(result).to.be.true;
-      expect(dbHelperStub.updateInDatabase.calledOnce).to.be.true;
-      expect(dbHelperStub.removeDocumentsFromCollection.calledOnce).to.be.true;
+      expect(dbHelperStub.removeDocumentsFromCollection.callCount).to.equal(2);
     });
   });
 

--- a/tests/unit/peerCodec.test.js
+++ b/tests/unit/peerCodec.test.js
@@ -15,6 +15,11 @@ const {
   decodePeerExchange,
   encodePeerUpdate,
   decodePeerUpdate,
+  encodeRequestTempMessages,
+  encodeRequestAppRunning,
+  encodeRequestAppInstalling,
+  encodeRequestAppInstallingErrors,
+  decodeSyncTimestamp,
 } = require('../../ZelBack/src/services/utils/peerCodec');
 
 describe('peerCodec', () => {
@@ -235,6 +240,52 @@ describe('peerCodec', () => {
       expect(decoded.addOutbound).to.deep.equal([]);
       expect(decoded.addInbound).to.deep.equal([]);
       expect(decoded.rm).to.deep.equal([]);
+    });
+  });
+
+  describe('sync messages', () => {
+    it('should encode REQUEST_TEMP_MESSAGES with timestamp', () => {
+      const buf = encodeRequestTempMessages(1777626000000);
+      expect(buf.length).to.equal(9);
+      expect(buf[0]).to.equal(MSG_TYPE.REQUEST_TEMP_MESSAGES);
+      expect(decodeSyncTimestamp(buf)).to.equal(1777626000000);
+    });
+
+    it('should encode REQUEST_APP_RUNNING with timestamp', () => {
+      const buf = encodeRequestAppRunning(1777626000000);
+      expect(buf.length).to.equal(9);
+      expect(buf[0]).to.equal(MSG_TYPE.REQUEST_APP_RUNNING);
+      expect(decodeSyncTimestamp(buf)).to.equal(1777626000000);
+    });
+
+    it('should encode REQUEST_APP_INSTALLING with timestamp', () => {
+      const buf = encodeRequestAppInstalling(1777626000000);
+      expect(buf.length).to.equal(9);
+      expect(buf[0]).to.equal(MSG_TYPE.REQUEST_APP_INSTALLING);
+      expect(decodeSyncTimestamp(buf)).to.equal(1777626000000);
+    });
+
+    it('should encode REQUEST_APP_INSTALLING_ERRORS with timestamp', () => {
+      const buf = encodeRequestAppInstallingErrors(1777626000000);
+      expect(buf.length).to.equal(9);
+      expect(buf[0]).to.equal(MSG_TYPE.REQUEST_APP_INSTALLING_ERRORS);
+      expect(decodeSyncTimestamp(buf)).to.equal(1777626000000);
+    });
+
+    it('should default to timestamp 0', () => {
+      const buf = encodeRequestTempMessages();
+      expect(decodeSyncTimestamp(buf)).to.equal(0);
+    });
+
+    it('should handle short buffer in decodeSyncTimestamp', () => {
+      const buf = Buffer.from([0x20]);
+      expect(decodeSyncTimestamp(buf)).to.equal(0);
+    });
+
+    it('should roundtrip large timestamps', () => {
+      const ts = Date.now();
+      const buf = encodeRequestAppRunning(ts);
+      expect(decodeSyncTimestamp(buf)).to.equal(ts);
     });
   });
 });

--- a/tests/unit/peerNotification.test.js
+++ b/tests/unit/peerNotification.test.js
@@ -114,13 +114,40 @@ describe('peerNotification tests', () => {
     });
   });
 
-  describe('handleMissingMasterSlaveContainer', () => {
+  describe('handleMissingMasterSlaveContainer (stoppedAppsRecovery)', () => {
+    let stoppedAppsRecovery;
+
+    beforeEach(() => {
+      stoppedAppsRecovery = proxyquire('../../ZelBack/src/services/appLifecycle/stoppedAppsRecovery', {
+        config: {
+          database: {
+            appslocal: { collections: { appsInformation: 'localAppsInformation' }, database: 'localapps' },
+            appsglobal: { database: 'globalapps', collections: { appsLocations: 'appsLocations' } },
+          },
+        },
+        '../dbHelper': dbHelperStub,
+        '../dockerService': dockerServiceStub,
+        '../serviceHelper': { delay: sinon.stub().resolves() },
+        '../generalService': { isNodeStatusConfirmed: sinon.stub().resolves(true), nodeTier: sinon.stub().resolves('cumulus') },
+        '../appDatabase/registryManager': { getApplicationGlobalSpecifications: sinon.stub().resolves(null) },
+        '../appManagement/appInspector': appInspectorStub,
+        './appInstaller': appInstallerStub,
+        './appUninstaller': appUninstallerStub,
+        './advancedWorkflows': {},
+        '../appTamperingDetectionService': { recordEvent: sinon.stub().resolves(), isNetworkMissingError: sinon.stub().returns(false) },
+        '../utils/globalState': { backupInProgress: [], restoreInProgress: [], appsMonitored: new Map() },
+        '../utils/cacheManager': { default: { stoppedAppsCache: new Map() } },
+        '../appQuery/appQueryService': { decryptEnterpriseApps: sinon.stub().callsFake(async (apps) => apps) },
+        '../utils/appConstants': { localAppsInformation: 'localAppsInformation' },
+        '../fluxNetworkHelper': { getFluxNodePrivateKey: sinon.stub().returns('') },
+        '../../lib/log': logStub,
+      });
+    });
+
     it('should return early if container exists', async () => {
       dockerServiceStub.getDockerContainerOnly.resolves({ Id: 'abc123' });
 
-      await peerNotification.handleMissingMasterSlaveContainer(
-        'MyComponent_testapp', 'testapp', {}, () => ({}),
-      );
+      await stoppedAppsRecovery.handleMissingMasterSlaveContainer('MyComponent_testapp', 'testapp');
 
       expect(appInstallerStub.installApplicationHard.called).to.be.false;
       expect(appUninstallerStub.removeAppLocally.called).to.be.false;
@@ -135,9 +162,7 @@ describe('peerNotification tests', () => {
       };
       dbHelperStub.findOneInDatabase.resolves(appSpec);
 
-      await peerNotification.handleMissingMasterSlaveContainer(
-        'MyComponent_testapp', 'testapp', {}, () => ({}),
-      );
+      await stoppedAppsRecovery.handleMissingMasterSlaveContainer('MyComponent_testapp', 'testapp');
 
       expect(appInstallerStub.installApplicationHard.calledOnce).to.be.true;
       expect(appInspectorStub.startAppMonitoring.calledWith('MyComponent_testapp')).to.be.true;
@@ -146,11 +171,9 @@ describe('peerNotification tests', () => {
 
     it('should remove app when recreation fails and container still missing', async () => {
       dockerServiceStub.getDockerContainerOnly.resolves(null);
-      dbHelperStub.findOneInDatabase.resolves(null); // causes recreateMissingContainers to throw
+      dbHelperStub.findOneInDatabase.resolves(null);
 
-      await peerNotification.handleMissingMasterSlaveContainer(
-        'MyComponent_testapp', 'testapp', {}, () => ({}),
-      );
+      await stoppedAppsRecovery.handleMissingMasterSlaveContainer('MyComponent_testapp', 'testapp');
 
       expect(appUninstallerStub.removeAppLocally.calledOnce).to.be.true;
       expect(appUninstallerStub.removeAppLocally.firstCall.args[0]).to.equal('testapp');
@@ -158,15 +181,12 @@ describe('peerNotification tests', () => {
     });
 
     it('should skip removal when recreation fails but container was created by another process', async () => {
-      // First call: missing. Second call (in catch): now exists
       dockerServiceStub.getDockerContainerOnly
         .onFirstCall().resolves(null)
         .onSecondCall().resolves({ Id: 'abc123' });
-      dbHelperStub.findOneInDatabase.resolves(null); // causes recreateMissingContainers to throw
+      dbHelperStub.findOneInDatabase.resolves(null);
 
-      await peerNotification.handleMissingMasterSlaveContainer(
-        'MyComponent_testapp', 'testapp', {}, () => ({}),
-      );
+      await stoppedAppsRecovery.handleMissingMasterSlaveContainer('MyComponent_testapp', 'testapp');
 
       expect(appUninstallerStub.removeAppLocally.called).to.be.false;
       expect(logStub.info.calledWithMatch(/created by another process/)).to.be.true;

--- a/tests/unit/syncthingHealthMonitor.test.js
+++ b/tests/unit/syncthingHealthMonitor.test.js
@@ -1236,7 +1236,7 @@ describe('syncthingHealthMonitor tests', () => {
       expect(result.actions).to.have.length(1);
       expect(result.actions[0].action).to.equal('remove');
       expect(removeAppLocallyFn.calledOnce).to.be.true;
-      expect(removeAppLocallyFn.calledWith('myapp', null, true, false, false)).to.be.true;
+      expect(removeAppLocallyFn.calledWith('myapp', null, true, false, true)).to.be.true;
     });
 
     it('should clean up cache for folders that no longer exist', async () => {


### PR DESCRIPTION
## Summary

Replaces the timer-based spawner startup (125-minute fixed wait) with an event-driven architecture that syncs all ephemeral app state from peers in seconds. A restarting node now reaches spawner readiness in ~30 seconds instead of 2+ hours. Also fixes a broken TTL on the install errors collection and enables the spawner to skip apps with network-wide install failures.

### Key changes:
- **AppSyncOrchestrator**: State machine coordinating hash sync, DB rebuild, and spawner startup via events instead of timers
- **Signed broadcast sync protocol**: Four binary message types (0x20-0x23) for syncing temp messages, apprunning locations, appinstalling locations, and install errors from peers over WebSocket
- **Spawner expiration filter**: Pipeline-level check prevents spawning expired/cancelled apps (the original bug fix)
- **Immediate promotion**: Temp messages arriving for known hashes are promoted instantly instead of waiting for the 30-minute sweep
- **Network-wide error check**: Spawner skips apps with 5+ install failures across distinct nodes
- **Install errors TTL fix**: Broken `cachedAt` index replaced with working `broadcastedAt` (24-hour TTL)

## The Problem

Cancelled enterprise apps (`expire: 100`) were being installed on nodes that restarted after the cancellation. Six root causes identified:

1. No expiration check in the spawner aggregation pipeline
2. Stale `globalAppsInformation` rebuilt at boot before hash sync
3. Slow hash sync: 30-minute loop, 500 at a time, one peer
4. 95% threshold skipping bulk sync for nodes down briefly
5. Missed gossip: P2P gossip is fire-and-forget, no replay
6. Timer-based spawner: starts on fixed clock regardless of DB state

Additionally, the install errors collection had a broken TTL (index on `cachedAt` which was never set — 19,000+ records accumulating indefinitely on production nodes) and an unsigned HTTP bulk fetch (`getPeerAppsInstallingErrorMessages`) that trusted one peer's aggregate data without verification.

## Architecture

### Before (timer-based)
```
T+0        Boot, rebuild DB from incomplete data
T+15-30m   Hash sync starts (30-min loop)
T+62m      Enterprise spawner (TIMER) — may use stale data
T+125m     Non-enterprise spawner (TIMER) — may use stale data
```

### After (event-driven)
```
T+0        Boot, AppSyncOrchestrator starts
T+~30s     Peer threshold (12) → sync all 4 data types from peers
T+~31s     All syncs complete, location data ready
T+varies   Explorer syncs → hash sync → DB rebuild
T+varies   Node confirmed → spawnerReady
```

### State Machine
```
INITIALIZING ──► SYNCING ──► READY
                   ▲            |
                   |            v
                RESYNCING ◄── DEGRADED
```

## Signed Broadcast Sync Protocol

| Message | Code | Data | Chunk Size |
|---------|------|------|------------|
| Temp Messages | 0x20 | App registrations/updates not yet on-chain | 2000 |
| App Running | 0x21 | Node → running apps mapping | 2000 |
| App Installing | 0x22 | In-progress installations | 2000 |
| Install Errors | 0x23 | Failed installations per node per app hash | 2000 |

### How it works

1. Receiver sends 9-byte binary request: `[type:1][sinceTimestamp:8]`
2. Sender opens MongoDB cursor (consistent snapshot), streams in chunks of 2000 — caps memory usage regardless of dataset size
3. Each chunk is a signed broadcast containing an array of inner signed broadcasts
4. Receiver verifies each inner broadcast signature against deterministic node list
5. Verified broadcasts bulk-written to both signed and location collections
6. Final chunk has `done: true` → receiver knows sync is complete

### Security

- **Two-layer verification**: Outer broadcast proves a real node sent the response. Inner broadcasts are individually verified — pubkey checked against deterministic node list, signature verified via `bitcoinjs-message`
- **Rate limiting**: 5-minute cooldown per peer per sync type
- **Clock offset adjustment**: `sinceTimestamp` adjusted by `peer.remoteClockOffsetMs` before sender queries
- **No trust in aggregates**: Unlike the old `getPeerAppsInstallingErrorMessages` (which fetched unsigned data via HTTP from one peer), every synced record is cryptographically verified back to its originating node

### Capability

Single `appStateSync` capability covers all four sync types. Defined once in `FluxPeerSocket.js` as `FLUX_CAPABILITIES`, used by both WebSocket client (outbound request headers) and server (inbound response headers). Previously capabilities were duplicated in two files with different values — fixed.

### Sender-Side Filtering

Each sync type filters by validity on the sender side to avoid sending records that have technically expired but haven't been cleaned up yet by MongoDB's TTL thread (~60s lag):
- **Running**: Only sends records newer than 125 minutes (matches TTL)
- **Installing**: Only sends records newer than 15 minutes (matches TTL)
- **Install errors**: Only sends records newer than 24 hours (matches TTL)

## Dual-Collection Storage

Each ephemeral data type stored in two collections:
- **Signed collection** (new): Full broadcast with `pubKey`, `signature`, `data` — used for serving sync requests
- **Location collection** (existing, unchanged): Existing flat rows — used by all existing queries (spawner, advancedWorkflows, etc.)

Both written on every gossip message. Installing collections cleaned up when app transitions to running.

**Why duplicate instead of replacing?** There are 15+ direct queries against the existing location collections scattered across the codebase (messageStore, peerNotification, fluxCommunication, nodeStatusMonitor, stoppedAppsRecovery, advancedWorkflows, appController, syncthingMonitor). A separate branch centralizes all these queries through `registryManager`. Changing the document shape in this PR would conflict with that work. The signed collections add ~1.7MB overhead (running) — trivial. Once the centralization branch is rebased on top of this, the dual-collection pattern can be collapsed into a single collection with an aggregation-based `appLocation()` query.

| Signed | Location | TTL |
|--------|----------|-----|
| `fluxapprunningbroadcasts` | `zelappslocation` | 125 min |
| `fluxappinstallingbroadcasts` | `appsinstallinglocations` | 15 min |
| `fluxappinstallingerrorsbroadcasts` | `appsInstallingErrorsLocations` | 24 hours |

### Validity Windows

| Data Type | Gossip Validity | Sync Validity | TTL |
|-----------|----------------|---------------|-----|
| Running | 5 min | 125 min | 125 min |
| Installing | 5 min | 15 min | 15 min |
| Install Errors | 5 min | 24 hours | 24 hours |

Gossip validity is short because gossip messages are relayed — stale messages indicate network issues. Sync validity matches TTL because sync is a point-in-time snapshot of the sender's DB.

## Install Errors Fix

### What was broken
- TTL index on `cachedAt` — field never set in any document, nothing ever expired
- 19,304 records on production (chud), oldest 3 weeks, 98% had `expireAt: null`
- Null-expiry logic: when 5+ errors accumulated for same app+hash, set `expireAt: null` (persist forever)
- `removeDocumentsFromCollection({})` wiped collection on every restart (inconsistent with other ephemeral collections)
- `getPeerAppsInstallingErrorMessages` fetched unsigned error data via HTTP from one random peer

### What was fixed
- TTL index changed from `cachedAt` to `broadcastedAt` with 86400s (24-hour) expiry
- Removed null-expiry logic
- Removed startup wipe (consistent with other collections, TTL handles cleanup)
- Removed `getPeerAppsInstallingErrorMessages` — replaced by signed 0x23 sync
- Gossip validity reduced from 60 minutes to 5 minutes (consistent with installing messages)

### Spawner network-wide error check
Previously commented out (`appSpawner.js:336-340`). Re-enabled with new logic:
```js
const errorCount = await registryManager.countAppInstallingErrors(appHash);
if (errorCount >= 5) { // 5+ distinct nodes failed → broken spec
  globalState.spawnErrorsLongerAppCache.set(appHash, '');
  throw new Error(`...has ${errorCount} network-wide install failures, skipping`);
}
```

Two-layer error handling:
- **Network DB (24h TTL)**: Prevents untried nodes from wasting time. ~5 nodes retry per day as errors expire
- **Per-node in-memory (7 days)**: `spawnErrorsLongerAppCache` prevents nodes that already failed from retrying for a week

## Other Changes

- **Capability unification**: `FLUX_CAPABILITIES` extracted to `FluxPeerSocket.js` as single source of truth (was duplicated between `socketServer.js` and `fluxCommunication.js` with different values)
- **`X-Flux-Uptime`**: Now sent in both inbound and outbound connection headers (was outbound only)
- **`peerNotification.js`**: Simplified from 10-parameter injection to direct `globalState` imports
- **`messageVerifier.js`**: Removed ~165 lines of duplicate code
- **`appHashSyncService.js`**: Rewritten — multi-peer parallel fetch, no 95% threshold skip
- **Sync guard**: `#syncInProgress` flag prevents overlapping syncs in orchestrator

## Rollout Behavior

**During rollout (mixed network)**: Nodes running new code will find no `appStateSync` peers and fall back to the block-count timer — **125 minutes for non-enterprise, 62 minutes for enterprise**. This is the same behavior as today. All other improvements (hash sync, DB rebuild sequencing, spawner expiration filter, immediate promotion, network error check) apply immediately regardless.

**After full network upgrade**: Restarting nodes sync all location data from peers in ~1.5 seconds. Spawner can start as soon as explorer syncs + hash sync + DB rebuild completes — typically 2-5 minutes after restart instead of 2+ hours.

## Test Results

Tested on two dedicated test nodes.

### Test 1: Temp Message Sync
- Stopped sandwich, registered 2 test apps while it was down
- Restarted sandwich, peered to squidward
- Sandwich received 3 temp messages (chunkymonkey + 2 test apps), all processed
- Verified via `/apps/temporarymessages` API

### Test 2: App Running Sync (full, from clean slate)
```
handleAppRunningSyncResponse - Received 2000 broadcasts (done: false)
handleAppRunningSyncResponse - Received 1336 broadcasts (done: true)
handleAppRunningSyncResponse - Stored 2000 of 2000 verified broadcasts
handleAppRunningSyncResponse - Stored 1335 of 1335 verified broadcasts
```
1 broadcast failed: `nodeNotFound` (node dropped off network between storage and verification — expected)

### Test 3: App Installing Sync
```
handleAppInstallingSyncResponse - Received 57 broadcasts (done: true)
handleAppInstallingSyncResponse - Stored 57 of 57 verified broadcasts
```

### Test 4: Install Errors Sync
```
handleAppInstallingErrorsSyncResponse - Received 3 broadcasts (done: true)
handleAppInstallingErrorsSyncResponse - Stored 3 of 3 verified broadcasts
```

### Test 5: Collection Consistency
```
running broadcasts: 3335  apps: 5165  locations: 5166  match: ~✓ (1 from gossip)
installing broadcasts: 56  locations: 56  match: true
error broadcasts: 3  error locations: 3  match: true
```

### Test 6: Spawner Error Check
Inserted 6 test error records for a fake hash. Verified:
```
countDocuments({hash: "testhash..."}) = 6 → would skip (>=5): true
countDocuments({hash: "nonexistent"}) = 0 → would skip (>=5): false
```

### Test 7: Capability Advertisement
Fixed and verified: both inbound (server response) and outbound (client request) now advertise `appStateSync`. Previously server-side was missing new capabilities.

### Test 8: Installing Validity Window
Initial test showed 132 received, 44 stored. Root cause: sender was sending records up to 15 minutes old (TTL window) but receiver only accepted 5 minutes (gossip validity). Fixed: sender now filters to validity window, 100% stored on subsequent tests.

### Performance
```
T+0.0s   Boot
T+28.0s  Peer threshold reached (12 peers)
T+28.0s  All 4 sync requests sent
T+28.2s  Temp: 1 received, processed
T+28.3s  Installing: 57 received, verified, stored
T+28.3s  Errors: 3 received, verified, stored
T+28.7s  Running chunk 1: 2000 received
T+29.1s  Running chunk 2: 1336 received
T+29.7s  All syncs complete
```
**Total sync time: ~1.5 seconds** for full network state

## Files Changed

| File | Change |
|------|--------|
| `config/default.js` | New collection names, peer thresholds |
| `utils/peerCodec.js` | 0x20 sinceTimestamp, 0x21, 0x22, 0x23 encode/decode |
| `utils/FluxPeerSocket.js` | `FLUX_CAPABILITIES` constant |
| `utils/FluxPeerManager.js` | Binary handlers for 0x21-0x23, eligibility methods, threshold events |
| `utils/globalState.js` | `appRunningSyncComplete`, `spawnerPaused` |
| `lib/socketServer.js` | Uses shared `FLUX_CAPABILITIES`, adds `X-Flux-Uptime` |
| `appMessaging/messageStore.js` | Signed broadcast storage, batch operations, cleanup, error TTL fix |
| `appMessaging/appSyncOrchestrator.js` | Event-driven coordinator |
| `appMessaging/appHashSyncService.js` | Rewritten hash sync |
| `appMessaging/messageVerifier.js` | Removed duplicate code |
| `appMessaging/peerNotification.js` | Direct imports, simplified signature |
| `fluxCommunication.js` | Sync handlers, dispatch routes, capability, `X-Flux-Uptime` |
| `fluxCommunicationMessagesSender.js` | Cursor-based streaming responders |
| `serviceManager.js` | Collection indexes, orchestrator wiring, TTL fixes |
| `appLifecycle/appSpawner.js` | Event-driven startup, pause/resume, network error check |
| `appLifecycle/advancedWorkflows.js` | Removed `getPeerAppsInstallingErrorMessages` |
| `appDatabase/registryManager.js` | `countAppInstallingErrors`, cleaned projections |

## Test plan

- [x] Deploy on 2 test nodes, verify full sync lifecycle from clean slate
- [x] Verify all 4 sync types: temp messages, running, installing, errors
- [x] Verify collection consistency after sync and gossip
- [x] Verify installing cleanup: both collections cleaned on app→running transition
- [x] Verify capability advertisement in both connection directions
- [x] Verify sender-side validity filtering (installing, errors)
- [x] Verify spawner error check logic (count >= 5 threshold)
- [ ] Verify spawner starts after sync instead of after 125-minute timer (requires full network upgrade)
- [ ] Verify cancelled app is not reinstalled after sync
- [ ] Verify fallback: no `appStateSync` peers → block-count timer activates
- [ ] Run on mixed network (new + old nodes) — new nodes fall back gracefully
- [x] ~~Pre-PR: Change uptime threshold from 60s to 7500s~~ (done, 4 locations — matches apprunning TTL)

## Before merging

- [ ] Final code review
- [ ] Extended testing on test nodes (leave running for 24+ hours, verify TTL cleanup, error accumulation, spawner behavior)
- [ ] Review all commit messages and squash if needed