### PR TITLE
fix globalAppsInformation drift from concurrent app update promotions

### DIFF
--- a/ZelBack/src/services/appMessaging/messageVerifier.js
+++ b/ZelBack/src/services/appMessaging/messageVerifier.js
@@ -819,9 +819,12 @@ async function checkAndRequestApp(hash, txid, height, valueSat, i = 0) {
               const updateForSpecifications = permanentAppMessage.appSpecifications;
               updateForSpecifications.hash = permanentAppMessage.hash;
               updateForSpecifications.height = permanentAppMessage.height;
-              // object of appSpecifications extended for hash and height
-              // do not await this
-              updateAppSpecifications(updateForSpecifications);
+              // Awaited: updateAppSpecifications does findOne → compare height → replaceOne.
+              // Firing it in parallel lets two updates for the same app both read the
+              // pre-write state, both pass the height guard, and the one whose replaceOne
+              // lands second wins regardless of height — leaving globalAppsInformation
+              // pinned to an older update on nodes that received messages out of order.
+              await updateAppSpecifications(updateForSpecifications);
             } else {
               log.warn(`Apps message ${permanentAppMessage.hash} is underpaid ${valueSat} < ${appPrice * 1e8}`);
             }

--- a/ZelBack/src/services/dbHelper.js
+++ b/ZelBack/src/services/dbHelper.js
@@ -627,6 +627,53 @@ async function isReindexAppsInformationRequired(
       return true;
     }
 
+    // Detect spec drift: each alive app's globalAppsInformation doc must point
+    // to the same message (same hash + height) as the max-height message for
+    // that app in globalAppsMessages. Catches the race where two updates for
+    // the same app run updateAppSpecifications concurrently and the older
+    // update's replaceOne lands second, pinning globalAppsInformation to a
+    // stale spec. Counts match in that state, so the count check above misses
+    // it.
+    const driftPipeline = [
+      { $sort: { 'appSpecifications.name': 1, height: -1 } },
+      {
+        $group: {
+          _id: '$appSpecifications.name',
+          maxHeightMsg: { $first: '$$ROOT' },
+        },
+      },
+      {
+        $lookup: {
+          from: appsInformationCol,
+          localField: '_id',
+          foreignField: 'name',
+          as: 'currentInfo',
+        },
+      },
+      {
+        $match: {
+          $expr: {
+            $or: [
+              { $ne: [{ $arrayElemAt: ['$currentInfo.hash', 0] }, '$maxHeightMsg.hash'] },
+              { $ne: [{ $arrayElemAt: ['$currentInfo.height', 0] }, '$maxHeightMsg.height'] },
+            ],
+          },
+        },
+      },
+      { $count: 'count' },
+    ];
+    const driftCursor = await aggregateInDatabase(
+      appsGlobalDb,
+      appsMessagesCol,
+      driftPipeline,
+      { returnArray: false },
+    );
+    const driftResult = await driftCursor.next();
+    if (driftResult && driftResult.count > 0) {
+      log.info(`Found ${driftResult.count} apps with stale specs in appsInformation vs latest message, reindex required`);
+      return true;
+    }
+
     // Detect ghost flat fields on v4+ specs caused by $set accumulating
     // fields from prior spec versions. Fixed by replaceOne in registryManager.
     const ghostCount = await countInDatabase(appsGlobalDb, appsInformationCol, {


### PR DESCRIPTION
## Problem
                                                                                                                                                                                
  On fresh nodes syncing app messages from peers, `globalAppsInformation` could end up pinned to an older update's spec instead of the most recent one — even though all        
  messages were correctly stored in `globalAppsMessages` and the height guard in `updateAppSpecifications` was in place.                                                        
                                                                                                                                                                                
  Concrete example: an app registered at block 2538637 and updated at 2538651 and 2542210. On nodes that received the last two updates out of chain order (2542210 in temp      
  before 2538651), `globalAppsInformation` ended up holding specs from 2538651 instead of 2542210.
                                                                                                                                                                                
  ## Root cause                                                   

  `messageVerifier.checkAndRequestApp` fires `updateAppSpecifications` **without await** in the update branch (the register branch already awaits). `updateAppSpecifications` is
   itself read-then-write: `findOne` → compare `height` → `replaceOne`.
                                                                                                                                                                                
  When two updates for the same app are processed back-to-back inside the same `checkAndRequestMultipleApps` loop:                                                              
  
  1. Update A fires `updateAppSpecifications(A)` and the loop immediately moves on.                                                                                             
  2. Update B fires `updateAppSpecifications(B)` while A's chain is still in flight.
  3. Both `findOne`s read the same pre-write state, both pass the height guard, and the `replaceOne` that lands second wins regardless of which message is newer.               
                                                                                                                                                                                
  Fresh nodes hit this far more often than long-running nodes because they receive both updates within the same 30 s batch in `checkAndRequestMultipleApps`, with only DB       
  roundtrips between iterations — exactly the race window. Multiple unawaited `checkAndRequestMultipleApps` invocations from `appHashSyncService.continuousFluxAppHashesCheck`  
  (lines 239, 253) and `explorerService.insertAndRequestAppHashes` make it worse by allowing batches to overlap.                                                                
                                                                  
  No periodic job currently corrects the bad state:                                                                                                                             
  - `reconstructAppMessagesHashCollection` only touches the hashes-flag collection.
  - `reindexGlobalAppsInformation` runs at startup only via `validateAppsInformation`, and only when `isReindexAppsInformationRequired` returns true. The existing gate compares
   **app counts** between `globalAppsMessages` and `globalAppsInformation` — both still match in the corrupted state (same set of apps, just one with stale specs), so the gate 
  returns false and the wrong specs persist across reboots.                                                                                                                     
                                                                                                                                                                                
  ## Changes                                                      

  **`messageVerifier.js`** — `await` the `updateAppSpecifications` call in the update branch, matching the register branch. Serializes the read-then-write within a single      
  `checkAndRequestApp`, closing the race within a batch loop.
                                                                                                                                                                                
  **`dbHelper.isReindexAppsInformationRequired`** — add a `$lookup`-based drift detection stage between the count check and the ghost-fields check. The pipeline:               
  
  1. Sort `globalAppsMessages` by `(name, height DESC)`, group by name, take `$first` → max-height message per app.                                                             
  2. `$lookup` join into `globalAppsInformation` by name.         
  3. `$match` where the joined doc's `hash` ≠ max-height message `hash` OR `height` ≠ max-height message `height`.                                                              
  4. `$count` mismatches.                                                                                                                                                       
                                                                                                                                                                                
  Any drift → returns true → `reindexGlobalAppsInformation` runs, drops `globalAppsInformation`, and rebuilds it from `globalAppsMessages` using the same max-height-wins rule. 
                                                                                                                                                                                
  ## Effects on the upgrade                                                                                                                                                     
                                                                  
  - **Affected nodes** (already pinned to a stale update): on first boot of this release, `validateAppsInformation` detects the drift, fires the reindex,                       
  `globalAppsInformation` rebuilds correctly. Self-healing.
  - **Unaffected nodes**: gate returns false, normal startup. One extra cheap aggregation against the live-apps set on each boot.                                               
  - **Future regressions**: any other class of write desync that lands `globalAppsInformation` out of sync with the latest message gets corrected on next boot.                 
                                                                                                                                                                                
  ## Test plan                                                                                                                                                                  
                                                                                                                                                                                
  - [x] `npx mocha tests/unit/messageVerifier.test.js` — 7/7 pass.                                                                                                              
  - [x] `npx mocha tests/unit/dbHelper.test.js` — 32/32 pass.
  - [ ] Deploy to a node currently exhibiting the drift (one of the fresh nodes with `globalAppsInformation` showing the older update at block 2538651) and verify on first boot
   that the log line "Found N apps with stale specs in appsInformation vs latest message, reindex required" appears and `globalAppsInformation` ends up reflecting the latest   
  update at block 2542210.                                                                                                                                                      
  - [ ] Verify on an unaffected node that no spurious reindex fires (drift count = 0, gate returns false, normal startup).                                                      
  - [ ] Spot-check one app that's been recently updated post-deploy to confirm `globalAppsInformation` matches the max-height message in `globalAppsMessages`.