### PR TITLE
Handle g: syncthing mode per component, not per app

### DIFF
--- a/ZelBack/src/services/appLifecycle/stoppedAppsRecovery.js
+++ b/ZelBack/src/services/appLifecycle/stoppedAppsRecovery.js
@@ -2,9 +2,10 @@
  * Stopped Apps Recovery Service
  *
  * This module handles the recovery of Flux applications that are stopped on boot.
- * It checks for installed apps that have stopped containers and starts them,
- * but only if they do NOT use g: syncthing mode (master/slave mode).
- * Apps using g: syncthing mode are managed by the masterSlaveApps service.
+ * It iterates installed apps with stopped containers and starts every component
+ * that is NOT in g: syncthing mode. Components in g: mode are left stopped so the
+ * masterSlaveApps service can elect a primary. For mixed compose apps (some
+ * components g:, some not), only the non-g components are started here.
  */
 
 const config = require('config');
@@ -43,6 +44,36 @@ function appUsesGSyncthingMode(appSpec) {
   }
 
   return false;
+}
+
+/**
+ * Return the identifiers (component_appName for v>=4, appName for v<=3) of the
+ * components this service should start on boot — i.e. every component that does
+ * NOT use g: syncthing mode. g: components are intentionally left stopped so
+ * masterSlaveApps can elect a primary.
+ * @param {Object} appSpec - App specification
+ * @param {string} appName - Canonical app name (from container parsing); used as
+ *   the fallback when appSpec.name is absent (e.g. legacy specs or test fixtures).
+ * @returns {string[]} Identifiers ready to pass to advancedWorkflows.appDockerStart
+ */
+function getNonGComponentIdentifiers(appSpec, appName) {
+  if (!appSpec) {
+    return [];
+  }
+  const resolvedName = appSpec.name || appName;
+
+  // Compose apps (version >= 4): partition components by containerData.
+  if (appSpec.compose && appSpec.compose.length > 0) {
+    return appSpec.compose
+      .filter((comp) => !(comp.containerData && comp.containerData.includes('g:')))
+      .map((comp) => `${comp.name}_${resolvedName}`);
+  }
+
+  // Legacy single-component apps (version <= 3).
+  if (appSpec.containerData && appSpec.containerData.includes('g:')) {
+    return [];
+  }
+  return [resolvedName];
 }
 
 /**
@@ -165,14 +196,17 @@ function parseContainerName(containerName) {
 }
 
 /**
- * Start stopped apps that don't use g: syncthing mode in ANY component
- * If an app has ANY component using g: syncthing, ALL containers for that app are skipped
+ * Start stopped Flux app containers on boot, partitioned by g: syncthing mode.
+ * - Apps with no g: components: started normally (whole app).
+ * - Apps where every component is g:: skipped entirely (managed by masterSlaveApps).
+ * - Mixed compose apps: only non-g components started; g: components left stopped.
  * @returns {Promise<Object>} Results of the recovery operation
  */
 async function startStoppedAppsOnBoot() {
   const results = {
     appsChecked: 0,
     appsStarted: [],
+    appsPartiallyStarted: [], // mixed compose: non-g components started, g: components left for masterSlaveApps
     appsSkippedGMode: [],
     appsSkippedNoSpec: [],
     appsRemoved: [],
@@ -246,9 +280,18 @@ async function startStoppedAppsOnBoot() {
         continue;
       }
 
-      // Check if ANY component of the app uses g: syncthing mode
-      if (appUsesGSyncthingMode(appSpec)) {
-        log.info(`stoppedAppsRecovery - App ${appName} uses g: syncthing mode, skipping all its containers (managed by masterSlaveApps)`);
+      // Partition the app's components by g: syncthing mode. Non-g components are
+      // started here; g: components are left stopped for masterSlaveApps to elect a
+      // primary. If every component is g:, the app is skipped entirely.
+      const componentsToStart = getNonGComponentIdentifiers(appSpec, appName);
+      const totalComponents = (appSpec.compose && appSpec.compose.length > 0)
+        ? appSpec.compose.length
+        : 1;
+      const isPartial = componentsToStart.length > 0
+        && componentsToStart.length < totalComponents;
+
+      if (componentsToStart.length === 0) {
+        log.info(`stoppedAppsRecovery - App ${appName} uses g: syncthing mode in every component, skipping (managed by masterSlaveApps)`);
         results.appsSkippedGMode.push(appName);
         // eslint-disable-next-line no-continue
         continue;
@@ -278,24 +321,40 @@ async function startStoppedAppsOnBoot() {
         }
       }
 
-      // App has valid location - start it (handles all components)
-      log.info(`stoppedAppsRecovery - App ${appName} has valid location, starting app`);
+      // App has valid location - start the non-g components individually so that any
+      // g: siblings remain stopped (masterSlaveApps will start them only on the primary).
+      if (isPartial) {
+        log.info(`stoppedAppsRecovery - App ${appName} has valid location, starting ${componentsToStart.length}/${totalComponents} non-g components (g: components managed by masterSlaveApps)`);
+      } else {
+        log.info(`stoppedAppsRecovery - App ${appName} has valid location, starting app`);
+      }
 
-      try {
-        // eslint-disable-next-line no-await-in-loop
-        await advancedWorkflows.appDockerStart(appName);
-        results.appsStarted.push(appName);
-        log.info(`stoppedAppsRecovery - Successfully started app ${appName}`);
+      let anyComponentFailed = false;
+      // eslint-disable-next-line no-restricted-syntax
+      for (const identifier of componentsToStart) {
+        try {
+          // eslint-disable-next-line no-await-in-loop
+          await advancedWorkflows.appDockerStart(identifier);
+          log.info(`stoppedAppsRecovery - Successfully started ${identifier}`);
+          // Add small delay between starts to avoid overwhelming the system
+          // eslint-disable-next-line no-await-in-loop
+          await serviceHelper.delay(2000);
+        } catch (startError) {
+          anyComponentFailed = true;
+          log.error(`stoppedAppsRecovery - Failed to start ${identifier}: ${startError.message}`);
+          results.appsFailed.push({
+            app: identifier,
+            error: startError.message,
+          });
+        }
+      }
 
-        // Add small delay between app starts to avoid overwhelming the system
-        // eslint-disable-next-line no-await-in-loop
-        await serviceHelper.delay(2000);
-      } catch (startError) {
-        log.error(`stoppedAppsRecovery - Failed to start app ${appName}: ${startError.message}`);
-        results.appsFailed.push({
-          app: appName,
-          error: startError.message,
-        });
+      if (!anyComponentFailed) {
+        if (isPartial) {
+          results.appsPartiallyStarted.push(appName);
+        } else {
+          results.appsStarted.push(appName);
+        }
       }
     }
 
@@ -303,6 +362,7 @@ async function startStoppedAppsOnBoot() {
       'stoppedAppsRecovery - Recovery complete. '
       + `Apps checked: ${results.appsChecked}, `
       + `Apps started: ${results.appsStarted.length}, `
+      + `Apps partially started (mixed g:): ${results.appsPartiallyStarted.length}, `
       + `Apps removed (expired location): ${results.appsRemoved.length}, `
       + `Apps skipped (g: mode): ${results.appsSkippedGMode.length}, `
       + `Apps skipped (no spec): ${results.appsSkippedNoSpec.length}, `
@@ -319,6 +379,7 @@ module.exports = {
   startStoppedAppsOnBoot,
   getStoppedFluxContainers,
   appUsesGSyncthingMode,
+  getNonGComponentIdentifiers,
   appHasValidLocationOnNode,
   parseContainerName,
 };

--- a/ZelBack/src/services/appMessaging/peerNotification.js
+++ b/ZelBack/src/services/appMessaging/peerNotification.js
@@ -216,12 +216,35 @@ async function checkAndNotifyPeersOfRunningApps(
           // eslint-disable-next-line no-await-in-loop
           const appDetails = await registryManager.getApplicationGlobalSpecifications(mainAppName);
           const appInstalledMasterSlave = appsInstalled.find((app) => app.name === mainAppName);
-          const appInstalledSyncthing = appInstalledMasterSlave.compose.find((comp) => comp.containerData.includes('g:') || comp.containerData.includes('r:'));
-          const appInstalledMasterSlaveCheck = appInstalledMasterSlave.compose.find((comp) => comp.containerData.includes('g:'));
+          // App-level: any component using g:/r: marks the whole app as a syncthing app
+          // for broadcast purposes (masterSlaveAppsInstalled is included in installedAndRunning
+          // even when some components are stopped, since stopped slaves are expected).
+          const appInstalledSyncthing = appInstalledMasterSlave.compose
+            ? appInstalledMasterSlave.compose.find((comp) => comp.containerData.includes('g:') || comp.containerData.includes('r:'))
+            : (appInstalledMasterSlave.containerData
+              && (appInstalledMasterSlave.containerData.includes('g:') || appInstalledMasterSlave.containerData.includes('r:')));
+
+          // Component-level: classify the specific stopped component so that auto-restart
+          // and grace-period decisions are made per component rather than per app. Without
+          // this, a non-g component of a g: app would never be auto-restarted at runtime.
+          let stoppedCompIsG = false;
+          let stoppedCompIsRorG = false;
+          if (appInstalledMasterSlave.compose && appInstalledMasterSlave.compose.length > 0) {
+            const componentName = stoppedApp.split('_')[0];
+            const stoppedCompSpec = appInstalledMasterSlave.compose.find((c) => c.name === componentName);
+            if (stoppedCompSpec && stoppedCompSpec.containerData) {
+              stoppedCompIsG = stoppedCompSpec.containerData.includes('g:');
+              stoppedCompIsRorG = stoppedCompIsG || stoppedCompSpec.containerData.includes('r:');
+            }
+          } else if (appInstalledMasterSlave.containerData) {
+            stoppedCompIsG = appInstalledMasterSlave.containerData.includes('g:');
+            stoppedCompIsRorG = stoppedCompIsG || appInstalledMasterSlave.containerData.includes('r:');
+          }
+
           if (appInstalledSyncthing) {
             masterSlaveAppsInstalled.push(appInstalledMasterSlave);
           }
-          if (appInstalledMasterSlaveCheck && appDetails) {
+          if (stoppedCompIsG && appDetails) {
             const backupSkip = backupInProgress.some((backupItem) => stoppedApp === backupItem);
             const restoreSkip = restoreInProgress.some((backupItem) => stoppedApp === backupItem);
             if (!backupSkip && !restoreSkip) {
@@ -241,8 +264,10 @@ async function checkAndNotifyPeersOfRunningApps(
               // eslint-disable-next-line no-await-in-loop
               const containerExists = await dockerService.getDockerContainerOnly(stoppedApp);
 
-              // Check if container exists before applying syncthing delay
-              if (containerExists && appInstalledSyncthing) {
+              // 30-minute install grace applies only to syncthing components (r: here, since
+              // g: branched off above). Non-syncthing siblings of a g:/r: app must not inherit
+              // the delay — they should auto-restart immediately like any other component.
+              if (containerExists && stoppedCompIsRorG) {
                 const db = dbHelper.databaseConnection();
                 const database = db.db(config.database.appsglobal.database);
                 const queryFind = { name: mainAppName, ip: myIP };

--- a/tests/unit/peerNotification.test.js
+++ b/tests/unit/peerNotification.test.js
@@ -10,6 +10,9 @@ describe('peerNotification tests', () => {
   let appUninstallerStub;
   let appInspectorStub;
   let dbHelperStub;
+  let registryManagerStub;
+  let generalServiceStub;
+  let appTamperingDetectionStub;
 
   beforeEach(() => {
     logStub = {
@@ -44,6 +47,20 @@ describe('peerNotification tests', () => {
       findInDatabase: sinon.stub().resolves([]),
     };
 
+    registryManagerStub = {
+      getApplicationGlobalSpecifications: sinon.stub().resolves(null),
+    };
+
+    generalServiceStub = {
+      isNodeStatusConfirmed: sinon.stub().resolves(true),
+      nodeTier: sinon.stub().resolves('cumulus'),
+    };
+
+    appTamperingDetectionStub = {
+      recordEvent: sinon.stub().resolves(),
+      isNetworkMissingError: sinon.stub().returns(false),
+    };
+
     peerNotification = proxyquire('../../ZelBack/src/services/appMessaging/peerNotification', {
       config: {
         database: {
@@ -63,10 +80,7 @@ describe('peerNotification tests', () => {
         delay: sinon.stub().resolves(),
         ensureString: sinon.stub().returnsArg(0),
       },
-      '../generalService': {
-        isNodeStatusConfirmed: sinon.stub().resolves(true),
-        nodeTier: sinon.stub().resolves('cumulus'),
-      },
+      '../generalService': generalServiceStub,
       '../benchmarkService': {
         getBenchmarks: sinon.stub().resolves({
           status: 'success',
@@ -84,15 +98,14 @@ describe('peerNotification tests', () => {
       './messageStore': {
         storeAppRunningMessage: sinon.stub().resolves(),
       },
-      '../appDatabase/registryManager': {
-        getApplicationGlobalSpecifications: sinon.stub().resolves(null),
-      },
+      '../appDatabase/registryManager': registryManagerStub,
       '../appManagement/appInspector': appInspectorStub,
       '../appLifecycle/appUninstaller': appUninstallerStub,
       '../appLifecycle/appInstaller': appInstallerStub,
       '../appQuery/appQueryService': {
         decryptEnterpriseApps: sinon.stub().callsFake(async (apps) => apps),
       },
+      '../appTamperingDetectionService': appTamperingDetectionStub,
       '../utils/appConstants': {
         localAppsInformation: 'localAppsInformation',
       },
@@ -170,6 +183,153 @@ describe('peerNotification tests', () => {
 
       expect(appUninstallerStub.removeAppLocally.called).to.be.false;
       expect(logStub.info.calledWithMatch(/created by another process/)).to.be.true;
+    });
+  });
+
+  describe('checkAndNotifyPeersOfRunningApps - per-component g: handling', () => {
+    const mixedSpec = {
+      version: 8,
+      name: 'MixedApp',
+      hash: 'mixhash',
+      compose: [
+        { name: 'web', containerData: '' },
+        { name: 'db', containerData: 'g:/data' },
+      ],
+    };
+
+    const rOnlySpec = {
+      version: 8,
+      name: 'RApp',
+      hash: 'rhash',
+      compose: [
+        { name: 'web', containerData: 'r:/data' },
+      ],
+    };
+
+    function makeGlobalState() {
+      return {
+        backupInProgress: [],
+        restoreInProgress: [],
+        runningAppsCache: { clear: sinon.stub(), add: sinon.stub(), size: 0 },
+      };
+    }
+
+    function makeCacheManager(prepopulate = []) {
+      const stoppedAppsCache = new Map();
+      prepopulate.forEach((k) => stoppedAppsCache.set(k, ''));
+      return { stoppedAppsCache };
+    }
+
+    it('starts a stopped non-g component of a mixed compose app and leaves the g: sibling alone', async () => {
+      // Both components stopped at boot. After the patch, the non-g component must
+      // auto-start while the g: component is left for masterSlaveApps.
+      const installedApps = sinon.stub().resolves({ status: 'success', data: [mixedSpec] });
+      const listRunningApps = sinon.stub().resolves({ status: 'success', data: [] });
+      registryManagerStub.getApplicationGlobalSpecifications.withArgs('MixedApp').resolves(mixedSpec);
+
+      // Both containers exist (stopped). handleMissingMasterSlaveContainer returns
+      // early for the g: component because the container exists.
+      dockerServiceStub.getDockerContainerOnly.withArgs('web_MixedApp').resolves({ Id: 'web' });
+      dockerServiceStub.getDockerContainerOnly.withArgs('db_MixedApp').resolves({ Id: 'db' });
+      dbHelperStub.findOneInDatabase.resolves(null);
+
+      // Pre-warm the cache for the non-g component so the auto-restart fires immediately
+      const cacheManager = makeCacheManager(['web_MixedApp']);
+
+      await peerNotification.checkAndNotifyPeersOfRunningApps(
+        installedApps,
+        listRunningApps,
+        {},
+        false, false, false, false, false,
+        makeGlobalState,
+        cacheManager,
+      );
+
+      expect(dockerServiceStub.appDockerStart.calledWith('web_MixedApp')).to.equal(true);
+      expect(dockerServiceStub.appDockerStart.calledWith('db_MixedApp')).to.equal(false);
+      expect(appInstallerStub.installApplicationHard.called).to.equal(false);
+    });
+
+    it('routes a stopped g: component through handleMissingMasterSlaveContainer, never appDockerStart', async () => {
+      // On a slave: web is running, db (g:) is stopped.
+      const installedApps = sinon.stub().resolves({ status: 'success', data: [mixedSpec] });
+      const listRunningApps = sinon.stub().resolves({
+        status: 'success',
+        data: [{ Names: ['/fluxweb_MixedApp'] }],
+      });
+      registryManagerStub.getApplicationGlobalSpecifications.withArgs('MixedApp').resolves(mixedSpec);
+
+      // db container exists — handleMissingMasterSlaveContainer must short-circuit
+      dockerServiceStub.getDockerContainerOnly.withArgs('db_MixedApp').resolves({ Id: 'db' });
+      dbHelperStub.findOneInDatabase.resolves(null);
+
+      // Pre-warm cache to prove the warmup path was NOT what kept the g: component stopped
+      const cacheManager = makeCacheManager(['db_MixedApp']);
+
+      await peerNotification.checkAndNotifyPeersOfRunningApps(
+        installedApps,
+        listRunningApps,
+        {},
+        false, false, false, false, false,
+        makeGlobalState,
+        cacheManager,
+      );
+
+      expect(dockerServiceStub.appDockerStart.calledWith('db_MixedApp')).to.equal(false);
+      expect(appInstallerStub.installApplicationHard.called).to.equal(false);
+      // It was the masterSlave routing that did the short-circuit (container existence check)
+      expect(dockerServiceStub.getDockerContainerOnly.calledWith('db_MixedApp')).to.equal(true);
+    });
+
+    it('does not inherit the 30-minute install grace on a non-syncthing component of a g: app', async () => {
+      // Web is non-g/non-r. db is g:. Mixed compose. web is stopped; db is running.
+      // runningSince is recent — if the grace was applied (the bug), web would NOT start.
+      const installedApps = sinon.stub().resolves({ status: 'success', data: [mixedSpec] });
+      const listRunningApps = sinon.stub().resolves({
+        status: 'success',
+        data: [{ Names: ['/fluxdb_MixedApp'] }],
+      });
+      registryManagerStub.getApplicationGlobalSpecifications.withArgs('MixedApp').resolves(mixedSpec);
+
+      dockerServiceStub.getDockerContainerOnly.withArgs('web_MixedApp').resolves({ Id: 'web' });
+      // Recent runningSince — would trigger the grace if it applied to non-r components
+      dbHelperStub.findOneInDatabase.resolves({ runningSince: new Date().toISOString() });
+
+      const cacheManager = makeCacheManager(['web_MixedApp']);
+
+      await peerNotification.checkAndNotifyPeersOfRunningApps(
+        installedApps,
+        listRunningApps,
+        {},
+        false, false, false, false, false,
+        makeGlobalState,
+        cacheManager,
+      );
+
+      expect(dockerServiceStub.appDockerStart.calledWith('web_MixedApp')).to.equal(true);
+    });
+
+    it('still applies the 30-minute install grace to an r: component', async () => {
+      // r: component, recent runningSince — must NOT auto-start during grace window.
+      const installedApps = sinon.stub().resolves({ status: 'success', data: [rOnlySpec] });
+      const listRunningApps = sinon.stub().resolves({ status: 'success', data: [] });
+      registryManagerStub.getApplicationGlobalSpecifications.withArgs('RApp').resolves(rOnlySpec);
+
+      dockerServiceStub.getDockerContainerOnly.withArgs('web_RApp').resolves({ Id: 'web' });
+      dbHelperStub.findOneInDatabase.resolves({ runningSince: new Date().toISOString() });
+
+      const cacheManager = makeCacheManager(['web_RApp']);
+
+      await peerNotification.checkAndNotifyPeersOfRunningApps(
+        installedApps,
+        listRunningApps,
+        {},
+        false, false, false, false, false,
+        makeGlobalState,
+        cacheManager,
+      );
+
+      expect(dockerServiceStub.appDockerStart.calledWith('web_RApp')).to.equal(false);
     });
   });
 });

--- a/tests/unit/stoppedAppsRecovery.test.js
+++ b/tests/unit/stoppedAppsRecovery.test.js
@@ -334,5 +334,125 @@ describe('stoppedAppsRecovery tests', () => {
       expect(results.appsRemoved).to.deep.equal(['NormalApp']);
       expect(results.appsStarted).to.deep.equal([]);
     });
+
+    it('should partially start mixed compose: non-g components only, g: component left for masterSlaveApps', async () => {
+      // Mixed compose app: web (no g:) + db (g:) — both stopped at boot
+      dockerServiceStub.dockerListContainers.resolves([
+        { Names: ['/fluxweb_MixedApp'], State: 'exited' },
+        { Names: ['/fluxdb_MixedApp'], State: 'exited' },
+      ]);
+      dbHelperStub.findInDatabase.onFirstCall().resolves([{ name: 'MixedApp' }]);
+
+      registryManagerStub.getApplicationGlobalSpecifications.withArgs('MixedApp').resolves({
+        version: 8,
+        name: 'MixedApp',
+        compose: [
+          { name: 'web', containerData: '' },
+          { name: 'db', containerData: 'g:/data' },
+        ],
+      });
+
+      // Valid location
+      const futureExpiry = new Date(Date.now() + (300 * 1000));
+      dbHelperStub.findInDatabase.onSecondCall().resolves([{ expireAt: futureExpiry }]);
+
+      const results = await stoppedAppsRecovery.startStoppedAppsOnBoot();
+
+      expect(results.appsPartiallyStarted).to.deep.equal(['MixedApp']);
+      expect(results.appsStarted).to.deep.equal([]);
+      expect(results.appsSkippedGMode).to.deep.equal([]);
+      // Non-g component started
+      expect(advancedWorkflowsStub.appDockerStart.calledWith('web_MixedApp')).to.equal(true);
+      // g: component NOT started here (left for masterSlaveApps)
+      expect(advancedWorkflowsStub.appDockerStart.calledWith('db_MixedApp')).to.equal(false);
+    });
+
+    it('should skip a compose app where every component is g:', async () => {
+      dockerServiceStub.dockerListContainers.resolves([
+        { Names: ['/fluxa_AllGApp'], State: 'exited' },
+        { Names: ['/fluxb_AllGApp'], State: 'exited' },
+      ]);
+      dbHelperStub.findInDatabase.onFirstCall().resolves([{ name: 'AllGApp' }]);
+
+      registryManagerStub.getApplicationGlobalSpecifications.withArgs('AllGApp').resolves({
+        version: 8,
+        name: 'AllGApp',
+        compose: [
+          { name: 'a', containerData: 'g:/x' },
+          { name: 'b', containerData: 'g:/y' },
+        ],
+      });
+
+      const results = await stoppedAppsRecovery.startStoppedAppsOnBoot();
+
+      expect(results.appsSkippedGMode).to.deep.equal(['AllGApp']);
+      expect(results.appsStarted).to.deep.equal([]);
+      expect(results.appsPartiallyStarted).to.deep.equal([]);
+      expect(advancedWorkflowsStub.appDockerStart.called).to.equal(false);
+    });
+  });
+
+  describe('getNonGComponentIdentifiers', () => {
+    it('should return empty array when appSpec is null', () => {
+      expect(stoppedAppsRecovery.getNonGComponentIdentifiers(null, 'AppA')).to.deep.equal([]);
+    });
+
+    it('should return [appName] for a v<=3 app with no g:', () => {
+      const spec = { version: 3, containerData: '' };
+      expect(stoppedAppsRecovery.getNonGComponentIdentifiers(spec, 'AppA')).to.deep.equal(['AppA']);
+    });
+
+    it('should return [] for a v<=3 app with g:', () => {
+      const spec = { version: 3, containerData: 'g:/data' };
+      expect(stoppedAppsRecovery.getNonGComponentIdentifiers(spec, 'AppA')).to.deep.equal([]);
+    });
+
+    it('should return all component identifiers for a compose app with no g:', () => {
+      const spec = {
+        version: 8,
+        name: 'AppA',
+        compose: [
+          { name: 'web', containerData: '' },
+          { name: 'cache', containerData: 'r:/data' },
+        ],
+      };
+      expect(stoppedAppsRecovery.getNonGComponentIdentifiers(spec, 'AppA'))
+        .to.deep.equal(['web_AppA', 'cache_AppA']);
+    });
+
+    it('should return [] for a compose app where every component is g:', () => {
+      const spec = {
+        version: 8,
+        name: 'AppA',
+        compose: [
+          { name: 'a', containerData: 'g:/x' },
+          { name: 'b', containerData: 'g:/y' },
+        ],
+      };
+      expect(stoppedAppsRecovery.getNonGComponentIdentifiers(spec, 'AppA')).to.deep.equal([]);
+    });
+
+    it('should return only the non-g identifiers for a mixed compose app', () => {
+      const spec = {
+        version: 8,
+        name: 'AppA',
+        compose: [
+          { name: 'web', containerData: '' },
+          { name: 'db', containerData: 'g:/data' },
+          { name: 'worker', containerData: 'r:/q' },
+        ],
+      };
+      expect(stoppedAppsRecovery.getNonGComponentIdentifiers(spec, 'AppA'))
+        .to.deep.equal(['web_AppA', 'worker_AppA']);
+    });
+
+    it('should fall back to the supplied appName when appSpec.name is missing', () => {
+      const spec = {
+        version: 8,
+        compose: [{ name: 'web', containerData: '' }],
+      };
+      expect(stoppedAppsRecovery.getNonGComponentIdentifiers(spec, 'AppA'))
+        .to.deep.equal(['web_AppA']);
+    });
   });
 });


### PR DESCRIPTION
## Summary

  Currently FluxOS treats `g:` syncthing mode as an app-level property: if any   
  single component of a compose app uses `g:`, the entire app is treated as
  master/slave-managed. This means non-syncthing components in mixed compose apps
   are left stopped on boot, blocked from auto-restart on crash, and held back by
   a 30-minute install grace they don't need.

  This PR makes the decision **per component** instead.                          
   
  ## Behavior change                                                             
                                                                  
  | Scenario | Before | After |
  |---|---|---|
  | Boot on a slave node with `frontend` (no g:) + `db` (g:) | Both stay stopped 
  indefinitely | `frontend` starts; `db` waits for master/slave election |       
  | `frontend` crashes mid-session | Stays dead until next reboot | Auto-restarts
   on the next peer-check cycle |                                                
  | 30 minutes after install | `frontend` held back by syncthing grace |
  `frontend` runs immediately |                                                  
  | Master/slave election for `db` | Works as before | Unchanged |
  | All-`g:` compose app | Skipped entirely | Skipped entirely (unchanged) |     
  | All-non-`g:` app | Starts normally | Starts normally (unchanged) |           
                                                                                 
  ## Files changed                                                               
                                                                  
  - `ZelBack/src/services/appLifecycle/stoppedAppsRecovery.js` — new helper      
  `getNonGComponentIdentifiers()`; boot recovery now partitions components and
  starts each non-g one individually via                                         
  `advancedWorkflows.appDockerStart('comp_app')`. New `appsPartiallyStarted`
  result bucket for mixed compose apps.
  - `ZelBack/src/services/appMessaging/peerNotification.js` — auto-restart
  routing inside `checkAndNotifyPeersOfRunningApps` now classifies the specific  
  stopped component (`stoppedCompIsG` / `stoppedCompIsRorG`) instead of the whole
   app. The 30-minute install grace is also gated per component. App-level       
  broadcast logic (`masterSlaveAppsInstalled`) is preserved.      
  - `tests/unit/stoppedAppsRecovery.test.js` — 9 new tests (mixed compose, all-g
  compose, helper coverage).                                                     
  - `tests/unit/peerNotification.test.js` — 4 new tests (non-g auto-start, g:
  routing, grace inheritance, r: grace still applies).                           
                                                                  
  ## What's intentionally NOT in this PR (potential follow-ups)                  
                                                                  
  1. `advancedWorkflows.appDockerRestartWithPermissionsFix` step 4 still calls   
  `appDockerRestart(appname)`, restarting all components when this node becomes
  master. Cosmetic 5-10s blip, not breaking.                                     
  2. The restore path at `advancedWorkflows.js:2473` still restarts all
  components after restore; the backup path already does the per-component       
  partition. Inconsistency only.
                                                                                 
  ## Risk to flag for app authors                                                
  
  If a non-g component depends on its g: sibling being local (e.g. a frontend    
  hardcoded to `localhost:5432` against a local db container), running the
  frontend on a slave where the db is intentionally stopped will now start a     
  broken half. Apps that route through service mesh / FDM-style discovery are
  unaffected. Worth communicating before this ships.

  ## Test plan

  - [x] `npx mocha tests/unit/stoppedAppsRecovery.test.js                        
  tests/unit/peerNotification.test.js --exit` — 35 passing, including 13 new
  - [x] `node --check` clean on both source files                                
  - [x] No regression: all 22 pre-existing tests in these files still pass       
  - [ ] Manual: deploy a mixed-compose app (frontend + g: db) to a 3-node        
  cluster, reboot a slave, confirm frontend comes up and db stays slave-stopped  
  - [ ] Manual: kill the frontend container on a slave, wait one peer-check cycle
   (~60min in prod, can shorten for testing), confirm it auto-restarts           
  - [ ] Manual: install a fresh mixed app, confirm frontend starts immediately
  (not after 30 min)                                                             
  - [ ] Manual: confirm pure-g: and pure-non-g apps behave exactly as before