### PR TITLE
raise docker image size limit to 5GB + fix appSpawner cadence and deferral bugs 

### DIFF
--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -205,7 +205,7 @@ module.exports = {
     bannedPorts: ['16100-16299', '26100-26299', '30000-30099', 8384, 27017, 22, 23, 25, 3389, 5900, 5800, 161, 512, 513, 5901, 3388, 4444, 123, 53],
     enterprisePorts: ['0-1023', 8080, 8081, 8443, 6667],
     upnpBannedPorts: [],
-    maxImageSize: 2000000000, // 2000mb
+    maxImageSize: 5000000000, // 5000mb
     minimumInstances: 3,
     minimumInstancesV8: 1,
     minimumInstancesV8Block: 2176519, // block height where v8+ apps can have 1 instance - expected around December 19th 2025

--- a/ZelBack/src/services/appLifecycle/appSpawner.js
+++ b/ZelBack/src/services/appLifecycle/appSpawner.js
@@ -172,7 +172,7 @@ async function trySpawningGlobalApplication() {
     const numberOfGlobalApps = globalAppNamesLocation.length;
     if (!numberOfGlobalApps) {
       log.info('trySpawningGlobalApplication - No installable application found');
-      await serviceHelper.delay(30 * 60 * 1000);
+      await serviceHelper.delay(delayTime);
       trySpawningGlobalApplication();
       return;
     }
@@ -184,8 +184,8 @@ async function trySpawningGlobalApplication() {
     let appFromAppsToBeCheckedLater = false;
     let appFromAppsSyncthingToBeCheckedLater = false;
     const { appsToBeCheckedLater, appsSyncthingToBeCheckedLater } = globalState;
-    const appIndex = appsToBeCheckedLater.findIndex((app) => app.timeToCheck >= Date.now());
-    const appSyncthingIndex = appsSyncthingToBeCheckedLater.findIndex((app) => app.timeToCheck >= Date.now());
+    const appIndex = appsToBeCheckedLater.findIndex((app) => app.timeToCheck <= Date.now());
+    const appSyncthingIndex = appsSyncthingToBeCheckedLater.findIndex((app) => app.timeToCheck <= Date.now());
     let runningAppList = [];
     let installingAppList = [];
 
@@ -215,7 +215,7 @@ async function trySpawningGlobalApplication() {
       globalAppNamesLocation = globalAppNamesLocation.filter((app) => !runningApps.data.find((appsRunning) => appsRunning.Names[0].slice(5) === app.name)
         && !globalState.spawnErrorsLongerAppCache.has(app.hash)
         && !globalState.trySpawningGlobalAppCache.has(app.hash)
-        && !appsToBeCheckedLater.includes((appAux) => appAux.appName === app.name));
+        && !appsToBeCheckedLater.some((appAux) => appAux.appName === app.name));
       // filter apps that are non enterprise or are marked to install on my node
       globalAppNamesLocation = globalAppNamesLocation.filter((app) => app.nodes.length === 0 || app.nodes.find((ip) => ip === myIP) || app.version >= 8);
       // filter apps that dont have geolocation or that are forbidden to spawn on my node geolocation
@@ -229,7 +229,7 @@ async function trySpawningGlobalApplication() {
 
       if (globalAppNamesLocation.length === 0) {
         log.info('trySpawningGlobalApplication - No app currently to be processed');
-        await serviceHelper.delay(30 * 60 * 1000);
+        await serviceHelper.delay(delayTime);
         trySpawningGlobalApplication();
         return;
       }

--- a/tests/unit/globalconfig/default.js
+++ b/tests/unit/globalconfig/default.js
@@ -196,7 +196,7 @@ module.exports = {
     bannedPorts: ['16100-16299', '26100-26299', '30000-30099', 8384, 27017, 22, 23, 25, 3389, 5900, 5800, 161, 512, 513, 5901, 3388, 4444, 123, 53],
     upnpBannedPorts: ['81-442', 2189],
     enterprisePorts: ['0-1023', 8080, 8081, 8443, 6667],
-    maxImageSize: 2000000000, // 2000mb
+    maxImageSize: 5000000000, // 5000mb
     minimumInstances: 3,
     minimumInstancesV8: 1,
     minimumInstancesV8Block: 2176519, // block height where v8+ apps can have 1 instance - expected around December 19th 2025


### PR DESCRIPTION
### 1. Raise Docker image size limit to 5GB
                                                                                                                                                                                                                           
  `config.fluxapps.maxImageSize` bumped from 2GB to 5GB for all apps. No code paths needed plumbing — the existing limit is already enforced uniformly through `verifyRepository` and `verifyAndPullImage`.                
   
  ### 2. Fix `appSpawner` cadence and deferral bugs                                                                                                                                                                        
                                                                                                                                                                                                                         
  Three bugs in `ZelBack/src/services/appLifecycle/appSpawner.js` that together explain why enterprise apps could take up to 30 min to install on allowlisted nodes even though enterprise nodes are supposed to spawn-tick
   every 60s.
                                                                                                                                                                                                                           
  #### 2a. Enterprise spawn cadence ignored on empty-candidate paths                                                                                                                                                       
  `getSpawnDelays(isEnterprise=true, ...)` returns `delayTime: 60_000`, but the two early-exit branches in `trySpawningGlobalApplication` slept on a hardcoded `30 * 60 * 1000` instead of `delayTime`. As a result,
  whenever the post-filter candidate list was empty (the common case on a quiet enterprise node), the loop slept 30 minutes regardless of role.                                                                            
                                                                                                                                                                                                                         
  Observed in production logs from an enterprise node: every spawn cycle was exactly 30 min apart (`00:27:25 → 00:57:25 → 01:27:25 → ...`) until an enterprise-owned app finally appeared in the candidate set, at which   
  point selection and install completed within ~2 min. Worst-case registration→install latency was therefore bounded by the 30 min sleep instead of the intended ~60s.                                                   
                                                                                                                                                                                                                           
  Fix: replace both hardcoded delays with `delayTime`. Non-enterprise nodes are unaffected because `getSpawnDelays(false, 0)` already returns `delayTime: 30 * 60 * 1000`.                                                 
   
  #### 2b. Inverted `timeToCheck` comparison on deferred-app lists                                                                                                                                                         
  `appsToBeCheckedLater` / `appsSyncthingToBeCheckedLater` entries are pushed with a future `timeToCheck` (e.g. `Date.now() + 27 * 60 * 1000`) so the spawner can come back to them later. The lookup used `findIndex((app)
   => app.timeToCheck >= Date.now())`, which matches entries whose timer has **not** elapsed — the opposite of the intended semantics.                                                                                     
                                                                                                                                                                                                                         
  Effect: a freshly-deferred entry was immediately re-pulled on the very next iteration, bypassing every "will check in around 27m" / "will check in around 2m" deferral message in the file.                              
                                                                                                                                                                                                                         
  Fix: flip both comparisons to `<=`.                                                                                                                                                                                      
                                                                                                                                                                                                                         
  #### 2c. `appsToBeCheckedLater.includes(predicate)` is a silent no-op                                                                                                                                                    
  `Array.prototype.includes` does a SameValueZero equality check, not a predicate match, so `appsToBeCheckedLater.includes((appAux) => appAux.appName === app.name)` is always `false`. The intent was to skip apps that 
  are already queued for retry; in practice the filter never excluded anything.                                                                                                                                            
                                                                                                                                                                                                                         
  Fix: use `.some(predicate)`.                                                                                                                                                                                             
                                                                                                                                                                                                                         
  ## Test plan                                                                                                                                                                                                             
                                                                                                                                                                                                                         
  - [x] `node --check` passes on all modified files
  - [x] `npm run test:zelback:unit` — `appSpawner.test.js`, `enterpriseNetwork.test.js`, `globalState.test.js` all pass (45/45). No existing assertions cover the changed code paths so no test adjustments were needed.
  - [ ] Deploy to an enterprise node and confirm the spawn loop logs `trySpawningGlobalApplication - Checking for apps...` at ~60s cadence instead of every 30 min.                                                        
  - [ ] Register a fresh enterprise app and confirm the install lands on an allowlisted node within ~2 min of broadcast propagation.                                                                                       
  - [ ] Validate a 3-5GB image deploy succeeds and a >5GB image is rejected.