### PR TITLE
fix: standardize socket address handling for ip:port transition

### DIFF
--- a/ZelBack/src/services/analyticsService.js
+++ b/ZelBack/src/services/analyticsService.js
@@ -9,7 +9,7 @@ let bufferTotal = 0;
 let isFlushing = false;
 let consecutiveFailures = 0;
 let lastFailureTime = 0;
-let cachedNodeIp = null;
+let cachedNodeSocketAddress = null;
 let flushTimer = null;
 let analyticsUrlCached = '';
 let initialized = false;
@@ -26,9 +26,9 @@ const NODE_IP_REFRESH_INTERVAL = 600000; // 10 minutes
  */
 async function refreshNodeIp() {
   try {
-    const ip = await fluxNetworkHelper.getMyFluxIPandPort();
-    if (ip) {
-      cachedNodeIp = ip;
+    const localSocketAddr = await fluxNetworkHelper.getLocalSocketAddress();
+    if (localSocketAddr) {
+      cachedNodeSocketAddress = localSocketAddr;
     }
   } catch (error) {
     log.warn(`Analytics: failed to get node IP: ${error.message}`);
@@ -194,7 +194,7 @@ function analyticsMiddleware(req, res, next) {
         responseCode: res.statusCode,
         responseStatus: res.statusCode < 400 ? 'success' : 'error',
         responseTimeMs: Date.now() - startTime,
-        nodeIp: cachedNodeIp,
+        nodeIp: cachedNodeSocketAddress,
         ipAddress: clientIp,
         timestamp: new Date().toISOString(),
       };
@@ -236,7 +236,7 @@ function trackTerminalSession(zelidauth, appName, action, ipAddress, component) 
     responseCode: 200,
     responseStatus: 'success',
     responseTimeMs: 0,
-    nodeIp: cachedNodeIp,
+    nodeIp: cachedNodeSocketAddress,
     ipAddress: ipAddress || null,
     timestamp: new Date().toISOString(),
   };

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -13,7 +13,7 @@ const dockerService = require('../dockerService');
 const verificationHelper = require('../verificationHelper');
 const daemonServiceMiscRpcs = require('../daemonService/daemonServiceMiscRpcs');
 const fluxNetworkHelper = require('../fluxNetworkHelper');
-const { extractIp, extractPort, socketAddressesMatch } = require('../utils/socketAddressUtils');
+const { DEFAULT_API_PORT, extractIp, extractPort, socketAddressesMatch } = require('../utils/socketAddressUtils');
 const generalService = require('../generalService');
 // eslint-disable-next-line no-unused-vars
 const upnpService = require('../upnpService');
@@ -3910,7 +3910,7 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                   // Look up the correct port from runningAppList since FDM API returns IP without port
                   const previousMasterNode = runningAppList.find((x) => socketAddressesMatch(x.ip, previousMasterIp));
                   const ipToCheckAppRunning = extractIp(previousMasterIp);
-                  const portToCheckAppRunning = previousMasterNode ? extractPort(previousMasterNode.ip) : 16127;
+                  const portToCheckAppRunning = previousMasterNode ? extractPort(previousMasterNode.ip) : DEFAULT_API_PORT;
                   let previousMasterStillRunning = false;
                   try {
                     // eslint-disable-next-line no-await-in-loop

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -13,6 +13,7 @@ const dockerService = require('../dockerService');
 const verificationHelper = require('../verificationHelper');
 const daemonServiceMiscRpcs = require('../daemonService/daemonServiceMiscRpcs');
 const fluxNetworkHelper = require('../fluxNetworkHelper');
+const { extractIp, extractPort, socketAddressesMatch } = require('../utils/socketAddressUtils');
 const generalService = require('../generalService');
 // eslint-disable-next-line no-unused-vars
 const upnpService = require('../upnpService');
@@ -3048,9 +3049,9 @@ async function checkAndRemoveApplicationInstance() {
             return 0;
           });
           // eslint-disable-next-line no-await-in-loop
-          const myIP = await fluxNetworkHelper.getMyFluxIPandPort();
-          if (myIP) {
-            const index = runningAppList.findIndex((x) => x.ip === myIP);
+          const localSocketAddr = await fluxNetworkHelper.getLocalSocketAddress();
+          if (localSocketAddr) {
+            const index = runningAppList.findIndex((x) => socketAddressesMatch(x.ip, localSocketAddr));
             if (index === 0) {
               log.info(`Application ${installedApp.name} going to be removed from node as it was the latest one running it to install it..`);
               log.warn(`REMOVAL REASON: Too many instances - ${installedApp.name} running on ${runningAppList.length} instances (max: ${minInstances}) - This node is the newest instance`);
@@ -3549,8 +3550,8 @@ async function forceAppRemovals() {
     const appUninstaller = require('./appUninstaller');
 
     // Get current node's IP for checking app locations
-    const myIP = await fluxNetworkHelper.getMyFluxIPandPort();
-    if (!myIP) {
+    const localSocketAddr = await fluxNetworkHelper.getLocalSocketAddress();
+    if (!localSocketAddr) {
       log.warn('Unable to get node IP, skipping forceAppRemovals');
       return;
     }
@@ -3587,15 +3588,15 @@ async function forceAppRemovals() {
         // Check if this app is registered in locations for this node's IP
         let shouldBroadcast = false;
         try {
-          const locationQuery = { name: dApp, ip: myIP };
+          const locationQuery = { name: dApp, ip: localSocketAddr };
           const locationProjection = { projection: { _id: 0 } };
           // eslint-disable-next-line no-await-in-loop
           const appLocation = await dbHelper.findOneInDatabase(database, globalAppsLocations, locationQuery, locationProjection);
           if (appLocation) {
             shouldBroadcast = true;
-            log.info(`${dApp} found in locations for this IP (${myIP}), will broadcast removal`);
+            log.info(`${dApp} found in locations for this IP (${localSocketAddr}), will broadcast removal`);
           } else {
-            log.info(`${dApp} not found in locations for this IP (${myIP}), skipping broadcast`);
+            log.info(`${dApp} not found in locations for this IP (${localSocketAddr}), skipping broadcast`);
           }
         } catch (locationError) {
           log.error(`Error checking app location for ${dApp}: ${locationError.message}`);
@@ -3769,19 +3770,16 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
           // no ip means there was no row with ip on fdm
           // down means there was a row ip with status down
           // eslint-disable-next-line no-await-in-loop
-          let myIP;
+          let localSocketAddr;
           try {
             // eslint-disable-next-line no-await-in-loop
-            myIP = await fluxNetworkHelper.getMyFluxIPandPort();
+            localSocketAddr = await fluxNetworkHelper.getLocalSocketAddress();
           } catch (error) {
             log.error(`masterSlaveApps: Failed to get my IP for app:${installedApp.name}, error: ${error.message}`);
             // eslint-disable-next-line no-continue
             continue;
           }
-          if (myIP) {
-            if (myIP.indexOf(':') < 0) {
-              myIP += ':16127';
-            }
+          if (localSocketAddr) {
             // Validate ip is a string if it exists
             if (ip && typeof ip !== 'string') {
               log.error(`masterSlaveApps: Invalid IP type from FDM for app:${installedApp.name}, got: ${typeof ip}`);
@@ -3851,7 +3849,7 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                   }
                   return 0;
                 });
-                const index = runningAppList.findIndex((x) => x.ip.split(':')[0] === myIP.split(':')[0]);
+                const index = runningAppList.findIndex((x) => socketAddressesMatch(x.ip, localSocketAddr));
 
                 // Helper function to check if any lower-index nodes are running the app
                 const checkLowerIndexNodesRunning = async () => {
@@ -3865,8 +3863,8 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                     const nodeToCheck = runningAppList[i];
                     if (!nodeToCheck) continue;
 
-                    const ipToCheck = nodeToCheck.ip.split(':')[0];
-                    const portToCheck = nodeToCheck.ip.split(':')[1] || '16127';
+                    const ipToCheck = extractIp(nodeToCheck.ip);
+                    const portToCheck = extractPort(nodeToCheck.ip);
                     const source = CancelToken.source();
                     let isResolved = false;
 
@@ -3898,7 +3896,7 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                   // Index 0: Start immediately if no history
                   appDockerRestartWithPermissionsFix(installedApp.name, appId);
                   log.info(`masterSlaveApps: starting docker app:${installedApp.name} index: ${index}`);
-                } else if (!timeTostartNewMasterApp.has(identifier) && mastersRunningGSyncthingApps.has(identifier) && mastersRunningGSyncthingApps.get(identifier) !== myIP) {
+                } else if (!timeTostartNewMasterApp.has(identifier) && mastersRunningGSyncthingApps.has(identifier) && !socketAddressesMatch(mastersRunningGSyncthingApps.get(identifier), localSocketAddr)) {
                   // There was a previous master (not me), and it's no longer on FDM
                   const { CancelToken } = axios;
                   const source = CancelToken.source();
@@ -3911,9 +3909,9 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                   }, timeout * 2);
                   const previousMasterIp = mastersRunningGSyncthingApps.get(identifier);
                   // Look up the correct port from runningAppList since FDM API returns IP without port
-                  const previousMasterNode = runningAppList.find((x) => x.ip.split(':')[0] === previousMasterIp.split(':')[0]);
-                  const ipToCheckAppRunning = previousMasterIp.split(':')[0];
-                  const portToCheckAppRunning = previousMasterNode ? (previousMasterNode.ip.split(':')[1] || '16127') : '16127';
+                  const previousMasterNode = runningAppList.find((x) => socketAddressesMatch(x.ip, previousMasterIp));
+                  const ipToCheckAppRunning = extractIp(previousMasterIp);
+                  const portToCheckAppRunning = previousMasterNode ? extractPort(previousMasterNode.ip) : 16127;
                   let previousMasterStillRunning = false;
                   try {
                     // eslint-disable-next-line no-await-in-loop
@@ -3936,7 +3934,7 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                     appDockerRestartWithPermissionsFix(installedApp.name, appId);
                     log.info(`masterSlaveApps: starting docker app:${installedApp.name} index: ${index}`);
                   } else {
-                    const previousMasterIndex = runningAppList.findIndex((x) => x.ip.split(':')[0] === mastersRunningGSyncthingApps.get(identifier).split(':')[0]);
+                    const previousMasterIndex = runningAppList.findIndex((x) => socketAddressesMatch(x.ip, mastersRunningGSyncthingApps.get(identifier)));
                     let timetoStartApp = Date.now();
                     if (previousMasterIndex >= 0) {
                       log.info(`masterSlaveApps: app:${installedApp.name} had primary running at index: ${previousMasterIndex}`);
@@ -3989,10 +3987,10 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                 log.info(`masterSlaveApps: app:${installedApp.name} removed from timeTostartNewMasterApp cache, already started on another standby node`);
                 timeTostartNewMasterApp.delete(identifier);
               }
-              if (myIP.split(':')[0] !== ip.split(':')[0] && runningAppsNames.includes(identifier)) {
+              if (!socketAddressesMatch(localSocketAddr, ip) && runningAppsNames.includes(identifier)) {
                 appDockerStop(installedApp.name);
-                log.info(`masterSlaveApps: stopping docker app:${installedApp.name} it's running on ip:${ip} and myIP is: ${myIP}`);
-              } else if (myIP.split(':')[0] === ip.split(':')[0] && !runningAppsNames.includes(identifier)) {
+                log.info(`masterSlaveApps: stopping docker app:${installedApp.name} it's running on ip:${ip} and localSocketAddr is: ${localSocketAddr}`);
+              } else if (socketAddressesMatch(localSocketAddr, ip) && !runningAppsNames.includes(identifier)) {
                 // Check if app is ready (syncthing data is synced) before starting
                 let isReady = receiveOnlySyncthingAppsCache.has(appId) && receiveOnlySyncthingAppsCache.get(appId).restarted;
 

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -198,8 +198,7 @@ async function getMasterIpFromFdm(appName, axiosOptions) {
       if (response.data && response.data.status === 'success' && response.data.data) {
         const { ips } = response.data.data;
         if (ips && ips.length > 0) {
-          // Return the first IP, stripping the port if present
-          const ip = ips[0].split(':')[0];
+          const ip = extractIp(ips[0]);
           log.debug(`getMasterIpFromFdm: Got IP ${ip} for app ${appName} from ${region.name} FDM`);
           return { ip, fdmOk: true };
         }

--- a/ZelBack/src/services/appLifecycle/appInstaller.js
+++ b/ZelBack/src/services/appLifecycle/appInstaller.js
@@ -7,7 +7,6 @@ const dockerService = require('../dockerService');
 const dbHelper = require('../dbHelper');
 const messageHelper = require('../messageHelper');
 const generalService = require('../generalService');
-const benchmarkService = require('../benchmarkService');
 const daemonServiceMiscRpcs = require('../daemonService/daemonServiceMiscRpcs');
 const fluxNetworkHelper = require('../fluxNetworkHelper');
 const appUninstaller = require('./appUninstaller');
@@ -349,17 +348,8 @@ async function registerAppLocally(appSpecs, componentSpecs, res, test = false, s
       return false;
     }
 
-    const benchmarkResponse = await benchmarkService.getBenchmarks();
-    if (benchmarkResponse.status === 'error') {
-      throw new Error('FluxBench status Error. Application cannot be installed at the moment');
-    }
-    // get my external IP and check that it is longer than 5 in length.
-    let myIP = null;
-    if (benchmarkResponse.data.ipaddress) {
-      log.info(`Gathered IP ${benchmarkResponse.data.ipaddress}`);
-      myIP = benchmarkResponse.data.ipaddress.length > 5 ? benchmarkResponse.data.ipaddress : null;
-    }
-    if (myIP === null) {
+    const localSocketAddr = await fluxNetworkHelper.getLocalSocketAddress();
+    if (!localSocketAddr) {
       throw new Error('Unable to detect Flux IP address');
     }
 
@@ -596,7 +586,7 @@ async function registerAppLocally(appSpecs, componentSpecs, res, test = false, s
           name: appSpecifications.name,
           hash: appSpecifications.hash, // hash of application specifics that are running
           error: serviceHelper.ensureString(errorResponse),
-          ip: myIP,
+          ip: localSocketAddr,
           broadcastedAt,
         };
         // store it in local database first

--- a/ZelBack/src/services/appLifecycle/appSpawner.js
+++ b/ZelBack/src/services/appLifecycle/appSpawner.js
@@ -8,6 +8,7 @@ const fluxNetworkHelper = require('../fluxNetworkHelper');
 const geolocationService = require('../geolocationService');
 const daemonServiceMiscRpcs = require('../daemonService/daemonServiceMiscRpcs');
 const log = require('../../lib/log');
+const { normalizeSocketAddress, extractIp, socketAddressesMatch } = require('../utils/socketAddressUtils');
 
 // Import modular services
 const appQueryService = require('../appQuery/appQueryService');
@@ -129,12 +130,12 @@ async function trySpawningGlobalApplication() {
       return installDelay;
     }
     // get my external IP and check that it is longer than 5 in length.
-    let myIP = null;
+    let localSocketAddr = null;
     if (benchmarkResponse.data.ipaddress) {
       log.info(`Gathered IP ${benchmarkResponse.data.ipaddress}`);
-      myIP = benchmarkResponse.data.ipaddress.length > 5 ? benchmarkResponse.data.ipaddress : null;
+      localSocketAddr = benchmarkResponse.data.ipaddress.length > 5 ? normalizeSocketAddress(benchmarkResponse.data.ipaddress) : null;
     }
-    if (myIP === null) {
+    if (localSocketAddr === null) {
       throw new Error('Unable to detect Flux IP address');
     }
 
@@ -283,7 +284,7 @@ async function trySpawningGlobalApplication() {
         && !globalState.trySpawningGlobalAppCache.has(app.hash)
         && !appsToBeCheckedLater.some((appAux) => appAux.appName === app.name));
       // filter apps that are non enterprise or are marked to install on my node
-      globalAppNamesLocation = globalAppNamesLocation.filter((app) => app.nodes.length === 0 || app.nodes.find((ip) => ip === myIP) || app.version >= 8);
+      globalAppNamesLocation = globalAppNamesLocation.filter((app) => app.nodes.length === 0 || app.nodes.find((ip) => socketAddressesMatch(ip, localSocketAddr)) || app.version >= 8);
       // filter apps that dont have geolocation or that are forbidden to spawn on my node geolocation
       globalAppNamesLocation = globalAppNamesLocation.filter((app) => (app.geolocation.length === 0 || app.geolocation.filter((loc) => loc.startsWith('a!c')).length === 0 || !app.geolocation.find((loc) => loc.startsWith('a!c') && `a!c${myNodeLocation}`.startsWith(loc.replace('_NONE', '')))));
       // filter apps that dont have geolocation or have and match my node geolocation
@@ -300,7 +301,7 @@ async function trySpawningGlobalApplication() {
       log.info(`trySpawningGlobalApplication - Found ${globalAppNamesLocation.length} apps that are missing instances on the network and can be selected to try to spawn on my node.`);
       let random = Math.floor(Math.random() * globalAppNamesLocation.length);
       appToRunAux = globalAppNamesLocation[random];
-      const filterAppsWithNyNodeIP = globalAppNamesLocation.filter((app) => app.nodes.find((ip) => ip === myIP));
+      const filterAppsWithNyNodeIP = globalAppNamesLocation.filter((app) => app.nodes.find((ip) => socketAddressesMatch(ip, localSocketAddr)));
       if (filterAppsWithNyNodeIP.length > 0) {
         random = Math.floor(Math.random() * filterAppsWithNyNodeIP.length);
         appToRunAux = filterAppsWithNyNodeIP[random];
@@ -338,7 +339,7 @@ async function trySpawningGlobalApplication() {
 
     runningAppList = await registryManager.appLocation(appToRun);
 
-    const adjustedIP = myIP.split(':')[0]; // just IP address
+    const adjustedIP = extractIp(localSocketAddr); // just IP address
     // check if app not running on this device
     if (runningAppList.find((document) => document.ip.includes(adjustedIP))) {
       log.info(`trySpawningGlobalApplication - Application ${appToRun} is reported as already running on this Flux IP`);
@@ -416,8 +417,8 @@ async function trySpawningGlobalApplication() {
 
     // ensure ports unused
     // Get apps running specifically on this IP
-    const myIPAddress = myIP.split(':')[0]; // just IP address without port
-    const runningAppsOnThisIP = await registryManager.getRunningAppIpList(myIPAddress);
+    const localSocketAddrAddress = extractIp(localSocketAddr); // just IP address without port
+    const runningAppsOnThisIP = await registryManager.getRunningAppIpList(localSocketAddrAddress);
     const runningAppsNames = runningAppsOnThisIP.map((app) => app.name);
 
     await portManager.ensureApplicationPortsNotUsed(appSpecifications, runningAppsNames);
@@ -445,10 +446,10 @@ async function trySpawningGlobalApplication() {
       syncthingApp = appSpecifications.compose.find((comp) => comp.containerData.includes('g:') || comp.containerData.includes('r:') || comp.containerData.includes('s:'));
     }
 
-    const myIpWithoutPort = myIP.split(':')[0];
-    const lastIndex = myIpWithoutPort.lastIndexOf('.');
-    const secondLastIndex = myIpWithoutPort.substring(0, lastIndex).lastIndexOf('.');
-    const ipPrefix = myIpWithoutPort.substring(0, secondLastIndex + 1); // includes the '.' e.g. "192.168."
+    const localIp = extractIp(localSocketAddr);
+    const lastIndex = localIp.lastIndexOf('.');
+    const secondLastIndex = localIp.substring(0, lastIndex).lastIndexOf('.');
+    const ipPrefix = localIp.substring(0, secondLastIndex + 1); // includes the '.' e.g. "192.168."
 
     if (syncthingApp) {
       let sameIpRangeNode = runningAppList.find((location) => location.ip.startsWith(ipPrefix));
@@ -465,8 +466,8 @@ async function trySpawningGlobalApplication() {
         // check if there are connectivity to all nodes
         // eslint-disable-next-line no-restricted-syntax
         for (const node of runningAppList) {
-          const ip = node.ip.split(':')[0];
-          const port = node.ip.split(':')[1] || '16127';
+          const ip = extractIp(node.ip);
+          const port = extractPort(node.ip);
           // eslint-disable-next-line no-await-in-loop
           const isOpen = await fluxNetworkHelper.isPortOpen(ip, port);
           if (!isOpen) {
@@ -484,8 +485,8 @@ async function trySpawningGlobalApplication() {
         }
         // eslint-disable-next-line no-restricted-syntax
         for (const node of installingAppList) {
-          const ip = node.ip.split(':')[0];
-          const port = node.ip.split(':')[1] || '16127';
+          const ip = extractIp(node.ip);
+          const port = extractPort(node.ip);
           // eslint-disable-next-line no-await-in-loop
           const isOpen = await fluxNetworkHelper.isPortOpen(ip, port);
           if (!isOpen) {
@@ -505,7 +506,7 @@ async function trySpawningGlobalApplication() {
     }
 
     if (!appFromAppsToBeCheckedLater && !appFromAppsSyncthingToBeCheckedLater
-      && appToRunAux.nodes.length > 0 && !appToRunAux.nodes.find((ip) => ip === myIP)) {
+      && appToRunAux.nodes.length > 0 && !appToRunAux.nodes.find((ip) => socketAddressesMatch(ip, localSocketAddr))) {
       const deferral = config.fluxapps.spawnDeferrals.targetedNodesMs;
       const appToCheck = {
         timeToCheck: Date.now() + (appToRunAux.enterprise ? deferral.enterprise : deferral.standard),
@@ -566,7 +567,7 @@ async function trySpawningGlobalApplication() {
         globalState.trySpawningGlobalAppCache.delete(appHash);
         fluxEventBus.publish('spawner:deferred', { appName: appToRun, reason: 'datacenter', delayMs });
         delay = true;
-      } else if (appToRunAux.nodes.length > 0 && appToRunAux.nodes.find((ip) => ip === myIP)) {
+      } else if (appToRunAux.nodes.length > 0 && appToRunAux.nodes.find((ip) => socketAddressesMatch(ip, localSocketAddr))) {
         log.info(`trySpawningGlobalApplication - App ${appToRun} specs have this node as target ip`);
       } else if (appToRunAux.nodes.length === 0 && tier === 'bamf' && appHWrequirements.cpu < 3 && appHWrequirements.ram < 6000 && appHWrequirements.hdd < 150) {
         const deferral = config.fluxapps.spawnDeferrals.capacityGap.largeMs;
@@ -656,7 +657,7 @@ async function trySpawningGlobalApplication() {
       type: 'fluxappinstalling',
       version: 1,
       name: appSpecifications.name,
-      ip: myIP,
+      ip: localSocketAddr,
       broadcastedAt,
     };
 
@@ -683,7 +684,7 @@ async function trySpawningGlobalApplication() {
         return 0;
       });
       broadcastedAt = Date.now();
-      const index = installingAppList.findIndex((x) => x.ip === myIP);
+      const index = installingAppList.findIndex((x) => socketAddressesMatch(x.ip, localSocketAddr));
       if (runningAppList.length + index + 1 > minInstances) {
         log.info(`trySpawningGlobalApplication - Application ${appToRun} is already spawned or being installed on ${runningAppList.length + installingAppList.length} instances, my instance is number ${runningAppList.length + index + 1}`);
         return shortDelayTime;
@@ -705,7 +706,7 @@ async function trySpawningGlobalApplication() {
           return current.broadcastedAt < oldest.broadcastedAt ? current : oldest;
         });
         // If our node is not the oldest one, skip - let the first node continue
-        if (oldestNode.ip !== myIP) {
+        if (!socketAddressesMatch(oldestNode.ip, localSocketAddr)) {
           log.info(`trySpawningGlobalApplication - Application ${appToRun} uses syncthing and it is already being installed on Fluxnode with same ip range`);
           return shortDelayTime;
         }
@@ -748,7 +749,7 @@ async function trySpawningGlobalApplication() {
         }
         return 0;
       });
-      const index = runningAppList.findIndex((x) => x.ip === myIP);
+      const index = runningAppList.findIndex((x) => socketAddressesMatch(x.ip, localSocketAddr));
       log.info(`trySpawningGlobalApplication - Application ${appToRun} is already spawned on ${runningAppList.length} instances, my instance is number ${index + 1}`);
       if (index + 1 > minInstances) {
         log.info(`trySpawningGlobalApplication - Application ${appToRun} is going to be removed as already passed the instances required.`);

--- a/ZelBack/src/services/appLifecycle/appSpawner.js
+++ b/ZelBack/src/services/appLifecycle/appSpawner.js
@@ -8,7 +8,7 @@ const fluxNetworkHelper = require('../fluxNetworkHelper');
 const geolocationService = require('../geolocationService');
 const daemonServiceMiscRpcs = require('../daemonService/daemonServiceMiscRpcs');
 const log = require('../../lib/log');
-const { normalizeSocketAddress, extractIp, socketAddressesMatch } = require('../utils/socketAddressUtils');
+const { normalizeSocketAddress, extractIp, extractPort, socketAddressesMatch } = require('../utils/socketAddressUtils');
 
 // Import modular services
 const appQueryService = require('../appQuery/appQueryService');

--- a/ZelBack/src/services/appLifecycle/appStartupManager.js
+++ b/ZelBack/src/services/appLifecycle/appStartupManager.js
@@ -125,7 +125,7 @@ async function reconcileAppsOnBoot() {
     log.info(`appStartupManager - Stopped containers belong to ${appsWithStoppedContainers.size} app(s)`);
 
     // Get this node's IP for location checks
-    const myIp = await fluxNetworkHelper.getMyFluxIPandPort();
+    const localSocketAddr = await fluxNetworkHelper.getLocalSocketAddress();
 
     // Process each app
     // eslint-disable-next-line no-restricted-syntax
@@ -179,11 +179,11 @@ async function reconcileAppsOnBoot() {
       // Check if the app still has a valid location record for this node
       // If the node was offline longer than the TTL (~7 minutes after sigterm),
       // the location record expired and the app was respawned elsewhere
-      if (myIp) {
+      if (localSocketAddr) {
         // eslint-disable-next-line no-await-in-loop
-        const hasValidLocation = await appHasValidLocationOnNode(appName, myIp);
+        const hasValidLocation = await appHasValidLocationOnNode(appName, localSocketAddr);
         if (!hasValidLocation) {
-          log.warn(`appStartupManager - App ${appName} no longer has a valid location record for this node (${myIp}), removing locally`);
+          log.warn(`appStartupManager - App ${appName} no longer has a valid location record for this node (${localSocketAddr}), removing locally`);
           try {
             // eslint-disable-next-line no-await-in-loop
             await appUninstaller.removeAppLocally(appName, null, true, true, false);

--- a/ZelBack/src/services/appLifecycle/appUninstaller.js
+++ b/ZelBack/src/services/appLifecycle/appUninstaller.js
@@ -875,7 +875,7 @@ async function removeAppLocally(app, res, force = false, endResponse = true, sen
     fluxEventBus.publish('app:removed', { name: appName });
 
     if (sendMessage) {
-      const ip = await fluxNetworkHelper.getMyFluxIPandPort();
+      const ip = await fluxNetworkHelper.getLocalSocketAddress();
       if (ip) {
         const broadcastedAt = Date.now();
         const appRemovedMessage = {

--- a/ZelBack/src/services/appManagement/appController.js
+++ b/ZelBack/src/services/appManagement/appController.js
@@ -7,6 +7,7 @@ const dockerService = require('../dockerService');
 const registryManager = require('../appDatabase/registryManager');
 const appInspector = require('./appInspector');
 const fluxNetworkHelper = require('../fluxNetworkHelper');
+const { extractIp, extractPort } = require('../utils/socketAddressUtils');
 const log = require('../../lib/log');
 
 const globalCmdDelayMs = config.fluxapps.globalCmdDelayMs;
@@ -59,15 +60,15 @@ async function executeAppGlobalCommand(appname, command, zelidauth, paramA, bypa
   try {
     // get a list of the specific app locations
     const locations = await appLocation(appname);
-    const myIP = await fluxNetworkHelper.getMyFluxIPandPort();
-    const myUrl = myIP.split(':')[0];
-    const myUrlPort = myIP.split(':')[1] || '16127';
+    const localSocketAddr = await fluxNetworkHelper.getLocalSocketAddress();
+    const localIp = extractIp(localSocketAddr);
+    const localPort = extractPort(localSocketAddr);
     // eslint-disable-next-line no-restricted-syntax
     for (const appInstance of locations) {
       // HERE let the node we are connected to handle it
-      const ip = appInstance.ip.split(':')[0];
-      const port = appInstance.ip.split(':')[1] || '16127';
-      if (bypassMyIp && myUrl === ip && myUrlPort === port) {
+      const instanceIp = extractIp(appInstance.ip);
+      const instancePort = extractPort(appInstance.ip);
+      if (bypassMyIp && localIp === instanceIp && localPort === instancePort) {
         // eslint-disable-next-line no-continue
         continue;
       }
@@ -76,7 +77,7 @@ async function executeAppGlobalCommand(appname, command, zelidauth, paramA, bypa
           zelidauth,
         },
       };
-      let url = `http://${ip}:${port}/apps/${command}/${appname}`;
+      let url = `http://${instanceIp}:${instancePort}/apps/${command}/${appname}`;
       if (paramA) {
         url += `/${paramA}`;
       }

--- a/ZelBack/src/services/appMessaging/appHashSyncService.js
+++ b/ZelBack/src/services/appMessaging/appHashSyncService.js
@@ -498,7 +498,7 @@ async function broadcastHashRequest(hashes, peers) {
  */
 async function pickEphemeralTargets(count) {
   const nodeList = await fluxCommunicationUtils.deterministicFluxList();
-  const localSocketAddress = await fluxNetworkHelper.getMyFluxIPandPort();
+  const localSocketAddress = await fluxNetworkHelper.getLocalSocketAddress();
   const selfKey = localSocketAddress.includes(':') ? localSocketAddress : `${localSocketAddress}:16127`;
   const connectedKeys = new Set();
   for (const peer of peerManager.allValues()) {

--- a/ZelBack/src/services/appMessaging/appHashSyncService.js
+++ b/ZelBack/src/services/appMessaging/appHashSyncService.js
@@ -15,6 +15,7 @@ const { peerManager } = require('../utils/peerState');
 const fluxCommunicationUtils = require('../fluxCommunicationUtils');
 const { openEphemeralConnection } = require('../fluxCommunication');
 const fluxNetworkHelper = require('../fluxNetworkHelper');
+const { normalizeSocketAddress } = require('../utils/socketAddressUtils');
 const { CLOSE_CODES } = require('../utils/FluxPeerSocket');
 const { appSyncEvents, EVENTS } = require('../utils/appSyncEvents');
 const { HASH_EXPIRY_BLOCKS, HASH_RETRY_BACKOFF } = require('../utils/appConstants');
@@ -499,7 +500,7 @@ async function broadcastHashRequest(hashes, peers) {
 async function pickEphemeralTargets(count) {
   const nodeList = await fluxCommunicationUtils.deterministicFluxList();
   const localSocketAddress = await fluxNetworkHelper.getLocalSocketAddress();
-  const selfKey = localSocketAddress.includes(':') ? localSocketAddress : `${localSocketAddress}:16127`;
+  if (!localSocketAddress) return [];
   const connectedKeys = new Set();
   for (const peer of peerManager.allValues()) {
     connectedKeys.add(peer.key);
@@ -507,9 +508,9 @@ async function pickEphemeralTargets(count) {
   const candidates = [];
   for (const node of nodeList) {
     if (!node.ip) continue;
-    const key = node.ip.includes(':') ? node.ip : `${node.ip}:16127`;
+    const key = normalizeSocketAddress(node.ip);
     if (connectedKeys.has(key)) continue;
-    if (key === selfKey) continue;
+    if (key === localSocketAddress) continue;
     candidates.push(key);
   }
   for (let i = candidates.length - 1; i > 0; i -= 1) {

--- a/ZelBack/src/services/appMessaging/peerNotification.js
+++ b/ZelBack/src/services/appMessaging/peerNotification.js
@@ -2,7 +2,7 @@ const os = require('os');
 const config = require('config');
 const dbHelper = require('../dbHelper');
 const nodeConfirmationService = require('../nodeConfirmationService');
-const benchmarkService = require('../benchmarkService');
+const fluxNetworkHelper = require('../fluxNetworkHelper');
 const geolocationService = require('../geolocationService');
 const fluxCommunicationMessagesSender = require('../fluxCommunicationMessagesSender');
 const messageStore = require('./messageStore');
@@ -57,16 +57,8 @@ async function checkAndNotifyPeersOfRunningApps() {
       return;
     }
 
-    const benchmarkResponse = await benchmarkService.getBenchmarks();
-    let myIP = null;
-    if (benchmarkResponse.status === 'success') {
-      const benchmarkResponseData = benchmarkResponse.data;
-      if (benchmarkResponseData.ipaddress) {
-        log.info(`Gathered IP ${benchmarkResponseData.ipaddress}`);
-        myIP = benchmarkResponseData.ipaddress.length > 5 ? benchmarkResponseData.ipaddress : null;
-      }
-    }
-    if (myIP === null) {
+    const localSocketAddr = await fluxNetworkHelper.getLocalSocketAddress();
+    if (!localSocketAddr) {
       throw new Error('Unable to detect Flux IP address');
     }
 
@@ -88,7 +80,7 @@ async function checkAndNotifyPeersOfRunningApps() {
       return app.Names[0].slice(5);
     });
 
-    const { masterSlaveAppsInstalled, startedApps } = await containerHealthMonitor.monitorAndRecoverApps(myIP, appsInstalled, runningAppsNames);
+    const { masterSlaveAppsInstalled, startedApps } = await containerHealthMonitor.monitorAndRecoverApps(localSocketAddr, appsInstalled, runningAppsNames);
     runningAppsNames.push(...startedApps);
 
     const installedAndRunning = [];
@@ -115,7 +107,7 @@ async function checkAndNotifyPeersOfRunningApps() {
     try {
       // eslint-disable-next-line no-restricted-syntax
       for (const application of applicationsToBroadcast) {
-        const queryFind = { name: application.name, ip: myIP };
+        const queryFind = { name: application.name, ip: localSocketAddr };
         const projection = { _id: 0, runningSince: 1 };
         // eslint-disable-next-line no-await-in-loop
         const result = await dbHelper.findOneInDatabase(database, globalAppsLocations, queryFind, projection);
@@ -138,7 +130,7 @@ async function checkAndNotifyPeersOfRunningApps() {
         type: 'fluxapprunning',
         version: 2,
         apps,
-        ip: myIP,
+        ip: localSocketAddr,
         broadcastedAt: Date.now(),
         osUptime: os.uptime(),
         staticIp: geolocationService.isStaticIP(),

--- a/ZelBack/src/services/appMonitoring/availabilityChecker.js
+++ b/ZelBack/src/services/appMonitoring/availabilityChecker.js
@@ -303,7 +303,7 @@ async function checkMyAppsAvailability(installedAppsFn, dosState, portsNotWorkin
 
     const data = {
       ip: localIp,
-      port: localPort,
+      port: String(localPort),
       appname: 'appPortsTest',
       ports: [dosState.testingPort],
       pubKey,

--- a/ZelBack/src/services/appMonitoring/availabilityChecker.js
+++ b/ZelBack/src/services/appMonitoring/availabilityChecker.js
@@ -11,6 +11,7 @@ const networkStateService = require('../networkStateService');
 const fluxHttpTestServer = require('../utils/fluxHttpTestServer');
 const { decryptEnterpriseApps } = require('../appQuery/appQueryService');
 const log = require('../../lib/log');
+const { extractIp, extractPort } = require('../utils/socketAddressUtils');
 
 // Helper function to sign check app data
 async function signCheckAppData(message) {
@@ -295,8 +296,10 @@ async function checkMyAppsAvailability(installedAppsFn, dosState, portsNotWorkin
     };
 
     const pubKey = await fluxNetworkHelper.getFluxNodePublicKey();
-    const [localIp, localPort = '16127'] = localSocketAddress.split(':');
-    const [remoteIp, remotePort = '16127'] = remoteSocketAddress.split(':');
+    const localIp = extractIp(localSocketAddress);
+    const localPort = extractPort(localSocketAddress);
+    const remoteIp = extractIp(remoteSocketAddress);
+    const remotePort = extractPort(remoteSocketAddress);
 
     const data = {
       ip: localIp,

--- a/ZelBack/src/services/appMonitoring/availabilityChecker.js
+++ b/ZelBack/src/services/appMonitoring/availabilityChecker.js
@@ -128,7 +128,7 @@ async function checkMyAppsAvailability(installedAppsFn, dosState, portsNotWorkin
       return;
     }
 
-    const localSocketAddress = await fluxNetworkHelper.getMyFluxIPandPort();
+    const localSocketAddress = await fluxNetworkHelper.getLocalSocketAddress();
     if (!localSocketAddress) {
       log.info('No Public IP found. Application checks are disabled');
       await serviceHelper.delay(timeouts.appError);

--- a/ZelBack/src/services/appMonitoring/containerHealthMonitor.js
+++ b/ZelBack/src/services/appMonitoring/containerHealthMonitor.js
@@ -116,7 +116,7 @@ async function handleMissingMasterSlaveContainer(stoppedApp, mainAppName) {
   }
 }
 
-async function monitorAndRecoverApps(myIP, appsInstalled, runningAppsNames) {
+async function monitorAndRecoverApps(localSocketAddr, appsInstalled, runningAppsNames) {
   await globalState.waitForBootContainerStateSettled();
   const masterSlaveAppsInstalled = [];
   const startedApps = [];
@@ -176,7 +176,7 @@ async function monitorAndRecoverApps(myIP, appsInstalled, runningAppsNames) {
           if (containerExists && appInstalledSyncthing) {
             const db = dbHelper.databaseConnection();
             const database = db.db(config.database.appsglobal.database);
-            const queryFind = { name: mainAppName, ip: myIP };
+            const queryFind = { name: mainAppName, ip: localSocketAddr };
             const projection = { _id: 0, runningSince: 1 };
             // eslint-disable-next-line no-await-in-loop
             const result = await dbHelper.findOneInDatabase(database, globalAppsLocations, queryFind, projection);

--- a/ZelBack/src/services/appMonitoring/nodeStatusMonitor.js
+++ b/ZelBack/src/services/appMonitoring/nodeStatusMonitor.js
@@ -8,6 +8,7 @@ const fluxCommunicationUtils = require('../fluxCommunicationUtils');
 const messageStore = require('../appMessaging/messageStore');
 const nodeConfirmationService = require('../nodeConfirmationService');
 const log = require('../../lib/log');
+const { extractIp, extractPort } = require('../utils/socketAddressUtils');
 
 let removalInProgress = false;
 
@@ -112,8 +113,8 @@ async function monitorNodeStatus(installedAppsFn, removeAppLocallyFn) {
       // eslint-disable-next-line no-restricted-syntax
       for (const location of appsLocationsNotOnNodelist) {
         log.info(`monitorNodeStatus - Checking IP ${location}.`);
-        const ip = location.split(':')[0];
-        const port = location.split(':')[1] || '16127';
+        const ip = extractIp(location);
+        const port = extractPort(location);
         const { CancelToken } = axios;
         const source = CancelToken.source();
         let isResolved = false;

--- a/ZelBack/src/services/appMonitoring/syncthingFolderStateMachine.js
+++ b/ZelBack/src/services/appMonitoring/syncthingFolderStateMachine.js
@@ -7,6 +7,7 @@ const syncthingService = require('../syncthingService');
 const serviceHelper = require('../serviceHelper');
 const { appsFolder } = require('../utils/appConstants');
 const appTamperingDetectionService = require('../appTamperingDetectionService');
+const { socketAddressesMatch } = require('../utils/socketAddressUtils');
 const {
   MAX_SYNC_WAIT_EXECUTIONS,
   STALLED_SYNC_CHECK_COUNT,
@@ -184,22 +185,22 @@ async function getFolderSyncCompletion(folderId) {
  * Uses deterministic leader election to prevent race conditions.
  *
  * @param {Array<Object>} allPeersList - List of ALL peers including the current node
- * @param {string} myIP - The current node's IP address
+ * @param {string} localSocketAddr - The current node's IP address
  * @returns {boolean} True if this node is the designated leader
  */
-function isDesignatedLeader(allPeersList, myIP) {
+function isDesignatedLeader(allPeersList, localSocketAddr) {
   if (!allPeersList || allPeersList.length === 0) {
     return false; // Be conservative - wait for peers to broadcast
   }
 
   // Check if any OTHER peer is already running
-  const runningPeers = allPeersList.filter((peer) => peer.runningSince && peer.ip !== myIP);
+  const runningPeers = allPeersList.filter((peer) => peer.runningSince && !socketAddressesMatch(peer.ip, localSocketAddr));
   if (runningPeers.length > 0) {
     return false; // Someone else is already running
   }
 
   // Special case: single peer deployment
-  if (allPeersList.length === 1 && allPeersList[0].ip === myIP) {
+  if (allPeersList.length === 1 && socketAddressesMatch(allPeersList[0].ip, localSocketAddr)) {
     return true;
   }
 
@@ -219,20 +220,20 @@ function isDesignatedLeader(allPeersList, myIP) {
   });
 
   const leader = sortedPeers[0];
-  const isLeader = leader?.ip === myIP;
+  const isLeader = socketAddressesMatch(leader?.ip, localSocketAddr);
 
-  return isLeader && allPeersList.some((peer) => peer.ip === myIP);
+  return isLeader && allPeersList.some((peer) => socketAddressesMatch(peer.ip, localSocketAddr));
 }
 
 /**
  * Calculate required executions based on node index (fallback for time-based sync)
  * @param {Array} runningAppList - Sorted list of running apps
- * @param {string} myIP - Current node IP
+ * @param {string} localSocketAddr - Current node IP
  * @returns {number} Number of required executions
  */
-function calculateRequiredExecutions(runningAppList, myIP) {
+function calculateRequiredExecutions(runningAppList, localSocketAddr) {
   const sortedList = sortRunningAppList(runningAppList);
-  const index = sortedList.findIndex((x) => x.ip === myIP);
+  const index = sortedList.findIndex((x) => socketAddressesMatch(x.ip, localSocketAddr));
 
   let required = LEADER_ELECTION_MIN_EXECUTIONS;
   if (index > 0) {
@@ -430,7 +431,7 @@ async function handleReceiveOnlyTransition(params) {
     appId,
     cache,
     runningAppList,
-    myIP,
+    localSocketAddr,
     containerDataFlags,
     appDockerRestartFn,
     syncthingFolder,
@@ -439,7 +440,7 @@ async function handleReceiveOnlyTransition(params) {
   log.info(`handleReceiveOnlyTransition - ${appId} in cache and not restarted, processing receive-only logic`);
 
   // Check if this node is the designated leader
-  const isLeader = isDesignatedLeader(runningAppList, myIP);
+  const isLeader = isDesignatedLeader(runningAppList, localSocketAddr);
 
   if (isLeader) {
     log.info(`handleReceiveOnlyTransition - ${appId} is the designated leader (elected from ${runningAppList.length} peers), starting immediately`);
@@ -578,7 +579,7 @@ async function handleReceiveOnlyTransition(params) {
     // Fallback to time-based approach
     log.warn(`handleReceiveOnlyTransition - Could not get sync status for ${appId}, using fallback time-based logic`);
 
-    const numberOfExecutionsRequired = calculateRequiredExecutions(runningAppList, myIP);
+    const numberOfExecutionsRequired = calculateRequiredExecutions(runningAppList, localSocketAddr);
     cache.numberOfExecutionsRequired = numberOfExecutionsRequired;
 
     log.info(`handleReceiveOnlyTransition - ${appId} executions: ${cache.numberOfExecutions}/${cache.numberOfExecutionsRequired}`);
@@ -667,7 +668,7 @@ async function manageFolderSyncState(params) {
     syncthingAppsFirstRun,
     receiveOnlySyncthingAppsCache,
     appLocation,
-    myIP,
+    localSocketAddr,
     appDockerStopFn,
     appDockerRestartFn,
     appDeleteDataInMountPointFn,
@@ -747,7 +748,7 @@ async function manageFolderSyncState(params) {
       appId,
       cache,
       runningAppList,
-      myIP,
+      localSocketAddr,
       containerDataFlags,
       appDockerRestartFn,
       appDockerStopFn,

--- a/ZelBack/src/services/appMonitoring/syncthingMonitor.js
+++ b/ZelBack/src/services/appMonitoring/syncthingMonitor.js
@@ -109,8 +109,8 @@ async function processContainerData(params) {
     containerData,
     identifier,
     installedAppName,
-    myIP,
-    myDeviceId,
+    localSocketAddr,
+    localDeviceId,
     state,
     allFoldersResp,
     allDevicesResp,
@@ -147,13 +147,13 @@ async function processContainerData(params) {
 
   // Get and process app locations
   let locations = await appLocation(installedAppName);
-  locations = sortAndFilterLocations(locations, myIP);
+  locations = sortAndFilterLocations(locations, localSocketAddr);
 
   // Build device configuration (parallelized internally)
   const devices = await buildDeviceConfiguration(
     locations,
-    myIP,
-    myDeviceId,
+    localSocketAddr,
+    localDeviceId,
     state.syncthingDevicesIDCache,
     devicesConfiguration,
     devicesIds,
@@ -174,7 +174,7 @@ async function processContainerData(params) {
       syncthingAppsFirstRun: state.syncthingAppsFirstRun,
       receiveOnlySyncthingAppsCache: state.receiveOnlySyncthingAppsCache,
       appLocation,
-      myIP,
+      localSocketAddr,
       appDockerStopFn,
       appDockerRestartFn,
       appDeleteDataInMountPointFn,
@@ -317,15 +317,15 @@ async function syncthingAppsCore(state, installedAppsFn, getGlobalStateFn, appDo
     }
 
     // Get required IDs and configurations
-    const myDeviceId = await syncthingService.getDeviceId();
-    if (!myDeviceId) {
-      log.error('syncthingAppsCore - Failed to get myDeviceId');
+    const localDeviceId = await syncthingService.getDeviceId();
+    if (!localDeviceId) {
+      log.error('syncthingAppsCore - Failed to get localDeviceId');
       return;
     }
 
-    const myIP = await fluxNetworkHelper.getMyFluxIPandPort();
-    if (!myIP) {
-      log.error('syncthingAppsCore - Failed to get myIP');
+    const localSocketAddr = await fluxNetworkHelper.getLocalSocketAddress();
+    if (!localSocketAddr) {
+      log.error('syncthingAppsCore - Failed to get localSocketAddr');
       return;
     }
 
@@ -408,8 +408,8 @@ async function syncthingAppsCore(state, installedAppsFn, getGlobalStateFn, appDo
 
     // Shared parameters for processing
     const sharedParams = {
-      myIP,
-      myDeviceId,
+      localSocketAddr,
+      localDeviceId,
       state,
       allFoldersResp,
       allDevicesResp,
@@ -467,7 +467,7 @@ async function syncthingAppsCore(state, installedAppsFn, getGlobalStateFn, appDo
       (syncthingFolder) => !folderIds.includes(syncthingFolder.id),
     );
     const nonUsedDevices = allDevicesResp.data.filter(
-      (syncthingDevice) => !devicesIds.includes(syncthingDevice.deviceID) && syncthingDevice.deviceID !== myDeviceId,
+      (syncthingDevice) => !devicesIds.includes(syncthingDevice.deviceID) && syncthingDevice.deviceID !== localDeviceId,
     );
 
     // Parallelize cleanup operations

--- a/ZelBack/src/services/appMonitoring/syncthingMonitorHelpers.js
+++ b/ZelBack/src/services/appMonitoring/syncthingMonitorHelpers.js
@@ -9,7 +9,7 @@ const {
 } = require('./syncthingMonitorConstants');
 
 const cmdAsync = util.promisify(require('child_process').exec);
-const { extractIp, extractPort } = require('../utils/socketAddressUtils');
+const { extractIp, extractPort, socketAddressesMatch } = require('../utils/socketAddressUtils');
 
 /**
  * Helper function to get device ID from remote node with retry capability
@@ -60,17 +60,17 @@ async function getDeviceIDCached(name, cache) {
 /**
  * Sort and filter app locations
  * @param {Array} locations - App locations
- * @param {string} myIP - Current node IP
+ * @param {string} localSocketAddr - Current node socket address
  * @returns {Array} Sorted and filtered locations (excluding current node)
  */
-function sortAndFilterLocations(locations, myIP) {
+function sortAndFilterLocations(locations, localSocketAddr) {
   return locations
     .sort((a, b) => {
       if (a.ip < b.ip) return -1;
       if (a.ip > b.ip) return 1;
       return 0;
     })
-    .filter((loc) => loc.ip !== myIP);
+    .filter((loc) => !socketAddressesMatch(loc.ip, localSocketAddr));
 }
 
 /**
@@ -95,7 +95,7 @@ function sortRunningAppList(runningAppList) {
 /**
  * Build device configuration from locations
  * @param {Array} locations - App locations
- * @param {string} myIP - Current node IP
+ * @param {string} localSocketAddr - Current node socket address
  * @param {string} myDeviceId - Current node device ID
  * @param {Map} deviceCache - Device ID cache
  * @param {Array} devicesConfiguration - Array to populate with devices
@@ -105,7 +105,7 @@ function sortRunningAppList(runningAppList) {
  */
 async function buildDeviceConfiguration(
   locations,
-  myIP,
+  localSocketAddr,
   myDeviceId,
   deviceCache,
   devicesConfiguration,

--- a/ZelBack/src/services/appMonitoring/syncthingMonitorHelpers.js
+++ b/ZelBack/src/services/appMonitoring/syncthingMonitorHelpers.js
@@ -9,6 +9,7 @@ const {
 } = require('./syncthingMonitorConstants');
 
 const cmdAsync = util.promisify(require('child_process').exec);
+const { extractIp, extractPort } = require('../utils/socketAddressUtils');
 
 /**
  * Helper function to get device ID from remote node with retry capability
@@ -115,9 +116,9 @@ async function buildDeviceConfiguration(
 
   // Parallelize device ID fetching
   const devicePromises = locations.map(async (appInstance) => {
-    const ip = appInstance.ip.split(':')[0];
-    const port = appInstance.ip.split(':')[1] || '16127';
-    const addresses = [`tcp://${ip}:${+port + 2}`, `quic://${ip}:${+port + 2}`];
+    const ip = extractIp(appInstance.ip);
+    const port = extractPort(appInstance.ip);
+    const addresses = [`tcp://${ip}:${port + 2}`, `quic://${ip}:${port + 2}`];
     const name = `${ip}:${port}`;
 
     const deviceID = await getDeviceIDCached(name, deviceCache);

--- a/ZelBack/src/services/appMonitoring/syncthingMonitorHelpers.js
+++ b/ZelBack/src/services/appMonitoring/syncthingMonitorHelpers.js
@@ -9,7 +9,7 @@ const {
 } = require('./syncthingMonitorConstants');
 
 const cmdAsync = util.promisify(require('child_process').exec);
-const { extractIp, extractPort, socketAddressesMatch } = require('../utils/socketAddressUtils');
+const { normalizeSocketAddress, extractIp, extractPort, socketAddressesMatch } = require('../utils/socketAddressUtils');
 
 /**
  * Helper function to get device ID from remote node with retry capability
@@ -66,8 +66,10 @@ async function getDeviceIDCached(name, cache) {
 function sortAndFilterLocations(locations, localSocketAddr) {
   return locations
     .sort((a, b) => {
-      if (a.ip < b.ip) return -1;
-      if (a.ip > b.ip) return 1;
+      const addrA = normalizeSocketAddress(a.ip);
+      const addrB = normalizeSocketAddress(b.ip);
+      if (addrA < addrB) return -1;
+      if (addrA > addrB) return 1;
       return 0;
     })
     .filter((loc) => !socketAddressesMatch(loc.ip, localSocketAddr));

--- a/ZelBack/src/services/appNetwork/portManager.js
+++ b/ZelBack/src/services/appNetwork/portManager.js
@@ -501,7 +501,8 @@ async function checkInstallingAppPortAvailable(portsToTest = []) {
         throw new Error('Unable to get random test connection');
       }
 
-      const [askingIP, askingIpPort = '16127'] = randomSocketAddress.split(':');
+      const askingIP = extractIp(randomSocketAddress);
+      const askingIpPort = extractPort(randomSocketAddress);
 
       // first check against our IP address
       // eslint-disable-next-line no-await-in-loop

--- a/ZelBack/src/services/appNetwork/portManager.js
+++ b/ZelBack/src/services/appNetwork/portManager.js
@@ -2,6 +2,7 @@ const config = require('config');
 const axios = require('axios');
 const dbHelper = require('../dbHelper');
 const fluxNetworkHelper = require('../fluxNetworkHelper');
+const { extractIp, extractPort } = require('../utils/socketAddressUtils');
 const networkStateService = require('../networkStateService');
 const verificationHelper = require('../verificationHelper');
 const log = require('../../lib/log');
@@ -395,11 +396,12 @@ async function checkInstallingAppPortAvailable(portsToTest = []) {
   let nextTestingPort = 0;
 
   try {
-    const localSocketAddress = await fluxNetworkHelper.getMyFluxIPandPort();
+    const localSocketAddress = await fluxNetworkHelper.getLocalSocketAddress();
     if (!localSocketAddress) {
       throw new Error('Failed to detect Public IP');
     }
-    const [myIP, myPort = '16127'] = localSocketAddress.split(':');
+    const localIp = extractIp(localSocketAddress);
+    const localPort = extractPort(localSocketAddress);
 
     const pubKey = await fluxNetworkHelper.getFluxNodePublicKey();
     let somePortBanned = false;
@@ -475,8 +477,8 @@ async function checkInstallingAppPortAvailable(portsToTest = []) {
       timeout,
     };
     const data = {
-      ip: myIP,
-      port: myPort,
+      ip: localIp,
+      port: localPort,
       appname: 'appPortsTest',
       ports: portsToTest,
       pubKey,
@@ -595,20 +597,20 @@ async function callOtherNodeToKeepUpnpPortsOpen() {
   try {
     const userconfig = globalThis.userconfig;
     const apiPort = userconfig.initial.apiport || config.server.apiport;
-    let myIP = await fluxNetworkHelper.getMyFluxIPandPort();
-    if (!myIP) {
+    const localSocketAddr = await fluxNetworkHelper.getLocalSocketAddress();
+    if (!localSocketAddr) {
       return;
     }
 
-    const randomSocketAddress = await networkStateService.getRandomSocketAddress(myIP);
+    const randomSocketAddress = await networkStateService.getRandomSocketAddress(localSocketAddr);
 
     if (!randomSocketAddress) return;
 
-    const [askingIP, askingIpPort = '16127'] = randomSocketAddress.split(':');
+    const askingIP = extractIp(randomSocketAddress);
+    const askingIpPort = extractPort(randomSocketAddress);
+    const localIp = extractIp(localSocketAddr);
 
-    myIP = myIP.split(':')[0];
-
-    if (myIP === askingIP) {
+    if (localIp === askingIP) {
       callOtherNodeToKeepUpnpPortsOpen();
       return;
     }
@@ -662,7 +664,7 @@ async function callOtherNodeToKeepUpnpPortsOpen() {
     };
 
     const dataUPNP = {
-      ip: myIP,
+      ip: localIp,
       apiPort,
       ports,
       pubKey,

--- a/ZelBack/src/services/appRequirements/hwRequirements.js
+++ b/ZelBack/src/services/appRequirements/hwRequirements.js
@@ -2,7 +2,8 @@ const os = require('os');
 const config = require('config');
 const generalService = require('../generalService');
 const geolocationService = require('../geolocationService');
-const benchmarkService = require('../benchmarkService');
+const fluxNetworkHelper = require('../fluxNetworkHelper');
+const { socketAddressesMatch } = require('../utils/socketAddressUtils');
 const log = require('../../lib/log');
 
 // Node specifications (shared state)
@@ -208,23 +209,12 @@ async function checkAppGeolocationRequirements(appSpecs) {
 async function checkAppNodesRequirements(appSpecs) {
   if (appSpecs.version === 7 && appSpecs.nodes && appSpecs.nodes.length) {
     const myCollateral = await generalService.obtainNodeCollateralInformation();
-    const benchmarkResponse = await benchmarkService.getBenchmarks();
-
-    if (benchmarkResponse.status === 'error') {
+    const localSocketAddr = await fluxNetworkHelper.getLocalSocketAddress();
+    if (!localSocketAddr) {
       throw new Error('Unable to detect Flux IP address');
     }
 
-    let myIP = null;
-    if (benchmarkResponse.data.ipaddress) {
-      log.info(`Gathered IP ${benchmarkResponse.data.ipaddress}`);
-      myIP = benchmarkResponse.data.ipaddress.length > 5 ? benchmarkResponse.data.ipaddress : null;
-    }
-
-    if (myIP === null) {
-      throw new Error('Unable to detect Flux IP address');
-    }
-
-    if (appSpecs.nodes.includes(myIP) || appSpecs.nodes.includes(`${myCollateral.txhash}:${myCollateral.txindex}`)) {
+    if (appSpecs.nodes.find((node) => socketAddressesMatch(node, localSocketAddr)) || appSpecs.nodes.includes(`${myCollateral.txhash}:${myCollateral.txindex}`)) {
       return true;
     }
     throw new Error(`Application ${appSpecs.name} is not allowed to run on this node. Aborting.`);

--- a/ZelBack/src/services/appRequirements/hwRequirements.js
+++ b/ZelBack/src/services/appRequirements/hwRequirements.js
@@ -2,6 +2,7 @@ const os = require('os');
 const config = require('config');
 const generalService = require('../generalService');
 const geolocationService = require('../geolocationService');
+const benchmarkService = require('../benchmarkService');
 const fluxNetworkHelper = require('../fluxNetworkHelper');
 const { socketAddressesMatch } = require('../utils/socketAddressUtils');
 const log = require('../../lib/log');

--- a/ZelBack/src/services/appSystem/systemIntegration.js
+++ b/ZelBack/src/services/appSystem/systemIntegration.js
@@ -9,6 +9,7 @@ const dockerService = require('../dockerService');
 // eslint-disable-next-line no-unused-vars
 const daemonServiceFluxnodeRpcs = require('../daemonService/daemonServiceFluxnodeRpcs');
 const fluxNetworkHelper = require('../fluxNetworkHelper');
+const benchmarkService = require('../benchmarkService');
 const { socketAddressesMatch } = require('../utils/socketAddressUtils');
 const hwRequirements = require('../appRequirements/hwRequirements');
 const daemonServiceBenchmarkRpcs = require('../daemonService/daemonServiceBenchmarkRpcs');

--- a/ZelBack/src/services/appSystem/systemIntegration.js
+++ b/ZelBack/src/services/appSystem/systemIntegration.js
@@ -8,9 +8,8 @@ const verificationHelper = require('../verificationHelper');
 const dockerService = require('../dockerService');
 // eslint-disable-next-line no-unused-vars
 const daemonServiceFluxnodeRpcs = require('../daemonService/daemonServiceFluxnodeRpcs');
-// eslint-disable-next-line no-unused-vars
 const fluxNetworkHelper = require('../fluxNetworkHelper');
-const benchmarkService = require('../benchmarkService');
+const { socketAddressesMatch } = require('../utils/socketAddressUtils');
 const hwRequirements = require('../appRequirements/hwRequirements');
 const daemonServiceBenchmarkRpcs = require('../daemonService/daemonServiceBenchmarkRpcs');
 const generalService = require('../generalService');
@@ -128,23 +127,12 @@ function checkAppDataCenterRequirements(appSpecs) {
 async function checkAppNodesRequirements(appSpecs) {
   if (appSpecs.version === 7 && appSpecs.nodes && appSpecs.nodes.length) {
     const myCollateral = await generalService.obtainNodeCollateralInformation();
-    const benchmarkResponse = await benchmarkService.getBenchmarks();
-
-    if (benchmarkResponse.status === 'error') {
+    const localSocketAddr = await fluxNetworkHelper.getLocalSocketAddress();
+    if (!localSocketAddr) {
       throw new Error('Unable to detect Flux IP address');
     }
 
-    let myIP = null;
-    if (benchmarkResponse.data.ipaddress) {
-      log.info(`Gathered IP ${benchmarkResponse.data.ipaddress}`);
-      myIP = benchmarkResponse.data.ipaddress.length > 5 ? benchmarkResponse.data.ipaddress : null;
-    }
-
-    if (myIP === null) {
-      throw new Error('Unable to detect Flux IP address');
-    }
-
-    if (appSpecs.nodes.includes(myIP) || appSpecs.nodes.includes(`${myCollateral.txhash}:${myCollateral.txindex}`)) {
+    if (appSpecs.nodes.find((node) => socketAddressesMatch(node, localSocketAddr)) || appSpecs.nodes.includes(`${myCollateral.txhash}:${myCollateral.txindex}`)) {
       return true;
     }
     throw new Error(`Application ${appSpecs.name} is not allowed to run on this node. Aborting.`);

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -8,6 +8,7 @@ const pgpService = require('./pgpService');
 const deviceHelper = require('./deviceHelper');
 const generalService = require('./generalService');
 const fluxNetworkHelper = require('./fluxNetworkHelper');
+const { extractIp } = require('./utils/socketAddressUtils');
 const log = require('../lib/log');
 const cpuBurstHelper = require('./utils/cpuBurstHelper');
 
@@ -838,19 +839,19 @@ async function appDockerCreate(appSpecifications, appName, isComponent, fullAppS
   }
 
   let nodeId = null;
-  let nodeIP = null;
+  let nodeSocketAddr = null;
   let labels = null;
   if (syslogTarget && syslogIP) {
     const nodeCollateralInfo = await generalService.obtainNodeCollateralInformation().catch(() => { throw new Error('Host Identifier information not available at the moment'); });
     nodeId = nodeCollateralInfo.txhash + nodeCollateralInfo.txindex;
-    nodeIP = await fluxNetworkHelper.getMyFluxIPandPort();
-    if (!nodeIP) {
+    nodeSocketAddr = await fluxNetworkHelper.getLocalSocketAddress();
+    if (!nodeSocketAddr) {
       throw new Error('Not possible to get node IP');
     }
     labels = {
       app_name: `${appName}`,
       host_id: `${nodeId}`,
-      host_ip: `${nodeIP}`,
+      host_ip: `${nodeSocketAddr}`,
     };
   }
   log.info(`syslogTarget=${syslogTarget}, syslogIP=${syslogIP}`);
@@ -1011,8 +1012,8 @@ async function appDockerCreate(appSpecifications, appName, isComponent, fullAppS
   // via ${VAR} expansion in their own config files (e.g. Datadog's
   // DD_HOSTNAME=${FLUX_NODE_HOST_IP}). Appended last so they win over any
   // identically-named values supplied by the operator.
-  const myFluxIp = await fluxNetworkHelper.getMyFluxIPandPort();
-  const nodeHostIp = myFluxIp ? myFluxIp.split(':')[0] : null;
+  const localSocketAddr = await fluxNetworkHelper.getLocalSocketAddress();
+  const nodeHostIp = localSocketAddr ? extractIp(localSocketAddr) : null;
   if (nodeHostIp) {
     options.Env.push(`FLUX_NODE_HOST_IP=${nodeHostIp}`);
   } else {

--- a/ZelBack/src/services/explorerService.js
+++ b/ZelBack/src/services/explorerService.js
@@ -18,6 +18,7 @@ const registryManager = require('./appDatabase/registryManager');
 const advancedWorkflows = require('./appLifecycle/advancedWorkflows');
 const benchmarkService = require('./benchmarkService');
 const fluxNetworkhelper = require('./fluxNetworkHelper');
+const { extractIp } = require('./utils/socketAddressUtils');
 const fluxEventBus = require('./utils/fluxEventBus');
 const globalState = require('./utils/globalState');
 const { appSyncEvents, EVENTS: SYNC_EVENTS } = require('./utils/appSyncEvents');
@@ -658,16 +659,16 @@ async function processBlock(blockHeight, isInsightExplorer) {
           // we spread the network out (grouped by ip) over 4 hours so we don't
           // absolutely hammer the speedtest servers at the same time.
           const maxBenchDelay = 4 * 3_600_000;
-          const socketAddress = await fluxNetworkhelper.getMyFluxIPandPort();
+          const socketAddress = await fluxNetworkhelper.getLocalSocketAddress();
 
           // socketAddress can be null. If it is, we just use an empty string. This
           // has the effect of creating an initializer of just the block number. If
           // this happens, every node on the network that uses the block number will
           // run the bench at the same time. However this is an extreme edge case, as
           // all nodes should just return the ip.
-          const ip = socketAddress ? socketAddress.split(':')[0] : '';
+          const localIp = socketAddress ? extractIp(socketAddress) : '';
           // This is: string + number = string
-          const initializer = ip + blockDataVerbose.height;
+          const initializer = localIp + blockDataVerbose.height;
           const benchDelayMs = serviceHelper.randomDelayMs(maxBenchDelay, { initializer });
           const benchDelayS = Math.round((benchDelayMs / 1000) * 100) / 100;
 

--- a/ZelBack/src/services/fluxCommunication.js
+++ b/ZelBack/src/services/fluxCommunication.js
@@ -1482,7 +1482,7 @@ function getUnstableNodes(req, res) {
     if (entry.disconnects >= 5) {
       unstable.push({
         ip: extractIp(key),
-        port: extractPort(key),
+        port: String(extractPort(key)),
         disconnects: entry.disconnects,
         firstDisconnect: entry.firstDisconnect,
       });

--- a/ZelBack/src/services/fluxCommunication.js
+++ b/ZelBack/src/services/fluxCommunication.js
@@ -17,6 +17,7 @@ const { SIGTERM_EXPIRY_MS } = require('./utils/appConstants');
 const cacheManager = require('./utils/cacheManager').default;
 const networkStateService = require('./networkStateService');
 const nodeConfirmationService = require('./nodeConfirmationService');
+const { extractIp, extractPort, socketAddressesMatch } = require('./utils/socketAddressUtils');
 const registryManager = require('./appDatabase/registryManager');
 const fluxEventBus = require('./utils/fluxEventBus');
 const { appSyncEvents, EVENTS: SYNC_EVENTS } = require('./utils/appSyncEvents');
@@ -957,12 +958,12 @@ async function initiateAndHandleConnection(connection, source = PEER_SOURCE.RAND
     if (peerManager.has(key) || peerManager.isPending(key)) return;
     peerManager.markPending(key);
     if (!myPort) {
-      const myIP = await fluxNetworkHelper.getMyFluxIPandPort();
-      if (!myIP) {
+      const localSocketAddr = await fluxNetworkHelper.getLocalSocketAddress();
+      if (!localSocketAddr) {
         peerManager.clearPending(key);
         return;
       }
-      myPort = myIP.split(':')[1] || '16127';
+      myPort = extractPort(localSocketAddr);
     }
     const options = {
       handshakeTimeout: config.fluxapps.wsHandshakeTimeoutMs ?? 10000,
@@ -1179,32 +1180,32 @@ async function addOutgoingPeer(req, res) {
       const errMessage = messageHelper.createErrorMessage('No IP address specified.');
       return res.json(errMessage);
     }
-    const justIP = ip.split(':')[0];
+    const peerIp = extractIp(ip);
+    const peerPort = extractPort(ip);
 
     const remoteIP = req.ip || req.connection.remoteAddress || req.socket.remoteAddress || req.headers['x-forwarded-for'];
 
     const remoteIP4 = remoteIP.replace('::ffff:', '');
 
-    if (justIP !== remoteIP4) {
-      const errMessage = messageHelper.createErrorMessage(`Request ip ${remoteIP4} of ${remoteIP} doesn't match the ip: ${justIP} to connect.`);
+    if (peerIp !== remoteIP4) {
+      const errMessage = messageHelper.createErrorMessage(`Request ip ${remoteIP4} of ${remoteIP} doesn't match the ip: ${peerIp} to connect.`);
       return res.json(errMessage);
     }
-    const port = ip.split(':')[1] || '16127';
 
-    if (peerManager.has(`${justIP}:${port}`)) {
-      const errMessage = messageHelper.createErrorMessage(`Already connected to ${justIP}:${port}`);
+    if (peerManager.has(`${peerIp}:${peerPort}`)) {
+      const errMessage = messageHelper.createErrorMessage(`Already connected to ${peerIp}:${peerPort}`);
       return res.json(errMessage);
     }
 
     const nodeList = await fluxCommunicationUtils.deterministicFluxList();
-    const fluxNode = nodeList.find((node) => node.ip.split(':')[0] === ip.split(':')[0] && (node.ip.split(':')[1] || '16127') === port);
+    const fluxNode = nodeList.find((node) => socketAddressesMatch(node.ip, ip));
     if (!fluxNode) {
-      const errMessage = messageHelper.createErrorMessage(`FluxNode ${ip.split(':')[0]}:${port} is not confirmed on the network.`);
+      const errMessage = messageHelper.createErrorMessage(`FluxNode ${peerIp}:${peerPort} is not confirmed on the network.`);
       return res.json(errMessage);
     }
 
     initiateAndHandleConnection(ip, PEER_SOURCE.DETERMINISTIC);
-    const message = messageHelper.createSuccessMessage(`Outgoing connection to ${ip.split(':')[0]}:${port} initiated`);
+    const message = messageHelper.createSuccessMessage(`Outgoing connection to ${peerIp}:${peerPort} initiated`);
     return res.json(message);
   } catch (error) {
     log.error(error);
@@ -1251,9 +1252,9 @@ async function fluxDiscovery() {
       throw new Error('Node not confirmed. Flux discovery is awaiting.');
     }
 
-    const myIP = await fluxNetworkHelper.getMyFluxIPandPort();
+    const localSocketAddr = await fluxNetworkHelper.getLocalSocketAddress();
 
-    if (!myIP) {
+    if (!localSocketAddr) {
       throw new Error('Flux IP not detected. Flux discovery is awaiting.');
     }
 
@@ -1265,7 +1266,7 @@ async function fluxDiscovery() {
     peerManager.numberOfFluxNodes = sortedNodeList.length;
 
     log.info('Searching for my node on sortedNodeList');
-    const fluxNodeIndex = sortedNodeList.findIndex((ip) => ip === myIP);
+    const fluxNodeIndex = sortedNodeList.findIndex((addr) => socketAddressesMatch(addr, localSocketAddr));
     log.info(`My node was found on index: ${fluxNodeIndex} of ${sortedNodeList.length} nodes`);
     const minDeterministicOutPeers = Math.min(sortedNodeList.length, config.fluxapps.minOutgoing);
     // const minIncomingPeers = Math.min(sortedNodeList.length, 1.5 * config.fluxapps.minIncoming);
@@ -1274,21 +1275,21 @@ async function fluxDiscovery() {
     // always try to connect to deterministic nodes
     // established deterministic outgoing connections
     let deterministicPeerConnections = false;
-    const myIpGroup = FluxPeerManager.getIpGroup(myIP.split(':')[0]);
+    const myIpGroup = FluxPeerManager.getIpGroup(extractIp(localSocketAddr));
 
     // established deterministic 8 outgoing connections
     for (let i = 1; i <= minDeterministicOutPeers; i += 1) {
       const fixedIndex = fluxNodeIndex + i < sortedNodeList.length ? fluxNodeIndex + i : fluxNodeIndex + i - sortedNodeList.length;
-      const ip = sortedNodeList[fixedIndex];
-      const ipInc = ip.split(':')[0];
-      if (!ipInc || ipInc === myIP.split(':')[0]) {
+      const addr = sortedNodeList[fixedIndex];
+      const ipInc = extractIp(addr);
+      if (!ipInc || ipInc === extractIp(localSocketAddr)) {
         // eslint-disable-next-line no-continue
         continue;
       }
-      const portInc = ip.split(':')[1] || '16127';
+      const portInc = extractPort(addr);
       if (peerManager.shouldAttemptConnection(ipInc, portInc)) {
         deterministicPeerConnections = true;
-        initiateAndHandleConnection(ip, PEER_SOURCE.DETERMINISTIC);
+        initiateAndHandleConnection(addr, PEER_SOURCE.DETERMINISTIC);
         // eslint-disable-next-line no-await-in-loop
         await serviceHelper.delay(DISCOVERY.connectionDelayMs);
       }
@@ -1296,17 +1297,17 @@ async function fluxDiscovery() {
     // established deterministic 8 incoming connections
     for (let i = 1; i <= minDeterministicOutPeers; i += 1) {
       const fixedIndex = fluxNodeIndex - i >= 0 ? fluxNodeIndex - i : sortedNodeList.length + fluxNodeIndex - i;
-      const ip = sortedNodeList[fixedIndex];
-      const ipInc = ip.split(':')[0];
-      if (!ipInc || ipInc === myIP.split(':')[0]) {
+      const addr = sortedNodeList[fixedIndex];
+      const ipInc = extractIp(addr);
+      if (!ipInc || ipInc === extractIp(localSocketAddr)) {
         // eslint-disable-next-line no-continue
         continue;
       }
-      const portInc = ip.split(':')[1] || '16127';
+      const portInc = extractPort(addr);
       if (peerManager.shouldAttemptConnection(ipInc, portInc)) {
         // eslint-disable-next-line no-await-in-loop
         const result = await serviceHelper.axiosGet(
-          `http://${ipInc}:${portInc}/flux/addoutgoingpeer/${myIP}`,
+          `http://${ipInc}:${portInc}/flux/addoutgoingpeer/${localSocketAddr}`,
           { timeout: 5_000 },
         ).catch((error) => {
           peerManager.recordFailedConnection(ipInc, portInc);
@@ -1344,9 +1345,10 @@ async function fluxDiscovery() {
     while (peerManager.needsMorePeers(DIRECTION.OUTBOUND, outThresholds) && index < DISCOVERY.maxIterations) {
       index += 1;
       // eslint-disable-next-line no-await-in-loop
-      const connection = await networkStateService.getRandomSocketAddress(myIP);
+      const connection = await networkStateService.getRandomSocketAddress(localSocketAddr);
       if (connection) {
-        const [ipInc, portInc = '16127'] = connection.split(':');
+        const ipInc = extractIp(connection);
+        const portInc = extractPort(connection);
         if (!peerManager.canAcceptPeer(ipInc, portInc, DIRECTION.OUTBOUND, myIpGroup)) {
           // eslint-disable-next-line no-continue
           continue;
@@ -1371,9 +1373,10 @@ async function fluxDiscovery() {
     while (peerManager.needsMorePeers(DIRECTION.INBOUND, inThresholds) && index < DISCOVERY.maxIterations) {
       index += 1;
       // eslint-disable-next-line no-await-in-loop
-      const connection = await networkStateService.getRandomSocketAddress(myIP);
+      const connection = await networkStateService.getRandomSocketAddress(localSocketAddr);
       if (connection) {
-        const [ipInc, portInc = '16127'] = connection.split(':');
+        const ipInc = extractIp(connection);
+        const portInc = extractPort(connection);
         if (!peerManager.canAcceptPeer(ipInc, portInc, DIRECTION.INBOUND, myIpGroup)) {
           // eslint-disable-next-line no-continue
           continue;
@@ -1388,7 +1391,7 @@ async function fluxDiscovery() {
         triedIpGroups.add(ipGroup);
         // eslint-disable-next-line no-await-in-loop
         await serviceHelper.axiosGet(
-          `http://${ipInc}:${portInc}/flux/addoutgoingpeer/${myIP}`,
+          `http://${ipInc}:${portInc}/flux/addoutgoingpeer/${localSocketAddr}`,
           { timeout: 5_000 },
         ).catch((error) => log.error(error));
       }

--- a/ZelBack/src/services/fluxCommunication.js
+++ b/ZelBack/src/services/fluxCommunication.js
@@ -17,7 +17,7 @@ const { SIGTERM_EXPIRY_MS } = require('./utils/appConstants');
 const cacheManager = require('./utils/cacheManager').default;
 const networkStateService = require('./networkStateService');
 const nodeConfirmationService = require('./nodeConfirmationService');
-const { extractIp, extractPort, socketAddressesMatch } = require('./utils/socketAddressUtils');
+const { extractIp, extractPort, parseSocketAddress, socketAddressesMatch } = require('./utils/socketAddressUtils');
 const registryManager = require('./appDatabase/registryManager');
 const fluxEventBus = require('./utils/fluxEventBus');
 const { appSyncEvents, EVENTS: SYNC_EVENTS } = require('./utils/appSyncEvents');
@@ -825,12 +825,9 @@ async function removePeer(req, res) {
       return;
     }
 
-    const normalized = serviceHelper.normalizeNodeIpApiPort(
-      ip,
-      { portAsNumber: true },
-    );
+    const parsed = parseSocketAddress(ip);
 
-    if (!normalized) {
+    if (!parsed) {
       const unparsableError = messageHelper.createErrorMessage(
         'Unparsable `ip` parameter',
       );
@@ -838,7 +835,7 @@ async function removePeer(req, res) {
       return;
     }
 
-    const response = await fluxNetworkHelper.closeConnection(...normalized);
+    const response = await fluxNetworkHelper.closeConnection(parsed.ip, parsed.port);
 
     res.json(response);
   } catch (error) {
@@ -872,12 +869,9 @@ async function removeIncomingPeer(req, res) {
       return;
     }
 
-    const normalized = serviceHelper.normalizeNodeIpApiPort(
-      ip,
-      { portAsNumber: true },
-    );
+    const parsed = parseSocketAddress(ip);
 
-    if (!normalized) {
+    if (!parsed) {
       const unparsableError = messageHelper.createErrorMessage(
         'Unparsable `ip` parameter',
       );
@@ -885,7 +879,7 @@ async function removeIncomingPeer(req, res) {
       return;
     }
 
-    const response = await fluxNetworkHelper.closeIncomingConnection(...normalized);
+    const response = await fluxNetworkHelper.closeIncomingConnection(parsed.ip, parsed.port);
     res.json(response);
   } catch (error) {
     log.error(error);
@@ -947,13 +941,9 @@ function onOutboundUpgrade(response) {
 }
 
 async function initiateAndHandleConnection(connection, source = PEER_SOURCE.RANDOM) {
-  let ip = connection;
-  let port = config.server.apiport.toString();
+  const ip = extractIp(connection);
+  const port = extractPort(connection);
   try {
-    if (connection.includes(':')) {
-      ip = connection.split(':')[0];
-      port = connection.split(':')[1];
-    }
     const key = `${ip}:${port}`;
     if (peerManager.has(key) || peerManager.isPending(key)) return;
     peerManager.markPending(key);
@@ -1021,13 +1011,9 @@ async function initiateAndHandleConnection(connection, source = PEER_SOURCE.RAND
  */
 function openEphemeralConnection(connection) {
   return new Promise((resolve) => {
-    let ip = connection;
-    let port = config.server.apiport.toString();
+    const ip = extractIp(connection);
+    const port = extractPort(connection);
     try {
-      if (connection.includes(':')) {
-        ip = connection.split(':')[0];
-        port = connection.split(':')[1];
-      }
       const key = `${ip}:${port}`;
       if (peerManager.isPending(key)) {
         log.info(`Ephemeral connection to ${key} skipped: pending`);
@@ -1123,12 +1109,9 @@ async function addPeer(req, res) {
       return;
     }
 
-    const normalized = serviceHelper.normalizeNodeIpApiPort(
-      ip,
-      { portAsNumber: true },
-    );
+    const parsed = parseSocketAddress(ip);
 
-    if (!normalized) {
+    if (!parsed) {
       const unparsableError = messageHelper.createErrorMessage(
         'Unparsable `ip` parameter',
       );
@@ -1136,7 +1119,7 @@ async function addPeer(req, res) {
       return;
     }
 
-    const [peerIp, peerPort] = normalized;
+    const { ip: peerIp, port: peerPort } = parsed;
 
     if (peerManager.has(`${peerIp}:${peerPort}`)) {
       const errMessage = messageHelper.createErrorMessage(`Already connected to ${peerIp}:${peerPort}`);
@@ -1497,10 +1480,9 @@ function getUnstableNodes(req, res) {
   const unstable = [];
   for (const [key, entry] of peerManager.unstableEntries()) {
     if (entry.disconnects >= 5) {
-      const [ip, port] = key.split(':');
       unstable.push({
-        ip,
-        port,
+        ip: extractIp(key),
+        port: extractPort(key),
         disconnects: entry.disconnects,
         firstDisconnect: entry.firstDisconnect,
       });

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -24,6 +24,7 @@ const { CLOSE_CODES, DIRECTION } = require('./utils/FluxPeerSocket');
 const cacheManager = require('./utils/cacheManager').default;
 const networkStateService = require('./networkStateService');
 const fluxEventBus = require('./utils/fluxEventBus');
+const { normalizeSocketAddress, extractIp, extractPort, socketAddressesMatch } = require('./utils/socketAddressUtils');
 
 const isArcane = Boolean(process.env.FLUXOS_PATH);
 
@@ -45,8 +46,8 @@ let maxNumberOfIpChanges = 0;
 const myCache = cacheManager.ipCache;
 const { lruRateLimit } = require('./utils/rateLimit');
 
-// my external Flux IP from benchmark
-let myFluxIP = null;
+// This node's socket address (ip:port) from benchmark
+let localSocketAddress = null;
 
 /**
  * Converts a hexadecimal IP address (as found in /proc/net/route) to dotted decimal format.
@@ -322,7 +323,7 @@ async function isFluxAvailable(ip, port = config.server.apiport) {
     if (!config.server.allowedPorts.includes(+port)) {
       throw new Error('Invalid Port');
     }
-    const socketAddress = +port === config.server.apiport ? ip : `${ip}:${port}`;
+    const socketAddress = normalizeSocketAddress(`${ip}:${port}`);
     const isConfirmedNode = await fluxCommunicationUtils.socketAddressInFluxList(socketAddress);
     if (!isConfirmedNode) {
       return false;
@@ -565,13 +566,13 @@ async function keepUPNPPortsOpen(req, res) {
 }
 
 /**
- * Setter for myFluxIp.
+ * Setter for localSocketAddress.
  * Main goal for this is testing availability.
  *
- * @param {string} value new IP to be set
+ * @param {string} value ip or ip:port to be set (normalized to ip:port)
  */
-function setMyFluxIp(value) {
-  myFluxIP = value;
+function setLocalSocketAddress(value) {
+  localSocketAddress = value ? normalizeSocketAddress(value) : null;
 }
 
 /**
@@ -660,23 +661,18 @@ function isNodeDos() {
 }
 
 /**
- * To get Flux IP adress and port.
- * @returns {Promise<string>} IP address and port.
+ * Get this node's socket address (ip:port).
+ * @returns {Promise<string|null>} Normalized socket address (always ip:port) or null.
  */
-async function getMyFluxIPandPort() {
-  // I'm not sure of the intent here, but it does what it used to do.
-  // Fetches the ip, sets the ip to the fetched value on success, or sets
-  // it to null on error.
-  //
-  // I'm not sure we should be setting it to null, a bench call could fail
-  // for whatever reason, I believe we should only be setting this on success,
-  // or we should count failures to allow for bad rpc calls.
+async function getLocalSocketAddress() {
   const benchmarkResponse = await benchmarkService.getBenchmarks();
   const { status, data: { ipaddress = null } = {} } = benchmarkResponse;
-  const ip = status === 'success' ? ipaddress : null;
-
-  setMyFluxIp(ip);
-  return ip;
+  if (status !== 'success' || !ipaddress) {
+    setLocalSocketAddress(null);
+    return null;
+  }
+  setLocalSocketAddress(ipaddress);
+  return localSocketAddress;
 }
 
 /**
@@ -1136,8 +1132,8 @@ async function adjustExternalIP(ip) {
 
     if (oldUserConfigIp && v4exact.test(oldUserConfigIp) && !myCache.has(ip)) {
       myCache.set(ip, '');
-      const newIP = userconfig.initial.apiport !== 16127 ? `${ip}:${userconfig.initial.apiport}` : ip;
-      const oldIP = userconfig.initial.apiport !== 16127 ? `${oldUserConfigIp}:${userconfig.initial.apiport}` : oldUserConfigIp;
+      const newIP = normalizeSocketAddress(`${ip}:${userconfig.initial.apiport}`);
+      const oldIP = normalizeSocketAddress(`${oldUserConfigIp}:${userconfig.initial.apiport}`);
       log.info(`New public Ip detected: ${newIP}, old Ip: ${oldIP} , updating the FluxNode info on the network`);
       const measuredUptime = fluxUptime();
       if (await ipChangesOverLimit() && measuredUptime.status === 'success' && measuredUptime.data > config.fluxapps.minUpTime) {
@@ -1190,8 +1186,8 @@ async function adjustExternalIP(ip) {
 
           // eslint-disable-next-line no-await-in-loop
           const runningAppList = await registryManager.appLocation(app.name);
-          const findMyIP = runningAppList.find((instance) => instance.ip.split(':')[0] === ip);
-          if (findMyIP) {
+          const duplicateInstance = runningAppList.find((instance) => extractIp(instance.ip) === ip);
+          if (duplicateInstance) {
             log.info(`Aplication: ${app.name}, was found on the network already running under the same ip, uninstalling app`);
             log.warn(`REMOVAL REASON: Duplicate IP detected - ${app.name} already running on network with IP ${ip} (after IP change)`);
             // eslint-disable-next-line no-await-in-loop
@@ -1242,7 +1238,7 @@ async function checkMyFluxAvailability(retryNumber = 0) {
     return false;
   }
 
-  if (myFluxIP === null) return false;
+  if (localSocketAddress === null) return false;
 
   let userBlockedPorts = userconfig.initial.blockedPorts || [];
   userBlockedPorts = serviceHelper.ensureObject(userBlockedPorts);
@@ -1268,18 +1264,20 @@ async function checkMyFluxAvailability(retryNumber = 0) {
   }
 
   const randomSocketAddress = await networkStateService.getRandomSocketAddress(
-    myFluxIP,
+    localSocketAddress,
   );
 
   if (!randomSocketAddress) return false;
 
-  const [remoteIp, remotePort = '16127'] = randomSocketAddress.split(':');
+  const remoteIp = extractIp(randomSocketAddress);
+  const remotePort = extractPort(randomSocketAddress);
 
   const axiosConfig = {
     timeout: 7000,
   };
 
-  const [localIp, localApiPort = '16127'] = myFluxIP.split(':');
+  const localIp = extractIp(localSocketAddress);
+  const localApiPort = extractPort(localSocketAddress);
 
   const url = `http://${remoteIp}:${remotePort}/flux/`
     + `checkfluxavailability?ip=${localIp}&port=${localApiPort}`;
@@ -1315,14 +1313,14 @@ async function checkMyFluxAvailability(retryNumber = 0) {
       if (benchIpResponse.status === 'success') {
         log.info(`FluxBench reported public IP: ${benchIpResponse.data}`);
         const benchMyIP = benchIpResponse.data.length > 5 ? benchIpResponse.data : null;
-        if (benchMyIP && benchMyIP.split(':')[0] !== localIp) {
+        if (benchMyIP && extractIp(benchMyIP) !== localIp) {
           daemonServiceUtils.setStandardCache('getbenchmarks[]', null);
           log.info('New IP found... updating network');
           dosState = 0;
           setDosMessage(null);
-          await adjustExternalIP(benchMyIP.split(':')[0]);
+          await adjustExternalIP(extractIp(benchMyIP));
           return true;
-        } if (benchMyIP && benchMyIP.split(':')[0] === localIp) {
+        } if (benchMyIP && extractIp(benchMyIP) === localIp) {
           log.info('FluxBench reported the same Ip that was already in use');
         } else {
           log.info('FluxBench reported a invalid IP');
@@ -1352,7 +1350,7 @@ async function checkMyFluxAvailability(retryNumber = 0) {
   }
   const measuredUptime = fluxUptime();
   if (measuredUptime.status === 'success' && measuredUptime.data > config.fluxapps.minUpTime) { // node has been running for 30 minutes. Upon starting a node, there can be dos that needs resetting
-    const found = await fluxCommunicationUtils.getFluxnodeFromFluxList(myFluxIP);
+    const found = await fluxCommunicationUtils.getFluxnodeFromFluxList(localSocketAddress);
     const nodeCount = await fluxCommunicationUtils.getNodeCount();
 
     if (nodeCount > config.fluxapps.minIncoming + config.fluxapps.minOutgoing && found) { // our node MUST be in confirmed list in order to have some peers
@@ -1392,8 +1390,8 @@ async function checkDeterministicNodesCollisions() {
     // get node list with filter on this ip address
     // if it returns more than 1 object, shut down.
     // another precatuion might be comparing node list on multiple nodes. evaulate in the future
-    const myIP = await getMyFluxIPandPort();
-    if (myIP) {
+    const localSocketAddr = await getLocalSocketAddress();
+    if (localSocketAddr) {
       const syncStatus = daemonServiceMiscRpcs.isDaemonSynced();
       if (!syncStatus.data.synced) {
         setTimeout(() => {
@@ -1402,12 +1400,12 @@ async function checkDeterministicNodesCollisions() {
         return;
       }
       const nodeList = await fluxCommunicationUtils.deterministicFluxList();
-      const result = nodeList.filter((node) => node.ip === myIP);
+      const result = nodeList.filter((node) => socketAddressesMatch(node.ip, localSocketAddr));
       const nodeStatus = await daemonServiceFluxnodeRpcs.getFluxNodeStatus();
       if (nodeStatus.status === 'success') { // different scenario is caught elsewhere
         const myCollateral = nodeStatus.data.collateral;
         const myNode = result.find((node) => node.collateral === myCollateral);
-        const nodeCollateralDifferentIp = nodeList.find((node) => node.collateral === myCollateral && node.ip !== myIP);
+        const nodeCollateralDifferentIp = nodeList.find((node) => node.collateral === myCollateral && !socketAddressesMatch(node.ip, localSocketAddr));
         if (result.length > 1) {
           log.warn('Multiple Flux Node instances detected');
           if (myNode) {
@@ -1415,9 +1413,9 @@ async function checkDeterministicNodesCollisions() {
             const filterEarlierSame = result.filter((node) => (node.readded_confirmed_height || node.confirmed_height) <= myBlockHeight);
             // keep running only older collaterals
             if (filterEarlierSame.length >= 1) {
-              log.error(`Flux earlier collision detection on ip:${myIP}`);
+              log.error(`Flux earlier collision detection on ip:${localSocketAddr}`);
               dosState = 100;
-              setDosMessage(`Flux earlier collision detection on ip:${myIP}`);
+              setDosMessage(`Flux earlier collision detection on ip:${localSocketAddr}`);
               setTimeout(() => {
                 checkDeterministicNodesCollisions();
               }, 60 * 1000);
@@ -1438,8 +1436,8 @@ async function checkDeterministicNodesCollisions() {
         }
         if (nodeStatus.data.status === 'CONFIRMED' && nodeCollateralDifferentIp) {
           let errorCall = false;
-          const askingIP = nodeCollateralDifferentIp.ip.split(':')[0];
-          const askingIpPort = nodeCollateralDifferentIp.ip.split(':')[1] || '16127';
+          const askingIP = extractIp(nodeCollateralDifferentIp.ip);
+          const askingIpPort = extractPort(nodeCollateralDifferentIp.ip);
           log.info(`Detected same collateral on different IP: ${askingIP}:${askingIpPort}. Checking if other node is reachable...`);
 
           // First reachability check
@@ -1485,11 +1483,11 @@ async function checkDeterministicNodesCollisions() {
       // check via the confirmed-list gate in isFluxAvailable. Skip to avoid
       // spamming the network with requests that will always fail.
       const isConfirmed = nodeStatus.data?.status === 'CONFIRMED';
-      const inConfirmedList = await fluxCommunicationUtils.socketAddressInFluxList(myIP);
+      const inConfirmedList = await fluxCommunicationUtils.socketAddressInFluxList(localSocketAddr);
       if (!isConfirmed || !inConfirmedList) {
         const reason = !isConfirmed
           ? `Node status is ${nodeStatus.data?.status}`
-          : `Our IP ${myIP} is not in the confirmed flux list`;
+          : `Our IP ${localSocketAddr} is not in the confirmed flux list`;
         log.warn(`${reason}. Skipping remote availability check.`);
         setTimeout(() => {
           checkDeterministicNodesCollisions();
@@ -2220,7 +2218,7 @@ function getNumberOfPeers() {
 module.exports = {
   isFluxAvailable,
   checkFluxAvailability,
-  getMyFluxIPandPort,
+  getLocalSocketAddress,
   getFluxNodePrivateKey,
   getFluxNodePublicKey,
   checkDeterministicNodesCollisions,
@@ -2250,7 +2248,7 @@ module.exports = {
   parseTimesyncOffset,
   setStoredFluxBenchAllowed,
   getStoredFluxBenchAllowed,
-  setMyFluxIp,
+  setLocalSocketAddress,
   getDosMessage,
   setDosMessage,
   setDosStateValue,

--- a/ZelBack/src/services/fluxNodeService.js
+++ b/ZelBack/src/services/fluxNodeService.js
@@ -10,6 +10,7 @@ const log = require('../lib/log');
 const messageHelper = require('./messageHelper');
 const geolocationService = require('./geolocationService');
 const fluxNetworkHelper = require('./fluxNetworkHelper');
+const { extractIp } = require('./utils/socketAddressUtils');
 const generalService = require('./generalService');
 const dockerService = require('./dockerService');
 const benchmarkService = require('./benchmarkService');
@@ -29,14 +30,14 @@ async function getHostInfo(req, res) {
       hostInfo.appName = app;
       const nodeCollateralInfo = await generalService.obtainNodeCollateralInformation().catch(() => { throw new Error('Host Identifier information not available at the moment'); });
       hostInfo.id = nodeCollateralInfo.txhash + nodeCollateralInfo.txindex;
-      const myIP = await fluxNetworkHelper.getMyFluxIPandPort();
-      if (myIP) {
-        hostInfo.ip = myIP.split(':')[0];
-        const myGeo = await geolocationService.getNodeGeolocation();
-        if (myGeo) {
-          delete myGeo.ip;
-          delete myGeo.org;
-          hostInfo.geo = myGeo;
+      const localSocketAddr = await fluxNetworkHelper.getLocalSocketAddress();
+      if (localSocketAddr) {
+        hostInfo.ip = extractIp(localSocketAddr);
+        const nodeGeo = await geolocationService.getNodeGeolocation();
+        if (nodeGeo) {
+          delete nodeGeo.ip;
+          delete nodeGeo.org;
+          hostInfo.geo = nodeGeo;
         } else {
           throw new Error('Geolocation information not available at the moment');
         }

--- a/ZelBack/src/services/fluxService.js
+++ b/ZelBack/src/services/fluxService.js
@@ -656,15 +656,8 @@ function getNodeJsVersions(req, res) {
  * @returns {Promise<object>} Message.
  */
 async function getFluxIP(req, res) {
-  const benchmarkResponse = await benchmarkService.getBenchmarks();
-  let myIP = null;
-  if (benchmarkResponse.status === 'success') {
-    const benchmarkResponseData = benchmarkResponse.data;
-    if (benchmarkResponseData.ipaddress) {
-      myIP = benchmarkResponseData.ipaddress.length > 5 ? benchmarkResponseData.ipaddress : null;
-    }
-  }
-  const message = messageHelper.createDataMessage(myIP);
+  const localSocketAddr = await fluxNetworkHelper.getLocalSocketAddress();
+  const message = messageHelper.createDataMessage(localSocketAddr);
   return res ? res.json(message) : message;
 }
 

--- a/ZelBack/src/services/geolocationService.js
+++ b/ZelBack/src/services/geolocationService.js
@@ -97,7 +97,7 @@ async function setNodeGeolocation() {
     const previousIp = storedGeolocation ? storedGeolocation.ip : null;
 
     if (!storedGeolocation || localSocketAddr !== storedIp || execution % 4 === 0) {
-      log.info(`Checking geolocation of ${localSocketAddr}`);
+      log.info(`Checking geolocation of ${localIp}`);
       storedIp = localSocketAddr;
       // consider another service failover or stats db
       const ipApiUrl = `${config.geolocation.ipApiBaseUrl}/json/${localIp}?fields=status,continent,continentCode,country,countryCode,region,regionName,lat,lon,query,org,isp,proxy,hosting`;
@@ -136,11 +136,11 @@ async function setNodeGeolocation() {
             dataCenter: statsRes.data.data.dataCenter,
           };
         } else {
-          throw new Error(`Geolocation of IP ${localSocketAddr} is unavailable`);
+          throw new Error(`Geolocation of IP ${localIp} is unavailable`);
         }
       }
     }
-    log.info(`Geolocation of ${localSocketAddr} is ${JSON.stringify(storedGeolocation)}`);
+    log.info(`Geolocation of ${localIp} is ${JSON.stringify(storedGeolocation)}`);
 
     // Check if IP has changed
     const currentIp = storedGeolocation.ip;

--- a/ZelBack/src/services/geolocationService.js
+++ b/ZelBack/src/services/geolocationService.js
@@ -1,6 +1,7 @@
 const config = require('config');
 const log = require('../lib/log');
 const fluxNetworkHelper = require('./fluxNetworkHelper');
+const { extractIp } = require('./utils/socketAddressUtils');
 const serviceHelper = require('./serviceHelper');
 const dbHelper = require('./dbHelper');
 
@@ -81,8 +82,8 @@ async function getGeolocationFromDb() {
  */
 async function setNodeGeolocation() {
   try {
-    const myIP = await fluxNetworkHelper.getMyFluxIPandPort();
-    if (!myIP) {
+    const localSocketAddr = await fluxNetworkHelper.getLocalSocketAddress();
+    if (!localSocketAddr) {
       log.error('Flux IP not detected. Flux geolocation service is awaiting');
       setTimeout(() => {
         setNodeGeolocation();
@@ -90,14 +91,16 @@ async function setNodeGeolocation() {
       return;
     }
 
+    const localIp = extractIp(localSocketAddr);
+
     // Store previous IP to detect changes
     const previousIp = storedGeolocation ? storedGeolocation.ip : null;
 
-    if (!storedGeolocation || myIP !== storedIp || execution % 4 === 0) {
-      log.info(`Checking geolocation of ${myIP}`);
-      storedIp = myIP;
+    if (!storedGeolocation || localSocketAddr !== storedIp || execution % 4 === 0) {
+      log.info(`Checking geolocation of ${localSocketAddr}`);
+      storedIp = localSocketAddr;
       // consider another service failover or stats db
-      const ipApiUrl = `${config.geolocation.ipApiBaseUrl}/json/${myIP.split(':')[0]}?fields=status,continent,continentCode,country,countryCode,region,regionName,lat,lon,query,org,isp,proxy,hosting`;
+      const ipApiUrl = `${config.geolocation.ipApiBaseUrl}/json/${localIp}?fields=status,continent,continentCode,country,countryCode,region,regionName,lat,lon,query,org,isp,proxy,hosting`;
       const ipRes = await serviceHelper.axiosGet(ipApiUrl);
       if (ipRes.data.status === 'success' && ipRes.data.query !== '') {
         storedGeolocation = {
@@ -115,7 +118,7 @@ async function setNodeGeolocation() {
           dataCenter: ipRes.data.hosting,
         };
       } else {
-        const statsApiUrl = `${config.geolocation.statsApiBaseUrl}/fluxlocation/${myIP.split(':')[0]}`;
+        const statsApiUrl = `${config.geolocation.statsApiBaseUrl}/fluxlocation/${localIp}`;
         const statsRes = await serviceHelper.axiosGet(statsApiUrl);
         if (statsRes.data.status === 'success' && statsRes.data.data) {
           storedGeolocation = {
@@ -133,11 +136,11 @@ async function setNodeGeolocation() {
             dataCenter: statsRes.data.data.dataCenter,
           };
         } else {
-          throw new Error(`Geolocation of IP ${myIP} is unavailable`);
+          throw new Error(`Geolocation of IP ${localSocketAddr} is unavailable`);
         }
       }
     }
-    log.info(`Geolocation of ${myIP} is ${JSON.stringify(storedGeolocation)}`);
+    log.info(`Geolocation of ${localSocketAddr} is ${JSON.stringify(storedGeolocation)}`);
 
     // Check if IP has changed
     const currentIp = storedGeolocation.ip;

--- a/ZelBack/src/services/networkStateService.js
+++ b/ZelBack/src/services/networkStateService.js
@@ -1,6 +1,6 @@
 const daemonServiceFluxnodeRpcs = require('./daemonService/daemonServiceFluxnodeRpcs');
 const networkStateManager = require('./utils/networkStateManager');
-const { normalizeSocketAddress, extractIp } = require('./utils/socketAddressUtils');
+const { normalizeSocketAddress, extractIp, extractPort, DEFAULT_API_PORT } = require('./utils/socketAddressUtils');
 
 /**
  * @typedef {import('./utils/networkStateManager').Fluxnode} Fluxnode
@@ -143,10 +143,12 @@ async function socketAddressInNetworkState(socketAddress) {
   const found = await stateManager.includes(socketAddress, 'socketAddress');
   if (found) return true;
 
-  const normalized = normalizeSocketAddress(socketAddress);
-  const bareIp = extractIp(socketAddress);
-  const alt = normalized === socketAddress ? bareIp : normalized;
-  if (alt) return stateManager.includes(alt, 'socketAddress');
+  if (extractPort(socketAddress) === DEFAULT_API_PORT) {
+    const normalized = normalizeSocketAddress(socketAddress);
+    const bareIp = extractIp(socketAddress);
+    const alt = normalized === socketAddress ? bareIp : normalized;
+    if (alt) return stateManager.includes(alt, 'socketAddress');
+  }
 
   return false;
 }

--- a/ZelBack/src/services/networkStateService.js
+++ b/ZelBack/src/services/networkStateService.js
@@ -1,5 +1,6 @@
 const daemonServiceFluxnodeRpcs = require('./daemonService/daemonServiceFluxnodeRpcs');
 const networkStateManager = require('./utils/networkStateManager');
+const { normalizeSocketAddress, extractIp } = require('./utils/socketAddressUtils');
 
 /**
  * @typedef {import('./utils/networkStateManager').Fluxnode} Fluxnode
@@ -133,29 +134,18 @@ async function getFluxnodesByPubkey(pubkey) {
  * @param {string} socketAddress
  * @returns {Promise<boolean>}
  */
-// TODO: Remove once all nodes run fluxbench with always-attached port.
-// During the transition, the node list may contain either "ip" (old format)
-// or "ip:16127" (new format) for default-port nodes. This function checks
-// both formats so the lookup works regardless of which fluxbench version
-// produced the entry.
-function defaultPortAltAddress(socketAddress) {
-  const DEFAULT_API_PORT = 16127;
-  if (socketAddress.includes(':')) {
-    const [ip, port] = socketAddress.split(':');
-    if (+port === DEFAULT_API_PORT) return ip;
-  } else {
-    return `${socketAddress}:${DEFAULT_API_PORT}`;
-  }
-  return null;
-}
-
+// TODO: Remove alt-format lookup once all nodes run fluxbench with
+// always-attached port. During the transition, the node list may contain
+// either "ip" or "ip:16127" for default-port nodes.
 async function socketAddressInNetworkState(socketAddress) {
   if (!stateManager) return false;
 
   const found = await stateManager.includes(socketAddress, 'socketAddress');
   if (found) return true;
 
-  const alt = defaultPortAltAddress(socketAddress);
+  const normalized = normalizeSocketAddress(socketAddress);
+  const bareIp = extractIp(socketAddress);
+  const alt = normalized === socketAddress ? bareIp : normalized;
   if (alt) return stateManager.includes(alt, 'socketAddress');
 
   return false;

--- a/ZelBack/src/services/networkStateService.js
+++ b/ZelBack/src/services/networkStateService.js
@@ -133,12 +133,32 @@ async function getFluxnodesByPubkey(pubkey) {
  * @param {string} socketAddress
  * @returns {Promise<boolean>}
  */
+// TODO: Remove once all nodes run fluxbench with always-attached port.
+// During the transition, the node list may contain either "ip" (old format)
+// or "ip:16127" (new format) for default-port nodes. This function checks
+// both formats so the lookup works regardless of which fluxbench version
+// produced the entry.
+function defaultPortAltAddress(socketAddress) {
+  const DEFAULT_API_PORT = 16127;
+  if (socketAddress.includes(':')) {
+    const [ip, port] = socketAddress.split(':');
+    if (+port === DEFAULT_API_PORT) return ip;
+  } else {
+    return `${socketAddress}:${DEFAULT_API_PORT}`;
+  }
+  return null;
+}
+
 async function socketAddressInNetworkState(socketAddress) {
   if (!stateManager) return false;
 
   const found = await stateManager.includes(socketAddress, 'socketAddress');
+  if (found) return true;
 
-  return found;
+  const alt = defaultPortAltAddress(socketAddress);
+  if (alt) return stateManager.includes(alt, 'socketAddress');
+
+  return false;
 }
 
 /**

--- a/ZelBack/src/services/nodeConfirmationService.js
+++ b/ZelBack/src/services/nodeConfirmationService.js
@@ -132,9 +132,9 @@ async function poll() {
       }
     }
 
-    const myIP = await fluxNetworkHelper.getMyFluxIPandPort();
-    if (myIP && ourPubkey) {
-      const node = await networkStateService.getFluxnodeBySocketAddress(myIP);
+    const localSocketAddr = await fluxNetworkHelper.getLocalSocketAddress();
+    if (localSocketAddr && ourPubkey) {
+      const node = await networkStateService.getFluxnodeBySocketAddress(localSocketAddr);
       if (node && node.pubkey === ourPubkey) {
         newMessageCapable = true;
       }

--- a/ZelBack/src/services/serviceHelper.js
+++ b/ZelBack/src/services/serviceHelper.js
@@ -582,29 +582,6 @@ async function runCommand(userCmd, options = {}) {
   return res;
 }
 
-/**
- *
- * @param {string} raw A possible Fluxnode socket address. I.e. 1.2.3.4:16147
- * @param {{portAsNumber?: boolean}} options
- * @returns {Array<string, number | string> | null} The ip as a string, and the
- * port as either a number or string (depending on portAsNumber) If the input is
- * unparsable - returns null
- */
-function normalizeNodeIpApiPort(raw, options = {}) {
-  const portAsNumber = options.portAsNumber || false;
-
-  if (typeof raw !== 'string') return null;
-
-  const ipPattern = /^(?!0)(?!.*\.$)(?:(?:1?\d?\d|25[0-5]|2[0-4]\d)(?:\.|$)){4}$/;
-  const portPattern = /^(?:6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{0,3})(?:\s?,\s?(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{0,3}))*$/;
-  const [ip, port = '16127'] = raw.split(':');
-
-  if (!ipPattern.test(ip) || !portPattern.test(port)) return null;
-
-  const castPort = portAsNumber ? Number(port) : port;
-
-  return [ip, castPort];
-}
 
 /**
  * Parses a raw version string from dpkg-query into an object
@@ -735,5 +712,4 @@ module.exports = {
   randomDelayMs,
   runCommand,
   validIpv4Address,
-  normalizeNodeIpApiPort,
 };

--- a/ZelBack/src/services/utils/FluxPeerManager.js
+++ b/ZelBack/src/services/utils/FluxPeerManager.js
@@ -3,6 +3,7 @@ const config = require('config');
 const log = require('../../lib/log');
 const serviceHelper = require('../serviceHelper');
 const { FluxPeerSocket, CLOSE_CODES, PEER_SOURCE, DIRECTION, FLUX_VERSION, FLUX_CAPABILITIES } = require('./FluxPeerSocket');
+const { DEFAULT_API_PORT } = require('./socketAddressUtils');
 const peerCodec = require('./peerCodec');
 const fluxEventBus = require('./fluxEventBus');
 
@@ -803,9 +804,9 @@ class FluxPeerManager extends EventEmitter {
       if (typeof optionalPort === 'object' && optionalPort !== null) {
         // No :port in route — optionalPort is actually the request
         req = optionalPort;
-        port = '16127';
+        port = String(DEFAULT_API_PORT);
       } else {
-        port = optionalPort || '16127';
+        port = optionalPort || String(DEFAULT_API_PORT);
         req = request;
       }
 

--- a/ZelBack/src/services/utils/appUtilities.js
+++ b/ZelBack/src/services/utils/appUtilities.js
@@ -1089,11 +1089,11 @@ function parseContainerName(containerName) {
   };
 }
 
-async function appHasValidLocationOnNode(appName, myIp) {
+async function appHasValidLocationOnNode(appName, localSocketAddr) {
   try {
     const db = dbHelper.databaseConnection();
     const database = db.db(config.database.appsglobal.database);
-    const query = { name: appName, ip: myIp };
+    const query = { name: appName, ip: localSocketAddr };
     const projection = { _id: 0, expireAt: 1 };
     const records = await dbHelper.findInDatabase(database, globalAppsLocations, query, projection);
     if (!records || records.length === 0) {

--- a/ZelBack/src/services/utils/socketAddressUtils.js
+++ b/ZelBack/src/services/utils/socketAddressUtils.js
@@ -23,9 +23,19 @@ function extractPort(address) {
   return parts.length > 1 ? +parts[1] : DEFAULT_API_PORT;
 }
 
+const ipPattern = /^(?!0)(?!.*\.$)(?:(?:1?\d?\d|25[0-5]|2[0-4]\d)(?:\.|$)){4}$/;
+
+function parseSocketAddress(raw) {
+  if (typeof raw !== 'string') return null;
+  const ip = extractIp(raw);
+  const port = extractPort(raw);
+  if (!ipPattern.test(ip) || !Number.isInteger(port) || port < 1 || port > 65535) return null;
+  return { ip, port };
+}
+
 function socketAddressesMatch(a, b) {
-  if (a === b) return true;
   if (!a || !b) return false;
+  if (a === b) return true;
   const normalA = normalizeSocketAddress(a);
   const normalB = normalizeSocketAddress(b);
   return normalA === normalB;
@@ -36,5 +46,6 @@ module.exports = {
   normalizeSocketAddress,
   extractIp,
   extractPort,
+  parseSocketAddress,
   socketAddressesMatch,
 };

--- a/ZelBack/src/services/utils/socketAddressUtils.js
+++ b/ZelBack/src/services/utils/socketAddressUtils.js
@@ -1,0 +1,40 @@
+// Socket address utility functions for consistent ip:port handling.
+//
+// TODO: Once all nodes run fluxbench with always-attached port,
+// normalizeSocketAddress becomes a no-op and socketAddressesMatch
+// becomes ===. At that point simplify or remove this module.
+
+const DEFAULT_API_PORT = 16127;
+
+function normalizeSocketAddress(address) {
+  if (!address) return null;
+  if (address.includes(':')) return address;
+  return `${address}:${DEFAULT_API_PORT}`;
+}
+
+function extractIp(address) {
+  if (!address) return null;
+  return address.split(':')[0];
+}
+
+function extractPort(address) {
+  if (!address) return DEFAULT_API_PORT;
+  const parts = address.split(':');
+  return parts.length > 1 ? +parts[1] : DEFAULT_API_PORT;
+}
+
+function socketAddressesMatch(a, b) {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  const normalA = normalizeSocketAddress(a);
+  const normalB = normalizeSocketAddress(b);
+  return normalA === normalB;
+}
+
+module.exports = {
+  DEFAULT_API_PORT,
+  normalizeSocketAddress,
+  extractIp,
+  extractPort,
+  socketAddressesMatch,
+};

--- a/ZelBack/src/services/utils/socketAddressUtils.js
+++ b/ZelBack/src/services/utils/socketAddressUtils.js
@@ -24,13 +24,16 @@ function extractPort(address) {
 }
 
 const ipPattern = /^(?!0)(?!.*\.$)(?:(?:1?\d?\d|25[0-5]|2[0-4]\d)(?:\.|$)){4}$/;
+const portPattern = /^([1-9]\d{0,3}|[1-5]\d{4}|6[0-4]\d{3}|65[0-4]\d{2}|655[0-2]\d|6553[0-5])$/;
 
 function parseSocketAddress(raw) {
   if (typeof raw !== 'string') return null;
-  const ip = extractIp(raw);
-  const port = extractPort(raw);
-  if (!ipPattern.test(ip) || !Number.isInteger(port) || port < 1 || port > 65535) return null;
-  return { ip, port };
+  const parts = raw.split(':');
+  if (parts.length > 2) return null;
+  const ip = parts[0];
+  const portStr = parts[1] || String(DEFAULT_API_PORT);
+  if (!ipPattern.test(ip) || !portPattern.test(portStr)) return null;
+  return { ip, port: +portStr };
 }
 
 function socketAddressesMatch(a, b) {

--- a/ZelBack/src/services/utils/socketAddressUtils.js
+++ b/ZelBack/src/services/utils/socketAddressUtils.js
@@ -20,7 +20,7 @@ function extractIp(address) {
 function extractPort(address) {
   if (!address) return DEFAULT_API_PORT;
   const parts = address.split(':');
-  return parts.length > 1 ? +parts[1] : DEFAULT_API_PORT;
+  return parts.length > 1 && +parts[1] ? +parts[1] : DEFAULT_API_PORT;
 }
 
 const ipPattern = /^(?!0)(?!.*\.$)(?:(?:1?\d?\d|25[0-5]|2[0-4]\d)(?:\.|$)){4}$/;

--- a/apiServer.js
+++ b/apiServer.js
@@ -389,7 +389,7 @@ async function handleSigterm() {
     if (runningAppsCache.size > 0) {
       log.info(`Node was running ${runningAppsCache.size} apps, broadcasting shutdown notification to peers...`);
 
-      const ip = await fluxNetworkHelper.getMyFluxIPandPort();
+      const ip = await fluxNetworkHelper.getLocalSocketAddress();
       if (ip) {
         const sigtermMessage = {
           type: 'fluxnodesigterm',

--- a/tests/unit/advancedWorkflows.test.js
+++ b/tests/unit/advancedWorkflows.test.js
@@ -1022,7 +1022,7 @@ describe('advancedWorkflows tests', () => {
       });
 
       const fluxNetworkHelper = require('../../ZelBack/src/services/fluxNetworkHelper');
-      fluxNetworkHelperStub = sinon.stub(fluxNetworkHelper, 'getMyFluxIPandPort');
+      fluxNetworkHelperStub = sinon.stub(fluxNetworkHelper, 'getLocalSocketAddress');
 
       const registryManager = require('../../ZelBack/src/services/appDatabase/registryManager');
       registryManagerStub = sinon.stub(registryManager, 'appLocation');

--- a/tests/unit/appController.test.js
+++ b/tests/unit/appController.test.js
@@ -531,7 +531,7 @@ describe('appController tests', () => {
         { ip: '192.168.1.2:16127', name: 'TestApp' },
       ];
       sinon.stub(dbHelper, 'findInDatabase').resolves(locations);
-      sinon.stub(fluxNetworkHelper, 'getMyFluxIPandPort').resolves('192.168.1.3:16127');
+      sinon.stub(fluxNetworkHelper, 'getLocalSocketAddress').resolves('192.168.1.3:16127');
     });
 
     it('should execute command on all app instances', async () => {
@@ -553,7 +553,7 @@ describe('appController tests', () => {
       sinon.stub(dbHelper, 'findInDatabase').resolves(locations);
       // eslint-disable-next-line global-require, no-shadow
       const fluxNetworkHelper = require('../../ZelBack/src/services/fluxNetworkHelper');
-      sinon.stub(fluxNetworkHelper, 'getMyFluxIPandPort').resolves('192.168.1.3:16127');
+      sinon.stub(fluxNetworkHelper, 'getLocalSocketAddress').resolves('192.168.1.3:16127');
 
       // eslint-disable-next-line global-require
       const axios = require('axios');

--- a/tests/unit/appHashSyncService.test.js
+++ b/tests/unit/appHashSyncService.test.js
@@ -145,7 +145,7 @@ describe('appHashSyncService tests', () => {
       '../utils/FluxPeerSocket': { CLOSE_CODES: { EPHEMERAL_DONE: 4020 } },
       '../fluxCommunicationUtils': { deterministicFluxList: sinon.stub().resolves([]) },
       '../fluxCommunication': { openEphemeralConnection: sinon.stub().resolves(null) },
-      '../fluxNetworkHelper': { getMyFluxIPandPort: sinon.stub().resolves('10.0.0.99:16127') },
+      '../fluxNetworkHelper': { getLocalSocketAddress: sinon.stub().resolves('10.0.0.99:16127') },
     });
   });
 
@@ -240,7 +240,7 @@ describe('appHashSyncService tests', () => {
         '../utils/FluxPeerSocket': { CLOSE_CODES: { EPHEMERAL_DONE: 4020 } },
         '../fluxCommunicationUtils': { deterministicFluxList: sinon.stub().resolves([]) },
         '../fluxCommunication': { openEphemeralConnection: sinon.stub().resolves(null) },
-        '../fluxNetworkHelper': { getMyFluxIPandPort: sinon.stub().resolves('10.0.0.99:16127') },
+        '../fluxNetworkHelper': { getLocalSocketAddress: sinon.stub().resolves('10.0.0.99:16127') },
       });
 
       const mockDb = { db: sinon.stub().returns('database') };
@@ -801,7 +801,7 @@ describe('appHashSyncService tests', () => {
         '../nodeConfirmationService': { canSendMessages: sinon.stub().returns(true) },
         '../fluxCommunicationUtils': { deterministicFluxList: sinon.stub().resolves([]) },
         '../fluxCommunication': { openEphemeralConnection: sinon.stub().resolves(null) },
-        '../fluxNetworkHelper': { getMyFluxIPandPort: sinon.stub().resolves('10.0.0.99:16127') },
+        '../fluxNetworkHelper': { getLocalSocketAddress: sinon.stub().resolves('10.0.0.99:16127') },
       });
     });
 

--- a/tests/unit/appInstaller.test.js
+++ b/tests/unit/appInstaller.test.js
@@ -1085,9 +1085,8 @@ describe('appInstaller tests', () => {
         },
         '../serviceHelper': { ensureString: sinon.stub().returnsArg(0), ensureNumber: sinon.stub().returnsArg(0), delay: sinon.stub().resolves() },
         '../generalService': { nodeTier: sinon.stub().resolves('cumulus'), checkSynced: sinon.stub().resolves(true) },
-        '../benchmarkService': { getBenchmarks: sinon.stub().resolves({ status: 'success', data: { ipaddress: '192.168.1.1' } }) },
         '../daemonService/daemonServiceMiscRpcs': { isDaemonSynced: sinon.stub().returns({ status: 'success', data: { synced: true, height: 2094961 } }) },
-        '../fluxNetworkHelper': { getNumberOfPeers: sinon.stub().returns(15), isFirewallActive: sinon.stub().resolves(false), allowPort: sinon.stub().resolves({ status: true }), removeDockerContainerAccessToNonRoutable: sinon.stub().resolves(true) },
+        '../fluxNetworkHelper': { getLocalSocketAddress: sinon.stub().resolves('192.168.1.1:16127'), getNumberOfPeers: sinon.stub().returns(15), isFirewallActive: sinon.stub().resolves(false), allowPort: sinon.stub().resolves({ status: true }), removeDockerContainerAccessToNonRoutable: sinon.stub().resolves(true) },
         '../geolocationService': { isStaticIP: sinon.stub().returns(true) },
         '../dockerService': {
           dockerListContainers: sinon.stub().resolves([]),

--- a/tests/unit/appStartupManager.test.js
+++ b/tests/unit/appStartupManager.test.js
@@ -32,7 +32,7 @@ describe('appStartupManager tests', () => {
     };
 
     fluxNetworkHelperStub = {
-      getMyFluxIPandPort: sinon.stub(),
+      getLocalSocketAddress: sinon.stub(),
       isNodeDos: sinon.stub().returns(false),
     };
 
@@ -205,7 +205,7 @@ describe('appStartupManager tests', () => {
       registryManagerStub.getApplicationGlobalSpecifications.resolves({ version: 3, containerData: '' });
 
       // Default: node IP available
-      fluxNetworkHelperStub.getMyFluxIPandPort.resolves('10.0.0.1:16127');
+      fluxNetworkHelperStub.getLocalSocketAddress.resolves('10.0.0.1:16127');
     });
 
     it('should start app when location record has not expired', async () => {
@@ -261,7 +261,7 @@ describe('appStartupManager tests', () => {
     });
 
     it('should skip location check and start app when IP is not available', async () => {
-      fluxNetworkHelperStub.getMyFluxIPandPort.resolves(null);
+      fluxNetworkHelperStub.getLocalSocketAddress.resolves(null);
 
       dockerServiceStub.dockerListContainers.resolves([
         { Names: ['/fluxAppA'], State: 'exited' },

--- a/tests/unit/availabilityChecker.test.js
+++ b/tests/unit/availabilityChecker.test.js
@@ -120,7 +120,7 @@ describe('availabilityChecker tests', () => {
         data: { synced: true },
       });
       sinon.stub(generalService, 'isNodeStatusConfirmed').resolves(true);
-      sinon.stub(fluxNetworkHelper, 'getMyFluxIPandPort').resolves(null);
+      sinon.stub(fluxNetworkHelper, 'getLocalSocketAddress').resolves(null);
 
       await availabilityChecker.checkMyAppsAvailability(
         mockInstalledAppsFn,
@@ -138,7 +138,7 @@ describe('availabilityChecker tests', () => {
         data: { synced: true },
       });
       sinon.stub(generalService, 'isNodeStatusConfirmed').resolves(true);
-      sinon.stub(fluxNetworkHelper, 'getMyFluxIPandPort').resolves('192.168.1.100:16127');
+      sinon.stub(fluxNetworkHelper, 'getLocalSocketAddress').resolves('192.168.1.100:16127');
       mockInstalledAppsFn.resolves({ status: 'error', data: { message: 'Failed' } });
 
       await availabilityChecker.checkMyAppsAvailability(
@@ -161,7 +161,7 @@ describe('availabilityChecker tests', () => {
         data: { synced: true },
       });
       sinon.stub(generalService, 'isNodeStatusConfirmed').resolves(true);
-      sinon.stub(fluxNetworkHelper, 'getMyFluxIPandPort').resolves('192.168.1.100:16127');
+      sinon.stub(fluxNetworkHelper, 'getLocalSocketAddress').resolves('192.168.1.100:16127');
       mockInstalledAppsFn.resolves({ status: 'success', data: apps });
       sinon.stub(fluxNetworkHelper, 'isPortBanned').returns(false);
       sinon.stub(fluxNetworkHelper, 'isPortUserBlocked').returns(false);
@@ -188,7 +188,7 @@ describe('availabilityChecker tests', () => {
         data: { synced: true },
       });
       sinon.stub(generalService, 'isNodeStatusConfirmed').resolves(true);
-      sinon.stub(fluxNetworkHelper, 'getMyFluxIPandPort').resolves('192.168.1.100:16127');
+      sinon.stub(fluxNetworkHelper, 'getLocalSocketAddress').resolves('192.168.1.100:16127');
       mockInstalledAppsFn.resolves({ status: 'success', data: apps });
       sinon.stub(fluxNetworkHelper, 'isPortBanned').returns(false);
       sinon.stub(fluxNetworkHelper, 'isPortUserBlocked').returns(false);
@@ -221,7 +221,7 @@ describe('availabilityChecker tests', () => {
         data: { synced: true },
       });
       sinon.stub(generalService, 'isNodeStatusConfirmed').resolves(true);
-      sinon.stub(fluxNetworkHelper, 'getMyFluxIPandPort').resolves('192.168.1.100:16127');
+      sinon.stub(fluxNetworkHelper, 'getLocalSocketAddress').resolves('192.168.1.100:16127');
       mockInstalledAppsFn.resolves({ status: 'success', data: apps });
       sinon.stub(fluxNetworkHelper, 'isPortBanned').returns(false);
       sinon.stub(fluxNetworkHelper, 'isPortUserBlocked').returns(false);
@@ -245,7 +245,7 @@ describe('availabilityChecker tests', () => {
         data: { synced: true },
       });
       sinon.stub(generalService, 'isNodeStatusConfirmed').resolves(true);
-      sinon.stub(fluxNetworkHelper, 'getMyFluxIPandPort').resolves('192.168.1.100:16127');
+      sinon.stub(fluxNetworkHelper, 'getLocalSocketAddress').resolves('192.168.1.100:16127');
       mockInstalledAppsFn.resolves({ status: 'success', data: apps });
       sinon.stub(fluxNetworkHelper, 'isPortBanned').returns(true);
       sinon.stub(fluxNetworkHelper, 'isPortUserBlocked').returns(false);
@@ -268,7 +268,7 @@ describe('availabilityChecker tests', () => {
         data: { synced: true },
       });
       sinon.stub(generalService, 'isNodeStatusConfirmed').resolves(true);
-      sinon.stub(fluxNetworkHelper, 'getMyFluxIPandPort').resolves('192.168.1.100:16127');
+      sinon.stub(fluxNetworkHelper, 'getLocalSocketAddress').resolves('192.168.1.100:16127');
       mockInstalledAppsFn.resolves({ status: 'success', data: apps });
       sinon.stub(upnpService, 'isUPNP').returns(true);
       sinon.stub(fluxNetworkHelper, 'isPortBanned').returns(false);
@@ -293,7 +293,7 @@ describe('availabilityChecker tests', () => {
         data: { synced: true },
       });
       sinon.stub(generalService, 'isNodeStatusConfirmed').resolves(true);
-      sinon.stub(fluxNetworkHelper, 'getMyFluxIPandPort').resolves('192.168.1.100:16127');
+      sinon.stub(fluxNetworkHelper, 'getLocalSocketAddress').resolves('192.168.1.100:16127');
       mockInstalledAppsFn.resolves({ status: 'success', data: apps });
       sinon.stub(fluxNetworkHelper, 'isPortBanned').returns(false);
       sinon.stub(fluxNetworkHelper, 'isPortUserBlocked').returns(true);
@@ -319,7 +319,7 @@ describe('availabilityChecker tests', () => {
         data: { synced: true },
       });
       sinon.stub(generalService, 'isNodeStatusConfirmed').resolves(true);
-      sinon.stub(fluxNetworkHelper, 'getMyFluxIPandPort').resolves('192.168.1.100:16127');
+      sinon.stub(fluxNetworkHelper, 'getLocalSocketAddress').resolves('192.168.1.100:16127');
       mockInstalledAppsFn.resolves({ status: 'success', data: apps });
       sinon.stub(fluxNetworkHelper, 'isPortBanned').returns(false);
       sinon.stub(fluxNetworkHelper, 'isPortUserBlocked').returns(false);
@@ -342,7 +342,7 @@ describe('availabilityChecker tests', () => {
         data: { synced: true },
       });
       sinon.stub(generalService, 'isNodeStatusConfirmed').resolves(true);
-      sinon.stub(fluxNetworkHelper, 'getMyFluxIPandPort').resolves('192.168.1.100:16127');
+      sinon.stub(fluxNetworkHelper, 'getLocalSocketAddress').resolves('192.168.1.100:16127');
       mockInstalledAppsFn.resolves({ status: 'success', data: apps });
       sinon.stub(fluxNetworkHelper, 'isPortBanned').returns(false);
       sinon.stub(fluxNetworkHelper, 'isPortUserBlocked').returns(false);
@@ -367,7 +367,7 @@ describe('availabilityChecker tests', () => {
         data: { synced: true },
       });
       sinon.stub(generalService, 'isNodeStatusConfirmed').resolves(true);
-      sinon.stub(fluxNetworkHelper, 'getMyFluxIPandPort').resolves('192.168.1.100:16127');
+      sinon.stub(fluxNetworkHelper, 'getLocalSocketAddress').resolves('192.168.1.100:16127');
       mockInstalledAppsFn.resolves({ status: 'success', data: apps });
       sinon.stub(fluxNetworkHelper, 'isPortBanned').returns(false);
       sinon.stub(fluxNetworkHelper, 'isPortUserBlocked').returns(false);
@@ -391,7 +391,7 @@ describe('availabilityChecker tests', () => {
         data: { synced: true },
       });
       sinon.stub(generalService, 'isNodeStatusConfirmed').resolves(true);
-      sinon.stub(fluxNetworkHelper, 'getMyFluxIPandPort').resolves('192.168.1.100:16127');
+      sinon.stub(fluxNetworkHelper, 'getLocalSocketAddress').resolves('192.168.1.100:16127');
       mockInstalledAppsFn.resolves({ status: 'success', data: apps });
       sinon.stub(upnpService, 'isUPNP').returns(true);
       sinon.stub(fluxNetworkHelper, 'isPortBanned').returns(false);
@@ -422,7 +422,7 @@ describe('availabilityChecker tests', () => {
         data: { synced: true },
       });
       sinon.stub(generalService, 'isNodeStatusConfirmed').resolves(true);
-      sinon.stub(fluxNetworkHelper, 'getMyFluxIPandPort').resolves('192.168.1.100:16127');
+      sinon.stub(fluxNetworkHelper, 'getLocalSocketAddress').resolves('192.168.1.100:16127');
       mockInstalledAppsFn.resolves({ status: 'success', data: apps });
       sinon.stub(upnpService, 'isUPNP').returns(true);
       sinon.stub(fluxNetworkHelper, 'isPortBanned').returns(false);
@@ -467,7 +467,7 @@ describe('availabilityChecker tests', () => {
         data: { synced: true },
       });
       sinon.stub(generalService, 'isNodeStatusConfirmed').resolves(true);
-      sinon.stub(fluxNetworkHelper, 'getMyFluxIPandPort').resolves('192.168.1.100:16127');
+      sinon.stub(fluxNetworkHelper, 'getLocalSocketAddress').resolves('192.168.1.100:16127');
       mockInstalledAppsFn.resolves({ status: 'success', data: apps });
       sinon.stub(fluxNetworkHelper, 'isPortBanned').returns(false);
       sinon.stub(fluxNetworkHelper, 'isPortUserBlocked').returns(false);
@@ -494,7 +494,7 @@ describe('availabilityChecker tests', () => {
         data: { synced: true },
       });
       sinon.stub(generalService, 'isNodeStatusConfirmed').resolves(true);
-      sinon.stub(fluxNetworkHelper, 'getMyFluxIPandPort').resolves('192.168.1.100:16127');
+      sinon.stub(fluxNetworkHelper, 'getLocalSocketAddress').resolves('192.168.1.100:16127');
       mockInstalledAppsFn.resolves({ status: 'success', data: apps });
       sinon.stub(fluxNetworkHelper, 'isPortBanned').returns(false);
       sinon.stub(fluxNetworkHelper, 'isPortUserBlocked').returns(false);

--- a/tests/unit/fluxCommunication.test.js
+++ b/tests/unit/fluxCommunication.test.js
@@ -851,7 +851,7 @@ describe('fluxCommunication tests', () => {
       ensureObjectSpy = sinon.spy(serviceHelper, 'ensureObject');
       peerManager.reset();
       daemonServiceMiscRpcsStub = sinon.stub(daemonServiceMiscRpcs, 'isDaemonSynced');
-      sinon.stub(fluxNetworkHelper, 'getMyFluxIPandPort').returns('44.192.51.11:16127');
+      sinon.stub(fluxNetworkHelper, 'getLocalSocketAddress').returns('44.192.51.11:16127');
     });
 
     afterEach(() => {
@@ -1357,7 +1357,7 @@ describe('fluxCommunication tests', () => {
 
     it('should return warning if ip cannot be detected', async () => {
       sinon.stub(nodeConfirmationService, 'isConfirmed').returns(true);
-      sinon.stub(fluxNetworkHelper, 'getMyFluxIPandPort').returns(null);
+      sinon.stub(fluxNetworkHelper, 'getLocalSocketAddress').returns(null);
       daemonServiceStub.returns({
         data: {
           synced: true,
@@ -1397,8 +1397,8 @@ describe('fluxCommunication tests', () => {
       ];
 
       sinon.stub(nodeConfirmationService, 'isConfirmed').returns(true);
-      sinon.stub(fluxNetworkHelper, 'getMyFluxIPandPort').returns('44.192.51.11');
-      fluxNetworkHelper.setMyFluxIp('44.192.51.11');
+      sinon.stub(fluxNetworkHelper, 'getLocalSocketAddress').returns('44.192.51.11');
+      fluxNetworkHelper.setLocalSocketAddress('44.192.51.11');
       sinon.stub(fluxCommunicationUtils, 'getFluxnodeFromFluxList').returns('44.192.51.11');
       sinon.stub(fluxCommunicationUtils, 'deterministicFluxList').returns(fluxNodeList);
 

--- a/tests/unit/fluxNetworkHelper.test.js
+++ b/tests/unit/fluxNetworkHelper.test.js
@@ -223,7 +223,7 @@ describe('fluxNetworkHelper tests', () => {
     });
   });
 
-  describe('getMyFluxIPandPort tests', () => {
+  describe('getLocalSocketAddress tests', () => {
     let benchStub;
 
     beforeEach(() => {
@@ -242,7 +242,7 @@ describe('fluxNetworkHelper tests', () => {
       };
       benchStub.resolves(getBenchmarkResponseData);
 
-      const getIpResult = await fluxNetworkHelper.getMyFluxIPandPort();
+      const getIpResult = await fluxNetworkHelper.getLocalSocketAddress();
 
       expect(getIpResult).to.equal(ip);
       sinon.assert.calledOnce(benchStub);
@@ -254,7 +254,7 @@ describe('fluxNetworkHelper tests', () => {
       };
       benchStub.resolves(getBenchmarkResponseData);
 
-      const getIpResult = await fluxNetworkHelper.getMyFluxIPandPort();
+      const getIpResult = await fluxNetworkHelper.getLocalSocketAddress();
 
       expect(getIpResult).to.be.null;
       sinon.assert.calledOnce(benchStub);
@@ -268,10 +268,46 @@ describe('fluxNetworkHelper tests', () => {
       };
       benchStub.resolves(getBenchmarkResponseData);
 
-      const getIpResult = await fluxNetworkHelper.getMyFluxIPandPort();
+      const getIpResult = await fluxNetworkHelper.getLocalSocketAddress();
 
       expect(getIpResult).to.be.null;
       sinon.assert.calledOnce(benchStub);
+    });
+
+    it('should normalize bare IP from old fluxbench to ip:port', async () => {
+      const getBenchmarkResponseData = {
+        status: 'success',
+        data: { ipaddress: '85.159.213.248' },
+      };
+      benchStub.resolves(getBenchmarkResponseData);
+
+      const result = await fluxNetworkHelper.getLocalSocketAddress();
+
+      expect(result).to.equal('85.159.213.248:16127');
+    });
+
+    it('should return ip:port as-is from new fluxbench', async () => {
+      const getBenchmarkResponseData = {
+        status: 'success',
+        data: { ipaddress: '85.159.213.248:16127' },
+      };
+      benchStub.resolves(getBenchmarkResponseData);
+
+      const result = await fluxNetworkHelper.getLocalSocketAddress();
+
+      expect(result).to.equal('85.159.213.248:16127');
+    });
+
+    it('should preserve non-default port from fluxbench', async () => {
+      const getBenchmarkResponseData = {
+        status: 'success',
+        data: { ipaddress: '85.159.213.248:16147' },
+      };
+      benchStub.resolves(getBenchmarkResponseData);
+
+      const result = await fluxNetworkHelper.getLocalSocketAddress();
+
+      expect(result).to.equal('85.159.213.248:16147');
     });
   });
 
@@ -809,7 +845,7 @@ describe('fluxNetworkHelper tests', () => {
 
     beforeEach(() => {
       fluxNetworkHelper.setStoredFluxBenchAllowed('5.0.0');
-      fluxNetworkHelper.setMyFluxIp('129.3.3.3');
+      fluxNetworkHelper.setLocalSocketAddress('129.3.3.3');
       const deterministicFluxnodeListResponse = [
         {
           collateral: 'COutPoint(38c04da72786b08adb309259cdd6d2128ea9059d0334afca127a5dc4e75bf174, 0)',
@@ -849,7 +885,7 @@ describe('fluxNetworkHelper tests', () => {
     });
 
     it('should return false if fluxIp is null', async () => {
-      fluxNetworkHelper.setMyFluxIp(null);
+      fluxNetworkHelper.setLocalSocketAddress(null);
 
       const result = await fluxNetworkHelper.checkMyFluxAvailability();
 
@@ -1084,7 +1120,7 @@ describe('fluxNetworkHelper tests', () => {
 
       // Stub fluxNetworkHelper internal functions
       fluxNetworkHelper.setStoredFluxBenchAllowed('5.0.0');
-      fluxNetworkHelper.setMyFluxIp('127.0.0.1');
+      fluxNetworkHelper.setLocalSocketAddress('127.0.0.1');
     });
 
     afterEach(() => {
@@ -1366,7 +1402,7 @@ describe('fluxNetworkHelper tests', () => {
 
     beforeEach(() => {
       fluxNetworkHelper.setStoredFluxBenchAllowed('5.0.0');
-      fluxNetworkHelper.setMyFluxIp('129.3.3.3');
+      fluxNetworkHelper.setLocalSocketAddress('129.3.3.3');
       sinon.stub(daemonServiceWalletRpcs, 'createConfirmationTransaction').returns(true);
       sinon.stub(serviceHelper, 'delay').returns(true);
       sinon.stub(fluxCommunicationUtils, 'socketAddressInFluxList').resolves(true);

--- a/tests/unit/fluxService.test.js
+++ b/tests/unit/fluxService.test.js
@@ -1176,58 +1176,45 @@ describe('fluxService tests', () => {
   });
 
   describe('getFluxIP tests', () => {
-    let benchmarkStub;
+    let getLocalSocketAddressStub;
 
     beforeEach(() => {
-      benchmarkStub = sinon.stub(benchmarkService, 'getBenchmarks');
+      getLocalSocketAddressStub = sinon.stub(fluxNetworkHelper, 'getLocalSocketAddress');
     });
 
     afterEach(() => {
-      benchmarkStub.restore();
+      getLocalSocketAddressStub.restore();
     });
 
-    it('should return IP and Port if benchmark response is correct, no response passed', async () => {
-      const ip = '127.0.0.1:5050';
-      const getBenchmarkResponseData = {
-        status: 'success',
-        data: { ipaddress: ip },
-      };
-      benchmarkStub.resolves(getBenchmarkResponseData);
+    it('should return socket address if available, no response passed', async () => {
+      getLocalSocketAddressStub.resolves('127.0.0.1:5050');
       const expectedResponse = {
         status: 'success',
-        data: ip,
+        data: '127.0.0.1:5050',
       };
 
       const getIpResult = await fluxService.getFluxIP();
 
       expect(getIpResult).to.eql(expectedResponse);
-      sinon.assert.calledOnce(benchmarkStub);
+      sinon.assert.calledOnce(getLocalSocketAddressStub);
     });
 
-    it('should return IP and Port if benchmark response is correct, response passed', async () => {
-      const ip = '127.0.0.1:5050';
-      const getBenchmarkResponseData = {
-        status: 'success',
-        data: { ipaddress: ip },
-      };
-      benchmarkStub.resolves(getBenchmarkResponseData);
+    it('should return socket address if available, response passed', async () => {
+      getLocalSocketAddressStub.resolves('127.0.0.1:5050');
       const expectedResponse = {
         status: 'success',
-        data: ip,
+        data: '127.0.0.1:5050',
       };
       const res = generateResponse();
 
       const getIpResult = await fluxService.getFluxIP(undefined, res);
 
       expect(getIpResult).to.eql(`Response: ${expectedResponse}`);
-      sinon.assert.calledOnce(benchmarkStub);
+      sinon.assert.calledOnce(getLocalSocketAddressStub);
     });
 
-    it('should return null if daemon\'s response is invalid', async () => {
-      const getBenchmarkResponseData = {
-        status: 'error',
-      };
-      benchmarkStub.resolves(getBenchmarkResponseData);
+    it('should return null if IP cannot be detected', async () => {
+      getLocalSocketAddressStub.resolves(null);
       const expectedResponse = {
         status: 'success',
         data: null,
@@ -1236,25 +1223,7 @@ describe('fluxService tests', () => {
       const getIpResult = await fluxService.getFluxIP();
 
       expect(getIpResult).to.be.eql(expectedResponse);
-      sinon.assert.calledOnce(benchmarkStub);
-    });
-
-    it('should return null if daemon\'s response IP is too short', async () => {
-      const ip = '12734';
-      const getBenchmarkResponseData = {
-        status: 'success',
-        data: { ipaddress: ip },
-      };
-      benchmarkStub.resolves(getBenchmarkResponseData);
-      const expectedResponse = {
-        status: 'success',
-        data: null,
-      };
-
-      const getIpResult = await fluxService.getFluxIP();
-
-      expect(getIpResult).to.be.eql(expectedResponse);
-      sinon.assert.calledOnce(benchmarkStub);
+      sinon.assert.calledOnce(getLocalSocketAddressStub);
     });
   });
 

--- a/tests/unit/geolocationService.test.js
+++ b/tests/unit/geolocationService.test.js
@@ -51,7 +51,7 @@ describe('geolocationService tests', () => {
     };
 
     fluxNetworkHelperStub = {
-      getMyFluxIPandPort: sinon.stub(),
+      getLocalSocketAddress: sinon.stub(),
       hasPublicIpOnInterface: sinon.stub(),
     };
 
@@ -177,7 +177,7 @@ describe('geolocationService tests', () => {
   describe('setNodeGeolocation tests', () => {
     beforeEach(() => {
       // Setup default successful response
-      fluxNetworkHelperStub.getMyFluxIPandPort.resolves('185.199.108.1:16127');
+      fluxNetworkHelperStub.getLocalSocketAddress.resolves('185.199.108.1:16127');
       fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(true);
       serviceHelperStub.axiosGet.resolves({
         data: {
@@ -200,7 +200,7 @@ describe('geolocationService tests', () => {
     });
 
     it('should not proceed if IP is not detected', async () => {
-      fluxNetworkHelperStub.getMyFluxIPandPort.resolves(null);
+      fluxNetworkHelperStub.getLocalSocketAddress.resolves(null);
 
       await geolocationService.setNodeGeolocation();
 
@@ -311,7 +311,7 @@ describe('geolocationService tests', () => {
 
     testOrgs.forEach(({ org, expected }) => {
       it(`should ${expected ? 'detect' : 'not detect'} "${org}" as static IP org`, async () => {
-        fluxNetworkHelperStub.getMyFluxIPandPort.resolves('185.199.108.1:16127');
+        fluxNetworkHelperStub.getLocalSocketAddress.resolves('185.199.108.1:16127');
         fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(false); // No public IP on interface
         serviceHelperStub.axiosGet.resolves({
           data: {
@@ -341,7 +341,7 @@ describe('geolocationService tests', () => {
 
   describe('Database storage tests', () => {
     beforeEach(() => {
-      fluxNetworkHelperStub.getMyFluxIPandPort.resolves('185.199.108.1:16127');
+      fluxNetworkHelperStub.getLocalSocketAddress.resolves('185.199.108.1:16127');
       fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(false);
       serviceHelperStub.axiosGet.resolves({
         data: {

--- a/tests/unit/nodeConfirmationService.test.js
+++ b/tests/unit/nodeConfirmationService.test.js
@@ -6,7 +6,7 @@ describe('nodeConfirmationService', () => {
   let service;
   let clock;
   let getFluxNodeStatusStub;
-  let getMyFluxIPandPortStub;
+  let getLocalSocketAddressStub;
   let getFluxNodePublicKeyStub;
   let getFluxnodeBySocketAddressStub;
   let logStub;
@@ -14,7 +14,7 @@ describe('nodeConfirmationService', () => {
   beforeEach(() => {
     clock = sinon.useFakeTimers({ shouldAdvanceTime: false });
     getFluxNodeStatusStub = sinon.stub();
-    getMyFluxIPandPortStub = sinon.stub();
+    getLocalSocketAddressStub = sinon.stub();
     getFluxNodePublicKeyStub = sinon.stub();
     getFluxnodeBySocketAddressStub = sinon.stub();
     logStub = { info: sinon.stub(), warn: sinon.stub(), error: sinon.stub() };
@@ -22,7 +22,7 @@ describe('nodeConfirmationService', () => {
     service = proxyquire('../../ZelBack/src/services/nodeConfirmationService', {
       './daemonService/daemonServiceFluxnodeRpcs': { getFluxNodeStatus: getFluxNodeStatusStub },
       './fluxNetworkHelper': {
-        getMyFluxIPandPort: getMyFluxIPandPortStub,
+        getLocalSocketAddress: getLocalSocketAddressStub,
         getFluxNodePublicKey: getFluxNodePublicKeyStub,
       },
       './networkStateService': { getFluxnodeBySocketAddress: getFluxnodeBySocketAddressStub },
@@ -38,7 +38,7 @@ describe('nodeConfirmationService', () => {
   function setupConfirmed() {
     getFluxNodeStatusStub.resolves({ status: 'success', data: { status: 'CONFIRMED' } });
     getFluxNodePublicKeyStub.resolves('04abcdef1234567890');
-    getMyFluxIPandPortStub.resolves('1.2.3.4:16127');
+    getLocalSocketAddressStub.resolves('1.2.3.4:16127');
     getFluxnodeBySocketAddressStub.resolves({ pubkey: '04abcdef1234567890' });
   }
 
@@ -49,7 +49,7 @@ describe('nodeConfirmationService', () => {
   function setupConfirmedButIpMissing() {
     getFluxNodeStatusStub.resolves({ status: 'success', data: { status: 'CONFIRMED' } });
     getFluxNodePublicKeyStub.resolves('04abcdef1234567890');
-    getMyFluxIPandPortStub.resolves('1.2.3.4:16127');
+    getLocalSocketAddressStub.resolves('1.2.3.4:16127');
     getFluxnodeBySocketAddressStub.resolves(null);
   }
 
@@ -122,7 +122,7 @@ describe('nodeConfirmationService', () => {
     it('should return false when confirmed but pubkey mismatch', async () => {
       getFluxNodeStatusStub.resolves({ status: 'success', data: { status: 'CONFIRMED' } });
       getFluxNodePublicKeyStub.resolves('04abcdef1234567890');
-      getMyFluxIPandPortStub.resolves('1.2.3.4:16127');
+      getLocalSocketAddressStub.resolves('1.2.3.4:16127');
       getFluxnodeBySocketAddressStub.resolves({ pubkey: '04different9876543210' });
 
       await service.start();
@@ -134,7 +134,7 @@ describe('nodeConfirmationService', () => {
     it('should return false when confirmed but IP detection fails', async () => {
       getFluxNodeStatusStub.resolves({ status: 'success', data: { status: 'CONFIRMED' } });
       getFluxNodePublicKeyStub.resolves('04abcdef1234567890');
-      getMyFluxIPandPortStub.resolves(null);
+      getLocalSocketAddressStub.resolves(null);
 
       await service.start();
 

--- a/tests/unit/peerNotification.test.js
+++ b/tests/unit/peerNotification.test.js
@@ -50,11 +50,8 @@ describe('peerNotification tests', () => {
         isNodeStatusConfirmed: sinon.stub().resolves(true),
         nodeTier: sinon.stub().resolves('cumulus'),
       },
-      '../benchmarkService': {
-        getBenchmarks: sinon.stub().resolves({
-          status: 'success',
-          data: { ipaddress: '192.168.1.1' },
-        }),
+      '../fluxNetworkHelper': {
+        getLocalSocketAddress: sinon.stub().resolves('192.168.1.1:16127'),
       },
       '../geolocationService': {
         isStaticIP: sinon.stub().returns(true),
@@ -127,7 +124,7 @@ describe('peerNotification tests', () => {
 
       expect(monitorAndRecoverAppsStub.calledOnce).to.be.true;
       const [ip, apps, runningNames] = monitorAndRecoverAppsStub.firstCall.args;
-      expect(ip).to.equal('192.168.1.1');
+      expect(ip).to.equal('192.168.1.1:16127');
       expect(apps).to.have.length(1);
       expect(apps[0].name).to.equal('app1');
       expect(runningNames).to.deep.equal(['c1_app1']);

--- a/tests/unit/socketAddressUtils.test.js
+++ b/tests/unit/socketAddressUtils.test.js
@@ -1,0 +1,183 @@
+const { expect } = require('chai');
+const {
+  DEFAULT_API_PORT,
+  normalizeSocketAddress,
+  extractIp,
+  extractPort,
+  parseSocketAddress,
+  socketAddressesMatch,
+} = require('../../ZelBack/src/services/utils/socketAddressUtils');
+
+describe('socketAddressUtils tests', () => {
+  describe('DEFAULT_API_PORT', () => {
+    it('should be 16127', () => {
+      expect(DEFAULT_API_PORT).to.equal(16127);
+    });
+  });
+
+  describe('normalizeSocketAddress', () => {
+    it('should return null for null', () => {
+      expect(normalizeSocketAddress(null)).to.be.null;
+    });
+
+    it('should return null for undefined', () => {
+      expect(normalizeSocketAddress(undefined)).to.be.null;
+    });
+
+    it('should return null for empty string', () => {
+      expect(normalizeSocketAddress('')).to.be.null;
+    });
+
+    it('should append default port to bare IP', () => {
+      expect(normalizeSocketAddress('1.2.3.4')).to.equal('1.2.3.4:16127');
+    });
+
+    it('should return ip:port as-is when default port present', () => {
+      expect(normalizeSocketAddress('1.2.3.4:16127')).to.equal('1.2.3.4:16127');
+    });
+
+    it('should preserve non-default port', () => {
+      expect(normalizeSocketAddress('1.2.3.4:16137')).to.equal('1.2.3.4:16137');
+    });
+  });
+
+  describe('extractIp', () => {
+    it('should return null for null', () => {
+      expect(extractIp(null)).to.be.null;
+    });
+
+    it('should return null for undefined', () => {
+      expect(extractIp(undefined)).to.be.null;
+    });
+
+    it('should return bare IP as-is', () => {
+      expect(extractIp('1.2.3.4')).to.equal('1.2.3.4');
+    });
+
+    it('should strip default port', () => {
+      expect(extractIp('1.2.3.4:16127')).to.equal('1.2.3.4');
+    });
+
+    it('should strip non-default port', () => {
+      expect(extractIp('1.2.3.4:16137')).to.equal('1.2.3.4');
+    });
+  });
+
+  describe('extractPort', () => {
+    it('should return default port for null', () => {
+      expect(extractPort(null)).to.equal(16127);
+    });
+
+    it('should return default port for undefined', () => {
+      expect(extractPort(undefined)).to.equal(16127);
+    });
+
+    it('should return default port for bare IP', () => {
+      expect(extractPort('1.2.3.4')).to.equal(16127);
+    });
+
+    it('should return default port when explicitly present', () => {
+      expect(extractPort('1.2.3.4:16127')).to.equal(16127);
+    });
+
+    it('should return non-default port', () => {
+      expect(extractPort('1.2.3.4:16137')).to.equal(16137);
+    });
+
+    it('should return port as a number', () => {
+      const port = extractPort('1.2.3.4:16137');
+      expect(port).to.be.a('number');
+    });
+  });
+
+  describe('parseSocketAddress', () => {
+    it('should return null for null', () => {
+      expect(parseSocketAddress(null)).to.be.null;
+    });
+
+    it('should return null for undefined', () => {
+      expect(parseSocketAddress(undefined)).to.be.null;
+    });
+
+    it('should return null for non-string', () => {
+      expect(parseSocketAddress(12345)).to.be.null;
+    });
+
+    it('should return null for invalid IP', () => {
+      expect(parseSocketAddress('999.999.999.999')).to.be.null;
+    });
+
+    it('should return null for non-numeric port', () => {
+      expect(parseSocketAddress('1.2.3.4:abc')).to.be.null;
+    });
+
+    it('should return null for port out of range', () => {
+      expect(parseSocketAddress('1.2.3.4:70000')).to.be.null;
+    });
+
+    it('should return null for port 0', () => {
+      expect(parseSocketAddress('1.2.3.4:0')).to.be.null;
+    });
+
+    it('should parse bare IP with default port', () => {
+      const result = parseSocketAddress('1.2.3.4');
+      expect(result).to.deep.equal({ ip: '1.2.3.4', port: 16127 });
+    });
+
+    it('should parse ip:port', () => {
+      const result = parseSocketAddress('85.159.213.248:16147');
+      expect(result).to.deep.equal({ ip: '85.159.213.248', port: 16147 });
+    });
+
+    it('should return port as a number', () => {
+      const result = parseSocketAddress('1.2.3.4:16127');
+      expect(result.port).to.be.a('number');
+    });
+  });
+
+  describe('socketAddressesMatch', () => {
+    it('should match bare IP vs same IP with default port', () => {
+      expect(socketAddressesMatch('1.2.3.4', '1.2.3.4:16127')).to.be.true;
+    });
+
+    it('should match ip:port vs bare IP (reversed)', () => {
+      expect(socketAddressesMatch('1.2.3.4:16127', '1.2.3.4')).to.be.true;
+    });
+
+    it('should match identical ip:port', () => {
+      expect(socketAddressesMatch('1.2.3.4:16127', '1.2.3.4:16127')).to.be.true;
+    });
+
+    it('should match identical bare IPs', () => {
+      expect(socketAddressesMatch('1.2.3.4', '1.2.3.4')).to.be.true;
+    });
+
+    it('should not match different ports', () => {
+      expect(socketAddressesMatch('1.2.3.4:16137', '1.2.3.4:16127')).to.be.false;
+    });
+
+    it('should not match non-default port vs bare IP (implicit default)', () => {
+      expect(socketAddressesMatch('1.2.3.4:16137', '1.2.3.4')).to.be.false;
+    });
+
+    it('should return false for null vs address', () => {
+      expect(socketAddressesMatch(null, '1.2.3.4')).to.be.false;
+    });
+
+    it('should return false for null vs null', () => {
+      expect(socketAddressesMatch(null, null)).to.be.false;
+    });
+
+    it('should return false for undefined vs address', () => {
+      expect(socketAddressesMatch(undefined, '1.2.3.4')).to.be.false;
+    });
+
+    it('should not match different IPs', () => {
+      expect(socketAddressesMatch('1.2.3.4', '5.6.7.8')).to.be.false;
+    });
+
+    it('should not match different IPs with same port', () => {
+      expect(socketAddressesMatch('1.2.3.4:16127', '5.6.7.8:16127')).to.be.false;
+    });
+  });
+});

--- a/tests/unit/socketAddressUtils.test.js
+++ b/tests/unit/socketAddressUtils.test.js
@@ -119,6 +119,27 @@ describe('socketAddressUtils tests', () => {
       expect(parseSocketAddress('1.2.3.4:0')).to.be.null;
     });
 
+    it('should reject hex port', () => {
+      expect(parseSocketAddress('1.2.3.4:0x3F7F')).to.be.null;
+    });
+
+    it('should reject trailing garbage after port', () => {
+      expect(parseSocketAddress('1.2.3.4:16127:foo')).to.be.null;
+    });
+
+    it('should reject leading zero port', () => {
+      expect(parseSocketAddress('1.2.3.4:016127')).to.be.null;
+    });
+
+    it('should accept port 65535', () => {
+      const result = parseSocketAddress('1.2.3.4:65535');
+      expect(result).to.deep.equal({ ip: '1.2.3.4', port: 65535 });
+    });
+
+    it('should reject port 65536', () => {
+      expect(parseSocketAddress('1.2.3.4:65536')).to.be.null;
+    });
+
     it('should parse bare IP with default port', () => {
       const result = parseSocketAddress('1.2.3.4');
       expect(result).to.deep.equal({ ip: '1.2.3.4', port: 16127 });

--- a/tests/unit/socketAddressUtils.test.js
+++ b/tests/unit/socketAddressUtils.test.js
@@ -88,6 +88,14 @@ describe('socketAddressUtils tests', () => {
       const port = extractPort('1.2.3.4:16137');
       expect(port).to.be.a('number');
     });
+
+    it('should return default port for trailing colon', () => {
+      expect(extractPort('1.2.3.4:')).to.equal(16127);
+    });
+
+    it('should return default port for non-numeric port', () => {
+      expect(extractPort('1.2.3.4:abc')).to.equal(16127);
+    });
   });
 
   describe('parseSocketAddress', () => {

--- a/tests/unit/syncthingFolderStateMachine.test.js
+++ b/tests/unit/syncthingFolderStateMachine.test.js
@@ -228,7 +228,7 @@ describe('syncthingFolderStateMachine tests', () => {
         syncthingAppsFirstRun: false,
         receiveOnlySyncthingAppsCache: new Map(),
         appLocation: sinon.stub().resolves([]),
-        myIP: '10.0.0.1:16127',
+        localSocketAddr: '10.0.0.1:16127',
         appDockerStopFn: sinon.stub().resolves(),
         appDockerRestartFn: sinon.stub().resolves(),
         appDeleteDataInMountPointFn: sinon.stub().resolves(),

--- a/tests/unit/syncthingMonitor.test.js
+++ b/tests/unit/syncthingMonitor.test.js
@@ -22,7 +22,7 @@ const dockerServiceMock = {
 };
 
 const fluxNetworkHelperMock = {
-  getMyFluxIPandPort: sinon.stub(),
+  getLocalSocketAddress: sinon.stub(),
 };
 
 const syncthingServiceMock = {
@@ -125,7 +125,7 @@ describe('syncthingMonitor tests', () => {
     syncthingServiceMock.getFolderIdErrors.reset();
     syncthingServiceMock.getConfigRestartRequired.reset();
     syncthingServiceMock.systemRestart.reset();
-    fluxNetworkHelperMock.getMyFluxIPandPort.reset();
+    fluxNetworkHelperMock.getLocalSocketAddress.reset();
     dockerServiceMock.dockerContainerInspect.reset();
     dockerServiceMock.appDockerStart.reset();
     syncthingHealthMonitorMock.monitorFolderHealth.reset();
@@ -158,7 +158,7 @@ describe('syncthingMonitor tests', () => {
     it('should return control object with stop and isActive methods', () => {
       mockInstalledAppsFn.resolves({ status: 'success', data: [] });
       syncthingServiceMock.getDeviceId.resolves('DEVICE-ID');
-      fluxNetworkHelperMock.getMyFluxIPandPort.resolves('10.0.0.1:16127');
+      fluxNetworkHelperMock.getLocalSocketAddress.resolves('10.0.0.1:16127');
 
       monitorControl = syncthingMonitor.syncthingApps(
         mockState,
@@ -178,7 +178,7 @@ describe('syncthingMonitor tests', () => {
     it('should stop monitoring when stop is called', () => {
       mockInstalledAppsFn.resolves({ status: 'success', data: [] });
       syncthingServiceMock.getDeviceId.resolves('DEVICE-ID');
-      fluxNetworkHelperMock.getMyFluxIPandPort.resolves('10.0.0.1:16127');
+      fluxNetworkHelperMock.getLocalSocketAddress.resolves('10.0.0.1:16127');
 
       monitorControl = syncthingMonitor.syncthingApps(
         mockState,
@@ -267,7 +267,7 @@ describe('syncthingMonitor tests', () => {
       mockInstalledAppsFn.onSecondCall().resolves({ status: 'success', data: [] });
 
       syncthingServiceMock.getDeviceId.resolves('DEVICE-ID');
-      fluxNetworkHelperMock.getMyFluxIPandPort.resolves('10.0.0.1:16127');
+      fluxNetworkHelperMock.getLocalSocketAddress.resolves('10.0.0.1:16127');
 
       monitorControl = syncthingMonitor.syncthingApps(
         mockState,
@@ -303,7 +303,7 @@ describe('syncthingMonitor tests', () => {
     it('should run at regular intervals', async () => {
       mockInstalledAppsFn.resolves({ status: 'success', data: [] });
       syncthingServiceMock.getDeviceId.resolves('DEVICE-ID');
-      fluxNetworkHelperMock.getMyFluxIPandPort.resolves('10.0.0.1:16127');
+      fluxNetworkHelperMock.getLocalSocketAddress.resolves('10.0.0.1:16127');
 
       monitorControl = syncthingMonitor.syncthingApps(
         mockState,

--- a/tests/unit/syncthingMonitorHelpers.test.js
+++ b/tests/unit/syncthingMonitorHelpers.test.js
@@ -52,6 +52,30 @@ describe('syncthingMonitorHelpers tests', () => {
       const result = helpers.sortAndFilterLocations([], '10.0.0.1:16127');
       expect(result).to.be.an('array').that.is.empty;
     });
+
+    it('should sort consistently with mixed bare IP and ip:port formats', () => {
+      const locations = [
+        { ip: '10.0.0.2:16127' },
+        { ip: '10.0.0.1' },
+      ];
+
+      const result = helpers.sortAndFilterLocations(locations, '10.0.0.9:16127');
+
+      expect(result[0].ip).to.equal('10.0.0.1');
+      expect(result[1].ip).to.equal('10.0.0.2:16127');
+    });
+
+    it('should filter bare IP when localSocketAddr is ip:port', () => {
+      const locations = [
+        { ip: '10.0.0.1' },
+        { ip: '10.0.0.2:16127' },
+      ];
+
+      const result = helpers.sortAndFilterLocations(locations, '10.0.0.1:16127');
+
+      expect(result).to.have.lengthOf(1);
+      expect(result[0].ip).to.equal('10.0.0.2:16127');
+    });
   });
 
   describe('getContainerDataFlags', () => {

--- a/tests/unit/systemIntegration.test.js
+++ b/tests/unit/systemIntegration.test.js
@@ -10,6 +10,7 @@ const dockerService = require('../../ZelBack/src/services/dockerService');
 const benchmarkService = require('../../ZelBack/src/services/benchmarkService');
 const daemonServiceBenchmarkRpcs = require('../../ZelBack/src/services/daemonService/daemonServiceBenchmarkRpcs');
 const generalService = require('../../ZelBack/src/services/generalService');
+const fluxNetworkHelper = require('../../ZelBack/src/services/fluxNetworkHelper');
 
 describe('systemIntegration tests', () => {
   let req;
@@ -305,10 +306,7 @@ describe('systemIntegration tests', () => {
         txhash: 'abc123',
         txindex: 0,
       });
-      sinon.stub(benchmarkService, 'getBenchmarks').resolves({
-        status: 'success',
-        data: { ipaddress: '123' }, // Too short
-      });
+      sinon.stub(fluxNetworkHelper, 'getLocalSocketAddress').resolves(null);
 
       try {
         await systemIntegration.checkAppNodesRequirements(appSpecs);


### PR DESCRIPTION
## Problem

FluxOS has a systemic fragility around IP address handling. The root cause is that fluxbench historically omits the API port for nodes running on the default port (16127), reporting just `1.2.3.4` instead of `1.2.3.4:16127`. This forces FluxOS to compensate — every file that touches node IPs has to decide whether to strip a port, add a port, or compare with `.split(':')[0]`. Over time this led to ~30 files each implementing their own ad-hoc parsing: `ip.split(':')[0]`, `ip.split(':')[1] || '16127'`, `myIP === node.ip`, and various conditional port-stripping patterns — all slightly different, all easy to break.

A companion fluxbench change will always attach the API port, but deploying it against the current codebase would cause nodes to go DOS — remote nodes would fail to match `1.2.3.4:16127` against `1.2.3.4` in their node lists and report the node as unreachable. This PR must be deployed network-wide first so all nodes can handle both formats during the transition.

## Approach

Rather than patching individual comparison sites, this PR consolidates all socket address logic into a single utility module (`socketAddressUtils.js`) and refactors every consumer to use it:

- **`normalizeSocketAddress(addr)`** — ensures ip:port format, defaults to :16127
- **`extractIp(addr)`** — replaces every `.split(':')[0]`
- **`extractPort(addr)`** — replaces every `.split(':')[1] || '16127'` (always returns a number, falls back to DEFAULT_API_PORT for malformed input)
- **`parseSocketAddress(raw)`** — validates and parses user input with strict IP and port regex (moved from `serviceHelper.normalizeNodeIpApiPort`)
- **`socketAddressesMatch(a, b)`** — format-agnostic comparison, replaces all `=== myIP` checks

### Variable naming cleanup

The codebase used `myFluxIP`, `myIP`, `ip` etc. interchangeably for both bare IPs and socket addresses. This made it impossible to tell at a glance what format a variable held. This PR establishes a naming convention:

| Old | New | Holds |
|-----|-----|-------|
| `myFluxIP` / `myIP` | `localSocketAddr` | socket address (ip:port) |
| `getMyFluxIPandPort()` | `getLocalSocketAddress()` | returns normalized ip:port |
| `setMyFluxIp()` | `setLocalSocketAddress()` | normalizes on set |
| `myUrl` / `myIpWithoutPort` | `localIp` | bare IP only |

### Manual benchmark fetch consolidation

Six files were doing their own `benchmarkService.getBenchmarks()` call and extracting `myIP` from the response instead of using the centralized `getLocalSocketAddress()`. These have been refactored to use the single path:

- `appInstaller.js`, `systemIntegration.js`, `fluxService.js`, `peerNotification.js`, `hwRequirements.js` — replaced manual fetch with `getLocalSocketAddress()`
- `containerHealthMonitor.js`, `appUtilities.js` — renamed `myIP` parameter to `localSocketAddr`
- `appSpecs.nodes.includes(myIP)` replaced with `.find((node) => socketAddressesMatch(node, localSocketAddr))` matching the pattern already in `appSpawner.js`

### What was removed

- `normalizeNodeIpApiPort` from `serviceHelper.js` — socket address validation doesn't belong in a general helper. Replaced by `parseSocketAddress` in `socketAddressUtils`.
- `defaultPortAltAddress` from `networkStateService.js` — was a duplicate of `normalizeSocketAddress` added as a quick compatibility fix. Now uses the shared utility, gated on `DEFAULT_API_PORT` to prevent false positives for non-default-port lookups.
- Every manual `.split(':')` pattern for socket addresses across the codebase (replaced with `extractIp`/`extractPort`).
- All hardcoded `16127` magic numbers in service code replaced with `DEFAULT_API_PORT` from `socketAddressUtils`.

### Hardening

- `extractPort` returns `DEFAULT_API_PORT` for malformed input (trailing colon, non-numeric port) instead of 0 or NaN
- `parseSocketAddress` uses strict port regex (1-65535 decimal only — rejects hex, leading zeros, trailing garbage)
- `socketAddressesMatch(null, null)` returns `false` (not `true` via the `a === b` fast path)
- `sortAndFilterLocations` normalizes addresses before sorting to ensure deterministic order with mixed formats
- API response port fields preserve string type to maintain backward compatibility

## Rollout

This is one half of a two-part change. The sequence matters:

1. **This PR rolls out network-wide first** — all nodes gain `socketAddressesMatch()` so they can handle both formats
2. **Then** the fluxbench change can be deployed — nodes will accept the new ip:port format without going DOS

Once all nodes run the new fluxbench, `normalizeSocketAddress` becomes a no-op and `socketAddressesMatch` becomes `===`. At that point the module can be simplified further.

## Files changed (45)

- **New**: `socketAddressUtils.js`, `socketAddressUtils.test.js`
- **Core refactor** (30 service files): renamed functions/variables, replaced comparisons, split patterns, and manual benchmark fetches
- **Tests updated** (13 test files): mock renames + 46 new utility tests + format-transition tests + mixed-format sort/filter tests

## Deployment verification

Deployed to chalk, charlie, and chud. All three nodes:
- Found on valid indexes in the deterministic node list
- Confirmed with `messageCapable=true`
- Geolocation resolving correctly
- No errors from the refactor

## Test plan

- [x] 460 unit tests passing across 13 test files
- [x] `socketAddressUtils.test.js` — 46 tests covering all functions and edge cases
- [x] Format-transition tests verify bare IP → ip:port normalization
- [x] Mixed-format sort and filter tests for syncthing peer ordering
- [x] Live deployment on 3 nodes — healthy startup confirmed
- [ ] Monitor deployed nodes through 2+ benchmark cycles
- [ ] Verify no DOS state changes over 24h

🤖 Generated with [Claude Code](https://claude.com/claude-code)