### PR TITLE
feat: instant crash recovery via Docker event stream

### DIFF
--- a/ZelBack/src/services/appLifecycle/appStartupManager.js
+++ b/ZelBack/src/services/appLifecycle/appStartupManager.js
@@ -287,7 +287,7 @@ async function manageAppsOnBoot(bootContext) {
       }
     }
 
-    // Machine rebooted, locations still valid — wait for daemon + sync then reconcile.
+    // Locations still valid — wait for daemon + sync then reconcile.
     const DAEMON_TIMEOUT_MS = config.system.bootDaemonTimeoutMs ?? 300000;
     try {
       await Promise.race([

--- a/ZelBack/src/services/appLifecycle/appStartupManager.js
+++ b/ZelBack/src/services/appLifecycle/appStartupManager.js
@@ -274,11 +274,6 @@ async function removeAllApps(reason) {
 
 async function manageAppsOnBoot(bootContext) {
   try {
-    if (!bootContext.machineRebooted) {
-      log.info('appStartupManager - FluxOS-only restart, containers already running');
-      return;
-    }
-
     if (bootContext.firstBoot) {
       log.info('appStartupManager - First boot (no heartbeat history), waiting for sync');
     } else {

--- a/ZelBack/src/services/appMonitoring/containerCrashRecovery.js
+++ b/ZelBack/src/services/appMonitoring/containerCrashRecovery.js
@@ -7,10 +7,14 @@ const appInspector = require('../appManagement/appInspector');
 const BACKOFF_DELAYS_MS = [0, 30 * 1000, 5 * 60 * 1000, 15 * 60 * 1000, 30 * 60 * 1000];
 const BACKOFF_RESET_MS = 60 * 60 * 1000;
 
+// containerName -> [monotonicMs, ...]
+const restartHistory = new Map();
+
 const bootQueue = [];
 
 let eventStream = null;
 let stopped = false;
+let lineBuf = '';
 
 function isFluxContainer(name) {
   return name.startsWith('flux') || name.startsWith('zel');
@@ -28,22 +32,22 @@ function nowMs() {
 
 function getBackoffDelay(containerName) {
   const now = nowMs();
-  const history = globalState.containerRestartHistory.get(containerName);
+  const history = restartHistory.get(containerName);
   if (!history) return 0;
   const recent = history.filter((ts) => now - ts < BACKOFF_RESET_MS);
   if (recent.length === 0) {
-    globalState.containerRestartHistory.delete(containerName);
+    restartHistory.delete(containerName);
     return 0;
   }
-  globalState.containerRestartHistory.set(containerName, recent);
+  restartHistory.set(containerName, recent);
   const index = Math.min(recent.length, BACKOFF_DELAYS_MS.length - 1);
   return BACKOFF_DELAYS_MS[index];
 }
 
 function recordRestart(containerName) {
-  const history = globalState.containerRestartHistory.get(containerName) || [];
+  const history = restartHistory.get(containerName) || [];
   history.push(nowMs());
-  globalState.containerRestartHistory.set(containerName, history);
+  restartHistory.set(containerName, history);
 }
 
 async function handleContainerDie(event) {
@@ -53,13 +57,12 @@ async function handleContainerDie(event) {
 
   if (!containerName || !isFluxContainer(containerName)) return;
 
-  if (exitCode === 0) return;
-
   if (globalState.stoppingContainers.has(containerName)) {
     globalState.stoppingContainers.delete(containerName);
-    log.info(`containerCrashRecovery - ${containerName} was intentionally stopped, skipping`);
     return;
   }
+
+  if (exitCode === 0) return;
 
   if (!globalState.bootContainerStateSettled) {
     log.info(`containerCrashRecovery - ${containerName} died (exit ${exitCode}) during boot, queuing`);
@@ -108,9 +111,9 @@ async function waitForBootAndDrain() {
   if (!stopped) await drainBootQueue();
 }
 
-async function start() {
+async function subscribe() {
   if (eventStream) return;
-  stopped = false;
+  lineBuf = '';
 
   try {
     eventStream = await dockerService.dockerGetEvents({
@@ -119,13 +122,19 @@ async function start() {
 
     eventStream.on('data', (buf) => {
       if (stopped) return;
-      try {
-        const event = JSON.parse(buf.toString());
-        handleContainerDie(event).catch((err) => {
-          log.error(`containerCrashRecovery - event handler error: ${err.message}`);
-        });
-      } catch (parseErr) {
-        log.error(`containerCrashRecovery - failed to parse docker event: ${parseErr.message}`);
+      lineBuf += buf.toString();
+      const lines = lineBuf.split('\n');
+      lineBuf = lines.pop();
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const event = JSON.parse(line);
+          handleContainerDie(event).catch((err) => {
+            log.error(`containerCrashRecovery - event handler error: ${err.message}`);
+          });
+        } catch (parseErr) {
+          log.error(`containerCrashRecovery - failed to parse docker event: ${parseErr.message}`);
+        }
       }
     });
 
@@ -133,7 +142,7 @@ async function start() {
       log.error(`containerCrashRecovery - event stream error: ${err.message}`);
       eventStream = null;
       if (!stopped) {
-        setTimeout(() => start(), 10000);
+        setTimeout(() => subscribe(), 10000);
       }
     });
 
@@ -141,26 +150,32 @@ async function start() {
       log.warn('containerCrashRecovery - event stream ended');
       eventStream = null;
       if (!stopped) {
-        setTimeout(() => start(), 10000);
+        setTimeout(() => subscribe(), 10000);
       }
     });
 
     log.info('containerCrashRecovery - listening for container crash events');
-
-    waitForBootAndDrain().catch((err) => {
-      log.error(`containerCrashRecovery - boot queue drain failed: ${err.message}`);
-    });
   } catch (err) {
     log.error(`containerCrashRecovery - failed to subscribe to docker events: ${err.message}`);
     eventStream = null;
     if (!stopped) {
-      setTimeout(() => start(), 10000);
+      setTimeout(() => subscribe(), 10000);
     }
   }
 }
 
+async function start() {
+  stopped = false;
+  await subscribe();
+
+  waitForBootAndDrain().catch((err) => {
+    log.error(`containerCrashRecovery - boot queue drain failed: ${err.message}`);
+  });
+}
+
 function stop() {
   stopped = true;
+  bootQueue.splice(0);
   if (eventStream) {
     eventStream.destroy();
     eventStream = null;

--- a/ZelBack/src/services/appMonitoring/containerCrashRecovery.js
+++ b/ZelBack/src/services/appMonitoring/containerCrashRecovery.js
@@ -1,0 +1,130 @@
+const log = require('../../lib/log');
+const dockerService = require('../dockerService');
+const globalState = require('../utils/globalState');
+const appInspector = require('../appManagement/appInspector');
+
+const MAX_RESTARTS = 3;
+const RESTART_WINDOW_MS = 5 * 60 * 1000;
+
+// containerName -> [timestampMs, ...]
+const restartHistory = new Map();
+
+let eventStream = null;
+let stopped = false;
+
+function isFluxContainer(name) {
+  return name.startsWith('flux') || name.startsWith('zel');
+}
+
+function getComponentIdentifier(containerName) {
+  if (containerName.startsWith('flux')) return containerName.substring(4);
+  if (containerName.startsWith('zel')) return containerName.substring(3);
+  return containerName;
+}
+
+function isCrashLooping(containerName) {
+  const now = Date.now();
+  const history = restartHistory.get(containerName);
+  if (!history) return false;
+  const recent = history.filter((ts) => now - ts < RESTART_WINDOW_MS);
+  restartHistory.set(containerName, recent);
+  return recent.length >= MAX_RESTARTS;
+}
+
+function recordRestart(containerName) {
+  const history = restartHistory.get(containerName) || [];
+  history.push(Date.now());
+  restartHistory.set(containerName, history);
+}
+
+async function handleContainerDie(event) {
+  const containerName = event.Actor?.Attributes?.name;
+  const exitCodeStr = event.Actor?.Attributes?.exitCode;
+  const exitCode = parseInt(exitCodeStr, 10);
+
+  if (!containerName || !isFluxContainer(containerName)) return;
+
+  if (exitCode === 0) {
+    log.info(`containerCrashRecovery - ${containerName} exited cleanly (0), no action`);
+    return;
+  }
+
+  if (!globalState.bootContainerStateSettled) {
+    log.info(`containerCrashRecovery - ${containerName} died (exit ${exitCode}) but boot not settled, skipping`);
+    return;
+  }
+
+  if (isCrashLooping(containerName)) {
+    log.warn(`containerCrashRecovery - ${containerName} crash-looping (${MAX_RESTARTS} restarts in ${RESTART_WINDOW_MS / 1000}s), not restarting`);
+    return;
+  }
+
+  const identifier = getComponentIdentifier(containerName);
+  log.warn(`containerCrashRecovery - ${containerName} crashed (exit ${exitCode}), restarting as ${identifier}`);
+
+  try {
+    recordRestart(containerName);
+    await dockerService.appDockerStart(identifier);
+    appInspector.startAppMonitoring(identifier, globalState.appsMonitored);
+    log.info(`containerCrashRecovery - ${identifier} restarted successfully`);
+  } catch (err) {
+    log.error(`containerCrashRecovery - failed to restart ${identifier}: ${err.message}`);
+  }
+}
+
+async function start() {
+  if (eventStream) return;
+  stopped = false;
+
+  try {
+    eventStream = await dockerService.dockerGetEvents({
+      filters: { type: ['container'], event: ['die'] },
+    });
+
+    eventStream.on('data', (buf) => {
+      if (stopped) return;
+      try {
+        const event = JSON.parse(buf.toString());
+        handleContainerDie(event).catch((err) => {
+          log.error(`containerCrashRecovery - event handler error: ${err.message}`);
+        });
+      } catch (parseErr) {
+        log.error(`containerCrashRecovery - failed to parse docker event: ${parseErr.message}`);
+      }
+    });
+
+    eventStream.on('error', (err) => {
+      log.error(`containerCrashRecovery - event stream error: ${err.message}`);
+      eventStream = null;
+      if (!stopped) {
+        setTimeout(() => start(), 10000);
+      }
+    });
+
+    eventStream.on('end', () => {
+      log.warn('containerCrashRecovery - event stream ended');
+      eventStream = null;
+      if (!stopped) {
+        setTimeout(() => start(), 10000);
+      }
+    });
+
+    log.info('containerCrashRecovery - listening for container crash events');
+  } catch (err) {
+    log.error(`containerCrashRecovery - failed to subscribe to docker events: ${err.message}`);
+    eventStream = null;
+    if (!stopped) {
+      setTimeout(() => start(), 10000);
+    }
+  }
+}
+
+function stop() {
+  stopped = true;
+  if (eventStream) {
+    eventStream.destroy();
+    eventStream = null;
+  }
+}
+
+module.exports = { start, stop };

--- a/ZelBack/src/services/appMonitoring/containerCrashRecovery.js
+++ b/ZelBack/src/services/appMonitoring/containerCrashRecovery.js
@@ -7,9 +7,6 @@ const appInspector = require('../appManagement/appInspector');
 const BACKOFF_DELAYS_MS = [0, 30 * 1000, 5 * 60 * 1000, 15 * 60 * 1000, 30 * 60 * 1000];
 const BACKOFF_RESET_MS = 60 * 60 * 1000;
 
-// containerName -> [monotonicMs, ...]
-const restartHistory = new Map();
-
 const bootQueue = [];
 
 let eventStream = null;
@@ -31,22 +28,22 @@ function nowMs() {
 
 function getBackoffDelay(containerName) {
   const now = nowMs();
-  const history = restartHistory.get(containerName);
+  const history = globalState.containerRestartHistory.get(containerName);
   if (!history) return 0;
   const recent = history.filter((ts) => now - ts < BACKOFF_RESET_MS);
   if (recent.length === 0) {
-    restartHistory.delete(containerName);
+    globalState.containerRestartHistory.delete(containerName);
     return 0;
   }
-  restartHistory.set(containerName, recent);
+  globalState.containerRestartHistory.set(containerName, recent);
   const index = Math.min(recent.length, BACKOFF_DELAYS_MS.length - 1);
   return BACKOFF_DELAYS_MS[index];
 }
 
 function recordRestart(containerName) {
-  const history = restartHistory.get(containerName) || [];
+  const history = globalState.containerRestartHistory.get(containerName) || [];
   history.push(nowMs());
-  restartHistory.set(containerName, history);
+  globalState.containerRestartHistory.set(containerName, history);
 }
 
 async function handleContainerDie(event) {

--- a/ZelBack/src/services/appMonitoring/containerCrashRecovery.js
+++ b/ZelBack/src/services/appMonitoring/containerCrashRecovery.js
@@ -5,7 +5,7 @@ const appInspector = require('../appManagement/appInspector');
 
 // immediate, 30s, 5m, 15m, 30m cap
 const BACKOFF_DELAYS_MS = [0, 30 * 1000, 5 * 60 * 1000, 15 * 60 * 1000, 30 * 60 * 1000];
-const BACKOFF_RESET_MS = 60 * 60 * 1000;
+const STABLE_RUN_MS = 10 * 60 * 1000;
 
 // containerName -> [monotonicMs, ...]
 const restartHistory = new Map();
@@ -33,14 +33,15 @@ function nowMs() {
 function getBackoffDelay(containerName) {
   const now = nowMs();
   const history = restartHistory.get(containerName);
-  if (!history) return 0;
-  const recent = history.filter((ts) => now - ts < BACKOFF_RESET_MS);
-  if (recent.length === 0) {
+  if (!history || history.length === 0) return 0;
+
+  const lastRestart = history[history.length - 1];
+  if (now - lastRestart > STABLE_RUN_MS) {
     restartHistory.delete(containerName);
     return 0;
   }
-  restartHistory.set(containerName, recent);
-  const index = Math.min(recent.length, BACKOFF_DELAYS_MS.length - 1);
+
+  const index = Math.min(history.length, BACKOFF_DELAYS_MS.length - 1);
   return BACKOFF_DELAYS_MS[index];
 }
 

--- a/ZelBack/src/services/appMonitoring/containerCrashRecovery.js
+++ b/ZelBack/src/services/appMonitoring/containerCrashRecovery.js
@@ -9,6 +9,8 @@ const RESTART_WINDOW_MS = 5 * 60 * 1000;
 // containerName -> [timestampMs, ...]
 const restartHistory = new Map();
 
+const bootQueue = [];
+
 let eventStream = null;
 let stopped = false;
 
@@ -46,8 +48,15 @@ async function handleContainerDie(event) {
 
   if (exitCode === 0) return;
 
+  if (globalState.stoppingContainers.has(containerName)) {
+    globalState.stoppingContainers.delete(containerName);
+    log.info(`containerCrashRecovery - ${containerName} was intentionally stopped, skipping`);
+    return;
+  }
+
   if (!globalState.bootContainerStateSettled) {
-    log.info(`containerCrashRecovery - ${containerName} died (exit ${exitCode}) but boot not settled, skipping`);
+    log.info(`containerCrashRecovery - ${containerName} died (exit ${exitCode}) during boot, queuing`);
+    bootQueue.push(event);
     return;
   }
 
@@ -67,6 +76,21 @@ async function handleContainerDie(event) {
   } catch (err) {
     log.error(`containerCrashRecovery - failed to restart ${identifier}: ${err.message}`);
   }
+}
+
+async function drainBootQueue() {
+  if (bootQueue.length === 0) return;
+  log.info(`containerCrashRecovery - draining ${bootQueue.length} queued event(s)`);
+  while (bootQueue.length > 0) {
+    const event = bootQueue.shift();
+    // eslint-disable-next-line no-await-in-loop
+    await handleContainerDie(event);
+  }
+}
+
+async function waitForBootAndDrain() {
+  await globalState.waitForBootContainerStateSettled();
+  if (!stopped) await drainBootQueue();
 }
 
 async function start() {
@@ -107,6 +131,10 @@ async function start() {
     });
 
     log.info('containerCrashRecovery - listening for container crash events');
+
+    waitForBootAndDrain().catch((err) => {
+      log.error(`containerCrashRecovery - boot queue drain failed: ${err.message}`);
+    });
   } catch (err) {
     log.error(`containerCrashRecovery - failed to subscribe to docker events: ${err.message}`);
     eventStream = null;

--- a/ZelBack/src/services/appMonitoring/containerCrashRecovery.js
+++ b/ZelBack/src/services/appMonitoring/containerCrashRecovery.js
@@ -3,10 +3,11 @@ const dockerService = require('../dockerService');
 const globalState = require('../utils/globalState');
 const appInspector = require('../appManagement/appInspector');
 
-const MAX_RESTARTS = 3;
-const RESTART_WINDOW_MS = 5 * 60 * 1000;
+// immediate, 30s, 5m, 15m, 30m cap
+const BACKOFF_DELAYS_MS = [0, 30 * 1000, 5 * 60 * 1000, 15 * 60 * 1000, 30 * 60 * 1000];
+const BACKOFF_RESET_MS = 60 * 60 * 1000;
 
-// containerName -> [timestampMs, ...]
+// containerName -> [monotonicMs, ...]
 const restartHistory = new Map();
 
 const bootQueue = [];
@@ -24,18 +25,27 @@ function getComponentIdentifier(containerName) {
   return containerName;
 }
 
-function isCrashLooping(containerName) {
-  const now = Date.now();
+function nowMs() {
+  return Number(process.hrtime.bigint() / 1_000_000n);
+}
+
+function getBackoffDelay(containerName) {
+  const now = nowMs();
   const history = restartHistory.get(containerName);
-  if (!history) return false;
-  const recent = history.filter((ts) => now - ts < RESTART_WINDOW_MS);
+  if (!history) return 0;
+  const recent = history.filter((ts) => now - ts < BACKOFF_RESET_MS);
+  if (recent.length === 0) {
+    restartHistory.delete(containerName);
+    return 0;
+  }
   restartHistory.set(containerName, recent);
-  return recent.length >= MAX_RESTARTS;
+  const index = Math.min(recent.length, BACKOFF_DELAYS_MS.length - 1);
+  return BACKOFF_DELAYS_MS[index];
 }
 
 function recordRestart(containerName) {
   const history = restartHistory.get(containerName) || [];
-  history.push(Date.now());
+  history.push(nowMs());
   restartHistory.set(containerName, history);
 }
 
@@ -60,13 +70,21 @@ async function handleContainerDie(event) {
     return;
   }
 
-  if (isCrashLooping(containerName)) {
-    log.warn(`containerCrashRecovery - ${containerName} crash-looping (${MAX_RESTARTS} restarts in ${RESTART_WINDOW_MS / 1000}s), not restarting`);
-    return;
-  }
-
   const identifier = getComponentIdentifier(containerName);
-  log.warn(`containerCrashRecovery - ${containerName} crashed (exit ${exitCode}), restarting as ${identifier}`);
+  const delay = getBackoffDelay(containerName);
+
+  if (delay > 0) {
+    log.warn(`containerCrashRecovery - ${containerName} crashed (exit ${exitCode}), waiting ${delay / 1000}s before restarting`);
+    await new Promise((resolve) => { setTimeout(resolve, delay); });
+    if (stopped) return;
+    const container = await dockerService.getDockerContainerOnly(identifier);
+    if (!container || container.State === 'running') {
+      log.info(`containerCrashRecovery - ${containerName} already handled during backoff, skipping`);
+      return;
+    }
+  } else {
+    log.warn(`containerCrashRecovery - ${containerName} crashed (exit ${exitCode}), restarting as ${identifier}`);
+  }
 
   try {
     recordRestart(containerName);

--- a/ZelBack/src/services/appMonitoring/containerCrashRecovery.js
+++ b/ZelBack/src/services/appMonitoring/containerCrashRecovery.js
@@ -44,10 +44,7 @@ async function handleContainerDie(event) {
 
   if (!containerName || !isFluxContainer(containerName)) return;
 
-  if (exitCode === 0) {
-    log.info(`containerCrashRecovery - ${containerName} exited cleanly (0), no action`);
-    return;
-  }
+  if (exitCode === 0) return;
 
   if (!globalState.bootContainerStateSettled) {
     log.info(`containerCrashRecovery - ${containerName} died (exit ${exitCode}) but boot not settled, skipping`);

--- a/ZelBack/src/services/appMonitoring/containerCrashRecovery.js
+++ b/ZelBack/src/services/appMonitoring/containerCrashRecovery.js
@@ -59,6 +59,7 @@ async function handleContainerDie(event) {
 
   if (globalState.stoppingContainers.has(containerName)) {
     globalState.stoppingContainers.delete(containerName);
+    log.info(`containerCrashRecovery - ${containerName} was intentionally stopped (exit ${exitCode}), skipping`);
     return;
   }
 

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -11,6 +11,8 @@ const fluxNetworkHelper = require('./fluxNetworkHelper');
 const log = require('../lib/log');
 const cpuBurstHelper = require('./utils/cpuBurstHelper');
 
+const globalState = require('./utils/globalState');
+
 const isArcane = Boolean(process.env.FLUXOS_PATH);
 
 const fluxDirPath = process.env.FLUXOS_PATH || path.join(process.env.HOME, 'zelflux');
@@ -59,6 +61,11 @@ function getAppIdentifier(appName) {
  * @param {string} appName
  * @returns {string} app docker name id
  */
+function getDockerName(idOrName) {
+  const name = getAppIdentifier(idOrName);
+  return name.startsWith('/') ? name.substring(1) : name;
+}
+
 function getAppDockerNameIdentifier(appName) {
   // this id is used for volumes, docker names so we know it reall belongs to flux
   const name = getAppIdentifier(appName);
@@ -1095,6 +1102,7 @@ async function appDockerStart(idOrName) {
     // container ID or name
     const dockerContainer = await getDockerContainerByIdOrName(idOrName);
 
+    globalState.stoppingContainers.delete(getDockerName(idOrName));
     await dockerContainer.start(); // may throw
 
     // Apply CFS burst after start — cgroup paths only exist once the container
@@ -1143,8 +1151,16 @@ async function appDockerStop(idOrName, timeout) {
     return `Flux App ${idOrName} is already stopped.`;
   }
 
-  const opts = timeout !== undefined ? { t: timeout } : {};
-  await dockerContainer.stop(opts);
+  const dockerName = getDockerName(idOrName);
+  globalState.stoppingContainers.add(dockerName);
+
+  try {
+    const opts = timeout !== undefined ? { t: timeout } : {};
+    await dockerContainer.stop(opts);
+  } catch (err) {
+    globalState.stoppingContainers.delete(dockerName);
+    throw err;
+  }
   return `Flux App ${idOrName} successfully stopped.`;
 }
 
@@ -1163,11 +1179,15 @@ async function appDockerRestart(idOrName) {
   const containerInfo = await dockerContainer.inspect();
   if (!containerInfo.State.Running) {
     // If stopped, start it instead of restarting
+    globalState.stoppingContainers.delete(getDockerName(idOrName));
     await dockerContainer.start();
     return `Flux App ${idOrName} was stopped, successfully started.`;
   }
 
+  const dockerName = getDockerName(idOrName);
+  globalState.stoppingContainers.add(dockerName);
   await dockerContainer.restart();
+  globalState.stoppingContainers.delete(dockerName);
   return `Flux App ${idOrName} successfully restarted.`;
 }
 
@@ -1181,7 +1201,15 @@ async function appDockerKill(idOrName) {
   // container ID or name
   const dockerContainer = await getDockerContainerByIdOrName(idOrName);
 
-  await dockerContainer.kill();
+  const dockerName = getDockerName(idOrName);
+  globalState.stoppingContainers.add(dockerName);
+
+  try {
+    await dockerContainer.kill();
+  } catch (err) {
+    globalState.stoppingContainers.delete(dockerName);
+    throw err;
+  }
   return `Flux App ${idOrName} successfully killed.`;
 }
 
@@ -1195,6 +1223,7 @@ async function appDockerRemove(idOrName) {
   // container ID or name
   const dockerContainer = await getDockerContainerByIdOrName(idOrName);
 
+  globalState.stoppingContainers.delete(getDockerName(idOrName));
   await dockerContainer.remove();
   return `Flux App ${idOrName} successfully removed.`;
 }
@@ -1210,6 +1239,7 @@ async function appDockerForceRemove(idOrName, removeVolumes = true) {
   // container ID or name
   const dockerContainer = await getDockerContainerByIdOrName(idOrName);
 
+  globalState.stoppingContainers.delete(getDockerName(idOrName));
   await dockerContainer.remove({ force: true, v: removeVolumes });
   return `Flux App ${idOrName} successfully force removed.`;
 }

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -1102,9 +1102,7 @@ async function appDockerStart(idOrName) {
     // container ID or name
     const dockerContainer = await getDockerContainerByIdOrName(idOrName);
 
-    const dockerName = getDockerName(idOrName);
-    globalState.stoppingContainers.delete(dockerName);
-    globalState.containerRestartHistory.delete(dockerName);
+    globalState.stoppingContainers.delete(getDockerName(idOrName));
     await dockerContainer.start(); // may throw
 
     // Apply CFS burst after start — cgroup paths only exist once the container
@@ -1188,8 +1186,11 @@ async function appDockerRestart(idOrName) {
 
   const dockerName = getDockerName(idOrName);
   globalState.stoppingContainers.add(dockerName);
-  await dockerContainer.restart();
-  globalState.stoppingContainers.delete(dockerName);
+  try {
+    await dockerContainer.restart();
+  } finally {
+    globalState.stoppingContainers.delete(dockerName);
+  }
   return `Flux App ${idOrName} successfully restarted.`;
 }
 

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -1582,12 +1582,13 @@ async function dockerVersion() {
 }
 
 /**
- * Returns docker events
+ * Returns docker events stream
  *
- * @returns {object}
+ * @param {object} options - Docker event filter options
+ * @returns {object} Readable stream of Docker events
  */
-async function dockerGetEvents() {
-  const events = await docker.getEvents();
+async function dockerGetEvents(options = {}) {
+  const events = await docker.getEvents(options);
   return events;
 }
 

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -1102,7 +1102,9 @@ async function appDockerStart(idOrName) {
     // container ID or name
     const dockerContainer = await getDockerContainerByIdOrName(idOrName);
 
-    globalState.stoppingContainers.delete(getDockerName(idOrName));
+    const dockerName = getDockerName(idOrName);
+    globalState.stoppingContainers.delete(dockerName);
+    globalState.containerRestartHistory.delete(dockerName);
     await dockerContainer.start(); // may throw
 
     // Apply CFS burst after start — cgroup paths only exist once the container

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -23,6 +23,7 @@ const nodeStatusMonitor = require('./appMonitoring/nodeStatusMonitor');
 const peerNotification = require('./appMessaging/peerNotification');
 const syncthingMonitor = require('./appMonitoring/syncthingMonitor');
 const daemonHealthMonitor = require('./appMonitoring/daemonHealthMonitor');
+const containerCrashRecovery = require('./appMonitoring/containerCrashRecovery');
 const advancedWorkflows = require('./appLifecycle/advancedWorkflows');
 const imageManager = require('./appSecurity/imageManager');
 const appSpawner = require('./appLifecycle/appSpawner');
@@ -264,6 +265,10 @@ async function startFluxFunctions() {
     // Non-destructive — doesn't stop containers, just prevents Docker from auto-starting
     // them on future daemon restarts. FluxOS manages container startup after dbReady.
     dockerService.migrateContainerRestartPolicies();
+
+    // Subscribe to Docker container die events for immediate crash recovery.
+    // Gates on bootContainerStateSettled internally so boot reconciliation runs first.
+    containerCrashRecovery.start();
 
     // Read boot context early — determines startup behavior for container management.
     const bootContext = await AppSyncOrchestrator.readBootContext();

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -267,15 +267,14 @@ async function startFluxFunctions() {
     dockerService.migrateContainerRestartPolicies();
 
     // Subscribe to Docker container die events for immediate crash recovery.
-    // Gates on bootContainerStateSettled internally so boot reconciliation runs first.
+    // Events during boot are queued; drainBootQueue() replays them after boot settles.
     containerCrashRecovery.start();
 
     // Read boot context early — determines startup behavior for container management.
     const bootContext = await AppSyncOrchestrator.readBootContext();
 
     // App startup manager owns all boot-time container lifecycle decisions:
-    // FluxOS restart → skip (containers running). Locations expired → remove all.
-    // Machine rebooted → wait for dbReady, then start valid apps. Timeout → remove all.
+    // Locations expired → remove all. Otherwise wait for daemon/DB, then reconcile.
     appStartupManager.manageAppsOnBoot(bootContext).catch((error) => {
       log.error(`App startup manager error: ${error.message}`);
     });

--- a/ZelBack/src/services/utils/globalState.js
+++ b/ZelBack/src/services/utils/globalState.js
@@ -42,8 +42,6 @@ const runningAppsCache = new Set();
 // Containers intentionally stopped by FluxOS — crash recovery skips die events for these
 const stoppingContainers = new Set();
 
-// containerName -> [monotonicMs, ...] — tracks restart attempts for backoff
-const containerRestartHistory = new Map();
 
 // Cache references - these will be initialized from cacheManager
 let spawnErrorsLongerAppCache = null;
@@ -126,7 +124,6 @@ module.exports = {
   get folderHealthCache() { return folderHealthCache; },
   get runningAppsCache() { return runningAppsCache; },
   get stoppingContainers() { return stoppingContainers; },
-  get containerRestartHistory() { return containerRestartHistory; },
 
   get spawnErrorsLongerAppCache() { return spawnErrorsLongerAppCache; },
   set spawnErrorsLongerAppCache(value) { spawnErrorsLongerAppCache = value; },

--- a/ZelBack/src/services/utils/globalState.js
+++ b/ZelBack/src/services/utils/globalState.js
@@ -42,6 +42,9 @@ const runningAppsCache = new Set();
 // Containers intentionally stopped by FluxOS — crash recovery skips die events for these
 const stoppingContainers = new Set();
 
+// containerName -> [monotonicMs, ...] — tracks restart attempts for backoff
+const containerRestartHistory = new Map();
+
 // Cache references - these will be initialized from cacheManager
 let spawnErrorsLongerAppCache = null;
 let trySpawningGlobalAppCache = null;
@@ -123,6 +126,7 @@ module.exports = {
   get folderHealthCache() { return folderHealthCache; },
   get runningAppsCache() { return runningAppsCache; },
   get stoppingContainers() { return stoppingContainers; },
+  get containerRestartHistory() { return containerRestartHistory; },
 
   get spawnErrorsLongerAppCache() { return spawnErrorsLongerAppCache; },
   set spawnErrorsLongerAppCache(value) { spawnErrorsLongerAppCache = value; },

--- a/ZelBack/src/services/utils/globalState.js
+++ b/ZelBack/src/services/utils/globalState.js
@@ -39,6 +39,9 @@ let pendingAppUpdatesCache = null;
 // Running apps cache - tracks app names that have been broadcasted as running
 const runningAppsCache = new Set();
 
+// Containers intentionally stopped by FluxOS — crash recovery skips die events for these
+const stoppingContainers = new Set();
+
 // Cache references - these will be initialized from cacheManager
 let spawnErrorsLongerAppCache = null;
 let trySpawningGlobalAppCache = null;
@@ -119,6 +122,7 @@ module.exports = {
   get syncthingDevicesIDCache() { return syncthingDevicesIDCache; },
   get folderHealthCache() { return folderHealthCache; },
   get runningAppsCache() { return runningAppsCache; },
+  get stoppingContainers() { return stoppingContainers; },
 
   get spawnErrorsLongerAppCache() { return spawnErrorsLongerAppCache; },
   set spawnErrorsLongerAppCache(value) { spawnErrorsLongerAppCache = value; },

--- a/tests/unit/appStartupManager.test.js
+++ b/tests/unit/appStartupManager.test.js
@@ -487,14 +487,16 @@ describe('appStartupManager tests', () => {
   });
 
   describe('manageAppsOnBoot', () => {
-    it('should skip recovery on FluxOS-only restart', async () => {
+    it('should reconcile on FluxOS-only restart (no stopped containers)', async () => {
       const bootContext = {
         machineRebooted: false, downtimeMs: 1000, cleanShutdown: true,
       };
+      dockerServiceStub.dockerListContainers.resolves([]);
+      dbHelperStub.findInDatabase.resolves([]);
 
       await appStartupManager.manageAppsOnBoot(bootContext);
 
-      expect(logStub.info.calledWithMatch(/FluxOS-only restart/)).to.be.true;
+      expect(globalStateStub.waitForDbReady.calledOnce).to.be.true;
       expect(appUninstallerStub.removeAppLocally.called).to.be.false;
     });
 
@@ -591,9 +593,11 @@ describe('appStartupManager tests', () => {
     });
 
     it('should set bootContainerStateSettled on every exit path', async () => {
-      // FluxOS restart path
+      // FluxOS restart path (still reconciles, no stopped containers)
       globalStateStub.bootContainerStateSettled = false;
-      await appStartupManager.manageAppsOnBoot({ machineRebooted: false });
+      dockerServiceStub.dockerListContainers.resolves([]);
+      dbHelperStub.findInDatabase.resolves([]);
+      await appStartupManager.manageAppsOnBoot({ machineRebooted: false, downtimeMs: 1000, cleanShutdown: true });
       expect(globalStateStub.bootContainerStateSettled).to.be.true;
 
       // Expired locations path

--- a/tests/unit/containerCrashRecovery.test.js
+++ b/tests/unit/containerCrashRecovery.test.js
@@ -20,6 +20,7 @@ describe('containerCrashRecovery tests', () => {
       bootContainerStateSettled: true,
       appsMonitored: {},
       stoppingContainers: new Set(),
+      containerRestartHistory: new Map(),
     };
     appInspectorStub = { startAppMonitoring: sinon.stub() };
 

--- a/tests/unit/containerCrashRecovery.test.js
+++ b/tests/unit/containerCrashRecovery.test.js
@@ -20,7 +20,6 @@ describe('containerCrashRecovery tests', () => {
       bootContainerStateSettled: true,
       appsMonitored: {},
       stoppingContainers: new Set(),
-      containerRestartHistory: new Map(),
     };
     appInspectorStub = { startAppMonitoring: sinon.stub() };
 
@@ -97,6 +96,53 @@ describe('containerCrashRecovery tests', () => {
       expect(dockerServiceStub.dockerGetEvents.calledOnce).to.be.true;
       clock.restore();
     });
+
+    it('should clear boot queue on stop()', async () => {
+      globalStateStub.bootContainerStateSettled = false;
+      globalStateStub.waitForBootContainerStateSettled = sinon.stub().returns(new Promise(() => {}));
+
+      const fakeStream = new EventEmitter();
+      fakeStream.destroy = sinon.stub();
+      dockerServiceStub.dockerGetEvents.resolves(fakeStream);
+      await crashRecovery.start();
+
+      const event = makeDieEvent('fluxwww_Osmosis', 1);
+      fakeStream.emit('data', Buffer.from(JSON.stringify(event) + '\n'));
+      await new Promise((r) => setImmediate(r));
+      expect(logStub.info.calledWithMatch(/during boot, queuing/)).to.be.true;
+
+      crashRecovery.stop();
+
+      globalStateStub.bootContainerStateSettled = true;
+      await new Promise((r) => setImmediate(r));
+      expect(dockerServiceStub.appDockerStart.called).to.be.false;
+    });
+
+    it('should not carry partial line buffer across reconnect', async () => {
+      const clock = sinon.useFakeTimers({ shouldAdvanceTime: true });
+      const fakeStream = new EventEmitter();
+      fakeStream.destroy = sinon.stub();
+      dockerServiceStub.dockerGetEvents.resolves(fakeStream);
+      await crashRecovery.start();
+
+      fakeStream.emit('data', Buffer.from('{"partial":"junk'));
+      await clock.tickAsync(0);
+
+      fakeStream.emit('error', new Error('disconnect'));
+
+      const fakeStream2 = new EventEmitter();
+      fakeStream2.destroy = sinon.stub();
+      dockerServiceStub.dockerGetEvents.resolves(fakeStream2);
+      await clock.tickAsync(10000);
+
+      const event = makeDieEvent('fluxwww_Osmosis', 1);
+      fakeStream2.emit('data', Buffer.from(JSON.stringify(event) + '\n'));
+      await clock.tickAsync(0);
+
+      expect(dockerServiceStub.appDockerStart.calledOnce).to.be.true;
+      expect(dockerServiceStub.appDockerStart.firstCall.args[0]).to.equal('www_Osmosis');
+      clock.restore();
+    });
   });
 
   describe('event handling', () => {
@@ -111,7 +157,7 @@ describe('containerCrashRecovery tests', () => {
 
     function emitDie(name, exitCode) {
       const event = makeDieEvent(name, exitCode);
-      fakeStream.emit('data', Buffer.from(JSON.stringify(event)));
+      fakeStream.emit('data', Buffer.from(JSON.stringify(event) + '\n'));
     }
 
     it('should restart a crashed flux container', async () => {
@@ -153,7 +199,16 @@ describe('containerCrashRecovery tests', () => {
       await new Promise((r) => setImmediate(r));
 
       expect(dockerServiceStub.appDockerStart.called).to.be.false;
-      expect(logStub.info.calledWithMatch(/intentionally stopped/)).to.be.true;
+      expect(globalStateStub.stoppingContainers.has('fluxwww_Osmosis')).to.be.false;
+    });
+
+    it('should consume stoppingContainers even on clean exit', async () => {
+      globalStateStub.stoppingContainers.add('fluxwww_Osmosis');
+
+      emitDie('fluxwww_Osmosis', 0);
+      await new Promise((r) => setImmediate(r));
+
+      expect(dockerServiceStub.appDockerStart.called).to.be.false;
       expect(globalStateStub.stoppingContainers.has('fluxwww_Osmosis')).to.be.false;
     });
 
@@ -172,7 +227,7 @@ describe('containerCrashRecovery tests', () => {
       await crashRecovery.start();
 
       const event = makeDieEvent('fluxwww_Osmosis', 1);
-      freshStream.emit('data', Buffer.from(JSON.stringify(event)));
+      freshStream.emit('data', Buffer.from(JSON.stringify(event) + '\n'));
       await new Promise((r) => setImmediate(r));
 
       expect(dockerServiceStub.appDockerStart.called).to.be.false;
@@ -248,6 +303,29 @@ describe('containerCrashRecovery tests', () => {
       await new Promise((r) => setImmediate(r));
 
       expect(logStub.error.calledWithMatch(/failed to restart/)).to.be.true;
+    });
+
+    it('should handle two events in one chunk', async () => {
+      const event1 = makeDieEvent('fluxwww_Osmosis', 1);
+      const event2 = makeDieEvent('fluxkaspad_foo', 1);
+      fakeStream.emit('data', Buffer.from(JSON.stringify(event1) + '\n' + JSON.stringify(event2) + '\n'));
+      await new Promise((r) => setImmediate(r));
+
+      expect(dockerServiceStub.appDockerStart.callCount).to.equal(2);
+      expect(dockerServiceStub.appDockerStart.firstCall.args[0]).to.equal('www_Osmosis');
+      expect(dockerServiceStub.appDockerStart.secondCall.args[0]).to.equal('kaspad_foo');
+    });
+
+    it('should handle an event split across two chunks', async () => {
+      const json = JSON.stringify(makeDieEvent('fluxwww_Osmosis', 1)) + '\n';
+      const mid = Math.floor(json.length / 2);
+      fakeStream.emit('data', Buffer.from(json.slice(0, mid)));
+      await new Promise((r) => setImmediate(r));
+      expect(dockerServiceStub.appDockerStart.called).to.be.false;
+
+      fakeStream.emit('data', Buffer.from(json.slice(mid)));
+      await new Promise((r) => setImmediate(r));
+      expect(dockerServiceStub.appDockerStart.calledOnce).to.be.true;
     });
   });
 });

--- a/tests/unit/containerCrashRecovery.test.js
+++ b/tests/unit/containerCrashRecovery.test.js
@@ -19,6 +19,7 @@ describe('containerCrashRecovery tests', () => {
     globalStateStub = {
       bootContainerStateSettled: true,
       appsMonitored: {},
+      stoppingContainers: new Set(),
     };
     appInspectorStub = { startAppMonitoring: sinon.stub() };
 
@@ -144,14 +145,45 @@ describe('containerCrashRecovery tests', () => {
       expect(dockerServiceStub.appDockerStart.called).to.be.false;
     });
 
-    it('should skip restart when boot not settled', async () => {
-      globalStateStub.bootContainerStateSettled = false;
+    it('should skip containers in the stoppingContainers set', async () => {
+      globalStateStub.stoppingContainers.add('fluxwww_Osmosis');
 
-      emitDie('fluxwww_Osmosis', 1);
+      emitDie('fluxwww_Osmosis', 137);
       await new Promise((r) => setImmediate(r));
 
       expect(dockerServiceStub.appDockerStart.called).to.be.false;
-      expect(logStub.info.calledWithMatch(/boot not settled/)).to.be.true;
+      expect(logStub.info.calledWithMatch(/intentionally stopped/)).to.be.true;
+      expect(globalStateStub.stoppingContainers.has('fluxwww_Osmosis')).to.be.false;
+    });
+
+    it('should queue events when boot not settled and drain after', async () => {
+      // Need a fresh instance with boot not settled from the start
+      crashRecovery.stop();
+      globalStateStub.bootContainerStateSettled = false;
+      let resolveBootSettled;
+      globalStateStub.waitForBootContainerStateSettled = sinon.stub().returns(
+        new Promise((resolve) => { resolveBootSettled = resolve; }),
+      );
+
+      const freshStream = new EventEmitter();
+      freshStream.destroy = sinon.stub();
+      dockerServiceStub.dockerGetEvents.resolves(freshStream);
+      await crashRecovery.start();
+
+      const event = makeDieEvent('fluxwww_Osmosis', 1);
+      freshStream.emit('data', Buffer.from(JSON.stringify(event)));
+      await new Promise((r) => setImmediate(r));
+
+      expect(dockerServiceStub.appDockerStart.called).to.be.false;
+      expect(logStub.info.calledWithMatch(/during boot, queuing/)).to.be.true;
+
+      globalStateStub.bootContainerStateSettled = true;
+      resolveBootSettled();
+      await new Promise((r) => setImmediate(r));
+      await new Promise((r) => setImmediate(r));
+
+      expect(dockerServiceStub.appDockerStart.calledOnce).to.be.true;
+      expect(dockerServiceStub.appDockerStart.firstCall.args[0]).to.equal('www_Osmosis');
     });
 
     it('should detect crash loops and stop restarting', async () => {

--- a/tests/unit/containerCrashRecovery.test.js
+++ b/tests/unit/containerCrashRecovery.test.js
@@ -186,33 +186,58 @@ describe('containerCrashRecovery tests', () => {
       expect(dockerServiceStub.appDockerStart.firstCall.args[0]).to.equal('www_Osmosis');
     });
 
-    it('should detect crash loops and stop restarting', async () => {
-      for (let i = 0; i < 3; i++) {
-        emitDie('fluxwww_Osmosis', 1);
-        // eslint-disable-next-line no-await-in-loop
-        await new Promise((r) => setImmediate(r));
-      }
-
-      expect(dockerServiceStub.appDockerStart.callCount).to.equal(3);
-
+    it('should restart immediately on first crash', async () => {
       emitDie('fluxwww_Osmosis', 1);
       await new Promise((r) => setImmediate(r));
 
-      expect(dockerServiceStub.appDockerStart.callCount).to.equal(3);
-      expect(logStub.warn.calledWithMatch(/crash-looping/)).to.be.true;
+      expect(dockerServiceStub.appDockerStart.calledOnce).to.be.true;
+      expect(logStub.warn.calledWithMatch(/crashed.*restarting/)).to.be.true;
     });
 
-    it('should not apply crash loop of one container to another', async () => {
-      for (let i = 0; i < 3; i++) {
-        emitDie('fluxwww_Osmosis', 1);
-        // eslint-disable-next-line no-await-in-loop
-        await new Promise((r) => setImmediate(r));
-      }
+    it('should apply backoff delay on second crash', async () => {
+      const clock = sinon.useFakeTimers({ shouldAdvanceTime: true });
+
+      emitDie('fluxwww_Osmosis', 1);
+      await clock.tickAsync(0);
+      expect(dockerServiceStub.appDockerStart.callCount).to.equal(1);
+
+      dockerServiceStub.getDockerContainerOnly = sinon.stub().resolves({ State: 'exited' });
+      emitDie('fluxwww_Osmosis', 1);
+      await clock.tickAsync(0);
+      expect(dockerServiceStub.appDockerStart.callCount).to.equal(1);
+      expect(logStub.warn.calledWithMatch(/waiting 30s/)).to.be.true;
+
+      await clock.tickAsync(30000);
+      expect(dockerServiceStub.appDockerStart.callCount).to.equal(2);
+
+      clock.restore();
+    });
+
+    it('should skip restart if container handled during backoff', async () => {
+      const clock = sinon.useFakeTimers({ shouldAdvanceTime: true });
+
+      emitDie('fluxwww_Osmosis', 1);
+      await clock.tickAsync(0);
+
+      dockerServiceStub.getDockerContainerOnly = sinon.stub().resolves({ State: 'running' });
+      emitDie('fluxwww_Osmosis', 1);
+      await clock.tickAsync(0);
+
+      await clock.tickAsync(30000);
+      expect(dockerServiceStub.appDockerStart.callCount).to.equal(1);
+      expect(logStub.info.calledWithMatch(/already handled during backoff/)).to.be.true;
+
+      clock.restore();
+    });
+
+    it('should not apply backoff of one container to another', async () => {
+      emitDie('fluxwww_Osmosis', 1);
+      await new Promise((r) => setImmediate(r));
 
       emitDie('fluxEthereumNodeLight_EthereumNodeLight', 1);
       await new Promise((r) => setImmediate(r));
 
-      expect(dockerServiceStub.appDockerStart.callCount).to.equal(4);
+      expect(dockerServiceStub.appDockerStart.callCount).to.equal(2);
     });
 
     it('should handle docker start failure gracefully', async () => {

--- a/tests/unit/containerCrashRecovery.test.js
+++ b/tests/unit/containerCrashRecovery.test.js
@@ -134,6 +134,7 @@ describe('containerCrashRecovery tests', () => {
       await new Promise((r) => setImmediate(r));
 
       expect(dockerServiceStub.appDockerStart.called).to.be.false;
+      expect(logStub.warn.called).to.be.false;
     });
 
     it('should ignore non-flux containers', async () => {

--- a/tests/unit/containerCrashRecovery.test.js
+++ b/tests/unit/containerCrashRecovery.test.js
@@ -286,6 +286,32 @@ describe('containerCrashRecovery tests', () => {
       clock.restore();
     });
 
+    it('should reset backoff after container runs for 10+ minutes', async () => {
+      const clock = sinon.useFakeTimers({ shouldAdvanceTime: true });
+
+      // First crash — immediate
+      emitDie('fluxwww_Osmosis', 1);
+      await clock.tickAsync(0);
+      expect(dockerServiceStub.appDockerStart.callCount).to.equal(1);
+
+      // Second crash — 30s backoff
+      dockerServiceStub.getDockerContainerOnly = sinon.stub().resolves({ State: 'exited' });
+      emitDie('fluxwww_Osmosis', 1);
+      await clock.tickAsync(30000);
+      expect(dockerServiceStub.appDockerStart.callCount).to.equal(2);
+
+      // Container runs successfully for 10+ minutes, then crashes again
+      await clock.tickAsync(11 * 60 * 1000);
+      emitDie('fluxwww_Osmosis', 1);
+      await clock.tickAsync(0);
+
+      // Should be immediate again (backoff reset), not 5m
+      expect(dockerServiceStub.appDockerStart.callCount).to.equal(3);
+      expect(logStub.warn.calledWithMatch(/waiting 5/)).to.be.false;
+
+      clock.restore();
+    });
+
     it('should not apply backoff of one container to another', async () => {
       emitDie('fluxwww_Osmosis', 1);
       await new Promise((r) => setImmediate(r));

--- a/tests/unit/containerCrashRecovery.test.js
+++ b/tests/unit/containerCrashRecovery.test.js
@@ -1,0 +1,194 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+const { EventEmitter } = require('events');
+const proxyquire = require('proxyquire').noCallThru();
+
+describe('containerCrashRecovery tests', () => {
+  let crashRecovery;
+  let dockerServiceStub;
+  let globalStateStub;
+  let appInspectorStub;
+  let logStub;
+
+  beforeEach(() => {
+    logStub = { info: sinon.stub(), warn: sinon.stub(), error: sinon.stub() };
+    dockerServiceStub = {
+      appDockerStart: sinon.stub().resolves('started'),
+      dockerGetEvents: sinon.stub(),
+    };
+    globalStateStub = {
+      bootContainerStateSettled: true,
+      appsMonitored: {},
+    };
+    appInspectorStub = { startAppMonitoring: sinon.stub() };
+
+    crashRecovery = proxyquire('../../ZelBack/src/services/appMonitoring/containerCrashRecovery', {
+      '../../lib/log': logStub,
+      '../dockerService': dockerServiceStub,
+      '../utils/globalState': globalStateStub,
+      '../appManagement/appInspector': appInspectorStub,
+    });
+  });
+
+  afterEach(() => {
+    crashRecovery.stop();
+    sinon.restore();
+  });
+
+  function makeDieEvent(name, exitCode) {
+    return {
+      Type: 'container',
+      Action: 'die',
+      Actor: { Attributes: { name, exitCode: String(exitCode) } },
+    };
+  }
+
+  describe('start/stop', () => {
+    it('should subscribe to docker die events', async () => {
+      const fakeStream = new EventEmitter();
+      fakeStream.destroy = sinon.stub();
+      dockerServiceStub.dockerGetEvents.resolves(fakeStream);
+
+      await crashRecovery.start();
+
+      expect(dockerServiceStub.dockerGetEvents.calledOnce).to.be.true;
+      const opts = dockerServiceStub.dockerGetEvents.firstCall.args[0];
+      expect(opts.filters.type).to.deep.equal(['container']);
+      expect(opts.filters.event).to.deep.equal(['die']);
+    });
+
+    it('should reconnect on stream error', async () => {
+      const clock = sinon.useFakeTimers();
+      const fakeStream = new EventEmitter();
+      fakeStream.destroy = sinon.stub();
+      dockerServiceStub.dockerGetEvents.resolves(fakeStream);
+
+      await crashRecovery.start();
+      fakeStream.emit('error', new Error('connection lost'));
+
+      expect(logStub.error.calledWithMatch(/event stream error/)).to.be.true;
+
+      const fakeStream2 = new EventEmitter();
+      fakeStream2.destroy = sinon.stub();
+      dockerServiceStub.dockerGetEvents.resolves(fakeStream2);
+
+      clock.tick(10000);
+      await Promise.resolve();
+
+      expect(dockerServiceStub.dockerGetEvents.calledTwice).to.be.true;
+      clock.restore();
+    });
+
+    it('should not reconnect after stop()', async () => {
+      const clock = sinon.useFakeTimers();
+      const fakeStream = new EventEmitter();
+      fakeStream.destroy = sinon.stub();
+      dockerServiceStub.dockerGetEvents.resolves(fakeStream);
+
+      await crashRecovery.start();
+      crashRecovery.stop();
+      fakeStream.emit('error', new Error('connection lost'));
+
+      clock.tick(15000);
+      await Promise.resolve();
+
+      expect(dockerServiceStub.dockerGetEvents.calledOnce).to.be.true;
+      clock.restore();
+    });
+  });
+
+  describe('event handling', () => {
+    let fakeStream;
+
+    beforeEach(async () => {
+      fakeStream = new EventEmitter();
+      fakeStream.destroy = sinon.stub();
+      dockerServiceStub.dockerGetEvents.resolves(fakeStream);
+      await crashRecovery.start();
+    });
+
+    function emitDie(name, exitCode) {
+      const event = makeDieEvent(name, exitCode);
+      fakeStream.emit('data', Buffer.from(JSON.stringify(event)));
+    }
+
+    it('should restart a crashed flux container', async () => {
+      emitDie('fluxwww_Osmosis', 1);
+      await new Promise((r) => setImmediate(r));
+
+      expect(dockerServiceStub.appDockerStart.calledOnce).to.be.true;
+      expect(dockerServiceStub.appDockerStart.firstCall.args[0]).to.equal('www_Osmosis');
+      expect(appInspectorStub.startAppMonitoring.calledOnce).to.be.true;
+    });
+
+    it('should restart a crashed zel container', async () => {
+      emitDie('zelKadenaChainWebNode', 1);
+      await new Promise((r) => setImmediate(r));
+
+      expect(dockerServiceStub.appDockerStart.calledOnce).to.be.true;
+      expect(dockerServiceStub.appDockerStart.firstCall.args[0]).to.equal('KadenaChainWebNode');
+    });
+
+    it('should ignore clean exits (code 0)', async () => {
+      emitDie('fluxwww_Osmosis', 0);
+      await new Promise((r) => setImmediate(r));
+
+      expect(dockerServiceStub.appDockerStart.called).to.be.false;
+    });
+
+    it('should ignore non-flux containers', async () => {
+      emitDie('nginx_proxy', 1);
+      await new Promise((r) => setImmediate(r));
+
+      expect(dockerServiceStub.appDockerStart.called).to.be.false;
+    });
+
+    it('should skip restart when boot not settled', async () => {
+      globalStateStub.bootContainerStateSettled = false;
+
+      emitDie('fluxwww_Osmosis', 1);
+      await new Promise((r) => setImmediate(r));
+
+      expect(dockerServiceStub.appDockerStart.called).to.be.false;
+      expect(logStub.info.calledWithMatch(/boot not settled/)).to.be.true;
+    });
+
+    it('should detect crash loops and stop restarting', async () => {
+      for (let i = 0; i < 3; i++) {
+        emitDie('fluxwww_Osmosis', 1);
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise((r) => setImmediate(r));
+      }
+
+      expect(dockerServiceStub.appDockerStart.callCount).to.equal(3);
+
+      emitDie('fluxwww_Osmosis', 1);
+      await new Promise((r) => setImmediate(r));
+
+      expect(dockerServiceStub.appDockerStart.callCount).to.equal(3);
+      expect(logStub.warn.calledWithMatch(/crash-looping/)).to.be.true;
+    });
+
+    it('should not apply crash loop of one container to another', async () => {
+      for (let i = 0; i < 3; i++) {
+        emitDie('fluxwww_Osmosis', 1);
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise((r) => setImmediate(r));
+      }
+
+      emitDie('fluxEthereumNodeLight_EthereumNodeLight', 1);
+      await new Promise((r) => setImmediate(r));
+
+      expect(dockerServiceStub.appDockerStart.callCount).to.equal(4);
+    });
+
+    it('should handle docker start failure gracefully', async () => {
+      dockerServiceStub.appDockerStart.rejects(new Error('container gone'));
+
+      emitDie('fluxwww_Osmosis', 1);
+      await new Promise((r) => setImmediate(r));
+
+      expect(logStub.error.calledWithMatch(/failed to restart/)).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Instant crash recovery for Docker containers via event stream subscription, replacing the 1-2 hour polling gap left after PR #1726 removed `restart: always`.

### What it does
- Subscribes to Docker `die` events for real-time crash detection
- Restarts crashed containers (non-zero exit) with exponential backoff
- Suppresses restart for intentional FluxOS stops (uninstall, redeploy, backup, API stop)
- Queues events during boot and drains after `bootContainerStateSettled`
- Reconciles exited containers on FluxOS-only restarts (previously skipped)

### Backoff schedule

| Attempt | Delay | Cumulative |
|---------|-------|------------|
| 1st | immediate | 0s |
| 2nd | 30s | 30s |
| 3rd | 5 min | 5m 30s |
| 4th | 15 min | 20m 30s |
| 5th+ | 30 min (cap) | 50m 30s+ |

Backoff resets after 10 minutes of stable running — if the container ran for 10+ minutes since the last restart, the next crash starts fresh at immediate. Never gives up — permanently broken containers are retried at the 30m cap indefinitely until the operator uninstalls.

### Suppression mechanism

`appDockerStop`/`Kill` add the container to `globalState.stoppingContainers`. `appDockerStart`/`Remove`/`ForceRemove` clear it. The crash recovery handler checks and consumes the entry — no TTL, no leaks.

| Scenario | Behaviour |
|----------|-----------|
| Container crashes | Restarted with backoff |
| `docker stop` clean exit (code 0) | Filtered by exit code, suppression consumed |
| `docker stop` dirty exit (code 137) | Filtered by suppression set |
| Container removed (uninstall) | Suppression cleared on remove |
| Crash during boot | Queued, drained after boot settles |
| Container handled during backoff wait | Checked after delay, skipped |

### Files changed

| File | Change |
|------|--------|
| `containerCrashRecovery.js` (new) | Docker event stream listener, backoff, boot queue, NDJSON line buffer |
| `dockerService.js` | Suppression in stop/kill/restart, cleanup in start/remove, filter passthrough for `getEvents` |
| `appStartupManager.js` | Remove `machineRebooted` gate so FluxOS restarts reconcile exited containers |
| `serviceManager.js` | Wire up crash recovery on startup |
| `globalState.js` | `stoppingContainers` Set |

## Test plan

Verified on live Arcane nodes (46.225.195.244, 119.246.12.164):

| Test | Verified | Evidence |
|------|----------|----------|
| External `docker kill` → immediate restart | Yes | Log: `crashed (exit 137), restarting` → `restarted successfully` |
| Second crash → 30s backoff | Yes | Log: `waiting 30s before restarting` → restarted 30s later |
| FluxOS API stop, clean exit (0) → not restarted | Yes | Container stayed exited, no crash recovery log |
| FluxOS API stop, dirty exit (137) → suppressed | Yes | Log: `was intentionally stopped (exit 137), skipping` |
| Boot reconciliation, expired location → removed | Yes | Log: `no longer has a valid location record, removing locally` |
| Boot reconciliation, no stopped containers → no-op | Yes | Log: `No stopped containers found` |
| Boot queue drain | Yes | Log: `draining 1 queued event(s)` |
| 20 unit tests | Yes | All passing |
| 65 dockerService tests | Yes | All passing |
| 33 appStartupManager tests | Yes | All passing |

Written against bc64c97e7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)