### PR TITLE
Handle g: master/slave per component in masterSlaveApps + restore #1728 recovery behavior

### DIFF
--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -3892,8 +3892,11 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                       const response = await axios.get(`http://${ipToCheck}:${portToCheck}/apps/listrunningapps`, { timeout, cancelToken: source.token });
                       isResolved = true;
                       const appsRunning = response.data.data;
-                      if (appsRunning.find((app) => app.Names[0].includes(installedApp.name))) {
-                        log.info(`masterSlaveApps: app:${installedApp.name} is running on lower-index node (index ${i}) at ${ipToCheck}, will not start`);
+                      // Match on the g: component identifier, not the app name: non-g siblings
+                      // (e.g. a DB cluster component) run on every node and must not be mistaken
+                      // for the master/slave component being active there.
+                      if (appsRunning.find((app) => app.Names[0].includes(identifier))) {
+                        log.info(`masterSlaveApps: component:${identifier} is running on lower-index node (index ${i}) at ${ipToCheck}, will not start`);
                         return true;
                       }
                     } catch (error) {
@@ -3907,8 +3910,8 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
 
                 if (index === 0 && !mastersRunningGSyncthingApps.has(identifier)) {
                   // Index 0: Start immediately if no history
-                  appDockerRestartWithPermissionsFix(installedApp.name, appId);
-                  log.info(`masterSlaveApps: starting docker app:${installedApp.name} index: ${index}`);
+                  appDockerRestartWithPermissionsFix(identifier, appId);
+                  log.info(`masterSlaveApps: starting docker component:${identifier} index: ${index}`);
                 } else if (!timeTostartNewMasterApp.has(identifier) && mastersRunningGSyncthingApps.has(identifier) && !socketAddressesMatch(mastersRunningGSyncthingApps.get(identifier), localSocketAddr)) {
                   // There was a previous master (not me), and it's no longer on FDM
                   const { CancelToken } = axios;
@@ -3931,8 +3934,11 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                     const response = await axios.get(`http://${ipToCheckAppRunning}:${portToCheckAppRunning}/apps/listrunningapps`, { timeout, cancelToken: source.token });
                     isResolved = true;
                     const appsRunning = response.data.data;
-                    if (appsRunning.find((app) => app.Names[0].includes(installedApp.name))) {
-                      log.info(`masterSlaveApps: app:${installedApp.name} is not on fdm but previous master is running it at: ${ipToCheckAppRunning}:${portToCheckAppRunning}`);
+                    // Match on the g: component identifier, not the app name: non-g siblings
+                    // running on the previous master must not be mistaken for the master/slave
+                    // component still being active there.
+                    if (appsRunning.find((app) => app.Names[0].includes(identifier))) {
+                      log.info(`masterSlaveApps: component:${identifier} is not on fdm but previous master is running it at: ${ipToCheckAppRunning}:${portToCheckAppRunning}`);
                       previousMasterStillRunning = true;
                     }
                   } catch (error) {
@@ -3944,8 +3950,8 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                   }
                   // Previous master is not running, determine next primary
                   if (index === 0) {
-                    appDockerRestartWithPermissionsFix(installedApp.name, appId);
-                    log.info(`masterSlaveApps: starting docker app:${installedApp.name} index: ${index}`);
+                    appDockerRestartWithPermissionsFix(identifier, appId);
+                    log.info(`masterSlaveApps: starting docker component:${identifier} index: ${index}`);
                   } else {
                     const previousMasterIndex = runningAppList.findIndex((x) => socketAddressesMatch(x.ip, mastersRunningGSyncthingApps.get(identifier)));
                     let timetoStartApp = Date.now();
@@ -3964,8 +3970,8 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                       // eslint-disable-next-line no-await-in-loop
                       const lowerNodeRunning = await checkLowerIndexNodesRunning();
                       if (!lowerNodeRunning) {
-                        appDockerRestartWithPermissionsFix(installedApp.name, appId);
-                        log.info(`masterSlaveApps: starting docker app:${installedApp.name} index: ${index}`);
+                        appDockerRestartWithPermissionsFix(identifier, appId);
+                        log.info(`masterSlaveApps: starting docker component:${identifier} index: ${index}`);
                       }
                     } else {
                       log.info(`masterSlaveApps: will start docker app:${installedApp.name} at ${timetoStartApp.toString()}`);
@@ -3977,8 +3983,8 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                   // eslint-disable-next-line no-await-in-loop
                   const lowerNodeRunning = await checkLowerIndexNodesRunning();
                   if (!lowerNodeRunning) {
-                    appDockerRestartWithPermissionsFix(installedApp.name, appId);
-                    log.info(`masterSlaveApps: starting docker app:${installedApp.name} index: ${index} that was scheduled to start at ${timeTostartNewMasterApp.get(identifier).toString()}`);
+                    appDockerRestartWithPermissionsFix(identifier, appId);
+                    log.info(`masterSlaveApps: starting docker component:${identifier} index: ${index} that was scheduled to start at ${timeTostartNewMasterApp.get(identifier).toString()}`);
                     timeTostartNewMasterApp.delete(identifier);
                   } else {
                     log.info(`masterSlaveApps: not starting app:${installedApp.name} index: ${index} - lower-index node is already running`);
@@ -4001,8 +4007,10 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                 timeTostartNewMasterApp.delete(identifier);
               }
               if (!socketAddressesMatch(localSocketAddr, ip) && runningAppsNames.includes(identifier)) {
-                appDockerStop(installedApp.name);
-                log.info(`masterSlaveApps: stopping docker app:${installedApp.name} it's running on ip:${ip} and localSocketAddr is: ${localSocketAddr}`);
+                // Stop only the g: component on this standby node. Non-g siblings (e.g. a DB
+                // cluster component that needs all instances running) must keep running.
+                appDockerStop(identifier);
+                log.info(`masterSlaveApps: stopping docker component:${identifier} it's running on ip:${ip} and localSocketAddr is: ${localSocketAddr}`);
               } else if (socketAddressesMatch(localSocketAddr, ip) && !runningAppsNames.includes(identifier)) {
                 // Check if app is ready (syncthing data is synced) before starting
                 let isReady = receiveOnlySyncthingAppsCache.has(appId) && receiveOnlySyncthingAppsCache.get(appId).restarted;
@@ -4032,8 +4040,8 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                 }
 
                 if (isReady) {
-                  appDockerRestartWithPermissionsFix(installedApp.name, appId);
-                  log.info(`masterSlaveApps: starting docker app:${installedApp.name}`);
+                  appDockerRestartWithPermissionsFix(identifier, appId);
+                  log.info(`masterSlaveApps: starting docker component:${identifier}`);
                 } else {
                   log.info(`masterSlaveApps: app:${installedApp.name} is registered as primary on FDM but not ready yet (syncthing not synced), skipping start for this cycle`);
                 }

--- a/ZelBack/src/services/appMonitoring/containerHealthMonitor.js
+++ b/ZelBack/src/services/appMonitoring/containerHealthMonitor.js
@@ -150,12 +150,35 @@ async function monitorAndRecoverApps(localSocketAddr, appsInstalled, runningApps
       const appDetails = await registryManager.getApplicationGlobalSpecifications(mainAppName);
       const appInstalledMasterSlave = appsInstalled.find((app) => app.name === mainAppName);
       const composeSpecs = appInstalledMasterSlave?.compose;
-      const appInstalledSyncthing = composeSpecs?.find((comp) => comp.containerData.includes('g:') || comp.containerData.includes('r:'));
-      const appInstalledMasterSlaveCheck = composeSpecs?.find((comp) => comp.containerData.includes('g:'));
+      // App-level: any component using g:/r: marks the whole app as a syncthing app
+      // for broadcast purposes (masterSlaveAppsInstalled is included in installedAndRunning
+      // even when some components are stopped, since stopped slaves are expected).
+      const appInstalledSyncthing = composeSpecs
+        ? composeSpecs.find((comp) => comp.containerData.includes('g:') || comp.containerData.includes('r:'))
+        : (appInstalledMasterSlave?.containerData
+          && (appInstalledMasterSlave.containerData.includes('g:') || appInstalledMasterSlave.containerData.includes('r:')));
+
+      // Component-level: classify the specific stopped component so that auto-restart
+      // and grace-period decisions are made per component rather than per app. Without
+      // this, a non-g component of a g: app would never be auto-restarted at runtime.
+      let stoppedCompIsG = false;
+      let stoppedCompIsRorG = false;
+      if (composeSpecs && composeSpecs.length > 0) {
+        const componentName = stoppedApp.split('_')[0];
+        const stoppedCompSpec = composeSpecs.find((c) => c.name === componentName);
+        if (stoppedCompSpec && stoppedCompSpec.containerData) {
+          stoppedCompIsG = stoppedCompSpec.containerData.includes('g:');
+          stoppedCompIsRorG = stoppedCompIsG || stoppedCompSpec.containerData.includes('r:');
+        }
+      } else if (appInstalledMasterSlave?.containerData) {
+        stoppedCompIsG = appInstalledMasterSlave.containerData.includes('g:');
+        stoppedCompIsRorG = stoppedCompIsG || appInstalledMasterSlave.containerData.includes('r:');
+      }
+
       if (appInstalledSyncthing) {
         masterSlaveAppsInstalled.push(appInstalledMasterSlave);
       }
-      if (appInstalledMasterSlaveCheck && appDetails) {
+      if (stoppedCompIsG && appDetails) {
         const backupSkip = backupInProgress.some((backupItem) => stoppedApp === backupItem);
         const restoreSkip = restoreInProgress.some((backupItem) => stoppedApp === backupItem);
         if (!backupSkip && !restoreSkip) {
@@ -173,7 +196,10 @@ async function monitorAndRecoverApps(localSocketAddr, appsInstalled, runningApps
           // eslint-disable-next-line no-await-in-loop
           const containerExists = await dockerService.getDockerContainerOnly(stoppedApp);
 
-          if (containerExists && appInstalledSyncthing) {
+          // 30-minute install grace applies only to syncthing components (r: here, since
+          // g: branched off above). Non-syncthing siblings of a g:/r: app must not inherit
+          // the delay — they should auto-restart immediately like any other component.
+          if (containerExists && stoppedCompIsRorG) {
             const db = dbHelper.databaseConnection();
             const database = db.db(config.database.appsglobal.database);
             const queryFind = { name: mainAppName, ip: localSocketAddr };

--- a/tests/unit/advancedWorkflows.test.js
+++ b/tests/unit/advancedWorkflows.test.js
@@ -1276,6 +1276,108 @@ describe('advancedWorkflows tests', () => {
       expect(serviceHelperStub.called).to.be.true;
       expect(fluxNetworkHelperStub.called).to.be.true;
     });
+
+    it('stops only the g: component on a standby node, leaving non-g siblings running', async () => {
+      const appName = 'n8napp';
+      const dockerService = require('../../ZelBack/src/services/dockerService');
+      dockerServiceStub.returns('fluxn8n_n8napp');
+      const appDockerStopStub = sinon.stub(dockerService, 'appDockerStop').resolves();
+
+      // Mixed compose app: n8n uses g: master/slave, pgcluster needs all instances running
+      const installedApps = sinon.stub().resolves({
+        status: 'success',
+        data: [
+          {
+            name: appName,
+            version: 8,
+            compose: [
+              { name: 'n8n', containerData: 'g:/home/node/.n8n' },
+              { name: 'pgcluster', containerData: '/var/lib/postgresql/data' },
+            ],
+          },
+        ],
+      });
+      // Both components currently running on this node
+      const listRunningApps = sinon.stub().resolves({
+        status: 'success',
+        data: [
+          { Names: ['/fluxn8n_n8napp'] },
+          { Names: ['/fluxpgcluster_n8napp'] },
+        ],
+      });
+
+      const receiveOnlyCache = new Map();
+      const https = require('https');
+
+      // FDM reports the primary is another node
+      serviceHelperStub.resolves({ data: { status: 'success', data: { ips: ['192.168.1.99'] } } });
+      // This node's address differs from the FDM primary -> we are a standby
+      fluxNetworkHelperStub.resolves('192.168.1.5:16127');
+
+      await advancedWorkflows.masterSlaveApps(
+        globalState,
+        installedApps,
+        listRunningApps,
+        receiveOnlyCache,
+        [],
+        [],
+        https,
+      );
+
+      // Only the g: component must be stopped - not the whole app, not the pgcluster sibling
+      expect(appDockerStopStub.calledWith('n8n_n8napp')).to.be.true;
+      expect(appDockerStopStub.neverCalledWith('pgcluster_n8napp')).to.be.true;
+      expect(appDockerStopStub.neverCalledWith(appName)).to.be.true;
+    });
+
+    it('does not stop anything on a standby node when the g: component is already stopped', async () => {
+      const appName = 'n8napp';
+      const dockerService = require('../../ZelBack/src/services/dockerService');
+      dockerServiceStub.returns('fluxn8n_n8napp');
+      const appDockerStopStub = sinon.stub(dockerService, 'appDockerStop').resolves();
+
+      const installedApps = sinon.stub().resolves({
+        status: 'success',
+        data: [
+          {
+            name: appName,
+            version: 8,
+            compose: [
+              { name: 'n8n', containerData: 'g:/home/node/.n8n' },
+              { name: 'pgcluster', containerData: '/var/lib/postgresql/data' },
+            ],
+          },
+        ],
+      });
+      // Steady state on a standby: only the non-g component is running
+      const listRunningApps = sinon.stub().resolves({
+        status: 'success',
+        data: [
+          { Names: ['/fluxpgcluster_n8napp'] },
+        ],
+      });
+
+      const receiveOnlyCache = new Map();
+      const https = require('https');
+
+      // FDM reports the primary is another node
+      serviceHelperStub.resolves({ data: { status: 'success', data: { ips: ['192.168.1.99'] } } });
+      fluxNetworkHelperStub.resolves('192.168.1.5:16127');
+
+      await advancedWorkflows.masterSlaveApps(
+        globalState,
+        installedApps,
+        listRunningApps,
+        receiveOnlyCache,
+        [],
+        [],
+        https,
+      );
+
+      // The g: component is not running here and we are not primary - nothing to stop.
+      // The running pgcluster sibling must be left alone.
+      expect(appDockerStopStub.called).to.be.false;
+    });
   });
 
   describe('validateApplicationUpdateCompatibility tests', () => {

--- a/tests/unit/containerHealthMonitor.test.js
+++ b/tests/unit/containerHealthMonitor.test.js
@@ -5,6 +5,12 @@ const proxyquire = require('proxyquire').noCallThru();
 describe('containerHealthMonitor tests', () => {
   let containerHealthMonitor;
   let globalStateStub;
+  let dockerServiceStub;
+  let dbHelperStub;
+  let registryManagerStub;
+  let appInstallerStub;
+  let appUninstallerStub;
+  let stoppedAppsCache;
 
   beforeEach(() => {
     globalStateStub = {
@@ -15,20 +21,48 @@ describe('containerHealthMonitor tests', () => {
       appsMonitored: new Map(),
     };
 
+    dockerServiceStub = {
+      getDockerContainerOnly: sinon.stub().resolves(null),
+      appDockerStart: sinon.stub().resolves(),
+      dockerListContainers: sinon.stub().resolves([]),
+    };
+
+    dbHelperStub = {
+      databaseConnection: sinon.stub().returns({ db: () => ({}) }),
+      findInDatabase: sinon.stub().resolves([]),
+      findOneInDatabase: sinon.stub().resolves(null),
+    };
+
+    registryManagerStub = {
+      getApplicationGlobalSpecifications: sinon.stub().resolves(null),
+    };
+
+    appInstallerStub = {
+      installApplicationHard: sinon.stub().resolves(),
+      installApplicationSoft: sinon.stub().resolves(),
+    };
+
+    appUninstallerStub = {
+      removeAppLocally: sinon.stub().resolves(),
+    };
+
+    stoppedAppsCache = new Map();
+
     containerHealthMonitor = proxyquire('../../ZelBack/src/services/appMonitoring/containerHealthMonitor', {
       '../../lib/log': { info: sinon.stub(), warn: sinon.stub(), error: sinon.stub() },
-      '../dbHelper': { databaseConnection: sinon.stub(), findInDatabase: sinon.stub(), findOneInDatabase: sinon.stub() },
-      '../dockerService': { getDockerContainerOnly: sinon.stub(), appDockerStart: sinon.stub(), dockerListContainers: sinon.stub() },
+      '../dbHelper': dbHelperStub,
+      '../dockerService': dockerServiceStub,
       '../generalService': { nodeTier: sinon.stub().resolves('cumulus') },
-      '../appDatabase/registryManager': { getApplicationGlobalSpecifications: sinon.stub() },
-      '../appLifecycle/appInstaller': { installApplicationHard: sinon.stub().resolves() },
-      '../appLifecycle/appUninstaller': { removeAppLocally: sinon.stub().resolves() },
+      '../appDatabase/registryManager': registryManagerStub,
+      '../appLifecycle/appInstaller': appInstallerStub,
+      '../appLifecycle/appUninstaller': appUninstallerStub,
       '../appManagement/appInspector': { startAppMonitoring: sinon.stub() },
       '../appTamperingDetectionService': { recordEvent: sinon.stub().resolves(), isNetworkMissingError: sinon.stub().returns(false) },
       '../utils/globalState': globalStateStub,
-      '../utils/cacheManager': { default: { stoppedAppsCache: new Map() } },
+      '../utils/cacheManager': { default: { stoppedAppsCache } },
       '../appQuery/appQueryService': { decryptEnterpriseApps: sinon.stub().callsFake(async (apps) => apps) },
       '../utils/appConstants': { localAppsInformation: 'localAppsInformation' },
+      '../utils/volumeService': { verifyAppVolumeMount: sinon.stub().resolves(false) },
     });
   });
 
@@ -50,6 +84,123 @@ describe('containerHealthMonitor tests', () => {
       await promise;
       expect(monitorResolved).to.be.true;
       expect(globalStateStub.waitForBootContainerStateSettled.calledOnce).to.be.true;
+    });
+  });
+
+  describe('monitorAndRecoverApps - per-component g: handling', () => {
+    // Mixed compose app: n8n uses g: master/slave mode, pgcluster must run on all instances
+    const mixedSpec = {
+      version: 8,
+      name: 'MixedApp',
+      hash: 'mixhash',
+      compose: [
+        { name: 'n8n', containerData: 'g:/home/node/.n8n' },
+        { name: 'pgcluster', containerData: '/var/lib/postgresql/data' },
+      ],
+    };
+
+    const rOnlySpec = {
+      version: 8,
+      name: 'RApp',
+      hash: 'rhash',
+      compose: [
+        { name: 'web', containerData: 'r:/data' },
+      ],
+    };
+
+    it('auto-starts a stopped non-g component of a mixed compose app and leaves the g: sibling alone', async () => {
+      // Both components stopped (e.g. right after masterSlaveApps whole-app stop on a standby,
+      // or after a node reboot). The non-g component must auto-start; the g: component must be
+      // left for masterSlaveApps to manage.
+      registryManagerStub.getApplicationGlobalSpecifications.withArgs('MixedApp').resolves(mixedSpec);
+
+      // Both containers exist (created but stopped)
+      dockerServiceStub.getDockerContainerOnly.withArgs('n8n_MixedApp').resolves({ Id: 'n8n' });
+      dockerServiceStub.getDockerContainerOnly.withArgs('pgcluster_MixedApp').resolves({ Id: 'pg' });
+
+      // Pre-warm the stopped-apps cache so the auto-restart fires on this cycle
+      stoppedAppsCache.set('pgcluster_MixedApp', '');
+
+      await containerHealthMonitor.monitorAndRecoverApps('10.0.0.1:16127', [mixedSpec], []);
+
+      expect(dockerServiceStub.appDockerStart.calledWith('pgcluster_MixedApp')).to.equal(true);
+      expect(dockerServiceStub.appDockerStart.calledWith('n8n_MixedApp')).to.equal(false);
+      expect(appInstallerStub.installApplicationHard.called).to.equal(false);
+      expect(appUninstallerStub.removeAppLocally.called).to.equal(false);
+    });
+
+    it('does not auto-start a stopped g: component (managed by masterSlaveApps)', async () => {
+      // Steady state on a standby node: pgcluster running, n8n (g:) stopped.
+      registryManagerStub.getApplicationGlobalSpecifications.withArgs('MixedApp').resolves(mixedSpec);
+
+      // The g: component's container exists - handleMissingMasterSlaveContainer must
+      // short-circuit and never start or recreate it.
+      dockerServiceStub.getDockerContainerOnly.withArgs('n8n_MixedApp').resolves({ Id: 'n8n' });
+
+      // Pre-warm cache to prove the cache warmup path is NOT what keeps the g: component stopped
+      stoppedAppsCache.set('n8n_MixedApp', '');
+
+      await containerHealthMonitor.monitorAndRecoverApps('10.0.0.1:16127', [mixedSpec], ['pgcluster_MixedApp']);
+
+      expect(dockerServiceStub.appDockerStart.called).to.equal(false);
+      expect(appInstallerStub.installApplicationHard.called).to.equal(false);
+      expect(appUninstallerStub.removeAppLocally.called).to.equal(false);
+    });
+
+    it('does not apply the 30-minute syncthing grace to a non-syncthing sibling of a g: app', async () => {
+      // The non-g component was installed less than 30 minutes ago. The grace period is meant
+      // for syncthing data sync only - the non-g component must still start immediately.
+      registryManagerStub.getApplicationGlobalSpecifications.withArgs('MixedApp').resolves(mixedSpec);
+      dockerServiceStub.getDockerContainerOnly.withArgs('pgcluster_MixedApp').resolves({ Id: 'pg' });
+
+      // runningSince very recent -> inside the 30 min window
+      dbHelperStub.findOneInDatabase.resolves({ runningSince: new Date().toISOString() });
+
+      stoppedAppsCache.set('pgcluster_MixedApp', '');
+
+      await containerHealthMonitor.monitorAndRecoverApps('10.0.0.1:16127', [mixedSpec], ['n8n_MixedApp']);
+
+      expect(dockerServiceStub.appDockerStart.calledWith('pgcluster_MixedApp')).to.equal(true);
+    });
+
+    it('applies the 30-minute grace to a stopped r: component installed less than 30m ago', async () => {
+      registryManagerStub.getApplicationGlobalSpecifications.withArgs('RApp').resolves(rOnlySpec);
+      dockerServiceStub.getDockerContainerOnly.withArgs('web_RApp').resolves({ Id: 'web' });
+
+      // runningSince very recent -> inside the 30 min window -> must NOT start yet
+      dbHelperStub.findOneInDatabase.resolves({ runningSince: new Date().toISOString() });
+
+      stoppedAppsCache.set('web_RApp', '');
+
+      await containerHealthMonitor.monitorAndRecoverApps('10.0.0.1:16127', [rOnlySpec], []);
+
+      expect(dockerServiceStub.appDockerStart.called).to.equal(false);
+      expect(appUninstallerStub.removeAppLocally.called).to.equal(false);
+    });
+
+    it('starts a stopped r: component once the 30-minute grace has passed', async () => {
+      registryManagerStub.getApplicationGlobalSpecifications.withArgs('RApp').resolves(rOnlySpec);
+      dockerServiceStub.getDockerContainerOnly.withArgs('web_RApp').resolves({ Id: 'web' });
+
+      // runningSince 31 minutes ago -> grace passed
+      dbHelperStub.findOneInDatabase.resolves({ runningSince: new Date(Date.now() - 31 * 60 * 1000).toISOString() });
+
+      stoppedAppsCache.set('web_RApp', '');
+
+      await containerHealthMonitor.monitorAndRecoverApps('10.0.0.1:16127', [rOnlySpec], []);
+
+      expect(dockerServiceStub.appDockerStart.calledWith('web_RApp')).to.equal(true);
+    });
+
+    it('still includes g:/r: apps in masterSlaveAppsInstalled for broadcast even with stopped components', async () => {
+      registryManagerStub.getApplicationGlobalSpecifications.withArgs('MixedApp').resolves(mixedSpec);
+      dockerServiceStub.getDockerContainerOnly.resolves({ Id: 'x' });
+
+      const result = await containerHealthMonitor.monitorAndRecoverApps('10.0.0.1:16127', [mixedSpec], ['pgcluster_MixedApp']);
+
+      // The app must still be broadcast as installed-and-running so standby nodes
+      // stay in apps/location and remain promotion-eligible.
+      expect(result.masterSlaveAppsInstalled).to.deep.include(mixedSpec);
     });
   });
 });


### PR DESCRIPTION
## Summary

Completes the per-component `g:` syncthing work started in #1728, in two parts:

### 1. Regression fix: restore #1728 behavior in container recovery (`containerHealthMonitor.js`)

#1728 (merged May 7) made runtime auto-restart decisions per component in `peerNotification.js`. The May 14 refactor (0636fc23c) moved that logic into `containerHealthMonitor.js` but started from the pre-#1728 version of the code, silently reverting it to app-level checks. (The boot-recovery half of #1728 survived the refactor — it lives in `appStartupManager.js` / `appUtilities.getNonGComponentIdentifiers`.)

Restored at the new location:
- A stopped component is only treated as master/slave-managed if **that component** uses `g:` (`stoppedCompIsG`), not if any sibling does
- The 30-minute install grace applies only to `r:`/`g:` components, not to non-syncthing siblings
- v≤3 single-component apps handled via the `containerData` fallback

### 2. `masterSlaveApps` stops/starts only the g: component, not the whole app

`masterSlaveApps` already tracks everything per component (`identifier`, `appId`, `mastersRunningGSyncthingApps`), but the docker stop/start calls passed `installedApp.name`, which expands to **every** component of a compose app. On standby nodes this stopped all components — including non-g siblings that must run on every instance.

- 6 stop/start call sites now pass the component `identifier`
- The two remote "is it running there" checks (lower-index node, previous master) now match on the component identifier, so non-g siblings running on every node are not mistaken for the master/slave component being active remotely

### Why this matters

A mixed compose app like **n8n (`g:`) + flux-pg-cluster (HA postgres)** is impossible with whole-app behavior: the pg cluster components get stopped on standby nodes, so etcd never has quorum, replication never happens, and a failover promotes a node with an empty data directory. With both fixes, the `g:` component fails over master/slave style while its siblings keep running on all instances.

### Backward compatibility

- v≤3 apps: `identifier === app name` — unchanged behavior
- Single-component compose apps: stopping/starting the only component ≡ stopping/starting the app
- Multi-component `g:` apps: only the `g:` component fails over (intended post-#1728 behavior)

## Tests

- Ported the #1728 per-component test cases to `containerHealthMonitor.test.js` (7 tests) — the two regression cases **fail against current development** and pass with this PR
- Added standby-stop and steady-state `masterSlaveApps` cases with a mixed n8n+pgcluster spec (2 tests)
- All existing `masterSlaveApps`, `peerNotification`, `appStartupManager`, `containerCrashRecovery` tests still pass