### PR TITLE
fix: default-port nodes never become message-capable → boot wipes all apps

### DIFF
--- a/ZelBack/src/services/networkStateService.js
+++ b/ZelBack/src/services/networkStateService.js
@@ -1,6 +1,5 @@
 const daemonServiceFluxnodeRpcs = require('./daemonService/daemonServiceFluxnodeRpcs');
 const networkStateManager = require('./utils/networkStateManager');
-const { normalizeSocketAddress, extractIp, extractPort, DEFAULT_API_PORT } = require('./utils/socketAddressUtils');
 
 /**
  * @typedef {import('./utils/networkStateManager').Fluxnode} Fluxnode
@@ -134,23 +133,12 @@ async function getFluxnodesByPubkey(pubkey) {
  * @param {string} socketAddress
  * @returns {Promise<boolean>}
  */
-// TODO: Remove alt-format lookup once all nodes run fluxbench with
-// always-attached port. During the transition, the node list may contain
-// either "ip" or "ip:16127" for default-port nodes.
 async function socketAddressInNetworkState(socketAddress) {
   if (!stateManager) return false;
 
-  const found = await stateManager.includes(socketAddress, 'socketAddress');
-  if (found) return true;
-
-  if (extractPort(socketAddress) === DEFAULT_API_PORT) {
-    const normalized = normalizeSocketAddress(socketAddress);
-    const bareIp = extractIp(socketAddress);
-    const alt = normalized === socketAddress ? bareIp : normalized;
-    if (alt) return stateManager.includes(alt, 'socketAddress');
-  }
-
-  return false;
+  // Default-port format ("ip" vs "ip:16127") is reconciled inside
+  // networkStateManager, which canonicalises both index keys and lookups.
+  return stateManager.includes(socketAddress, 'socketAddress');
 }
 
 /**

--- a/ZelBack/src/services/utils/networkStateManager.js
+++ b/ZelBack/src/services/utils/networkStateManager.js
@@ -1,5 +1,6 @@
 const { EventEmitter } = require('node:events');
 const { FluxController } = require('./fluxController');
+const { normalizeSocketAddress } = require('./socketAddressUtils');
 
 const log = require('../../lib/log');
 
@@ -233,7 +234,11 @@ class NetworkStateManager extends EventEmitter {
           || pubkeyIndex.set(node.pubkey, new Map()).get(node.pubkey);
 
         nodesByPubkey.set(node.ip, node);
-        socketAddressIndex.set(node.ip, node);
+        // Canonicalise the socketAddress key: the daemon list may carry a
+        // default-port node as either "ip" or "ip:16127". normalizeSocketAddress
+        // appends the default port only to a bare ip; explicit (UPnP) ports pass
+        // through unchanged. Lookups normalize the same way, so both forms resolve.
+        socketAddressIndex.set(normalizeSocketAddress(node.ip), node);
       });
 
       if (endIndex >= nodeCount) {
@@ -503,7 +508,8 @@ class NetworkStateManager extends EventEmitter {
     // latest block
     await this.waitIndexesReady;
 
-    const cached = this.#indexes[type].get(filter);
+    const key = type === 'socketAddress' ? normalizeSocketAddress(filter) : filter;
+    const cached = this.#indexes[type].get(key);
     const clone = cached ? NetworkStateManager.deepClone(cached) : null;
 
     return clone;
@@ -524,7 +530,8 @@ class NetworkStateManager extends EventEmitter {
     // latest block
     await this.waitIndexesReady;
 
-    const found = this.#indexes[type].has(filter);
+    const key = type === 'socketAddress' ? normalizeSocketAddress(filter) : filter;
+    const found = this.#indexes[type].has(key);
 
     return found;
   }

--- a/tests/unit/networkStateManager.test.js
+++ b/tests/unit/networkStateManager.test.js
@@ -304,6 +304,68 @@ describe('networkStateManager tests', () => {
     expect(response).to.deep.equal(expectedResponse);
   });
 
+  describe('default-port (16127) socketAddress normalization', () => {
+    const mkNode = (ip, pubkey) => ({
+      collateral: `COutPoint(${pubkey}, 0)`,
+      txhash: pubkey,
+      outidx: '0',
+      ip,
+      network: '',
+      added_height: 1,
+      confirmed_height: 1,
+      last_confirmed_height: 1,
+      last_paid_height: 0,
+      tier: 'CUMULUS',
+      payment_address: 't1abc',
+      pubkey,
+      activesince: '1',
+      lastpaid: '1',
+      amount: '1000.00',
+      rank: 0,
+    });
+    // bareNode: default-port node the daemon list carries WITHOUT a port.
+    // portedNode: default-port node the daemon list carries WITH :16127.
+    // upnpNode: explicit non-default port (must be unaffected).
+    const bareNode = mkNode('203.0.113.5', 'aa'.repeat(33));
+    const portedNode = mkNode('203.0.113.6:16127', 'bb'.repeat(33));
+    const upnpNode = mkNode('203.0.113.7:16137', 'cc'.repeat(33));
+    const state = [bareNode, portedNode, upnpNode];
+
+    let nsm;
+
+    beforeEach(async () => {
+      fetcher.resolves(state);
+      nsm = new NetworkStateManager(fetcher, {
+        stateEvent: 'blocksProcessed',
+        stateEmitter: new EventEmitter(),
+      });
+      await nsm.start();
+    });
+
+    it('resolves a bare-listed default-port node when queried with :16127', async () => {
+      expect(await nsm.search('203.0.113.5:16127', 'socketAddress')).to.deep.equal(bareNode);
+    });
+
+    it('resolves a bare-listed default-port node when queried bare', async () => {
+      expect(await nsm.search('203.0.113.5', 'socketAddress')).to.deep.equal(bareNode);
+    });
+
+    it('resolves a :16127-listed default-port node when queried bare', async () => {
+      expect(await nsm.search('203.0.113.6', 'socketAddress')).to.deep.equal(portedNode);
+    });
+
+    it('includes() matches both default-port representations', async () => {
+      expect(await nsm.includes('203.0.113.5:16127', 'socketAddress')).to.equal(true);
+      expect(await nsm.includes('203.0.113.6', 'socketAddress')).to.equal(true);
+    });
+
+    it('leaves explicit (UPnP) ports unaffected', async () => {
+      expect(await nsm.search('203.0.113.7:16137', 'socketAddress')).to.deep.equal(upnpNode);
+      // a bare query normalizes to :16127 and must NOT match a non-default-port node
+      expect(await nsm.search('203.0.113.7', 'socketAddress')).to.equal(null);
+    });
+  });
+
   it('should return null if searching by non existent pubkey', async () => {
     const blockEmitter = new EventEmitter();
 


### PR DESCRIPTION
## Problem

On default-port (16127) FluxNodes, `nodeConfirmationService.canSendMessages()` is permanently `false` — the self-lookup `getFluxnodeBySocketAddress()` never resolves the node against its own pubkey. That stalls `AppSyncOrchestrator`: `dbReady` only opens via the ~2h block-timer fallback instead of the fast hash-sync path, so `manageAppsOnBoot()` hits `removeAllApps('Sync timeout')` after 300s on every restart, **wiping all installed apps**.

## Root cause

Since #1737, `getLocalSocketAddress()` returns the normalized `ip:16127` form. But the `networkStateManager` socketAddress index is keyed by `node.ip` exactly as the daemon lists it — which is **bare** for default-port nodes. So `getFluxnodeBySocketAddress("ip:16127")` does an exact `Map.get()` against the bare key, misses, and returns `null`.

\#1737 added a bare↔`:16127` fallback to `socketAddressInNetworkState` but not to `getFluxnodeBySocketAddress`, so the message-capability path stayed broken. Non-default (UPnP) ports are unaffected — they're always explicit.

## Fix

Canonicalize at the `networkStateManager` boundary: normalize the socketAddress index key on build, and normalize the lookup filter in `search()` / `includes()`. `normalizeSocketAddress` only appends the default port to a bare IP, so explicit (UPnP) ports pass through unchanged. Removes the now-redundant per-consumer fallback in `socketAddressInNetworkState`.

## Impact

Sweep of 677 reachable default-port nodes: **0 of 667** on the current release hold any apps, vs 33–50% on pre-#1737 versions. Public/default-port nodes are ~27% of the network, so this silently removed a large share of durable app-hosting capacity (and feeds directly into apps being unable to reach their target instance counts).

## Testing

- Added regression tests covering bare↔`:16127` resolution and that a bare query does not match a non-default-port node (networkStateManager suite, all green).
- **Validated end-to-end on a live node.** Before the fix the node held **0 apps** with a permanently gated spawner. After deploying the fix and restarting:
  - `Message capability gained` now fires (it never did before) and stays stable.
  - `DB ready` opens in **~53s** (previously ~2h via the block-timer fallback) — well inside the 300s boot timeout, so `removeAllApps('Sync timeout')` cannot trigger.
  - The spawner becomes active and goes all the way through: **selects → installs → and is now running a real app container** (a healthy `yurinnick/folding-at-home` instance, `Up` and serving).
  - **0** `Sync timeout` / `removeAllApps` / removals since boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)