### PR TITLE
fix: IP-granular matching for FDM master selection (UPnP master flap)

### DIFF
--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -13,7 +13,9 @@ const dockerService = require('../dockerService');
 const verificationHelper = require('../verificationHelper');
 const daemonServiceMiscRpcs = require('../daemonService/daemonServiceMiscRpcs');
 const fluxNetworkHelper = require('../fluxNetworkHelper');
-const { DEFAULT_API_PORT, extractIp, extractPort, socketAddressesMatch } = require('../utils/socketAddressUtils');
+const {
+  DEFAULT_API_PORT, extractIp, extractPort, socketAddressesMatch, ipsMatch,
+} = require('../utils/socketAddressUtils');
 const generalService = require('../generalService');
 // eslint-disable-next-line no-unused-vars
 const upnpService = require('../upnpService');
@@ -180,8 +182,8 @@ function getFdmIndex(appName) {
  * Tries EU, USA, and ASIA FDM servers in order until one succeeds.
  * @param {string} appName - Application name
  * @param {Object} axiosOptions - Axios request options
- * @returns {Promise<{ip: string|null, fdmOk: boolean}>} The master socket address (ip:port,
- *   or bare ip for default-port masters) and success status
+ * @returns {Promise<{ip: string|null, fdmOk: boolean}>} The master IP (FDM returns a bare IP;
+ *   compare it with ipsMatch, which ignores the port) and success status
  */
 async function getMasterIpFromFdm(appName, axiosOptions) {
   const fdmIndex = getFdmIndex(appName);
@@ -198,16 +200,11 @@ async function getMasterIpFromFdm(appName, axiosOptions) {
       const response = await serviceHelper.axiosGet(url, axiosOptions);
 
       if (response.data && response.data.status === 'success' && response.data.data) {
-        const { ips: socketAddresses } = response.data.data;
-        if (socketAddresses && socketAddresses.length > 0) {
-          // Keep the full ip:port socket address from FDM. Stripping the port here would
-          // normalize a UPnP master (e.g. x:16157) down to the default API port (x:16127)
-          // in downstream socketAddressesMatch checks, so the node would fail to recognise
-          // itself as primary and repeatedly stop its own container. Default-port masters
-          // are already bare, so this passes them through unchanged.
-          const [socketAddress] = socketAddresses;
-          log.debug(`getMasterIpFromFdm: Got socket address ${socketAddress} for app ${appName} from ${region.name} FDM`);
-          return { ip: socketAddress, fdmOk: true };
+        const { ips } = response.data.data;
+        if (ips && ips.length > 0) {
+          const ip = extractIp(ips[0]);
+          log.debug(`getMasterIpFromFdm: Got IP ${ip} for app ${appName} from ${region.name} FDM`);
+          return { ip, fdmOk: true };
         }
       }
       // No IPs returned from this region, try next
@@ -3868,7 +3865,7 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                   }
                   return 0;
                 });
-                const index = runningAppList.findIndex((x) => socketAddressesMatch(x.ip, localSocketAddr));
+                const index = runningAppList.findIndex((x) => ipsMatch(x.ip, localSocketAddr));
 
                 // Helper function to check if any lower-index nodes are running the app
                 const checkLowerIndexNodesRunning = async () => {
@@ -3918,7 +3915,7 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                   // Index 0: Start immediately if no history
                   appDockerRestartWithPermissionsFix(identifier, appId);
                   log.info(`masterSlaveApps: starting docker component:${identifier} index: ${index}`);
-                } else if (!timeTostartNewMasterApp.has(identifier) && mastersRunningGSyncthingApps.has(identifier) && !socketAddressesMatch(mastersRunningGSyncthingApps.get(identifier), localSocketAddr)) {
+                } else if (!timeTostartNewMasterApp.has(identifier) && mastersRunningGSyncthingApps.has(identifier) && !ipsMatch(mastersRunningGSyncthingApps.get(identifier), localSocketAddr)) {
                   // There was a previous master (not me), and it's no longer on FDM
                   const { CancelToken } = axios;
                   const source = CancelToken.source();
@@ -3931,7 +3928,7 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                   }, timeout * 2);
                   const previousMasterIp = mastersRunningGSyncthingApps.get(identifier);
                   // Look up the correct port from runningAppList since FDM API returns IP without port
-                  const previousMasterNode = runningAppList.find((x) => socketAddressesMatch(x.ip, previousMasterIp));
+                  const previousMasterNode = runningAppList.find((x) => ipsMatch(x.ip, previousMasterIp));
                   const ipToCheckAppRunning = extractIp(previousMasterIp);
                   const portToCheckAppRunning = previousMasterNode ? extractPort(previousMasterNode.ip) : DEFAULT_API_PORT;
                   let previousMasterStillRunning = false;
@@ -3959,7 +3956,7 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                     appDockerRestartWithPermissionsFix(identifier, appId);
                     log.info(`masterSlaveApps: starting docker component:${identifier} index: ${index}`);
                   } else {
-                    const previousMasterIndex = runningAppList.findIndex((x) => socketAddressesMatch(x.ip, mastersRunningGSyncthingApps.get(identifier)));
+                    const previousMasterIndex = runningAppList.findIndex((x) => ipsMatch(x.ip, mastersRunningGSyncthingApps.get(identifier)));
                     let timetoStartApp = Date.now();
                     if (previousMasterIndex >= 0) {
                       log.info(`masterSlaveApps: app:${installedApp.name} had primary running at index: ${previousMasterIndex}`);
@@ -4012,12 +4009,12 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                 log.info(`masterSlaveApps: app:${installedApp.name} removed from timeTostartNewMasterApp cache, already started on another standby node`);
                 timeTostartNewMasterApp.delete(identifier);
               }
-              if (!socketAddressesMatch(localSocketAddr, ip) && runningAppsNames.includes(identifier)) {
+              if (!ipsMatch(localSocketAddr, ip) && runningAppsNames.includes(identifier)) {
                 // Stop only the g: component on this standby node. Non-g siblings (e.g. a DB
                 // cluster component that needs all instances running) must keep running.
                 appDockerStop(identifier);
                 log.info(`masterSlaveApps: stopping docker component:${identifier} it's running on ip:${ip} and localSocketAddr is: ${localSocketAddr}`);
-              } else if (socketAddressesMatch(localSocketAddr, ip) && !runningAppsNames.includes(identifier)) {
+              } else if (ipsMatch(localSocketAddr, ip) && !runningAppsNames.includes(identifier)) {
                 // Check if app is ready (syncthing data is synced) before starting
                 let isReady = receiveOnlySyncthingAppsCache.has(appId) && receiveOnlySyncthingAppsCache.get(appId).restarted;
 

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -180,7 +180,8 @@ function getFdmIndex(appName) {
  * Tries EU, USA, and ASIA FDM servers in order until one succeeds.
  * @param {string} appName - Application name
  * @param {Object} axiosOptions - Axios request options
- * @returns {Promise<{ip: string|null, fdmOk: boolean}>} The master IP (without port) and success status
+ * @returns {Promise<{ip: string|null, fdmOk: boolean}>} The master socket address (ip:port,
+ *   or bare ip for default-port masters) and success status
  */
 async function getMasterIpFromFdm(appName, axiosOptions) {
   const fdmIndex = getFdmIndex(appName);
@@ -197,11 +198,16 @@ async function getMasterIpFromFdm(appName, axiosOptions) {
       const response = await serviceHelper.axiosGet(url, axiosOptions);
 
       if (response.data && response.data.status === 'success' && response.data.data) {
-        const { ips } = response.data.data;
-        if (ips && ips.length > 0) {
-          const ip = extractIp(ips[0]);
-          log.debug(`getMasterIpFromFdm: Got IP ${ip} for app ${appName} from ${region.name} FDM`);
-          return { ip, fdmOk: true };
+        const { ips: socketAddresses } = response.data.data;
+        if (socketAddresses && socketAddresses.length > 0) {
+          // Keep the full ip:port socket address from FDM. Stripping the port here would
+          // normalize a UPnP master (e.g. x:16157) down to the default API port (x:16127)
+          // in downstream socketAddressesMatch checks, so the node would fail to recognise
+          // itself as primary and repeatedly stop its own container. Default-port masters
+          // are already bare, so this passes them through unchanged.
+          const [socketAddress] = socketAddresses;
+          log.debug(`getMasterIpFromFdm: Got socket address ${socketAddress} for app ${appName} from ${region.name} FDM`);
+          return { ip: socketAddress, fdmOk: true };
         }
       }
       // No IPs returned from this region, try next

--- a/ZelBack/src/services/utils/socketAddressUtils.js
+++ b/ZelBack/src/services/utils/socketAddressUtils.js
@@ -44,6 +44,21 @@ function socketAddressesMatch(a, b) {
   return normalA === normalB;
 }
 
+// Compare two addresses at IP granularity, ignoring the port entirely.
+//
+// Use this - not socketAddressesMatch - whenever one operand comes from FDM's
+// /appips endpoint. FDM tracks an app's master per IP (a node can only run one
+// instance of an app on a given IP, enforced by host port mapping) and returns a
+// bare IP. socketAddressesMatch would normalize that bare IP to the default API
+// port (16127), so it never matches a UPnP master on a non-default port (e.g.
+// :16157) - the node fails to recognize itself as primary and stops its own
+// container. Matching on IP alone is correct here because the IP uniquely
+// identifies the instance.
+function ipsMatch(a, b) {
+  if (!a || !b) return false;
+  return extractIp(a) === extractIp(b);
+}
+
 module.exports = {
   DEFAULT_API_PORT,
   normalizeSocketAddress,
@@ -51,4 +66,5 @@ module.exports = {
   extractPort,
   parseSocketAddress,
   socketAddressesMatch,
+  ipsMatch,
 };

--- a/tests/unit/advancedWorkflows.test.js
+++ b/tests/unit/advancedWorkflows.test.js
@@ -1378,6 +1378,113 @@ describe('advancedWorkflows tests', () => {
       // The running pgcluster sibling must be left alone.
       expect(appDockerStopStub.called).to.be.false;
     });
+
+    it('does NOT stop its own container when it is the primary on a UPnP (non-default) port', async () => {
+      // Regression: FDM reports masters as ip:port. A UPnP node (e.g. :16157) that IS the
+      // primary must recognise itself and keep running. The pre-fix code stripped the port
+      // from the FDM response, normalized the bare IP to :16127, failed to match its own
+      // :16157 socket, and repeatedly stopped its own container (start/stop flap loop).
+      const appName = 'valheim1777035136949';
+      const dockerService = require('../../ZelBack/src/services/dockerService');
+      dockerServiceStub.returns('fluxvalheim_valheim1777035136949');
+      const appDockerStopStub = sinon.stub(dockerService, 'appDockerStop').resolves();
+
+      // Compose app with a g: component so the identifier is component_app: this makes the
+      // (mistaken) stop call hit dockerService.appDockerStop directly, so the assertion
+      // actually observes the bug if it regresses.
+      const installedApps = sinon.stub().resolves({
+        status: 'success',
+        data: [
+          {
+            name: appName,
+            version: 8,
+            compose: [
+              { name: 'valheim', containerData: 'g:/root/.config/valheim' },
+            ],
+          },
+        ],
+      });
+      // The g: component is currently running on this node (it is the primary).
+      const listRunningApps = sinon.stub().resolves({
+        status: 'success',
+        data: [
+          { Names: ['/fluxvalheim_valheim1777035136949'] },
+        ],
+      });
+
+      const receiveOnlyCache = new Map();
+      const https = require('https');
+
+      // FDM reports the primary as this node's full ip:port socket (UPnP port preserved).
+      serviceHelperStub.resolves({ data: { status: 'success', data: { ips: ['90.228.196.203:16157'] } } });
+      // This node's API socket is the same UPnP socket -> we are the primary.
+      fluxNetworkHelperStub.resolves('90.228.196.203:16157');
+
+      await advancedWorkflows.masterSlaveApps(
+        globalState,
+        installedApps,
+        listRunningApps,
+        receiveOnlyCache,
+        [],
+        [],
+        https,
+      );
+
+      // We are the primary - the container must be left running, never stopped.
+      expect(appDockerStopStub.called).to.be.false;
+    });
+
+    it('stops the g: component on a UPnP standby when FDM names a different ip:port primary', async () => {
+      // Guards the inverse: with ip:port now flowing end-to-end, a genuine standby (different
+      // IP, also on a non-default port) must still be detected and stopped.
+      const appName = 'n8napp';
+      const dockerService = require('../../ZelBack/src/services/dockerService');
+      dockerServiceStub.returns('fluxn8n_n8napp');
+      const appDockerStopStub = sinon.stub(dockerService, 'appDockerStop').resolves();
+
+      const installedApps = sinon.stub().resolves({
+        status: 'success',
+        data: [
+          {
+            name: appName,
+            version: 8,
+            compose: [
+              { name: 'n8n', containerData: 'g:/home/node/.n8n' },
+              { name: 'pgcluster', containerData: '/var/lib/postgresql/data' },
+            ],
+          },
+        ],
+      });
+      const listRunningApps = sinon.stub().resolves({
+        status: 'success',
+        data: [
+          { Names: ['/fluxn8n_n8napp'] },
+          { Names: ['/fluxpgcluster_n8napp'] },
+        ],
+      });
+
+      const receiveOnlyCache = new Map();
+      const https = require('https');
+
+      // FDM primary is a different node, also advertised with an explicit port.
+      serviceHelperStub.resolves({ data: { status: 'success', data: { ips: ['192.168.1.99:16157'] } } });
+      // This node has a different IP (and its own non-default port) -> we are a standby.
+      fluxNetworkHelperStub.resolves('192.168.1.5:16137');
+
+      await advancedWorkflows.masterSlaveApps(
+        globalState,
+        installedApps,
+        listRunningApps,
+        receiveOnlyCache,
+        [],
+        [],
+        https,
+      );
+
+      // Only the g: component is stopped; the non-g sibling is left running.
+      expect(appDockerStopStub.calledWith('n8n_n8napp')).to.be.true;
+      expect(appDockerStopStub.neverCalledWith('pgcluster_n8napp')).to.be.true;
+    });
   });
 
   describe('validateApplicationUpdateCompatibility tests', () => {

--- a/tests/unit/advancedWorkflows.test.js
+++ b/tests/unit/advancedWorkflows.test.js
@@ -1380,10 +1380,11 @@ describe('advancedWorkflows tests', () => {
     });
 
     it('does NOT stop its own container when it is the primary on a UPnP (non-default) port', async () => {
-      // Regression: FDM reports masters as ip:port. A UPnP node (e.g. :16157) that IS the
-      // primary must recognise itself and keep running. The pre-fix code stripped the port
-      // from the FDM response, normalized the bare IP to :16127, failed to match its own
-      // :16157 socket, and repeatedly stopped its own container (start/stop flap loop).
+      // Regression: FDM returns a bare master IP (production format). A UPnP node (e.g.
+      // :16157) that IS the primary must recognise itself and keep running. The pre-fix
+      // code compared with socketAddressesMatch, which normalized the bare IP to :16127,
+      // failed to match its own :16157 socket, and repeatedly stopped its own container
+      // (start/stop flap loop). ipsMatch compares on IP only, so it matches.
       const appName = 'valheim1777035136949';
       const dockerService = require('../../ZelBack/src/services/dockerService');
       dockerServiceStub.returns('fluxvalheim_valheim1777035136949');
@@ -1415,9 +1416,9 @@ describe('advancedWorkflows tests', () => {
       const receiveOnlyCache = new Map();
       const https = require('https');
 
-      // FDM reports the primary as this node's full ip:port socket (UPnP port preserved).
-      serviceHelperStub.resolves({ data: { status: 'success', data: { ips: ['90.228.196.203:16157'] } } });
-      // This node's API socket is the same UPnP socket -> we are the primary.
+      // FDM returns a bare IP (current production behavior - no FDM change required).
+      serviceHelperStub.resolves({ data: { status: 'success', data: { ips: ['90.228.196.203'] } } });
+      // This node's API socket is on a non-default UPnP port at the same IP -> we are the primary.
       fluxNetworkHelperStub.resolves('90.228.196.203:16157');
 
       await advancedWorkflows.masterSlaveApps(
@@ -1434,9 +1435,9 @@ describe('advancedWorkflows tests', () => {
       expect(appDockerStopStub.called).to.be.false;
     });
 
-    it('stops the g: component on a UPnP standby when FDM names a different ip:port primary', async () => {
-      // Guards the inverse: with ip:port now flowing end-to-end, a genuine standby (different
-      // IP, also on a non-default port) must still be detected and stopped.
+    it('stops the g: component on a UPnP standby when FDM names a different primary IP', async () => {
+      // Guards the inverse: a genuine standby (different IP, itself on a non-default port)
+      // must still be detected and stopped - ipsMatch must not over-match across IPs.
       const appName = 'n8napp';
       const dockerService = require('../../ZelBack/src/services/dockerService');
       dockerServiceStub.returns('fluxn8n_n8napp');
@@ -1466,8 +1467,8 @@ describe('advancedWorkflows tests', () => {
       const receiveOnlyCache = new Map();
       const https = require('https');
 
-      // FDM primary is a different node, also advertised with an explicit port.
-      serviceHelperStub.resolves({ data: { status: 'success', data: { ips: ['192.168.1.99:16157'] } } });
+      // FDM primary is a different node, returned as a bare IP (production format).
+      serviceHelperStub.resolves({ data: { status: 'success', data: { ips: ['192.168.1.99'] } } });
       // This node has a different IP (and its own non-default port) -> we are a standby.
       fluxNetworkHelperStub.resolves('192.168.1.5:16137');
 

--- a/tests/unit/socketAddressUtils.test.js
+++ b/tests/unit/socketAddressUtils.test.js
@@ -6,6 +6,7 @@ const {
   extractPort,
   parseSocketAddress,
   socketAddressesMatch,
+  ipsMatch,
 } = require('../../ZelBack/src/services/utils/socketAddressUtils');
 
 describe('socketAddressUtils tests', () => {
@@ -207,6 +208,40 @@ describe('socketAddressUtils tests', () => {
 
     it('should not match different IPs with same port', () => {
       expect(socketAddressesMatch('1.2.3.4:16127', '5.6.7.8:16127')).to.be.false;
+    });
+  });
+
+  describe('ipsMatch', () => {
+    it('should match a bare IP against a non-default-port socket on the same IP', () => {
+      // The core case: FDM returns a bare IP, the node is on a UPnP port.
+      expect(ipsMatch('1.2.3.4', '1.2.3.4:16157')).to.be.true;
+      expect(ipsMatch('1.2.3.4:16157', '1.2.3.4')).to.be.true;
+    });
+
+    it('should match a bare IP against a default-port socket on the same IP', () => {
+      expect(ipsMatch('1.2.3.4', '1.2.3.4:16127')).to.be.true;
+    });
+
+    it('should match two bare IPs that are equal', () => {
+      expect(ipsMatch('1.2.3.4', '1.2.3.4')).to.be.true;
+    });
+
+    it('should match sockets on the same IP with different ports', () => {
+      // Unlike socketAddressesMatch, the port is ignored entirely.
+      expect(ipsMatch('1.2.3.4:16137', '1.2.3.4:16157')).to.be.true;
+    });
+
+    it('should not match different IPs regardless of port', () => {
+      expect(ipsMatch('1.2.3.4', '5.6.7.8')).to.be.false;
+      expect(ipsMatch('1.2.3.4:16157', '5.6.7.8:16157')).to.be.false;
+      expect(ipsMatch('1.2.3.4:16157', '5.6.7.8')).to.be.false;
+    });
+
+    it('should return false when either argument is missing', () => {
+      expect(ipsMatch(null, '1.2.3.4')).to.be.false;
+      expect(ipsMatch('1.2.3.4', null)).to.be.false;
+      expect(ipsMatch(null, null)).to.be.false;
+      expect(ipsMatch(undefined, '1.2.3.4')).to.be.false;
     });
   });
 });


### PR DESCRIPTION
> **Note:** this branch has two commits. The first (`keep FDM master socket port`) was the original socket-based approach; the second (`use IP-granular matching / ipsMatch`) **supersedes** it. The description below reflects the final state. The net diff is the `ipsMatch` approach.

## Problem

A master/slave app whose primary lands on a **UPnP node** never stabilizes. The primary container starts, loads, then is stopped ~30s later — repeatedly. On a live Valheim master (`valheim1777035136949` on `90.228.196.203:16157`) we observed **268 starts / 268 stops in one day**; the container's own logs showed it stopping itself:

```
masterSlaveApps: stopping docker component:...valheim1777035136949
  it's running on ip:90.228.196.203 and localSocketAddr is: 90.228.196.203:16157
```

The FDM domain points at that master, so users can't connect while it's down.

## Root cause

`masterSlaveApps` asks FDM `GET /appips/<app>` for the current primary and compares it against the node's own socket (`localSocketAddr`). FDM returns a **bare IP** (it tracks an app's master per-IP).

PR #1737's `ip:port` standardization sweep mechanically converted the deliberately **IP-only** comparisons here (`x.ip.split(':')[0] === myIP.split(':')[0]`) into `socketAddressesMatch`. That helper normalizes a bare IP to the **default API port `16127`**:

```
socketAddressesMatch("90.228.196.203:16157", "90.228.196.203" -> "90.228.196.203:16127")
  → 16157 ≠ 16127 → false
```

So a UPnP master fails to recognise **itself** as primary, stops its own container, and flaps forever. Default-port masters accidentally matched (their real port *is* 16127), so only UPnP-hosted masters were affected — a large share of the fleet.

## Fix

Restore IP-granular comparison. Add `ipsMatch(a, b)` to `socketAddressUtils` (compares on IP only, ignoring the port) and use it at the six master/slave comparison sites. `getMasterIpFromFdm` is left untouched.

**Why IP-granular is correct here:** FDM master identity is **per-IP** — only one instance of an app can run on a given IP (enforced by host port mapping). So the IP uniquely identifies the instance; the port is irrelevant for "is this node the master?". (The unrelated `checkAndRemoveApplicationInstance` site keeps `socketAddressesMatch` — it compares two real node sockets, not an FDM value.)

## No FDM change / no rollout ordering

This works against the **current, unmodified FDM** (which returns a bare IP) — `ipsMatch` strips the port from `localSocketAddr` and compares IPs. So:

- **No `flux-domain-manager` change is required** (the companion FDM PR was closed).
- **No deployment ordering** — FluxOS can be shipped on its own.
- It can be **validated on the affected node immediately** by deploying only patched FluxOS.
- It's immune to a node's UPnP port changing, and can't be re-broken by FDM behavior.

(An earlier approach had FDM return `ip:port` and FluxOS keep it; this was dropped in favour of the self-contained IP-only fix, since the per-IP invariant makes socket precision unnecessary.)

## Testing

- `tests/unit/socketAddressUtils.test.js` — `ipsMatch` unit tests (bare↔ported same-IP match, same-IP different-port match, cross-IP non-match, null handling).
- `tests/unit/advancedWorkflows.test.js` — full `masterSlaveApps` suite, **9 passing** (7 existing + 2 new), with FDM mocked as a **bare IP** (production format):
  - *does NOT stop its own container when it is the primary on a UPnP (non-default) port* — pins the flap bug.
  - *stops the g: component on a UPnP standby when FDM names a different primary IP* — guards `ipsMatch` doesn't over-match across IPs.
- Both regression tests were verified to **fail under `socketAddressesMatch`** and **pass under `ipsMatch`** with bare-IP FDM input.


## Live validation on the affected node

Deployed this branch to the real Valheim master (`90.228.196.203`, UPnP API port `:16157`) against the **current production FDM** (no FDM change) — switched the node's FluxOS checkout to `fix/masterslave-fdm-port`, truncated logs, and restarted `fluxos.service`.

The node's own debug.log shows it sailing through the exact condition that used to kill it:

```
08:36:02  no primary set -> starting docker component (index 0)     # started once
08:37:03  getMasterIpFromFdm: Got IP 90.228.196.203 from EU FDM     # FDM now names THIS node (bare IP)
08:37:33  Got IP 90.228.196.203
08:38:03  Got IP 90.228.196.203
08:38:33  Got IP 90.228.196.203
08:39:03  Got IP 90.228.196.203                                     # still master, NO stop
```

`Got IP 90.228.196.203` (bare) against a node on `:16157` is precisely what old `socketAddressesMatch` normalized to `:16127` and mismatched, triggering the self-stop. With `ipsMatch` the node recognises itself and stays up.

| metric | before (old code) | after (`ipsMatch`) |
|---|---|---|
| starts / stops | 268 / 268 per day | **1 / 0** |
| container | `exited` (flapping) | **`Up`, RestartCount=0** |
| FDM-master cycles survived | killed ~30s after each | **4+ with zero stops** |

It held running across ~2 minutes of FDM continuously reporting it as master; the old code would have stopped it within 30s of the first such report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

