### PR TITLE
fix: restart containers on any exit + bound crash-backoff (quick fix)

### DIFF
--- a/ZelBack/src/services/appMonitoring/containerCrashRecovery.js
+++ b/ZelBack/src/services/appMonitoring/containerCrashRecovery.js
@@ -48,6 +48,11 @@ function getBackoffDelay(containerName) {
 function recordRestart(containerName) {
   const history = restartHistory.get(containerName) || [];
   history.push(nowMs());
+  // only the count (capped by the backoff ladder) and the last timestamp are
+  // ever read, so keep the array bounded for perpetually crashing containers
+  if (history.length > BACKOFF_DELAYS_MS.length) {
+    history.splice(0, history.length - BACKOFF_DELAYS_MS.length);
+  }
   restartHistory.set(containerName, history);
 }
 
@@ -63,8 +68,6 @@ async function handleContainerDie(event) {
     log.info(`containerCrashRecovery - ${containerName} was intentionally stopped (exit ${exitCode}), skipping`);
     return;
   }
-
-  if (exitCode === 0) return;
 
   if (!globalState.bootContainerStateSettled) {
     log.info(`containerCrashRecovery - ${containerName} died (exit ${exitCode}) during boot, queuing`);

--- a/ZelBack/src/services/appMonitoring/containerCrashRecovery.js
+++ b/ZelBack/src/services/appMonitoring/containerCrashRecovery.js
@@ -88,6 +88,14 @@ async function handleContainerDie(event) {
       return;
     }
   } else {
+    // confirm the container still exists and is not already running before restarting.
+    // covers a container stopped+removed outside the appDockerStop chokepoint (its die
+    // event would otherwise trigger a doomed appDockerStart and a misleading error log).
+    const container = await dockerService.getDockerContainerOnly(identifier);
+    if (!container || container.State === 'running') {
+      log.info(`containerCrashRecovery - ${containerName} no longer exists or already running, skipping`);
+      return;
+    }
     log.warn(`containerCrashRecovery - ${containerName} crashed (exit ${exitCode}), restarting as ${identifier}`);
   }
 
@@ -187,4 +195,10 @@ function stop() {
   }
 }
 
-module.exports = { start, stop };
+// exposed for tests: lets a test assert the backoff history stays bounded by the ladder length
+function restartHistoryLength(containerName) {
+  const history = restartHistory.get(containerName);
+  return history ? history.length : 0;
+}
+
+module.exports = { start, stop, restartHistoryLength };

--- a/tests/unit/containerCrashRecovery.test.js
+++ b/tests/unit/containerCrashRecovery.test.js
@@ -15,6 +15,8 @@ describe('containerCrashRecovery tests', () => {
     dockerServiceStub = {
       appDockerStart: sinon.stub().resolves('started'),
       dockerGetEvents: sinon.stub(),
+      // default: container exists and is exited, so the restart path proceeds
+      getDockerContainerOnly: sinon.stub().resolves({ State: 'exited' }),
     };
     globalStateStub = {
       bootContainerStateSettled: true,
@@ -312,7 +314,7 @@ describe('containerCrashRecovery tests', () => {
       clock.restore();
     });
 
-    it('should pin backoff at the 30m cap and not escalate beyond it', async () => {
+    it('should pin backoff at the 30m cap and keep restartHistory bounded', async () => {
       const clock = sinon.useFakeTimers({ shouldAdvanceTime: true });
       dockerServiceStub.getDockerContainerOnly = sinon.stub().resolves({ State: 'exited' });
 
@@ -333,13 +335,41 @@ describe('containerCrashRecovery tests', () => {
         expect(dockerServiceStub.appDockerStart.callCount).to.equal(expectedCount);
       }
 
-      // further crashes stay pinned at the 30m cap (history bounded, ladder index pinned)
-      emitDie('fluxwww_Osmosis', 1);
-      await clock.tickAsync(30 * 60 * 1000);
-      expect(dockerServiceStub.appDockerStart.callCount).to.equal(expectedCount + 1);
-      expect(logStub.warn.calledWithMatch(/waiting 1800s/)).to.be.true;
+      // several more crashes: the delay stays pinned at the 30m cap...
+      // eslint-disable-next-line no-restricted-syntax
+      for (let i = 0; i < 4; i += 1) {
+        emitDie('fluxwww_Osmosis', 1);
+        // eslint-disable-next-line no-await-in-loop
+        await clock.tickAsync(30 * 60 * 1000);
+        expectedCount += 1;
+        expect(dockerServiceStub.appDockerStart.callCount).to.equal(expectedCount);
+        expect(logStub.warn.calledWithMatch(/waiting 1800s/)).to.be.true;
+      }
+
+      // ...and recordRestart's trim keeps the history bounded to the ladder length
+      // (it would be 9 here without the cap). This asserts the trim itself, not just pinning.
+      expect(crashRecovery.restartHistoryLength('fluxwww_Osmosis')).to.equal(5);
 
       clock.restore();
+    });
+
+    it('should skip restart when the container no longer exists (removed outside appDockerStop)', async () => {
+      dockerServiceStub.getDockerContainerOnly = sinon.stub().resolves(null);
+
+      emitDie('fluxwww_Osmosis', 0);
+      await new Promise((r) => setImmediate(r));
+
+      expect(dockerServiceStub.appDockerStart.called).to.be.false;
+      expect(logStub.info.calledWithMatch(/no longer exists or already running/)).to.be.true;
+    });
+
+    it('should skip restart when the container is already running again', async () => {
+      dockerServiceStub.getDockerContainerOnly = sinon.stub().resolves({ State: 'running' });
+
+      emitDie('fluxwww_Osmosis', 1);
+      await new Promise((r) => setImmediate(r));
+
+      expect(dockerServiceStub.appDockerStart.called).to.be.false;
     });
 
     it('should not apply backoff of one container to another', async () => {

--- a/tests/unit/containerCrashRecovery.test.js
+++ b/tests/unit/containerCrashRecovery.test.js
@@ -177,12 +177,12 @@ describe('containerCrashRecovery tests', () => {
       expect(dockerServiceStub.appDockerStart.firstCall.args[0]).to.equal('KadenaChainWebNode');
     });
 
-    it('should ignore clean exits (code 0)', async () => {
+    it('should restart on a clean exit (code 0) by default (restart-always)', async () => {
       emitDie('fluxwww_Osmosis', 0);
       await new Promise((r) => setImmediate(r));
 
-      expect(dockerServiceStub.appDockerStart.called).to.be.false;
-      expect(logStub.warn.called).to.be.false;
+      expect(dockerServiceStub.appDockerStart.calledOnce).to.be.true;
+      expect(dockerServiceStub.appDockerStart.firstCall.args[0]).to.equal('www_Osmosis');
     });
 
     it('should ignore non-flux containers', async () => {
@@ -308,6 +308,36 @@ describe('containerCrashRecovery tests', () => {
       // Should be immediate again (backoff reset), not 5m
       expect(dockerServiceStub.appDockerStart.callCount).to.equal(3);
       expect(logStub.warn.calledWithMatch(/waiting 5/)).to.be.false;
+
+      clock.restore();
+    });
+
+    it('should pin backoff at the 30m cap and not escalate beyond it', async () => {
+      const clock = sinon.useFakeTimers({ shouldAdvanceTime: true });
+      dockerServiceStub.getDockerContainerOnly = sinon.stub().resolves({ State: 'exited' });
+
+      // first crash restarts immediately
+      emitDie('fluxwww_Osmosis', 1);
+      await clock.tickAsync(0);
+      expect(dockerServiceStub.appDockerStart.callCount).to.equal(1);
+
+      // ladder escalates: 30s, 5m, 15m, 30m
+      const ladder = [30 * 1000, 5 * 60 * 1000, 15 * 60 * 1000, 30 * 60 * 1000];
+      let expectedCount = 1;
+      // eslint-disable-next-line no-restricted-syntax
+      for (const delay of ladder) {
+        emitDie('fluxwww_Osmosis', 1);
+        // eslint-disable-next-line no-await-in-loop
+        await clock.tickAsync(delay);
+        expectedCount += 1;
+        expect(dockerServiceStub.appDockerStart.callCount).to.equal(expectedCount);
+      }
+
+      // further crashes stay pinned at the 30m cap (history bounded, ladder index pinned)
+      emitDie('fluxwww_Osmosis', 1);
+      await clock.tickAsync(30 * 60 * 1000);
+      expect(dockerServiceStub.appDockerStart.callCount).to.equal(expectedCount + 1);
+      expect(logStub.warn.calledWithMatch(/waiting 1800s/)).to.be.true;
 
       clock.restore();
     });


### PR DESCRIPTION
## Summary

**Quick fix** to restore container restart-on-any-exit behaviour, plus a bounded crash-backoff history. This is a deliberately small, low-risk stopgap — see [Follow-up](#follow-up) for the full robust rework coming in a few days.

Before FluxOS took container restarts off Docker, containers ran Docker `restart: always`, which restarted clean (exit 0) exits too. A client whose containers exit 0 to free memory relied on that and silently lost auto-restart when FluxOS started managing restarts itself. This PR restores restart-on-any-exit.

## What changed

`ZelBack/src/services/appMonitoring/containerCrashRecovery.js` (the Docker `die`-event watcher):

1. **Restart on any exit.** Removed the hardcoded `if (exitCode === 0) return;`. The watcher now restarts a container regardless of exit code — i.e. Docker `restart: always` semantics.
2. **Bounded backoff history.** `recordRestart` now trims `restartHistory` to the backoff-ladder length. Previously it pushed a timestamp on every restart and never trimmed, so a perpetually crashing container grew the array forever. Behaviour-preserving (only the count, capped by the ladder, and the last timestamp are ever read).
3. **Hardening (review follow-ups).** The immediate-restart path now confirms the container still exists and isn't already running before restarting (mirroring the backoff path), avoiding a doomed restart + misleading error log for containers removed outside the normal stop path. The backoff-cap test was strengthened to actually assert the trim.

## Behaviour changes

- ✅ **exit-0 containers now restart** (previously ignored). Restores pre-FluxOS Docker `restart: always`; serves the exit-0-to-free-memory client.
- ⚠️ **A batch/one-shot container that exits 0 to *stay* stopped will now restart-loop**, paced by the backoff ladder (`0 / 30s / 5m / 15m / 30m`, then 30m). The backoff prevents hammering, but it never stops retrying. If any app relies on "exit 0 = stay stopped," this changes it. This is the known trade-off of restoring `restart: always` globally; it becomes per-component configurable in the follow-up (v9 `restartPolicy`).
- **Deliberate FluxOS stops are still safe.** `appstop` / `appkill` / redeploy / masterSlave standby / syncthing all register the container in `stoppingContainers` before stopping it, so the resulting `die` event is skipped regardless of exit code. Removing the exit-0 return does **not** make crash recovery fight an intentional stop.

## ⚠️ Caveat — user-stopped apps will still be restarted

This PR does **not** make a user stop durable, and intentionally so (it kept ballooning in scope — that belongs in the rework).

- Crash recovery itself will **not** fight a user `appstop` (the `stoppingContainers` check above handles that).
- **But** the hourly `monitorAndRecoverApps` resync still restarts any installed-but-stopped app — it has no "operator stopped" concept — so **a deliberately user-stopped app comes back within ~2h.** This is **pre-existing behaviour on `development`, unchanged by this PR.**

Durable user-stop (survives reboot, and the hourly monitor honours it) arrives with the follow-up.

## <a name="follow-up"></a>Follow-up — the full robust solution (separate PR, in a few days)

This stopgap is superseded by a rearchitecture that collapses the five imperative restart actuators (die-event watch, hourly resync, masterSlave election, syncthing FSMs, boot) into a **single level-based reconciler** driven by a per-component workqueue. It adds:

- **v9-compatible per-component `restartPolicy`** — the operator selects `always` (default) / `on-failure` / `no` / `unless-stopped`; exit-0 behaviour becomes configurable instead of global.
- **Durable operator-stop** — a user `appstop` sticks across reboots, and every recovery path honours it.
- **Durable backoff** — survives a FluxOS restart instead of resetting.
- **dockerd-restart orphan recovery** — a reconnect sweep catches containers exited while FluxOS was down (the "container exited for 1h30m" case).
- **syncthing data-safety** — never force-start on un-synced data.

When that lands, this PR's global behaviour change is replaced by the configurable policy, so there's nothing to revert.

## Testing

- Unit: `tests/unit/containerCrashRecovery.test.js` (23 passing), covering restart-on-exit-0, the bounded-history cap (verified to fail if the trim is removed), the immediate-restart existence guard, and the existing backoff ladder.
- Run: `env NODE_CONFIG_DIR=$PWD/tests/unit/globalconfig npx mocha tests/unit/containerCrashRecovery.test.js --exit`

## Commits

```
3daa27010 fix: guard immediate-restart path + actually test the backoff cap
aef0201c9 fix: restart containers on any exit + bound the crash-backoff history
```

_PR description written against `3daa27010`._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
