### PR TITLE
fix: decrypt previous enterprise spec in updateAppGlobaly before signature verify

### DIFF
--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -2900,9 +2900,25 @@ async function updateAppGlobaly(params) {
   const isEnterprise = Boolean(appSpecObj.version >= 8 && appSpecObj.enterprise);
   const toVerify = isEnterprise ? specificationFormatter(appSpecObj) : appSpecFormatted;
 
+  // appInfo comes from globalAppsInformation, where enterprise specs are stored with
+  // compose/contacts stripped to []. verifyAppMessageUpdateSignature expects the previous
+  // spec already decrypted (callers own the decryption) so its usersToExtend expire-only
+  // comparison sees the real compose/contacts. Decrypt here, mirroring the broadcast path's
+  // getPreviousAppSpecifications. Without this, enterprise subscription renewals signed by a
+  // usersToExtend address are rejected on secure nodes.
+  let previousAppSpec = appInfo;
+  if (appInfo.version >= 8 && appInfo.enterprise) {
+    try {
+      const decryptedPreviousSpec = await checkAndDecryptAppSpecs(appInfo, { daemonHeight: appInfo.height });
+      previousAppSpec = specificationFormatter(decryptedPreviousSpec);
+    } catch {
+      previousAppSpec = specificationFormatter(appInfo);
+    }
+  }
+
   // eslint-disable-next-line global-require
   const appMessaging = require('../appMessaging/messageVerifier');
-  await appMessaging.verifyAppMessageUpdateSignature(cleanMessageType, cleanTypeVersion, toVerify, cleanTimestamp, cleanSignature, appOwner, daemonHeight, appInfo);
+  await appMessaging.verifyAppMessageUpdateSignature(cleanMessageType, cleanTypeVersion, toVerify, cleanTimestamp, cleanSignature, appOwner, daemonHeight, previousAppSpec);
 
   // Enforce version upgrade policy
   const { latestSupportedSpecVersion } = config.fluxapps;


### PR DESCRIPTION
## Problem

Enterprise app **subscription renewals** submitted by the apps monitor (a `usersToExtend` whitelisted signer) are rejected on secure (Arcane) nodes with:

> Received signature does not correspond with Flux App owner or Flux App specifications are not properly formatted

## Root cause

The synchronous `/apps/appupdate` handler `updateAppGlobaly` passes the raw `appInfo` from `globalAppsInformation` as `previousAppSpec`. Enterprise specs are stored there with `compose`/`contacts` stripped to `[]` (`registryManager.js` `isEnterprise` branch).

Since **commit `2c0e419d5` (2026-05-14, "fix: resolve 5 remaining hash sync signature verification failures")**, `verifyAppMessageUpdateSignature` no longer decrypts `previousAppSpec` itself — it relies on callers to do so. That commit updated the broadcast/promotion callers (which use the decrypting `getPreviousAppSpecifications`) but **not** this API caller.

So on a secure node the `usersToExtend` expire-only check compares:
- submitted spec → **decrypted**, `compose` populated
- previous spec → **raw `appInfo`**, `compose: []`

`isExpireOnlyUpdate` never matches → the `usersToExtend` signature is rejected.

## Blast radius (narrow)

| Who signs | App type | Result |
|---|---|---|
| App owner | any | ✅ unaffected (owner signature validates before the `usersToExtend` branch) |
| Extender (`usersToExtend`) | non-enterprise | ✅ unaffected (stored `compose` populated → matches) |
| Extender (`usersToExtend`) | **enterprise** | ❌ broken — and only on **secure** nodes, only since 2026-05-14 |

`updateAppGlobaly` is reached only via `POST /apps/appupdate` → `updateAppGlobalyApi`; the P2P propagation/promotion path is a separate, already-correct path.

## Fix

Decrypt `appInfo` for enterprise apps before passing it as `previousAppSpec`, mirroring `getPreviousAppSpecifications` (same try/catch fallback, so non-secure nodes that can't decrypt don't throw — they skip the comparison anyway). Restores pre-2026-05-14 behavior and aligns the API path with the broadcast path. No consensus divergence added.

## Testing

- Lint clean on the change (the one remaining `prefer-destructuring` error at line 3794 is pre-existing on `development`, unrelated).
- ✅ **Validated end-to-end on a live secure (Arcane) node** (`mule`, `systemsecure: true`, mainnet CUMULUS). Checked the branch out at `/dat/usr/lib/fluxos`, restarted `fluxos.service`, and routed the apps monitor's real `capsule` enterprise subscription renewal at it via `/apps/appupdate`. The node's `debug.log`:
  ```
  App capsule expire extension signed by userToExtend address 1MCBJn6qsy3YRY2YasdYMYdJcdhy1ev8Rd
  [isExpireOnlyUpdate] Specs match for app capsule
  ```
  Previously this logged `Specs differ`. The temp message (`fb2d8354…`, `fluxappupdate`) then **propagated and promoted network-wide** — the secure Arcane pool on `api.runonflux.io` accepted it via the broadcast path — and `capsule`'s on-chain `expire` advanced to the renewed value. The node was reverted to `master` afterward (Arcane runs signed/ISO builds; the manual checkout was temporary).
- Confirms the diagnosis on the secure path: the failure was the `compose`/`contacts` mismatch, not a signing-key problem (the whitelisted extender address verified correctly).

## Scope of impact observed in production

Only Stripe-subscription enterprise apps renewed by the monitor hit this path. At the time of the fix there were **5** such apps; the next one to enter its renewal window is ~30 days out, so a normal-cadence deploy of this fix has ample runway. `capsule` was the only app actually stuck (it had reached its renewal window) and is now renewed.

PR description updated against commit 621759ebf (validation performed 2026-06-09).

🤖 Generated with [Claude Code](https://claude.com/claude-code)