### PR TITLE
feat(info): expose connected MongoDB server version on /flux/info

### DIFF
--- a/ZelBack/src/services/dbHelper.js
+++ b/ZelBack/src/services/dbHelper.js
@@ -18,6 +18,12 @@ const mongoUrl = `mongodb://${config.database.url}:${config.database.port}/`;
 let openDBConnection = null;
 
 /**
+ * Cached MongoDB server version, populated once per connection.
+ * @type {string | null}
+ */
+let mongoDbVersion = null;
+
+/**
  * Returns MongoDB connection, if it was initiated before, otherwise returns null.
  *
  * @returns {mongodb.MongoClient | null}
@@ -47,8 +53,35 @@ async function connectMongoDb(url) {
  * @returns true
  */
 async function initiateDB() {
-  if (!openDBConnection) openDBConnection = await connectMongoDb();
+  if (!openDBConnection) {
+    openDBConnection = await connectMongoDb();
+    // Read the server version once, on the initial connect. It is informational
+    // and the getter swallows its own errors, so this cannot fail the connect.
+    await getMongoDbVersion();
+  }
   return true;
+}
+
+/**
+ * Returns the connected MongoDB server version, fetching and caching it on
+ * first use. The driver handshake only exposes the wire-protocol version, so
+ * the human-readable version is read once via a buildInfo command and reused.
+ * The version is informational: on any failure this resolves to null rather
+ * than throwing, so a transient read never sinks its callers, and a later
+ * call retries.
+ *
+ * @returns {Promise<string | null>} Server version, or null if unavailable.
+ */
+async function getMongoDbVersion() {
+  if (mongoDbVersion) return mongoDbVersion;
+  if (!openDBConnection) return null;
+  try {
+    const { version } = await openDBConnection.db('admin').command({ buildInfo: 1 });
+    mongoDbVersion = version;
+  } catch (error) {
+    log.warn(`Unable to read MongoDB version: ${error.message}`);
+  }
+  return mongoDbVersion;
 }
 
 /**
@@ -86,6 +119,7 @@ async function closeDbConnection() {
   if (openDBConnection) {
     await openDBConnection.close();
     openDBConnection = null;
+    mongoDbVersion = null;
   }
 }
 
@@ -962,6 +996,7 @@ module.exports = {
   findOneAndDeleteInDatabase,
   findOneAndUpdateInDatabase,
   findOneInDatabase,
+  getMongoDbVersion,
   initiateDB,
   insertManyToDatabase,
   insertOneToDatabase,

--- a/ZelBack/src/services/fluxService.js
+++ b/ZelBack/src/services/fluxService.js
@@ -11,6 +11,7 @@ const packageJson = require('../../../package.json');
 const serviceHelper = require('./serviceHelper');
 const verificationHelper = require('./verificationHelper');
 const messageHelper = require('./messageHelper');
+const dbHelper = require('./dbHelper');
 const daemonServiceUtils = require('./daemonService/daemonServiceUtils');
 const daemonServiceBlockchainRpcs = require('./daemonService/daemonServiceBlockchainRpcs');
 const daemonServiceFluxnodeRpcs = require('./daemonService/daemonServiceFluxnodeRpcs');
@@ -1234,6 +1235,7 @@ async function getFluxInfo(req, res) {
     info.flux.syncthingVersion = syncthingVersion.data.version;
     const dockerVersion = await dockerService.dockerVersion();
     info.flux.dockerVersion = dockerVersion.Version;
+    info.flux.mongoDbVersion = await dbHelper.getMongoDbVersion();
     const osDistInfo = await getOSDistributionInfo();
     info.flux.os = osDistInfo.distribution;
     info.flux.osVersion = osDistInfo.version;

--- a/tests/unit/dbHelper.test.js
+++ b/tests/unit/dbHelper.test.js
@@ -60,6 +60,23 @@ describe('dbHelper tests', () => {
     });
   });
 
+  describe('getMongoDbVersion tests', () => {
+    it('should return null when no connection is established', async () => {
+      await dbHelper.closeDbConnection();
+
+      expect(await dbHelper.getMongoDbVersion()).to.be.null;
+    });
+
+    it('should return the connected server version string', async () => {
+      await dbHelper.initiateDB();
+
+      const version = await dbHelper.getMongoDbVersion();
+
+      expect(version).to.be.a('string');
+      expect(version).to.match(/^\d+\.\d+\.\d+/);
+    });
+  });
+
   describe('distinctDatabase tests', () => {
     let database;
     let collection;


### PR DESCRIPTION
## What

Adds the connected MongoDB server version to `GET /flux/info` as `data.flux.mongoDbVersion`, alongside the existing Docker and Syncthing versions. This was the one backing-service version FluxOS never surfaced.

## How

- `dbHelper.js`: reads the server version once per connection via a `buildInfo` command and caches it in a new `getMongoDbVersion()`. The read is **informational** — it swallows its own errors and returns `null`, so it can never turn `/flux/info` into an error response. The cache is warmed on the initial connect (`initiateDB`) and cleared on close so a reconnect re-reads it.
- `fluxService.getFluxInfo()`: surfaces `info.flux.mongoDbVersion`, grouped with the other backing-service versions.

`buildInfo` is the lowest-privilege, most universally available source for the human-readable version (the driver handshake only exposes the wire-protocol version). It works on MongoDB 3.6+, so it succeeds on every node the driver can already talk to.

No standalone endpoint was added: like Docker and Syncthing, MongoDB is a backing service, so it belongs only in the consolidated `/flux/info` rather than minting a new per-field route.

## Testing

- New unit tests in `tests/unit/dbHelper.test.js` cover `getMongoDbVersion()` (returns `null` when unconnected; semver string when connected).
- Existing `dbHelper` (34) and `getFluxInfo` (14) unit suites pass with no new lint errors.
- Validated end-to-end against a live node running MongoDB: `/flux/info` reports `flux.mongoDbVersion` correctly (e.g. `8.0.20`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
