### PR TITLE
refactor: drop all zelAppSpecifications legacy references (supersedes #1717)

### DIFF
--- a/ZelBack/src/services/appDatabase/registryManager.js
+++ b/ZelBack/src/services/appDatabase/registryManager.js
@@ -1998,7 +1998,7 @@ async function rescanGlobalAppsInformation(height = 0, removeLastInformation = f
 
     // eslint-disable-next-line no-restricted-syntax
     for (const message of results) {
-      const updateForSpecifications = message.appSpecifications || message.zelAppSpecifications;
+      const updateForSpecifications = message.appSpecifications;
       updateForSpecifications.hash = message.hash;
       updateForSpecifications.height = message.height;
       // eslint-disable-next-line no-await-in-loop
@@ -2112,33 +2112,10 @@ async function getPreviousAppSpecifications(specifications, verificationTimestam
       }
     }
   });
-  // some early app have zelAppSepcifications
-  const appsQueryB = {
-    'zelAppSpecifications.name': specifications.name,
-  };
-  const permanentAppMessageB = await dbHelper.findInDatabase(database, globalAppsMessages, appsQueryB, projection);
-  permanentAppMessageB.forEach((foundMessage) => {
-    // has to be registration message
-    const validTypes = ['zelappregister', 'fluxappregister', 'zelappupdate', 'fluxappupdate'];
-    if (validTypes.includes(foundMessage.type)) {
-      if (!latestPermanentRegistrationMessage && foundMessage.timestamp <= verificationTimestamp) {
-        // no message and found message is not newer than our message
-        latestPermanentRegistrationMessage = foundMessage;
-      } else if (latestPermanentRegistrationMessage && latestPermanentRegistrationMessage.height <= foundMessage.height) {
-        // we have some message and the message is quite new
-        if (latestPermanentRegistrationMessage.timestamp < foundMessage.timestamp
-          && foundMessage.timestamp <= verificationTimestamp) {
-          // but our message is newer. foundMessage has to have lower timestamp than our new message
-          latestPermanentRegistrationMessage = foundMessage;
-        }
-      }
-    }
-  });
   if (!latestPermanentRegistrationMessage) {
     return null;
   }
-  const appSpecs = latestPermanentRegistrationMessage.appSpecifications
-    || latestPermanentRegistrationMessage.zelAppSpecifications;
+  const appSpecs = latestPermanentRegistrationMessage.appSpecifications;
   if (!appSpecs) {
     throw new Error(`Previous specifications for ${specifications.name} update message does not exists! This should not happen.`);
   }

--- a/ZelBack/src/services/appLifecycle/appUninstaller.js
+++ b/ZelBack/src/services/appLifecycle/appUninstaller.js
@@ -847,7 +847,7 @@ async function removeAppLocally(app, res, force = false, endResponse = true, sen
           const projection = { projection: { _id: 0 } };
           const messages = await dbHelper.findInDatabase(database, globalAppsMessages, query, projection);
           const appMessages = messages.filter((message) => {
-            const specifications = message.appSpecifications || message.zelAppSpecifications;
+            const specifications = message.appSpecifications;
             return specifications.name === appName;
           });
           let currentSpecifications;
@@ -857,7 +857,7 @@ async function removeAppLocally(app, res, force = false, endResponse = true, sen
             }
           });
           if (currentSpecifications && currentSpecifications.height) {
-            appSpecifications = currentSpecifications.appSpecifications || currentSpecifications.zelAppSpecifications;
+            ({ appSpecifications } = currentSpecifications);
           }
         }
       }

--- a/ZelBack/src/services/appMessaging/appHashSyncService.js
+++ b/ZelBack/src/services/appMessaging/appHashSyncService.js
@@ -270,7 +270,7 @@ async function processMessages(messages, onProgress) {
     const updateNames = new Set();
     for (const msg of newMessages) {
       if (msg.type === 'fluxappupdate' || msg.type === 'zelappupdate') {
-        const specs = msg.appSpecifications || msg.zelAppSpecifications;
+        const specs = msg.appSpecifications;
         if (specs) updateNames.add(specs.name);
       }
     }
@@ -295,7 +295,7 @@ async function processMessages(messages, onProgress) {
 
     for (const appMessage of newMessages) {
       try {
-        const specifications = appMessage.appSpecifications || appMessage.zelAppSpecifications;
+        const specifications = appMessage.appSpecifications;
         if (!specifications) continue;
 
         const appSpecFormatted = specificationFormatter(specifications);
@@ -345,7 +345,7 @@ async function processMessages(messages, onProgress) {
             failed += 1;
             continue;
           }
-          const prevSpecs = prevMsg.appSpecifications || prevMsg.zelAppSpecifications;
+          const prevSpecs = prevMsg.appSpecifications;
           let prevSpecsForVerification = prevSpecs;
           if (prevSpecs.version >= 8 && prevSpecs.enterprise) {
             try {

--- a/ZelBack/src/services/appMessaging/messageStore.js
+++ b/ZelBack/src/services/appMessaging/messageStore.js
@@ -81,12 +81,11 @@ async function storeAppTemporaryMessage(message, options = {}) {
   if (!message || typeof message !== 'object' || typeof message.type !== 'string' || typeof message.version !== 'number' || typeof message.signature !== 'string' || typeof message.timestamp !== 'number' || typeof message.hash !== 'string') {
     return new Error('Invalid Flux App message for storing');
   }
-  // expect one to be present
-  if (typeof message.appSpecifications !== 'object' && typeof message.zelAppSpecifications !== 'object') {
+  if (typeof message.appSpecifications !== 'object') {
     return new Error('Invalid Flux App message for storing');
   }
 
-  const specifications = message.appSpecifications || message.zelAppSpecifications;
+  const specifications = message.appSpecifications;
   // eslint-disable-next-line no-use-before-define
   const appSpecFormatted = specificationFormatter(specifications);
   const messageTimestamp = serviceHelper.ensureNumber(message.timestamp);

--- a/ZelBack/src/services/appMessaging/messageVerifier.js
+++ b/ZelBack/src/services/appMessaging/messageVerifier.js
@@ -41,7 +41,7 @@ async function verifyAppHash(message) {
    * @param timestamp number
    * @param signature string
    */
-  const specifications = message.appSpecifications || message.zelAppSpecifications;
+  const specifications = message.appSpecifications;
   let messToHash = message.type + message.version + JSON.stringify(specifications) + message.timestamp + message.signature;
   let messageHASH = await generalService.messageHash(messToHash);
 
@@ -463,7 +463,6 @@ async function checkAppMessageExistence(hash) {
   // const permanentAppMessage = {
   //   type: messageType,
   //   version: typeVersion,
-  //   zelAppSpecifications: appSpecFormatted,
   //   appSpecifications: appSpecFormatted,
   //   hash: messageHASH,
   //   timestamp,
@@ -630,7 +629,7 @@ async function checkAndRequestApp(hash, txid, height, valueSat, i = 0) {
       // if we have it in temporary storage, get the temporary message
       const tempMessage = await checkAppTemporaryMessageExistence(hash);
       if (tempMessage && typeof tempMessage === 'object' && !Array.isArray(tempMessage)) {
-        const specifications = tempMessage.appSpecifications || tempMessage.zelAppSpecifications;
+        const specifications = tempMessage.appSpecifications;
         if (!specifications) {
           log.error(`Temp message ${hash} has no specifications! Full message: ${JSON.stringify(tempMessage)}`);
           return false;
@@ -793,7 +792,7 @@ async function checkAndRequestApp(hash, txid, height, valueSat, i = 0) {
               log.error(`Last permanent message for ${specifications.name} not found`);
               return true;
             }
-            const previousSpecs = messageInfo.appSpecifications || messageInfo.zelAppSpecifications;
+            const previousSpecs = messageInfo.appSpecifications;
             // here comparison of height differences and specifications
             // price shall be price for standard registration plus minus already paid price according to old specifics. height remains height valid for 22000 blocks
             let appPrice = await appPricePerMonth(specifications, height, appPrices);

--- a/ZelBack/src/services/appQuery/appQueryService.js
+++ b/ZelBack/src/services/appQuery/appQueryService.js
@@ -341,13 +341,7 @@ async function getAppsMessagesCount(req, res) {
     const db = dbHelper.databaseConnection();
     const database = db.db(config.database.appsglobal.database);
 
-    // Query for both appSpecifications.owner and zelAppSpecifications.owner (legacy)
-    const query = {
-      $or: [
-        { 'appSpecifications.owner': appowner },
-        { 'zelAppSpecifications.owner': appowner },
-      ],
-    };
+    const query = { 'appSpecifications.owner': appowner };
 
     const count = await dbHelper.countInDatabase(database, globalAppsMessages, query);
     const countResponse = messageHelper.createDataMessage(count);

--- a/ZelBack/src/services/explorerService.js
+++ b/ZelBack/src/services/explorerService.js
@@ -33,6 +33,7 @@ const chainParamsMessagesCollection = config.database.chainparams.collections.ch
 let blockProccessingCanContinue = true;
 let someBlockIsProcessing = false;
 let isInInitiationOfBP = false;
+let zelAppSpecsMigrationDone = false;
 let explorerReadyEmitted = false;
 let operationBlocked = false;
 let pollTimeout = null;
@@ -800,6 +801,36 @@ async function cleanupDuplicateScannedHeight(database) {
   }
 }
 
+// One-time migration for nodes carrying records from before the Feb 2021
+// zelAppSpecifications → appSpecifications rename: bring data at rest in line
+// with the field name the rest of the code now reads exclusively, and drop the
+// indexes that backed the old field name. Idempotent (matches zero docs once
+// migrated). Safe to remove, along with the gating flag, once the whole fleet
+// has run it.
+async function migrateZelAppSpecifications(databaseGlobal) {
+  const col = databaseGlobal.collection(config.database.appsglobal.collections.appsMessages);
+  const result = await col.updateMany(
+    { zelAppSpecifications: { $exists: true } },
+    { $rename: { zelAppSpecifications: 'appSpecifications' } },
+  );
+  if (result.modifiedCount > 0) {
+    log.info(`Migrated ${result.modifiedCount} records from zelAppSpecifications to appSpecifications`);
+  }
+  const existingIndexes = await col.indexes();
+  const legacyIndexNames = [
+    'query for getting zelapp message based on zelapp specs name',
+    'query for getting zelapp message based on zelapp specs owner',
+    'query for getting zelapp message based on image',
+  ];
+  for (const idx of existingIndexes) {
+    if (legacyIndexNames.includes(idx.name)) {
+      // eslint-disable-next-line no-await-in-loop
+      await col.dropIndex(idx.name);
+      log.info(`Dropped legacy index: ${idx.name}`);
+    }
+  }
+}
+
 /**
  * To start the block processor.
  * @param {boolean} restoreDatabase True if database is to be restored.
@@ -1158,6 +1189,18 @@ async function initiateBlockProcessor(restoreDatabase, deepRestore, reindexOrRes
 
     await cleanupDuplicateScannedHeight(database);
 
+    if (!zelAppSpecsMigrationDone) {
+      // Wrapped so a malformed or fresh-sync DB (e.g. col.indexes() on a
+      // not-yet-created collection) can't stall block-processor init.
+      try {
+        const globalDb = db.db(config.database.appsglobal.database);
+        await migrateZelAppSpecifications(globalDb);
+        zelAppSpecsMigrationDone = true;
+      } catch (error) {
+        log.error(`zelAppSpecifications migration failed: ${error.message}`);
+      }
+    }
+
     let scannedBlockHeight = await getScannedBlockHeightFromDb(database);
 
     const daemonBlockCount = await daemonServiceBlockchainRpcs.getBlockCount();
@@ -1244,9 +1287,6 @@ async function initiateBlockProcessor(restoreDatabase, deepRestore, reindexOrRes
       await databaseGlobal.collection(config.database.appsglobal.collections.appsMessages).createIndex({ hash: 1 }, { name: 'query for getting zelapp message based on hash', unique: true });
       await databaseGlobal.collection(config.database.appsglobal.collections.appsMessages).createIndex({ txid: 1 }, { name: 'query for getting zelapp message based on txid' });
       await databaseGlobal.collection(config.database.appsglobal.collections.appsMessages).createIndex({ height: 1 }, { name: 'query for getting zelapp message based on height' });
-      await databaseGlobal.collection(config.database.appsglobal.collections.appsMessages).createIndex({ 'zelAppSpecifications.name': 1 }, { name: 'query for getting zelapp message based on zelapp specs name' });
-      await databaseGlobal.collection(config.database.appsglobal.collections.appsMessages).createIndex({ 'zelAppSpecifications.owner': 1 }, { name: 'query for getting zelapp message based on zelapp specs owner' });
-      await databaseGlobal.collection(config.database.appsglobal.collections.appsMessages).createIndex({ 'zelAppSpecifications.repotag': 1 }, { name: 'query for getting zelapp message based on image' });
       await databaseGlobal.collection(config.database.appsglobal.collections.appsMessages).createIndex({ 'appSpecifications.name': 1 }, { name: 'query for getting app message based on zelapp specs name' });
       await databaseGlobal.collection(config.database.appsglobal.collections.appsMessages).createIndex({ 'appSpecifications.owner': 1 }, { name: 'query for getting app message based on zelapp specs owner' });
       await databaseGlobal.collection(config.database.appsglobal.collections.appsMessages).createIndex({ 'appSpecifications.repotag': 1 }, { name: 'query for getting app message based on image' });
@@ -1961,6 +2001,11 @@ function setIsInInitiationOfBP(value) {
   isInInitiationOfBP = value;
 }
 
+// testing purposes
+function setZelAppSpecsMigrationDone(value) {
+  zelAppSpecsMigrationDone = value;
+}
+
 module.exports = {
   initiateBlockProcessor,
   processBlock,
@@ -1994,6 +2039,7 @@ module.exports = {
   processStandard,
   setBlockProccessingCanContinue,
   setIsInInitiationOfBP,
+  setZelAppSpecsMigrationDone,
   restoreDatabaseToBlockheightState,
 
   isExplorerSynced,

--- a/ZelBack/src/services/fluxCommunicationMessagesSender.js
+++ b/ZelBack/src/services/fluxCommunicationMessagesSender.js
@@ -94,7 +94,7 @@ async function respondWithAppMessage(msgObj, peer) {
         temporaryAppMessage = { // specification of temp message
           type: appMessage.type,
           version: appMessage.version,
-          appSpecifications: appMessage.appSpecifications || appMessage.zelAppSpecifications,
+          appSpecifications: appMessage.appSpecifications,
           hash: appMessage.hash,
           timestamp: appMessage.timestamp,
           signature: appMessage.signature,

--- a/tests/unit/explorerService.test.js
+++ b/tests/unit/explorerService.test.js
@@ -1750,6 +1750,7 @@ describe('explorerService tests', () => {
 
     afterEach(() => {
       explorerService.setIsInInitiationOfBP(false);
+      explorerService.setZelAppSpecsMigrationDone(false);
       sinon.restore();
     });
 
@@ -1763,6 +1764,7 @@ describe('explorerService tests', () => {
     });
 
     it('should throw and log error if getBlockCount does not return success', async () => {
+      explorerService.setZelAppSpecsMigrationDone(true);
       sinon.stub(dbHelper, 'countInDatabase').resolves(1);
       explorerService.setBlockProccessingCanContinue(false);
       getBlockCountStub.returns({
@@ -1785,7 +1787,7 @@ describe('explorerService tests', () => {
       sinon.stub(dbHelper, 'findInDatabase').resolves([]);
       sinon.stub(dbHelper, 'countInDatabase').resolves(1);
       const createIndexFake = sinon.fake.resolves(true);
-      const collectionFake = sinon.fake.returns({ createIndex: createIndexFake });
+      const collectionFake = sinon.fake.returns({ createIndex: createIndexFake, updateMany: sinon.fake.resolves({ modifiedCount: 0 }), indexes: sinon.fake.resolves([]) });
       const dbFake = sinon.fake.returns({ collection: collectionFake });
       sinon.stub(dbHelper, 'databaseConnection').returns({ db: dbFake });
       getBlockCountStub.returns({
@@ -1813,7 +1815,7 @@ describe('explorerService tests', () => {
       sinon.stub(dbHelper, 'findInDatabase').resolves([]);
       sinon.stub(dbHelper, 'countInDatabase').resolves(1);
       const createIndexFake = sinon.fake.resolves(true);
-      const collectionFake = sinon.fake.returns({ createIndex: createIndexFake });
+      const collectionFake = sinon.fake.returns({ createIndex: createIndexFake, updateMany: sinon.fake.resolves({ modifiedCount: 0 }), indexes: sinon.fake.resolves([]) });
       const dbFake = sinon.fake.returns({ collection: collectionFake });
       sinon.stub(dbHelper, 'databaseConnection').returns({ db: dbFake });
       getBlockCountStub.returns({ status: 'success', data: 200000 });
@@ -1836,7 +1838,7 @@ describe('explorerService tests', () => {
       findInDatabaseStub.returns({ generalScannedHeight: 1000 });
       dropCollectionStub.resolves(true);
       const createIndexFake = sinon.fake.resolves(true);
-      const collectionFake = sinon.fake.returns({ createIndex: createIndexFake });
+      const collectionFake = sinon.fake.returns({ createIndex: createIndexFake, updateMany: sinon.fake.resolves({ modifiedCount: 0 }), indexes: sinon.fake.resolves([]) });
       const dbFake = sinon.fake.returns({ collection: collectionFake });
       sinon.stub(dbHelper, 'databaseConnection').returns({ db: dbFake });
       getBlockCountStub.returns({
@@ -1865,7 +1867,7 @@ describe('explorerService tests', () => {
       findInDatabaseStub.returns({ generalScannedHeight: 1000 });
       dropCollectionStub.resolves(true);
       const createIndexFake = sinon.fake.resolves(true);
-      const collectionFake = sinon.fake.returns({ createIndex: createIndexFake });
+      const collectionFake = sinon.fake.returns({ createIndex: createIndexFake, updateMany: sinon.fake.resolves({ modifiedCount: 0 }), indexes: sinon.fake.resolves([]) });
       const dbFake = sinon.fake.returns({ collection: collectionFake });
       sinon.stub(dbHelper, 'databaseConnection').returns({ db: dbFake });
       getBlockCountStub.returns({
@@ -1894,7 +1896,7 @@ describe('explorerService tests', () => {
       findInDatabaseStub.returns({ generalScannedHeight: 0 });
       dropCollectionStub.resolves(true);
       const createIndexFake = sinon.fake.resolves(true);
-      const collectionFake = sinon.fake.returns({ createIndex: createIndexFake });
+      const collectionFake = sinon.fake.returns({ createIndex: createIndexFake, updateMany: sinon.fake.resolves({ modifiedCount: 0 }), indexes: sinon.fake.resolves([]) });
       const dbFake = sinon.fake.returns({ collection: collectionFake });
       sinon.stub(dbHelper, 'databaseConnection').returns({ db: dbFake });
       getBlockCountStub.returns({


### PR DESCRIPTION
## What

Removes the `zelAppSpecifications` legacy field entirely. The field was renamed to `appSpecifications` in Feb 2021, but read paths still carried an `appSpecifications || zelAppSpecifications` fallback and `explorerService` still created the legacy `zelAppSpecifications.*` indexes.

This **supersedes #1717**, which was branched before the `appMessaging` refactor (`messageStore` / `messageVerifier` / `appHashSyncService` split, `getPreviousAppSpecifications` moving to `registryManager`). Rebasing it produced conflicts against code that had since been rewritten, so the change was rebuilt fresh on `development`.

## Changes

- **Hard cutoff** — removed every `appSpecifications || zelAppSpecifications` read fallback (`registryManager`, `appUninstaller`, `appHashSyncService`, `messageStore`, `messageVerifier`, `appQueryService`, `fluxCommunicationMessagesSender`), including the now-dead legacy-key scan block in `getPreviousAppSpecifications` and the legacy `$or` branch in `appQueryService`.
- **Legacy indexes** — dropped the three `zelAppSpecifications.*` `createIndex` calls.
- **One-time migration** — `$rename` of `zelAppSpecifications` → `appSpecifications` plus a legacy-index drop, run once per process in `initiateBlockProcessor`, gated by a module flag and wrapped in `try/catch` so a malformed or fresh-sync DB can't stall block-processor init. Idempotent; safe to remove along with the flag once the fleet has run it.

## Why this is safe

- The message hash/signature is computed over the spec object's **value**, not the wrapper key — so the field name is freely renameable without invalidating any hash or signature.
- Inbound messages are already normalised to `appSpecifications` at ingestion (`storeAppTemporaryMessage`), and the permanent-message store already requires `appSpecifications`.
- Verified on the live network that stored permanent messages no longer carry the legacy field; the migration covers any node still holding pre-2021 records at rest.

## Addresses review feedback from #1717

1. **try/catch around the migration** — `col.indexes()` can throw on a never-created collection; the call is wrapped and logs on failure.
2. **Peer wire compatibility** — confirmed (see "Why this is safe"): no path still emits the legacy field, and the value-based hash makes the rename transparent.
3. **Cleanup follow-up** — the migration function and gating flag are commented as safe to delete once the fleet has fully upgraded.

## Testing

- Unit suites green for every touched module: `explorerService`, `registryManager`, `appUninstaller`, `appHashSyncService`, `messageStore`, `messageVerifier`, `appQueryService`, `fluxCommunicationMessagesSender`.
- Lint clean on all changed files (no new findings).

_PR description written against commit `ee594bdf0`._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
