### PR TITLE
Add 'qblocktechnology' to repositories list

### DIFF
--- a/helpers/repositories.json
+++ b/helpers/repositories.json
@@ -465,5 +465,6 @@
    "testnet32/flights_scraper",
    "kingsimpa69/50-50.io",
    "archivebox",
-   "jlesage/firefox"
+   "jlesage/firefox",
+   "qblocktechnology"
 ]


### PR DESCRIPTION
# What do you want to Run On Flux?

FluxIt — an AI-powered app builder that deploys the web apps it generates onto the
Flux network. Users describe an app, FluxIt generates it, and our platform packages
it as a Docker image and registers it on Flux.

All images are built and pushed exclusively by our own deployment pipeline (never
by end users directly) into a single repository, `qblocktechnology/fluxit-global-apps`,
with one tag per app (e.g. `qblocktechnology/fluxit-global-apps:app-<hash>`). Each
image is a lightweight Node.js web server runtime plus the generated app's static
files — no mining, no bandwidth sharing, no background workloads of any kind. Apps
that need a database use the already-whitelisted official `postgres` image as a
second compose component.

We are whitelisting the organisation (as recommended) since every app is a tag of
the same platform-controlled repository.

# Is your desired application running somewhere already?

The generated apps currently run in FluxIt's own preview environment prior to
deployment. Docker images are public on Docker Hub under
https://hub.docker.com/r/qblocktechnology/fluxit-global-apps

# Is your application open source?

The generated app images contain only static web content plus a standard Node.js
serving runtime; the FluxIt platform itself is closed source.

# Checklist:

- [x] Whitelist of application is only modifying repositories.json file
- [x] repositories.json is still a valid JSON file
- [x] Only whitelists single docker image organisation (one whitelist at a time, more whitelists, more PRs)
- [x] No other whitelist has been deleted
- [x] I agree with ToS https://cdn.runonflux.io/Flux_Terms_of_Service.pdf
- [x] Application follows ToS - Application is not malicious. Application is not a scam. Application does what is meant to do and does not mislead in any way. Application does not do anything illegal. Application is not a mining application (not even bandwidth mining).
- [x] In case application receives multiple reports, behaves maliciously, it will be blacklisted and removed from the network.