### PR TITLE
fix: FluxOS-owned app volume mounting, syncthing mount-safety hardening, and enterprise app lifecycle fixes

### DIFF
--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -1,9 +1,9 @@
 const config = require('config');
 const util = require('util');
 const df = require('node-df');
+const fs = require('node:fs');
 const path = require('node:path');
 const nodecmd = require('node-cmd');
-const systemcrontab = require('crontab');
 const axios = require('axios');
 const dbHelper = require('../dbHelper');
 const log = require('../../lib/log');
@@ -25,6 +25,8 @@ const {
   globalAppsMessages,
   globalAppsLocations,
   appsFolder,
+  appVolumesPath,
+  legacyAppVolumesPath,
 } = require('../utils/appConstants');
 const { specificationFormatter } = require('../utils/appSpecHelpers');
 const { checkAndDecryptAppSpecs } = require('../utils/enterpriseHelper');
@@ -48,8 +50,19 @@ const timeTostartNewMasterApp = new Map();
 
 // Promisified functions
 const cmdAsync = util.promisify(nodecmd.run);
-const crontabLoad = util.promisify(systemcrontab.load);
-const fluxDirPath = process.env.FLUXOS_PATH || path.join(process.env.HOME, 'zelflux');
+
+/**
+ * Runs a command as root via execFile (no shell, args passed as params) and
+ * throws on failure, preserving the throw-to-cleanup flow of volume
+ * construction.
+ * @param {string} cmd Binary to run.
+ * @param {string[]} params Arguments.
+ * @returns {Promise<void>}
+ */
+async function execAsRoot(cmd, params) {
+  const result = await serviceHelper.runCommand(cmd, { runAsRoot: true, params });
+  if (result.error) throw result.error;
+}
 
 // We need to avoid circular dependency, so we'll implement getInstalledAppsForDocker locally
 // eslint-disable-next-line no-unused-vars
@@ -493,14 +506,15 @@ async function createAppVolume(appSpecifications, appName, isComponent, res) {
       if (res.flush) res.flush();
     }
 
-    let execDD = `sudo fallocate -l ${appSpecifications.hdd}G ${useThisVolume.mount}/${appId}FLUXFSVOL`; // eg /mnt/sthMounted
+    // volume image path: at the root of the chosen host volume, or in the
+    // appvolumes directory when the root filesystem hosts it
+    let volumeFile = path.join(useThisVolume.mount, `${appId}FLUXFSVOL`);
     if (useThisVolume.mount === '/') {
-      const execMkdir = `sudo mkdir -p ${fluxDirPath}appvolumes`;
-      await cmdAsync(execMkdir);
-      execDD = `sudo fallocate -l ${appSpecifications.hdd}G ${fluxDirPath}appvolumes/${appId}FLUXFSVOL`; // if root mount then temp file is /flu/appvolumes
+      await execAsRoot('mkdir', ['-p', appVolumesPath]);
+      volumeFile = path.join(appVolumesPath, `${appId}FLUXFSVOL`);
     }
 
-    await cmdAsync(execDD);
+    await execAsRoot('fallocate', ['-l', `${appSpecifications.hdd}G`, volumeFile]);
     const allocateSpace2 = {
       status: 'Space allocated',
     };
@@ -518,11 +532,7 @@ async function createAppVolume(appSpecifications, appName, isComponent, res) {
       res.write(serviceHelper.ensureString(makeFilesystem));
       if (res.flush) res.flush();
     }
-    let execFS = `sudo mke2fs -t ext4 ${useThisVolume.mount}/${appId}FLUXFSVOL`;
-    if (useThisVolume.mount === '/') {
-      execFS = `sudo mke2fs -t ext4 ${fluxDirPath}appvolumes/${appId}FLUXFSVOL`;
-    }
-    await cmdAsync(execFS);
+    await execAsRoot('mke2fs', ['-t', 'ext4', volumeFile]);
     const makeFilesystem2 = {
       status: 'Filesystem created',
     };
@@ -540,8 +550,21 @@ async function createAppVolume(appSpecifications, appName, isComponent, res) {
       res.write(serviceHelper.ensureString(makeDirectory));
       if (res.flush) res.flush();
     }
-    const execDIR = `sudo mkdir -p ${appsFolder + appId}`;
-    await cmdAsync(execDIR);
+    const appDir = path.join(appsFolder, appId);
+    await execAsRoot('mkdir', ['-p', appDir]);
+
+    // The empty bare mountpoint is locked immutable before mounting so writes
+    // through it while the volume is unmounted (a syncthing pull, the
+    // container bind, a stray marker creation) fail with EPERM instead of
+    // silently landing on the host filesystem. The mounted volume shadows the
+    // flag. Both fleet filesystems (ext4, XFS) support it, so a failure is an
+    // anomaly - but the flag is defense-in-depth on top of the mount itself,
+    // so it must never fail the install.
+    const chattr = await serviceHelper.runCommand('chattr', { runAsRoot: true, params: ['+i', appDir], logError: false });
+    if (chattr.error) {
+      log.error(`createAppVolume - could not set ${appDir} immutable (unexpected on ext4/XFS): ${chattr.error.message}`);
+    }
+
     const makeDirectory2 = {
       status: 'Directory made',
     };
@@ -559,14 +582,7 @@ async function createAppVolume(appSpecifications, appName, isComponent, res) {
       res.write(serviceHelper.ensureString(mountingStatus));
       if (res.flush) res.flush();
     }
-    let volumeFile = `${useThisVolume.mount}/${appId}FLUXFSVOL`;
-    if (useThisVolume.mount === '/') {
-      volumeFile = `${fluxDirPath}appvolumes/${appId}FLUXFSVOL`;
-    }
-    // Wait for volume file to exist (handles encrypted volumes not yet mounted after reboot)
-    // This ensures @reboot cron jobs don't fail when the encrypted partition isn't ready
-    const execMount = `while [ ! -f ${volumeFile} ]; do sleep 5; done && sudo mount -o loop ${volumeFile} ${appsFolder + appId}`;
-    await cmdAsync(`sudo mount -o loop ${volumeFile} ${appsFolder + appId}`);
+    await execAsRoot('mount', ['-o', 'loop', volumeFile, appDir]);
     const mountingStatus2 = {
       status: 'Volume mounted',
     };
@@ -585,8 +601,7 @@ async function createAppVolume(appSpecifications, appName, isComponent, res) {
       res.write(serviceHelper.ensureString(makeAppDataDir));
       if (res.flush) res.flush();
     }
-    const execAppdataDir = `sudo mkdir -p ${appsFolder + appId}/appdata`;
-    await cmdAsync(execAppdataDir);
+    await execAsRoot('mkdir', ['-p', path.join(appDir, 'appdata')]);
     const makeAppDataDir2 = {
       status: 'Appdata directory created',
     };
@@ -642,10 +657,11 @@ async function createAppVolume(appSpecifications, appName, isComponent, res) {
         }
 
         // Create file directly at same level as appdata with 777 permissions
-        const filePath = `${appsFolder + appId}/${pathInfo.name}`;
-        const execCommands = `sudo touch ${filePath} && sudo chmod 777 ${filePath}`;
+        const filePath = path.join(appDir, pathInfo.name);
         // eslint-disable-next-line no-await-in-loop
-        await cmdAsync(execCommands);
+        await execAsRoot('touch', [filePath]);
+        // eslint-disable-next-line no-await-in-loop
+        await execAsRoot('chmod', ['777', filePath]);
 
         log.info(`File mount created with 777 permissions: ${pathInfo.name}`);
 
@@ -667,9 +683,8 @@ async function createAppVolume(appSpecifications, appName, isComponent, res) {
           res.write(serviceHelper.ensureString(createDirStatus));
           if (res.flush) res.flush();
         }
-        const execSubDIR = `sudo mkdir -p ${appsFolder + appId}/${pathInfo.name}`;
         // eslint-disable-next-line no-await-in-loop
-        await cmdAsync(execSubDIR);
+        await execAsRoot('mkdir', ['-p', path.join(appDir, pathInfo.name)]);
         const createDirStatus2 = {
           status: `Directory created: ${pathInfo.name}`,
         };
@@ -698,10 +713,8 @@ async function createAppVolume(appSpecifications, appName, isComponent, res) {
       res.write(serviceHelper.ensureString(permissionsDirectory));
       if (res.flush) res.flush();
     }
-    const execPERM = `sudo chmod 777 ${appsFolder + appId}`;
-    await cmdAsync(execPERM);
-    const execPERMdata = `sudo chmod 777 ${appsFolder + appId}/appdata`;
-    await cmdAsync(execPERMdata);
+    await execAsRoot('chmod', ['777', appDir]);
+    await execAsRoot('chmod', ['777', path.join(appDir, 'appdata')]);
 
     // Set permissions for all created paths (appdata and additional mounts at same level)
     // eslint-disable-next-line no-restricted-syntax
@@ -710,9 +723,8 @@ async function createAppVolume(appSpecifications, appName, isComponent, res) {
       if (pathInfo.name === 'appdata') {
         continue; // eslint-disable-line no-continue
       }
-      const execPERMpath = `sudo chmod 777 ${appsFolder + appId}/${pathInfo.name}`;
       // eslint-disable-next-line no-await-in-loop
-      await cmdAsync(execPERMpath);
+      await execAsRoot('chmod', ['777', path.join(appDir, pathInfo.name)]);
     }
     const permissionsDirectory2 = {
       status: 'Permissions adjusted',
@@ -737,9 +749,12 @@ async function createAppVolume(appSpecifications, appName, isComponent, res) {
         res.write(serviceHelper.ensureString(stFolderCreation));
         if (res.flush) res.flush();
       }
-      // Create .stfolder in parent directory for syncthing (not inside appdata)
-      const execDIRst = `sudo mkdir -p ${appsFolder + appId}/.stfolder`;
-      await cmdAsync(execDIRst);
+      // Create .stfolder in parent directory for syncthing (not inside appdata).
+      // The marker lives INSIDE the mounted volume, never on the bare
+      // mountpoint - it is syncthing's own guard against syncing an unmounted
+      // dir, and the immutable bare mountpoint guarantees it can never be
+      // recreated there.
+      await execAsRoot('mkdir', ['-p', path.join(appDir, '.stfolder')]);
       const stFolderCreation2 = {
         status: '.stfolder created',
       };
@@ -749,10 +764,9 @@ async function createAppVolume(appSpecifications, appName, isComponent, res) {
         if (res.flush) res.flush();
       }
 
-      // Create .stignore file to exclude backup directory (in parent directory)
-      const stignore = `sudo echo '/backup' >| ${appsFolder + appId}/.stignore`;
-      log.info(stignore);
-      await cmdAsync(stignore);
+      // Create .stignore file to exclude backup directory (in parent
+      // directory; the app dir is 777 by now so no elevation is needed)
+      await fs.promises.writeFile(path.join(appDir, '.stignore'), '/backup\n');
       const stiFileCreation = {
         status: '.stignore created',
       };
@@ -763,46 +777,9 @@ async function createAppVolume(appSpecifications, appName, isComponent, res) {
       }
     }
 
-    const cronStatus = {
-      status: 'Creating crontab...',
-    };
-    log.info(cronStatus);
-    if (res) {
-      res.write(serviceHelper.ensureString(cronStatus));
-      if (res.flush) res.flush();
-    }
-    const crontab = await crontabLoad();
-    const jobs = crontab.jobs();
-    let exists = false;
-    jobs.forEach((job) => {
-      if (job.comment() === appId) {
-        exists = true;
-      }
-      if (!job || !job.isValid()) {
-        // remove the job as its invalid anyway
-        crontab.remove(job);
-      }
-    });
-    if (!exists) {
-      const job = crontab.create(execMount, '@reboot', appId);
-      // check valid
-      if (job == null) {
-        throw new Error('Failed to create a cron job');
-      }
-      if (!job.isValid()) {
-        throw new Error('Failed to create a valid cron job');
-      }
-      // save
-      crontab.save();
-    }
-    const cronStatusB = {
-      status: 'Crontab adjusted.',
-    };
-    log.info(cronStatusB);
-    if (res) {
-      res.write(serviceHelper.ensureString(cronStatusB));
-      if (res.flush) res.flush();
-    }
+    // No @reboot crontab entry: remounting after reboot is owned by FluxOS
+    // itself (startup mount pass + reconciler), which re-asserts the mount as
+    // desired state instead of depending on an unreconciled crontab line.
     const message = messageHelper.createSuccessMessage('Flux App volume creation completed.');
     return message;
   } catch (error) {
@@ -817,19 +794,19 @@ async function createAppVolume(appSpecifications, appName, isComponent, res) {
       res.write(serviceHelper.ensureString(cleaningRemoval));
       if (res.flush) res.flush();
     }
-    // Unmount the volume if it's mounted
-    const execUnmount = `sudo umount ${appsFolder + appId}`;
-    // eslint-disable-next-line no-unused-vars
-    await cmdAsync(execUnmount).catch((_e) => {
+    const appDir = path.join(appsFolder, appId);
+    // Unmount the volume if it's mounted (failure = was not mounted, fine)
+    const unmount = await serviceHelper.runCommand('umount', { runAsRoot: true, params: [appDir], logError: false });
+    if (unmount.error) {
       log.warn('Volume not mounted or already unmounted during cleanup');
-    });
-    let execRemoveAlloc = `sudo rm -rf ${useThisVolume.mount}/${appId}FLUXFSVOL`;
-    if (useThisVolume.mount === '/') {
-      execRemoveAlloc = `sudo rm -rf ${fluxDirPath}appvolumes/${appId}FLUXFSVOL`;
     }
-    await cmdAsync(execRemoveAlloc).catch((e) => log.error(e));
-    const execFinal = `sudo rm -rf ${appsFolder + appId}`;
-    await cmdAsync(execFinal).catch((e) => log.error(e));
+    const volumeFile = useThisVolume.mount === '/'
+      ? path.join(appVolumesPath, `${appId}FLUXFSVOL`)
+      : path.join(useThisVolume.mount, `${appId}FLUXFSVOL`);
+    await serviceHelper.runCommand('rm', { runAsRoot: true, params: ['-rf', volumeFile] });
+    // clear the immutable flag set before mounting, or the removal fails
+    await serviceHelper.runCommand('chattr', { runAsRoot: true, params: ['-i', appDir], logError: false });
+    await serviceHelper.runCommand('rm', { runAsRoot: true, params: ['-rf', appDir] });
     const aloocationRemoval2 = {
       status: 'Pre-removal cleaning completed. Forcing removal.',
     };
@@ -2444,29 +2421,29 @@ async function appendRestoreTask(req, res) {
 async function removeTestAppMount(specifiedVolume) {
   try {
     const appId = 'flux_fluxTestVol';
+    const appDir = path.join(appsFolder, appId);
     log.info('Mount Test: Unmounting volume');
-    const execUnmount = `sudo umount ${appsFolder + appId}`;
-    await cmdAsync(execUnmount).then(() => {
+    const unmount = await serviceHelper.runCommand('umount', { runAsRoot: true, params: [appDir], logError: false });
+    if (unmount.error) {
+      log.info('Mount Test: Volume not mounted. Continuing. Most likely false positive.');
+    } else {
       log.info('Mount Test: Volume unmounted');
-    }).catch((e) => {
-      log.error(e);
-      log.error('Mount Test: An error occured while unmounting volume. Continuing. Most likely false positive.');
-    });
+    }
 
     log.info('Mount Test: Cleaning up data');
-    const execDelete = `sudo rm -rf ${appsFolder + appId}`;
-    await cmdAsync(execDelete).catch((e) => {
-      log.error(e);
-      log.error('Mount Test: An error occured while cleaning up data. Continuing. Most likely false positive.');
-    });
+    await serviceHelper.runCommand('rm', { runAsRoot: true, params: ['-rf', appDir] });
     log.info('Mount Test: Data cleaned');
     log.info('Mount Test: Cleaning up data volume');
-    const volumeToRemove = specifiedVolume || `${fluxDirPath}appvolumes/${appId}FLUXFSVOL`;
-    const execVolumeDelete = `sudo rm -rf ${volumeToRemove}`;
-    await cmdAsync(execVolumeDelete).catch((e) => {
-      log.error(e);
-      log.error('Mount Test: An error occured while cleaning up volume. Continuing. Most likely false positive.');
-    });
+    const volumesToRemove = specifiedVolume
+      ? [specifiedVolume]
+      // no volume given: remove from both the current location and the legacy
+      // glued location a previous FluxOS version may have left an image at
+      : [path.join(appVolumesPath, `${appId}FLUXFSVOL`), path.join(legacyAppVolumesPath, `${appId}FLUXFSVOL`)];
+    // eslint-disable-next-line no-restricted-syntax
+    for (const volumeToRemove of volumesToRemove) {
+      // eslint-disable-next-line no-await-in-loop
+      await serviceHelper.runCommand('rm', { runAsRoot: true, params: ['-rf', volumeToRemove] });
+    }
     log.info('Mount Test: Volume cleaned');
   } catch (error) {
     log.error('Mount Test Removal: Error');
@@ -2529,32 +2506,26 @@ async function testAppMount() {
     log.info('Mount Test: Space found');
     log.info('Mount Test: Allocating space...');
 
-    let volumePath = `${useThisVolume.mount}/${appId}FLUXFSVOL`; // eg /mnt/sthMounted/
+    let volumePath = path.join(useThisVolume.mount, `${appId}FLUXFSVOL`); // eg /mnt/sthMounted
     if (useThisVolume.mount === '/') {
-      const execMkdir = `sudo mkdir -p ${fluxDirPath}appvolumes`;
-      await cmdAsync(execMkdir);
-      volumePath = `${fluxDirPath}appvolumes/${appId}FLUXFSVOL`;// if root mount then temp file is in flux folder/appvolumes
+      await execAsRoot('mkdir', ['-p', appVolumesPath]);
+      volumePath = path.join(appVolumesPath, `${appId}FLUXFSVOL`); // if root mount then temp file is in flux folder/appvolumes
     }
 
-    const execDD = `sudo fallocate -l ${appSize}G ${volumePath}`;
-
-    await cmdAsync(execDD);
+    await execAsRoot('fallocate', ['-l', `${appSize}G`, volumePath]);
 
     log.info('Mount Test: Space allocated');
     log.info('Mount Test: Creating filesystem...');
 
-    const execFS = `sudo mke2fs -t ext4 ${volumePath}`;
-    await cmdAsync(execFS);
+    await execAsRoot('mke2fs', ['-t', 'ext4', volumePath]);
     log.info('Mount Test: Filesystem created');
     log.info('Mount Test: Making directory...');
 
-    const execDIR = `sudo mkdir -p ${appsFolder + appId}`;
-    await cmdAsync(execDIR);
+    await execAsRoot('mkdir', ['-p', path.join(appsFolder, appId)]);
     log.info('Mount Test: Directory made');
     log.info('Mount Test: Mounting volume...');
 
-    const execMount = `sudo mount -o loop ${volumePath} ${appsFolder + appId}`;
-    await cmdAsync(execMount);
+    await execAsRoot('mount', ['-o', 'loop', volumePath, path.join(appsFolder, appId)]);
     log.info('Mount Test: Volume mounted. Test completed.');
     dosMountMessage = '';
     // run removal
@@ -3722,7 +3693,7 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
         // eslint-disable-next-line no-await-in-loop
         const fdmResult = await getMasterIpFromFdm(installedApp.name, axiosOptions);
         const { ip } = fdmResult;
-        fdmOk = fdmResult.fdmOk;
+        ({ fdmOk } = fdmResult);
 
         if (!fdmOk) {
           log.warn(`masterSlaveApps: All FDM services failed for app:${installedApp.name}, skipping primary selection for this cycle`);

--- a/ZelBack/src/services/appLifecycle/appInstaller.js
+++ b/ZelBack/src/services/appLifecycle/appInstaller.js
@@ -989,8 +989,14 @@ async function installAppLocally(req, res) {
         && appSpecifications.enterprise
         && !appSpecifications.compose.length
       ) {
+        // the formatter strips spec metadata; height/hash must survive it -
+        // a local row stored without height is force-removed (with broadcast)
+        // by expireGlobalApplications' missing-height check on every sweep
+        const { height, hash } = appSpecifications;
         appSpecifications = await checkAndDecryptAppSpecs(appSpecifications);
         appSpecifications = specificationFormatter(appSpecifications);
+        appSpecifications.height = height;
+        appSpecifications.hash = hash;
       }
 
       // get current height

--- a/ZelBack/src/services/appLifecycle/appUninstaller.js
+++ b/ZelBack/src/services/appLifecycle/appUninstaller.js
@@ -20,6 +20,7 @@ const { checkAndDecryptAppSpecs } = require('../utils/enterpriseHelper');
 const { specificationFormatter } = require('../utils/appSpecHelpers');
 const { stopAppMonitoring } = require('../appManagement/appInspector');
 const appsRuntimeState = require('../appManagement/appsRuntimeState');
+const volumeService = require('../utils/volumeService');
 const imageManager = require('../appSecurity/imageManager');
 const fluxEventBus = require('../utils/fluxEventBus');
 
@@ -113,6 +114,10 @@ async function cleanupAppData(appId, entityName, res) {
     res.write(serviceHelper.ensureString({ status: `Cleaning up ${entityName} data...` }));
     if (res.flush) res.flush();
   }
+
+  // the bare mountpoint is kept immutable while unmounted (set at volume
+  // creation); clear the flag or the removal below fails
+  await serviceHelper.runCommand('chattr', { runAsRoot: true, params: ['-i', appsFolder + appId], logError: false });
 
   const execDelete = `sudo rm -rf ${appsFolder + appId}`;
   await cmdAsync(execDelete).catch((e) => {
@@ -346,11 +351,14 @@ async function hardUninstallComponent(appName, appId, componentSpecifications, r
   // Clean up data
   await cleanupAppData(appId, `component ${componentName}`, res);
 
-  // Clean up crontab and get volume path
-  const volumepath = await cleanupCrontab(appId, res);
+  // The backing image is discovered deterministically; the crontab (legacy
+  // remount mechanism) is only cleaned up, never relied on - a missing entry
+  // used to orphan the image on disk.
+  const discoveredVolume = await volumeService.getVolumeFilePath(appId);
+  const crontabVolume = await cleanupCrontab(appId, res);
 
   // Clean up volume path
-  await cleanupVolumePath(volumepath, `component ${componentName}`, res);
+  await cleanupVolumePath(discoveredVolume ?? crontabVolume, `component ${componentName}`, res);
 
   // Remove image (only if container was successfully removed)
   if (containerRemoved) {
@@ -494,11 +502,14 @@ async function hardUninstallApplication(appName, appId, appSpecifications, res, 
   // Clean up data
   await cleanupAppData(appId, appName, res);
 
-  // Clean up crontab and get volume path
-  const volumepath = await cleanupCrontab(appId, res);
+  // The backing image is discovered deterministically; the crontab (legacy
+  // remount mechanism) is only cleaned up, never relied on - a missing entry
+  // used to orphan the image on disk.
+  const discoveredVolume = await volumeService.getVolumeFilePath(appId);
+  const crontabVolume = await cleanupCrontab(appId, res);
 
   // Clean up volume path
-  await cleanupVolumePath(volumepath, appName, res);
+  await cleanupVolumePath(discoveredVolume ?? crontabVolume, appName, res);
 
   // Remove image (only if container was successfully removed)
   if (containerRemoved) {

--- a/ZelBack/src/services/appLifecycle/crontabAndMountsCleanup.js
+++ b/ZelBack/src/services/appLifecycle/crontabAndMountsCleanup.js
@@ -6,48 +6,70 @@ const dbHelper = require('../dbHelper');
 const { localAppsInformation } = require('../utils/appConstants');
 const dockerService = require('../dockerService');
 const volumeService = require('../utils/volumeService');
+const enterpriseHelper = require('../utils/enterpriseHelper');
 const appTamperingDetectionService = require('../appTamperingDetectionService');
 
 const crontabLoad = util.promisify(systemcrontab.load);
 
 /**
- * Get all locally installed app IDs
+ * Get all locally installed app IDs. Enterprise apps are stored locally with
+ * `compose` deliberately emptied (the components only exist inside the
+ * encrypted `enterprise` blob), so they are decrypted the same way the rest
+ * of the runtime reads them; when decryption is unavailable the component ids
+ * are derived from the app's FLUXFSVOL images on disk instead. A database
+ * failure throws: "could not enumerate" must surface as unknown to callers,
+ * never as "nothing is installed".
  * @returns {Promise<Set<string>>} Set of installed app IDs
  */
 async function getInstalledAppIds() {
   const installedAppIds = new Set();
 
-  try {
-    const dbopen = dbHelper.databaseConnection();
-    const appsDatabase = dbopen.db(config.database.appslocal.database);
+  const dbopen = dbHelper.databaseConnection();
+  const appsDatabase = dbopen.db(config.database.appslocal.database);
 
-    const appsProjection = {
-      projection: { _id: 0 },
-    };
+  const appsProjection = {
+    projection: { _id: 0 },
+  };
 
-    const apps = await dbHelper.findInDatabase(appsDatabase, localAppsInformation, {}, appsProjection);
+  const apps = await dbHelper.findInDatabase(appsDatabase, localAppsInformation, {}, appsProjection);
 
-    if (!apps || !Array.isArray(apps)) {
-      return installedAppIds;
+  if (!apps || !Array.isArray(apps)) {
+    return installedAppIds;
+  }
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const app of apps) {
+    if (app.version <= 3) {
+      // Legacy app - single app ID
+      installedAppIds.add(dockerService.getAppIdentifier(app.name));
+      // eslint-disable-next-line no-continue
+      continue;
     }
 
-    apps.forEach((app) => {
-      if (app.version <= 3) {
-        // Legacy app - single app ID
-        const appId = dockerService.getAppIdentifier(app.name);
-        installedAppIds.add(appId);
-      } else {
-        // Newer app - multiple components
-        if (app.compose && Array.isArray(app.compose)) {
-          app.compose.forEach((component) => {
-            const appId = dockerService.getAppIdentifier(`${component.name}_${app.name}`);
-            installedAppIds.add(appId);
-          });
-        }
+    let { compose } = app;
+    if ((!compose || compose.length === 0) && app.enterprise) {
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        const decrypted = await enterpriseHelper.checkAndDecryptAppSpecs(app);
+        compose = decrypted ? decrypted.compose : null;
+      } catch (error) {
+        log.warn(`getInstalledAppIds - could not decrypt enterprise app ${app.name} (${error.message}); deriving its components from volume images on disk`);
+        compose = null;
       }
-    });
-  } catch (error) {
-    log.error(`getInstalledAppIds - Error: ${error.message}`);
+      if (!compose || compose.length === 0) {
+        // eslint-disable-next-line no-await-in-loop
+        const diskAppIds = await volumeService.getComponentAppIdsFromVolumeFiles(app.name);
+        diskAppIds.forEach((appId) => installedAppIds.add(appId));
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+    }
+
+    if (compose && Array.isArray(compose)) {
+      compose.forEach((component) => {
+        installedAppIds.add(dockerService.getAppIdentifier(`${component.name}_${app.name}`));
+      });
+    }
   }
 
   return installedAppIds;
@@ -60,6 +82,16 @@ async function getInstalledAppIds() {
  */
 function isVolumeMountJob(command) {
   return command.includes('mount -o loop') && command.includes('FLUXFSVOL');
+}
+
+/**
+ * Extract the mountpoint from a legacy FLUXFSVOL mount command.
+ * @param {string} command - The crontab command
+ * @returns {string|null} Mountpoint path, or null when unparseable
+ */
+function extractMountPoint(command) {
+  const match = command.match(/sudo mount -o loop\s+\S+FLUXFSVOL\s+(\S+)/);
+  return match ? match[1] : null;
 }
 
 /**
@@ -100,15 +132,19 @@ async function ensureInstalledAppVolumesMounted() {
 }
 
 /**
- * Removes every legacy FLUXFSVOL @reboot remount entry from the root crontab.
- * FluxOS owns volume mounting now (boot pass above + reconciler), so the
- * entries are superseded - and a surviving entry could double-mount over a
- * FluxOS-owned mount on the next boot.
- * @returns {Promise<{removed: string[], errors: Array<{appId: string, error: string}>}>}
+ * Removes legacy FLUXFSVOL @reboot remount entries from the root crontab, but
+ * only those whose volume is currently mounted - proof the FluxOS-owned mount
+ * (boot pass above + reconciler) has demonstrably replaced the entry. An entry
+ * whose volume is NOT mounted is kept: it is the remaining safety net for the
+ * next boot, and removing it on the strength of a possibly-blind inventory is
+ * exactly how remount entries used to vanish. A surviving entry on a mounted
+ * volume would double-mount on the next boot, hence the cleanup.
+ * @returns {Promise<{removed: string[], kept: string[], errors: Array<{appId: string, error: string}>}>}
  */
 async function removeLegacyMountCrontabEntries() {
   const results = {
     removed: [],
+    kept: [],
     errors: [],
   };
 
@@ -121,17 +157,30 @@ async function removeLegacyMountCrontabEntries() {
   if (!crontab) return results;
 
   const jobs = crontab.jobs() || [];
-  jobs.forEach((job) => {
-    if (!job) return;
+  // eslint-disable-next-line no-restricted-syntax
+  for (const job of jobs) {
     let command = '';
     let comment = '';
     try {
-      command = job.command ? job.command() : '';
-      comment = job.comment ? job.comment() : '';
+      command = job && job.command ? job.command() : '';
+      comment = job && job.comment ? job.comment() : '';
     } catch (error) {
-      return;
+      // eslint-disable-next-line no-continue
+      continue;
     }
-    if (!isVolumeMountJob(command)) return;
+    if (!isVolumeMountJob(command)) {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+    const mountPoint = extractMountPoint(command);
+    // eslint-disable-next-line no-await-in-loop
+    const mounted = mountPoint ? await volumeService.isPathMounted(mountPoint) : false;
+    if (!mounted) {
+      log.warn(`removeLegacyMountCrontabEntries - keeping legacy entry for ${comment || command}: its volume is not currently mounted`);
+      results.kept.push(comment || command);
+      // eslint-disable-next-line no-continue
+      continue;
+    }
     try {
       crontab.remove(job);
       results.removed.push(comment || command);
@@ -139,7 +188,7 @@ async function removeLegacyMountCrontabEntries() {
       log.error(`removeLegacyMountCrontabEntries - failed to remove entry for ${comment}: ${error.message}`);
       results.errors.push({ appId: comment, error: error.message });
     }
-  });
+  }
 
   if (results.removed.length > 0) {
     try {
@@ -161,7 +210,7 @@ async function removeLegacyMountCrontabEntries() {
  */
 async function cleanupCrontabAndMounts() {
   const results = {
-    crontab: { removed: [], errors: [] },
+    crontab: { removed: [], kept: [], errors: [] },
     mounts: { mounted: [], alreadyMounted: [], failed: [] },
   };
 
@@ -173,7 +222,7 @@ async function cleanupCrontabAndMounts() {
     log.info(
       'cleanupCrontabAndMounts - Done. '
       + `Mounts: mounted ${results.mounts.mounted.length}, already mounted ${results.mounts.alreadyMounted.length}, failed ${results.mounts.failed.length}. `
-      + `Crontab: removed ${results.crontab.removed.length} legacy entr(ies), errors ${results.crontab.errors.length}`,
+      + `Crontab: removed ${results.crontab.removed.length} legacy entr(ies), kept ${results.crontab.kept.length}, errors ${results.crontab.errors.length}`,
     );
 
     return results;
@@ -189,4 +238,5 @@ module.exports = {
   ensureInstalledAppVolumesMounted,
   removeLegacyMountCrontabEntries,
   isVolumeMountJob,
+  extractMountPoint,
 };

--- a/ZelBack/src/services/appLifecycle/crontabAndMountsCleanup.js
+++ b/ZelBack/src/services/appLifecycle/crontabAndMountsCleanup.js
@@ -1,17 +1,14 @@
 const util = require('util');
 const systemcrontab = require('crontab');
-const nodecmd = require('node-cmd');
 const config = require('config');
 const log = require('../../lib/log');
 const dbHelper = require('../dbHelper');
-const { localAppsInformation, appsFolder } = require('../utils/appConstants');
+const { localAppsInformation } = require('../utils/appConstants');
 const dockerService = require('../dockerService');
-const appUninstaller = require('./appUninstaller');
-const { isPathMounted } = require('../appMonitoring/syncthingFolderStateMachine');
+const volumeService = require('../utils/volumeService');
 const appTamperingDetectionService = require('../appTamperingDetectionService');
 
 const crontabLoad = util.promisify(systemcrontab.load);
-const cmdAsync = util.promisify(nodecmd.run);
 
 /**
  * Get all locally installed app IDs
@@ -57,339 +54,131 @@ async function getInstalledAppIds() {
 }
 
 /**
- * Extract app name from appId
- * AppIds are in format: fluxappname or fluxcomponent_appname
- * @param {string} appId - App ID (e.g., fluxwp_wordpress123)
- * @returns {string} App name (e.g., wordpress123)
- */
-function extractAppNameFromAppId(appId) {
-  // Remove 'flux' prefix
-  const withoutFlux = appId.replace(/^flux/, '');
-
-  // If contains underscore, it's a component: component_appname
-  // We need the main app name (after the underscore)
-  if (withoutFlux.includes('_')) {
-    const parts = withoutFlux.split('_');
-    // Return the app name (last part after component name)
-    return parts.slice(1).join('_');
-  }
-
-  // Otherwise it's just the app name
-  return withoutFlux;
-}
-
-/**
- * Check if a crontab mount command has the wait logic
+ * Whether a crontab job is a legacy FLUXFSVOL remount entry.
  * @param {string} command - The crontab command
- * @returns {boolean} True if it has wait logic
+ * @returns {boolean} True if it is a volume mount job
  */
-function hasWaitLogic(command) {
-  return command.includes('while [ ! -f') && command.includes('do sleep') && command.includes('done &&');
+function isVolumeMountJob(command) {
+  return command.includes('mount -o loop') && command.includes('FLUXFSVOL');
 }
 
 /**
- * Extract volume file path from mount command
- * @param {string} command - The mount command
- * @returns {string|null} Volume file path or null
+ * Mounts the data volume of every locally installed app component. Derived
+ * from the installed-apps database and deterministic image discovery only -
+ * deliberately independent of the crontab, whose silent loss is exactly how
+ * volumes stayed unmounted after a reboot.
+ * @returns {Promise<{mounted: string[], alreadyMounted: string[], failed: Array<{appId: string, reason: string}>}>}
  */
-function extractVolumeFile(command) {
-  // Match: sudo mount -o loop /path/to/file /mount/point
-  // Or: while ... && sudo mount -o loop /path/to/file /mount/point
-  const match = command.match(/sudo mount -o loop\s+([^\s]+FLUXFSVOL)\s+/);
-  return match ? match[1] : null;
-}
+async function ensureInstalledAppVolumesMounted() {
+  const results = {
+    mounted: [],
+    alreadyMounted: [],
+    failed: [],
+  };
 
-/**
- * Extract app ID from crontab comment or mount path
- * @param {string} comment - Job comment
- * @param {string} command - Job command
- * @returns {string|null} App ID or null
- */
-function extractAppIdFromJob(comment, command) {
-  // Comment is typically the appId
-  if (comment && comment.includes('flux')) {
-    return comment;
-  }
+  const installedAppIds = await getInstalledAppIds();
+  log.info(`ensureInstalledAppVolumesMounted - Ensuring volumes of ${installedAppIds.size} installed app component(s) are mounted`);
 
-  // Try to extract from mount path
-  const match = command.match(/\/([^/]+FLUXFSVOL)/);
-  if (match) {
-    // Remove FLUXFSVOL suffix to get appId
-    return match[1].replace('FLUXFSVOL', '');
-  }
-
-  return null;
-}
-
-/**
- * Extract mount point from mount command
- * @param {string} command - The mount command
- * @returns {string|null} Mount point path or null
- */
-function extractMountPoint(command) {
-  // Match: sudo mount -o loop /path/to/file /mount/point
-  const match = command.match(/sudo mount -o loop\s+[^\s]+FLUXFSVOL\s+([^\s]+)/);
-  return match ? match[1] : null;
-}
-
-/**
- * Convert old mount command to new format with wait logic
- * @param {string} oldCommand - Old mount command without wait
- * @returns {string} New command with wait logic
- */
-function addWaitLogicToCommand(oldCommand) {
-  const volumeFile = extractVolumeFile(oldCommand);
-  if (!volumeFile) {
-    log.warn(`addWaitLogicToCommand - Could not extract volume file from: ${oldCommand}`);
-    return oldCommand;
-  }
-
-  // Extract mount point
-  const mountPoint = extractMountPoint(oldCommand);
-  if (!mountPoint) {
-    log.warn(`addWaitLogicToCommand - Could not extract mount point from: ${oldCommand}`);
-    return oldCommand;
-  }
-
-  return `while [ ! -f ${volumeFile} ]; do sleep 5; done && sudo mount -o loop ${volumeFile} ${mountPoint}`;
-}
-
-/**
- * Execute mount command for an app if not already mounted
- * @param {string} appId - App ID
- * @param {string} volumeFile - Volume file path
- * @param {string} mountPoint - Mount point path
- * @returns {Promise<{mounted: boolean, error: string|null}>} Mount result
- */
-async function ensureAppMounted(appId, volumeFile, mountPoint) {
-  try {
-    // Check if already mounted
-    const isMounted = await isPathMounted(mountPoint);
-    if (isMounted) {
-      log.info(`ensureAppMounted - ${appId} is already mounted at ${mountPoint}`);
-      return { mounted: true, error: null };
+  // eslint-disable-next-line no-restricted-syntax
+  for (const appId of installedAppIds) {
+    // eslint-disable-next-line no-await-in-loop
+    const mountResult = await volumeService.ensureAppVolumeMounted(appId);
+    if (!mountResult.mounted) {
+      log.error(`ensureInstalledAppVolumesMounted - ${appId} volume could not be mounted: ${mountResult.reason}`);
+      results.failed.push({ appId, reason: mountResult.reason });
+      // eslint-disable-next-line no-await-in-loop
+      await appTamperingDetectionService.recordEvent(appId, 'mount_vanished', `Volume not mountable at startup: ${mountResult.reason}`);
+    } else if (mountResult.alreadyMounted) {
+      results.alreadyMounted.push(appId);
+    } else {
+      log.info(`ensureInstalledAppVolumesMounted - mounted volume of ${appId}`);
+      results.mounted.push(appId);
     }
+  }
 
-    // Check if volume file exists
+  return results;
+}
+
+/**
+ * Removes every legacy FLUXFSVOL @reboot remount entry from the root crontab.
+ * FluxOS owns volume mounting now (boot pass above + reconciler), so the
+ * entries are superseded - and a surviving entry could double-mount over a
+ * FluxOS-owned mount on the next boot.
+ * @returns {Promise<{removed: string[], errors: Array<{appId: string, error: string}>}>}
+ */
+async function removeLegacyMountCrontabEntries() {
+  const results = {
+    removed: [],
+    errors: [],
+  };
+
+  const crontab = await crontabLoad().catch((error) => {
+    // mounting no longer depends on the crontab, so a load failure only delays
+    // this cleanup until the next start
+    log.warn(`removeLegacyMountCrontabEntries - could not load crontab: ${error.message}`);
+    return null;
+  });
+  if (!crontab) return results;
+
+  const jobs = crontab.jobs() || [];
+  jobs.forEach((job) => {
+    if (!job) return;
+    let command = '';
+    let comment = '';
     try {
-      const fs = require('node:fs');
-      await fs.promises.access(volumeFile);
-    } catch (err) {
-      log.warn(`ensureAppMounted - Volume file ${volumeFile} does not exist for ${appId}`);
-      return { mounted: false, error: 'Volume file does not exist' };
+      command = job.command ? job.command() : '';
+      comment = job.comment ? job.comment() : '';
+    } catch (error) {
+      return;
     }
-
-    // Check if mount point directory exists
+    if (!isVolumeMountJob(command)) return;
     try {
-      const fs = require('node:fs');
-      const stats = await fs.promises.stat(mountPoint);
-      if (!stats.isDirectory()) {
-        log.error(`ensureAppMounted - Mount point ${mountPoint} is not a directory for ${appId}`);
-        return { mounted: false, error: 'Mount point is not a directory' };
-      }
-    } catch (err) {
-      log.warn(`ensureAppMounted - Mount point ${mountPoint} does not exist for ${appId}, creating it`);
-      try {
-        await cmdAsync(`sudo mkdir -p ${mountPoint}`);
-      } catch (mkdirErr) {
-        log.error(`ensureAppMounted - Failed to create mount point ${mountPoint}: ${mkdirErr.message}`);
-        return { mounted: false, error: `Failed to create mount point: ${mkdirErr.message}` };
-      }
+      crontab.remove(job);
+      results.removed.push(comment || command);
+    } catch (error) {
+      log.error(`removeLegacyMountCrontabEntries - failed to remove entry for ${comment}: ${error.message}`);
+      results.errors.push({ appId: comment, error: error.message });
     }
+  });
 
-    // Execute mount command
-    log.info(`ensureAppMounted - Mounting ${appId}: ${volumeFile} -> ${mountPoint}`);
-    await cmdAsync(`sudo mount -o loop ${volumeFile} ${mountPoint}`);
-    log.info(`ensureAppMounted - Successfully mounted ${appId}`);
-    return { mounted: true, error: null };
-  } catch (error) {
-    log.error(`ensureAppMounted - Failed to mount ${appId}: ${error.message}`);
-    return { mounted: false, error: error.message };
+  if (results.removed.length > 0) {
+    try {
+      crontab.save();
+      log.info(`removeLegacyMountCrontabEntries - removed ${results.removed.length} legacy remount entr(ies): ${results.removed.join(', ')}`);
+    } catch (error) {
+      log.error(`removeLegacyMountCrontabEntries - failed to save crontab: ${error.message}`);
+      results.errors.push({ appId: 'global', error: error.message });
+    }
   }
+
+  return results;
 }
 
 /**
- * Cleanup and fix crontab mount entries
- * - Updates mount commands without wait logic to include it
- * - Removes mount entries for apps that are no longer installed
- * - Ensures all installed apps with crontab entries have active mounts
+ * Startup pass: mount every installed app's data volume, then drop the
+ * superseded legacy @reboot remount entries.
  * @returns {Promise<Object>} Cleanup results
  */
 async function cleanupCrontabAndMounts() {
   const results = {
-    crontab: {
-      updated: [],
-      removed: [],
-      unchanged: [],
-      errors: [],
-    },
-    mounts: {
-      mounted: [],
-      alreadyMounted: [],
-      failed: [],
-    },
+    crontab: { removed: [], errors: [] },
+    mounts: { mounted: [], alreadyMounted: [], failed: [] },
   };
 
   try {
-    log.info('cleanupCrontabAndMounts - Starting crontab and mounts cleanup');
-
-    // Get installed app IDs
-    const installedAppIds = await getInstalledAppIds();
-    log.info(`cleanupCrontabAndMounts - Found ${installedAppIds.size} installed apps`);
-
-    // Load crontab
-    const crontab = await crontabLoad();
-    const jobs = crontab.jobs();
-
-    if (!jobs || jobs.length === 0) {
-      log.info('cleanupCrontabAndMounts - No crontab jobs found');
-      if (installedAppIds.size > 0) {
-        // eslint-disable-next-line no-restricted-syntax
-        for (const appId of installedAppIds) {
-          // eslint-disable-next-line no-await-in-loop
-          await appTamperingDetectionService.recordEvent(appId, 'crontab_wiped', `Crontab empty despite ${installedAppIds.size} installed apps`);
-        }
-      }
-      return results;
-    }
-
-    const jobsToRemove = [];
-    const jobsToUpdate = [];
-    const mountsToVerify = [];
-
-    // Analyze each job
-    jobs.forEach((job) => {
-      if (!job || !job.isValid()) {
-        return;
-      }
-
-      const command = job.command ? job.command() : '';
-      const comment = job.comment ? job.comment() : '';
-
-      // Check if this is a mount job
-      if (!command.includes('sudo mount -o loop') || !command.includes('FLUXFSVOL')) {
-        return;
-      }
-
-      const appId = extractAppIdFromJob(comment, command);
-      if (!appId) {
-        log.warn(`cleanupCrontabAndMounts - Could not extract appId from job: ${comment}`);
-        return;
-      }
-
-      // Check if app is still installed
-      if (!installedAppIds.has(appId)) {
-        log.info(`cleanupCrontabAndMounts - App ${appId} not installed, marking for removal`);
-        jobsToRemove.push({ job, appId, comment });
-        return;
-      }
-
-      // Extract mount info for verification
-      const volumeFile = extractVolumeFile(command);
-      const mountPoint = extractMountPoint(command);
-      if (volumeFile && mountPoint) {
-        mountsToVerify.push({ appId, volumeFile, mountPoint });
-      }
-
-      // Check if mount command has wait logic
-      if (!hasWaitLogic(command)) {
-        log.info(`cleanupCrontabAndMounts - App ${appId} mount missing wait logic, marking for update`);
-        jobsToUpdate.push({
-          job, appId, comment, oldCommand: command,
-        });
-      } else {
-        results.crontab.unchanged.push(appId);
-      }
-    });
-
-    // Remove jobs for uninstalled apps
-    jobsToRemove.forEach(({ job, appId, comment }) => {
-      try {
-        crontab.remove(job);
-        results.crontab.removed.push(appId);
-        log.info(`cleanupCrontabAndMounts - Removed mount job for uninstalled app: ${appId} (comment: ${comment})`);
-      } catch (error) {
-        log.error(`cleanupCrontabAndMounts - Failed to remove job for ${appId}: ${error.message}`);
-        results.crontab.errors.push({ appId, action: 'remove', error: error.message });
-      }
-    });
-
-    // Update jobs without wait logic
-    // eslint-disable-next-line no-restricted-syntax
-    for (const {
-      job, appId, comment, oldCommand,
-    } of jobsToUpdate) {
-      try {
-        const newCommand = addWaitLogicToCommand(oldCommand);
-        if (newCommand !== oldCommand) {
-          // Remove old job and create new one
-          crontab.remove(job);
-          const newJob = crontab.create(newCommand, '@reboot', comment);
-          if (newJob && newJob.isValid()) {
-            results.crontab.updated.push(appId);
-            log.info(`cleanupCrontabAndMounts - Updated mount job for ${appId} to include wait logic`);
-          } else {
-            log.error(`cleanupCrontabAndMounts - Failed to create updated job for ${appId}, uninstalling app`);
-            results.crontab.errors.push({ appId, action: 'update', error: 'Failed to create new job' });
-            // Uninstall the app locally and notify peers
-            const appName = extractAppNameFromAppId(appId);
-            log.warn(`cleanupCrontabAndMounts - Removing app ${appName} due to crontab update failure`);
-            // eslint-disable-next-line no-await-in-loop
-            await appUninstaller.removeAppLocally(appName, null, true, false, true).catch((uninstallError) => {
-              log.error(`cleanupCrontabAndMounts - Failed to uninstall ${appName}: ${uninstallError.message}`);
-            });
-            // Remove from mounts to verify since app is being uninstalled
-            const mountIndex = mountsToVerify.findIndex((m) => m.appId === appId);
-            if (mountIndex !== -1) {
-              mountsToVerify.splice(mountIndex, 1);
-            }
-          }
-        }
-      } catch (error) {
-        log.error(`cleanupCrontabAndMounts - Failed to update job for ${appId}: ${error.message}`);
-        results.crontab.errors.push({ appId, action: 'update', error: error.message });
-      }
-    }
-
-    // Save crontab changes if any modifications were made
-    if (results.crontab.updated.length > 0 || results.crontab.removed.length > 0) {
-      crontab.save();
-      log.info(`cleanupCrontabAndMounts - Crontab saved. Updated: ${results.crontab.updated.length}, Removed: ${results.crontab.removed.length}`);
-    } else {
-      log.info('cleanupCrontabAndMounts - No crontab changes needed');
-    }
-
-    // Verify and create missing mounts for installed apps
-    log.info(`cleanupCrontabAndMounts - Verifying ${mountsToVerify.length} mounts for installed apps`);
-    // eslint-disable-next-line no-restricted-syntax
-    for (const { appId, volumeFile, mountPoint } of mountsToVerify) {
-      // eslint-disable-next-line no-await-in-loop
-      const mountResult = await ensureAppMounted(appId, volumeFile, mountPoint);
-      if (mountResult.error) {
-        results.mounts.failed.push({ appId, error: mountResult.error });
-        // eslint-disable-next-line no-await-in-loop
-        await appTamperingDetectionService.recordEvent(appId, 'mount_vanished', `Mount failed during crontab cleanup: ${mountResult.error}`);
-      } else if (mountResult.mounted) {
-        // Check if we actually mounted it or it was already mounted
-        const wasMounted = await isPathMounted(mountPoint);
-        if (wasMounted) {
-          // It's mounted now - but was it before?
-          // We'll track it as mounted regardless
-          results.mounts.mounted.push(appId);
-        }
-      }
-    }
+    // mounts first - they must never depend on the crontab step in any way
+    results.mounts = await ensureInstalledAppVolumesMounted();
+    results.crontab = await removeLegacyMountCrontabEntries();
 
     log.info(
-      'cleanupCrontabAndMounts - Cleanup complete. '
-      + `Crontab: Updated ${results.crontab.updated.length}, Removed ${results.crontab.removed.length}, Unchanged ${results.crontab.unchanged.length}, Errors ${results.crontab.errors.length}. `
-      + `Mounts: Ensured ${results.mounts.mounted.length}, Failed ${results.mounts.failed.length}`,
+      'cleanupCrontabAndMounts - Done. '
+      + `Mounts: mounted ${results.mounts.mounted.length}, already mounted ${results.mounts.alreadyMounted.length}, failed ${results.mounts.failed.length}. `
+      + `Crontab: removed ${results.crontab.removed.length} legacy entr(ies), errors ${results.crontab.errors.length}`,
     );
 
     return results;
   } catch (error) {
     log.error(`cleanupCrontabAndMounts - Critical error: ${error.message}`);
-    results.crontab.errors.push({ appId: 'global', action: 'cleanup', error: error.message });
     return results;
   }
 }
@@ -397,11 +186,7 @@ async function cleanupCrontabAndMounts() {
 module.exports = {
   cleanupCrontabAndMounts,
   getInstalledAppIds,
-  hasWaitLogic,
-  extractVolumeFile,
-  extractAppIdFromJob,
-  extractMountPoint,
-  addWaitLogicToCommand,
-  extractAppNameFromAppId,
-  ensureAppMounted,
+  ensureInstalledAppVolumesMounted,
+  removeLegacyMountCrontabEntries,
+  isVolumeMountJob,
 };

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -98,6 +98,15 @@ function notifyContainerStarted(identifier) {
 // completion, so this is just a backstop)
 const MANAGED_RETRY_MS = 5000;
 
+// an unmountable volume usually means its host filesystem is still coming up
+// (e.g. the encrypted data partition after a reboot) - retry on a pace that
+// won't spam, and keep deferring until it mounts
+const VOLUME_MOUNT_RETRY_MS = 30 * 1000;
+
+// identifiers whose missing backing image was already recorded as a tampering
+// event, so the paced retries don't re-record it every cycle
+const volumeMissingNoted = new Set();
+
 // The reconciler's canonical id is the bare component identifier
 // (`{component}_{app}`). Deciders disagree on the form they pass — masterSlave
 // uses the bare identifier, the syncthing flow passes the flux-prefixed docker
@@ -352,6 +361,32 @@ async function reconcile(rawIdentifier) {
     return;
   }
 
+  const mainAppName = identifier.split('_')[1] || identifier;
+
+  // The component's data volume is level-based desired state owned HERE, not by
+  // a @reboot crontab (unreconciled - its silent loss left volumes unmounted
+  // after reboot). It must be mounted before ANY actuation touches the app dir:
+  // a data wipe, mount-path creation or container start against the bare
+  // mountpoint writes to the host filesystem instead of the volume. It matters
+  // even while the container stays stopped - a g:/r: component's syncthing
+  // folder lives on it. An app whose volume cannot be mounted stays inert.
+  const volumeMount = await volumeService.ensureAppVolumeMounted(identifier);
+  if (!volumeMount.mounted) {
+    log.error(`appReconciler - ${identifier} data volume not mounted (${volumeMount.reason}); deferring all actuation`);
+    fluxEventBus.publish('reconciler:actuated', { identifier, action: 'volumeUnavailable', reason: volumeMount.reason });
+    if (volumeMount.reason === 'volume_file_missing' && !volumeMissingNoted.has(identifier)) {
+      volumeMissingNoted.add(identifier);
+      await appTamperingDetectionService.recordEvent(mainAppName, 'volume_missing', `Backing volume image for ${identifier} not found on disk`);
+    }
+    scheduleRetry(identifier, VOLUME_MOUNT_RETRY_MS);
+    return;
+  }
+  volumeMissingNoted.delete(identifier);
+  if (!volumeMount.alreadyMounted) {
+    log.info(`appReconciler - mounted data volume for ${identifier}`);
+    fluxEventBus.publish('reconciler:actuated', { identifier, action: 'volumeMounted' });
+  }
+
   const actual = await dockerActual(identifier);
 
   // docker unreachable (e.g. dockerd restarting): defer rather than misread the
@@ -443,7 +478,6 @@ async function reconcile(rawIdentifier) {
   // Recreate any bind-mount paths removed while the container was stopped (e.g.
   // Syncthing cleanup of a g:/r: data folder) before starting — otherwise the
   // start fails on a missing mount source and the app backoff-loops forever.
-  const mainAppName = identifier.split('_')[1] || identifier;
   const isComponent = spec.appSpec.version >= 4 && Array.isArray(spec.appSpec.compose);
   await volumeService.ensureMountPathsExist(spec.comp, mainAppName, isComponent, isComponent ? spec.appSpec : null);
 

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -372,6 +372,22 @@ async function reconcile(rawIdentifier) {
   // folder lives on it. An app whose volume cannot be mounted stays inert.
   const volumeMount = await volumeService.ensureAppVolumeMounted(identifier);
   if (!volumeMount.mounted) {
+    // A stop takes nothing from the app dir, and deferring it would leave the
+    // container running over a missing volume with the mount-safety hold
+    // unenforceable - the incident's app kept running through the gutted
+    // window exactly this way. Honor a pending stop; defer everything else.
+    if (controllerDesired.get(identifier) === 'stopped') {
+      try {
+        const actualNow = await dockerActual(identifier);
+        if (actualNow.reachable && !actualNow.indeterminate && actualNow.running) {
+          log.info(`appReconciler - ${identifier} data volume unavailable but a stop is desired; stopping the container`);
+          await dockerService.appDockerStop(identifier);
+          fluxEventBus.publish('reconciler:actuated', { identifier, action: 'stopped', reason: 'controllerDesired' });
+        }
+      } catch (err) {
+        log.error(`appReconciler - ${identifier} stop under unavailable volume failed: ${err.message}`);
+      }
+    }
     log.error(`appReconciler - ${identifier} data volume not mounted (${volumeMount.reason}); deferring all actuation`);
     fluxEventBus.publish('reconciler:actuated', { identifier, action: 'volumeUnavailable', reason: volumeMount.reason });
     if (volumeMount.reason === 'volume_file_missing' && !volumeMissingNoted.has(identifier)) {

--- a/ZelBack/src/services/appMonitoring/syncthingFolderStateMachine.js
+++ b/ZelBack/src/services/appMonitoring/syncthingFolderStateMachine.js
@@ -1,12 +1,13 @@
 // Syncthing Folder State Machine - Manages folder sync transitions
-const util = require('util');
-const nodecmd = require('node-cmd');
+const fs = require('node:fs');
+const path = require('node:path');
 const log = require('../../lib/log');
 const dockerService = require('../dockerService');
 const appReconciler = require('./appReconciler');
 const appUninstaller = require('../appLifecycle/appUninstaller');
 const syncthingService = require('../syncthingService');
 const serviceHelper = require('../serviceHelper');
+const volumeService = require('../utils/volumeService');
 const { appsFolder } = require('../utils/appConstants');
 const appTamperingDetectionService = require('../appTamperingDetectionService');
 const { socketAddressesMatch } = require('../utils/socketAddressUtils');
@@ -21,23 +22,44 @@ const {
   ACTIVE_FOLDER_STATES,
 } = require('./syncthingMonitorConstants');
 
-const cmdAsync = util.promisify(nodecmd.run);
+const { isPathMounted } = volumeService;
 
 /**
- * Check if a path is a mount point (has a filesystem mounted on it)
- * This detects if loop devices or other filesystems are properly mounted
- * @param {string} dirPath - Directory path to check
- * @returns {Promise<boolean>} True if path is a mount point
+ * Counts regular files under a directory (recursive, early exit at `limit`),
+ * optionally skipping file names and directory subtrees. Pure fs - no child
+ * process, no shell, and immune to the output-buffer truncation a
+ * `find | wc` pipeline hits on huge trees (where a truncated listing could
+ * make a safety guard misread a populated folder as empty).
+ * @param {string} dirPath - Directory to scan
+ * @param {number} limit - Stop counting once this many files are found
+ * @param {{excludeNames?: string[], excludeDirs?: string[]}} options - Skips
+ * @returns {Promise<number>} Number of files found (capped at limit)
  */
-async function isPathMounted(dirPath) {
-  try {
-    // mountpoint command returns 0 if path is a mount point
-    await cmdAsync(`mountpoint -q ${dirPath}`);
-    return true;
-  } catch (error) {
-    // mountpoint returns non-zero if not a mount point
-    return false;
+async function countFilesUpTo(dirPath, limit, { excludeNames = [], excludeDirs = [] } = {}) {
+  let count = 0;
+  const pending = [dirPath];
+  while (pending.length > 0 && count < limit) {
+    const current = pending.pop();
+    let entries;
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      entries = await fs.promises.readdir(current, { withFileTypes: true });
+    } catch (error) {
+      // unreadable/missing directory - skip it, like find does
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+    // eslint-disable-next-line no-restricted-syntax
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (!excludeDirs.includes(entry.name)) pending.push(path.join(current, entry.name));
+      } else if (entry.isFile() && !excludeNames.includes(entry.name)) {
+        count += 1;
+        if (count >= limit) break;
+      }
+    }
   }
+  return count;
 }
 
 /**
@@ -46,18 +68,30 @@ async function isPathMounted(dirPath) {
  * @returns {Promise<{hasContent: boolean, fileCount: number}>} Content status
  */
 async function checkDirectoryHasContent(dirPath) {
-  try {
-    // Count files in directory (excluding . and ..)
-    const result = await cmdAsync(`find ${dirPath} -type f 2>/dev/null | head -100 | wc -l`);
-    const fileCount = parseInt(result.toString().trim(), 10) || 0;
-    return {
-      hasContent: fileCount > 0,
-      fileCount,
-    };
-  } catch (error) {
-    log.warn(`checkDirectoryHasContent - Error checking ${dirPath}: ${error.message}`);
-    return { hasContent: false, fileCount: 0 };
-  }
+  const fileCount = await countFilesUpTo(dirPath, 100);
+  return {
+    hasContent: fileCount > 0,
+    fileCount,
+  };
+}
+
+/**
+ * Like checkDirectoryHasContent, but counts only files inside the folder's
+ * SYNC SCOPE - the same scope the syncthing index describes. .stignore is
+ * syncthing's own ignore file (never synced itself) and /backup is what it is
+ * told to ignore, so both exist on a fresh volume without representing any
+ * synced data. Comparing this against the index's globalBytes is therefore
+ * like for like; the plain content check would let FluxOS's own housekeeping
+ * files mask an empty dataset.
+ * @param {string} dirPath - Directory path to check
+ * @returns {Promise<{hasContent: boolean, fileCount: number}>} Content status
+ */
+async function checkDirectoryHasSyncScopedContent(dirPath) {
+  const fileCount = await countFilesUpTo(dirPath, 100, { excludeNames: ['.stignore'], excludeDirs: ['backup'] });
+  return {
+    hasContent: fileCount > 0,
+    fileCount,
+  };
 }
 
 /**
@@ -79,7 +113,7 @@ async function verifyFolderMountSafety(appId, folderPath) {
   try {
     // Check 1: Does the base app directory exist?
     const baseDir = `${appsFolder}${appId}`;
-    const baseDirExists = await cmdAsync(`test -d ${baseDir} && echo "exists"`).then(() => true).catch(() => false);
+    const baseDirExists = await fs.promises.stat(baseDir).then((stats) => stats.isDirectory()).catch(() => false);
 
     if (!baseDirExists) {
       result.isSafe = false;
@@ -97,18 +131,23 @@ async function verifyFolderMountSafety(appId, folderPath) {
     result.hasContent = contentCheck.hasContent;
     result.fileCount = contentCheck.fileCount;
 
-    // Safety logic:
-    // If directory exists but is NOT mounted and has NO content, this is dangerous
-    // It might be an empty mount point waiting for loop device
-    if (!result.isMounted && !result.hasContent) {
+    // An unmounted app dir is NEVER safe to sync, whatever it contains.
+    // Content on the bare dir means writes already leaked onto the host
+    // filesystem (e.g. a sync pull while the volume was unmounted) - letting
+    // content buy a pass here is exactly how a stale sendreceive folder kept
+    // broadcasting deletions to the healthy master (observed live 2026-07-01).
+    if (!result.isMounted) {
       result.isSafe = false;
-      result.reason = 'empty_unmounted_directory';
-      log.error(`verifyFolderMountSafety - CRITICAL: ${appId} directory exists but not mounted and empty! Likely missing loop mount.`);
+      result.reason = result.hasContent ? 'unmounted_with_content' : 'empty_unmounted_directory';
+      log.error(`verifyFolderMountSafety - CRITICAL: ${appId} directory is not a mountpoint (${result.fileCount} file(s) present)! Missing loop mount.`);
+      if (result.hasContent) {
+        await appTamperingDetectionService.recordEvent(appId, 'mount_vanished', `App dir not mounted but holds ${result.fileCount} file(s) - data leaked onto the host filesystem`);
+      }
       return result;
     }
 
     // If mounted but empty, be cautious (could be race condition)
-    if (result.isMounted && !result.hasContent) {
+    if (!result.hasContent) {
       // Give a small grace period - maybe syncing hasn't completed yet
       // But this is still suspicious
       log.warn(`verifyFolderMountSafety - ${appId} is mounted but has no content (0 files). Potential data loss risk.`);
@@ -122,6 +161,34 @@ async function verifyFolderMountSafety(appId, folderPath) {
     result.reason = 'check_failed';
     return result;
   }
+}
+
+/**
+ * Full safety check for a folder that is (or is about to be) sendreceive.
+ * On top of the mount check, detects a stale ("phantom") index over an empty
+ * volume: the folder's global index claims data while the disk holds none.
+ * In sendreceive, syncthing treats those missing files as local deletions and
+ * broadcasts them, gutting the healthy peers (the deletion-propagation
+ * failure mode observed live 2026-07-01). A legitimately empty folder
+ * (globalBytes 0, e.g. a cold-start seed) does not trip this.
+ * @param {string} appId - App ID (also the syncthing folder id)
+ * @param {string} folderPath - Syncthing folder path
+ * @returns {Promise<{isSafe: boolean, reason: string, isMounted: boolean, hasContent: boolean}>}
+ */
+async function verifySendReceiveFolderSafety(appId, folderPath) {
+  const result = await verifyFolderMountSafety(appId, folderPath);
+  if (!result.isSafe) return result;
+
+  const syncStatus = await getFolderSyncCompletion(appId);
+  if (!syncStatus || syncStatus.globalBytes === 0) return result;
+
+  const dataCheck = await checkDirectoryHasSyncScopedContent(folderPath);
+  if (!dataCheck.hasContent) {
+    result.isSafe = false;
+    result.reason = 'phantom_index_empty_disk';
+    log.error(`verifySendReceiveFolderSafety - CRITICAL: ${appId} index claims ${syncStatus.globalBytes} bytes but the disk holds no synced files - stale index over an empty volume; sendreceive would broadcast deletions.`);
+  }
+  return result;
 }
 
 /**
@@ -140,8 +207,8 @@ async function fixAppdataPermissions(appId) {
     // Recursively set 777 permissions to allow any container user to write
     // This ensures containers running as any UID/GID can access their data
     // Covers both appdata (primary mount) and all additional mounts at the same level
-    const fixPermissions = `sudo chmod -R 777 ${appPath}`;
-    await cmdAsync(fixPermissions);
+    const chmod = await serviceHelper.runCommand('chmod', { runAsRoot: true, params: ['-R', '777', appPath] });
+    if (chmod.error) throw chmod.error;
     log.info(`fixAppdataPermissions - Fixed permissions on ${appPath} (includes appdata and all mount points)`);
   } catch (error) {
     log.warn(`fixAppdataPermissions - Could not fix permissions for ${appId}: ${error.message}`);
@@ -714,7 +781,19 @@ async function manageFolderSyncState(params) {
     // CRITICAL SAFETY CHECK: Verify mount is properly initialized before trusting sendreceive mode
     // This prevents data loss when loop mounts aren't ready after reboot
     const folderPath = syncFolder.path || `${appsFolder}${appId}/appdata`;
-    const mountSafety = await verifyFolderMountSafety(appId, folderPath);
+    let mountSafety = await verifySendReceiveFolderSafety(appId, folderPath);
+
+    if (!mountSafety.isSafe && !mountSafety.isMounted) {
+      // The detection is actionable: the backing image normally still exists,
+      // and FluxOS owns the mount - repair instead of just blocking. The
+      // re-verify still holds the folder back (receiveonly) if the freshly
+      // mounted volume disagrees with the index (phantom-index case).
+      const mountAttempt = await volumeService.ensureAppVolumeMounted(appId);
+      if (mountAttempt.mounted) {
+        log.info(`manageFolderSyncState - ${appId} volume was not mounted; mounted it, re-verifying folder safety`);
+        mountSafety = await verifySendReceiveFolderSafety(appId, folderPath);
+      }
+    }
 
     if (!mountSafety.isSafe) {
       // DANGER: Mount not ready! Switch to receiveonly to prevent data propagation
@@ -730,6 +809,11 @@ async function manageFolderSyncState(params) {
         blockedAt: Date.now(),
       };
       receiveOnlySyncthingAppsCache.set(appId, cache);
+
+      // Hold the container too: its binds point at the same unsafe dir. The
+      // reconciler is the actuator; the receiveonly machinery flips the
+      // verdict back to running once the folder is verifiably synced.
+      appReconciler.setControllerDesired(appId, 'stopped', `mount safety block: ${mountSafety.reason}`);
 
       // Return with skipUpdate=false so the folder config gets updated to receiveonly
       return { syncthingFolder, cache, skipUpdate: false };
@@ -821,7 +905,9 @@ module.exports = {
   getFolderSyncCompletion,
   isDesignatedLeader,
   verifyFolderMountSafety,
+  verifySendReceiveFolderSafety,
   isPathMounted,
   checkDirectoryHasContent,
+  checkDirectoryHasSyncScopedContent,
   nudgeFolderDevices,
 };

--- a/ZelBack/src/services/appMonitoring/syncthingFolderStateMachine.js
+++ b/ZelBack/src/services/appMonitoring/syncthingFolderStateMachine.js
@@ -535,6 +535,8 @@ async function handleReceiveOnlyTransition(params) {
 
   log.info(`handleReceiveOnlyTransition - ${appId} in cache and not restarted, processing receive-only logic`);
 
+  const folderPath = syncthingFolder.path || `${appsFolder}${appId}/appdata`;
+
   // Whether any CONNECTED peer genuinely holds the data. Gates the election (a true
   // cold start - nobody serving - must still elect one seed instead of standing off)
   // and is reused by the stall ladder below, so it is computed once per cycle here.
@@ -575,6 +577,18 @@ async function handleReceiveOnlyTransition(params) {
   // subsumes the data-version check) - a separate, proposed redesign, out of scope here.
   if (isLeader) {
     log.info(`handleReceiveOnlyTransition - ${appId} is the designated leader (elected from ${runningAppList.length} peers, confirmed ${cache.leaderStreak}x), starting immediately`);
+
+    // A folder must pass the sendreceive safety verification BEFORE it ever
+    // flips - the seed included. An empty cold-start folder passes (empty index
+    // over an empty disk); an unmounted dir, or a stale index claiming bytes
+    // over an empty volume, must never seed: sendreceive would broadcast the
+    // missing files as deletions.
+    const seedSafety = await verifySendReceiveFolderSafety(appId, folderPath);
+    if (!seedSafety.isSafe) {
+      log.warn(`handleReceiveOnlyTransition - ${appId} elected leader but not safe to seed (${seedSafety.reason}); staying receiveonly`);
+      syncthingFolder.type = 'receiveonly';
+      return { syncthingFolder, cache };
+    }
 
     // Fix permissions before changing to sendreceive - ensures correct ownership for synced data
     await fixAppdataPermissions(appId);
@@ -619,6 +633,14 @@ async function handleReceiveOnlyTransition(params) {
       return { syncthingFolder, cache };
     }
     if (syncStatus.isSynced) {
+      // Same pre-flip verification as the seed above: completion metrics come
+      // from the index, and an index can be stale - promotion requires the disk
+      // to actually hold the data the index claims.
+      const promoteSafety = await verifySendReceiveFolderSafety(appId, folderPath);
+      if (!promoteSafety.isSafe) {
+        log.warn(`handleReceiveOnlyTransition - ${appId} is synced but not safe to promote (${promoteSafety.reason}); staying receiveonly`);
+        return { syncthingFolder, cache };
+      }
       log.info(`handleReceiveOnlyTransition - ${appId} is synced (${syncStatus.syncPercentage.toFixed(2)}%), switching to sendreceive`);
       await fixAppdataPermissions(appId);
       syncthingFolder.type = 'sendreceive';

--- a/ZelBack/src/services/appMonitoring/syncthingMonitor.js
+++ b/ZelBack/src/services/appMonitoring/syncthingMonitor.js
@@ -26,6 +26,7 @@ const {
   folderNeedsUpdate,
 } = require('./syncthingMonitorHelpers');
 const volumeService = require('../utils/volumeService');
+const appReconciler = require('./appReconciler');
 const {
   manageFolderSyncState,
   verifyFolderMountSafety,
@@ -325,11 +326,34 @@ async function syncthingAppsCore(state, installedAppsFn, getGlobalStateFn) {
 
     // CRITICAL: Check if app folder mounts are ready before processing
     // This prevents syncthing operations when loop devices aren't mounted after reboot
+    // (checkAppFolderMounts repairs an unmounted volume itself when the backing
+    // image still exists, so reaching this branch means repair failed too)
     const unmountedApps = await checkAppFolderMounts(appsInstalled.data);
     if (unmountedApps.length > 0) {
       const unmountedList = unmountedApps.map((app) => app.appId).join(', ');
       log.warn(`syncthingAppsCore - Skipping processing: ${unmountedApps.length} app folders not mounted yet: ${unmountedList}`);
       log.warn('syncthingAppsCore - Waiting for app folders to be mounted before syncthing processing');
+
+      // Never leave an unsafe-mount folder sendreceive while processing is
+      // skipped: the syncthing daemon keeps running as configured, so an
+      // un-demoted sendreceive folder over a bad mount can still broadcast its
+      // (leaked or missing) disk state to the healthy peers. Demote those
+      // folders and hold their containers before bailing - idempotent, and the
+      // normal receiveonly machinery re-promotes once the mount is healthy.
+      const foldersResp = await syncthingService.getConfigFolders();
+      const folders = Array.isArray(foldersResp?.data) ? foldersResp.data : [];
+      // eslint-disable-next-line no-restricted-syntax
+      for (const { appId, reason } of unmountedApps) {
+        const folder = folders.find((f) => f.id === appId);
+        if (folder && folder.type === 'sendreceive') {
+          log.error(`syncthingAppsCore - SAFETY BLOCK: ${appId} folder is sendreceive over an unsafe mount (${reason}); switching to receiveonly and holding the container`);
+          // eslint-disable-next-line no-await-in-loop
+          await syncthingService.adjustConfigFolders('patch', { type: 'receiveonly' }, appId).catch((err) => {
+            log.error(`syncthingAppsCore - Failed to switch ${appId} to receiveonly: ${err.message}`);
+          });
+          appReconciler.setControllerDesired(appId, 'stopped', `mount safety block: ${reason}`);
+        }
+      }
       return;
     }
 

--- a/ZelBack/src/services/appMonitoring/syncthingMonitor.js
+++ b/ZelBack/src/services/appMonitoring/syncthingMonitor.js
@@ -25,10 +25,11 @@ const {
   requiresSyncing,
   folderNeedsUpdate,
 } = require('./syncthingMonitorHelpers');
+const volumeService = require('../utils/volumeService');
 const {
   manageFolderSyncState,
   verifyFolderMountSafety,
-  isPathMounted,
+  verifySendReceiveFolderSafety,
 } = require('./syncthingFolderStateMachine');
 const {
   monitorFolderHealth,
@@ -42,6 +43,26 @@ const globalAppsLocations = config.database.appsglobal.collections.appsLocations
 const fluxDirPath = process.env.FLUXOS_PATH || path.join(process.env.HOME, 'zelflux');
 const appsFolderPath = process.env.FLUX_APPS_FOLDER || path.join(fluxDirPath, 'ZelApps');
 const appsFolder = `${appsFolderPath}/`;
+
+/**
+ * Verify one app folder's mount safety, repairing an unmounted volume on the
+ * spot (FluxOS owns the mount - the backing image normally still exists, so
+ * the actionable response is to mount it, not just to report it).
+ * @param {string} appId - Docker app identifier
+ * @param {string} appFolder - App folder path
+ * @returns {Promise<{isSafe: boolean, reason: string}>} Result after any repair
+ */
+async function verifyAppFolderMountWithRepair(appId, appFolder) {
+  let mountSafety = await verifyFolderMountSafety(appId, appFolder);
+  if (!mountSafety.isSafe && !mountSafety.isMounted) {
+    const mountAttempt = await volumeService.ensureAppVolumeMounted(appId);
+    if (mountAttempt.mounted) {
+      log.info(`checkAppFolderMounts - ${appId} volume was not mounted; mounted it`);
+      mountSafety = await verifyFolderMountSafety(appId, appFolder);
+    }
+  }
+  return mountSafety;
+}
 
 /**
  * Check if app folders are properly mounted
@@ -60,7 +81,7 @@ async function checkAppFolderMounts(appsInstalled) {
       const appId = dockerService.getAppIdentifier(installedApp.name);
       const appFolder = `${appsFolder}${appId}`;
       // eslint-disable-next-line no-await-in-loop
-      const mountSafety = await verifyFolderMountSafety(appId, appFolder);
+      const mountSafety = await verifyAppFolderMountWithRepair(appId, appFolder);
       if (!mountSafety.isSafe) {
         // Folder exists but mount is not safe (empty and not mounted - likely unmounted loop device)
         unmountedApps.push({ appId, appName: installedApp.name, reason: mountSafety.reason });
@@ -72,7 +93,7 @@ async function checkAppFolderMounts(appsInstalled) {
         const appId = dockerService.getAppIdentifier(`${component.name}_${installedApp.name}`);
         const appFolder = `${appsFolder}${appId}`;
         // eslint-disable-next-line no-await-in-loop
-        const mountSafety = await verifyFolderMountSafety(appId, appFolder);
+        const mountSafety = await verifyAppFolderMountWithRepair(appId, appFolder);
         if (!mountSafety.isSafe) {
           unmountedApps.push({ appId, appName: installedApp.name, reason: mountSafety.reason });
         }
@@ -140,8 +161,13 @@ async function processContainerData(params) {
   const id = appId;
   const label = appId;
 
-  // Ensure .stfolder directory exists at appId level
-  await ensureStfolderExists(folder);
+  // Ensure .stfolder directory exists at appId level - refused on an
+  // unmounted dir (the marker may only ever live inside the volume)
+  const markerReady = await ensureStfolderExists(folder);
+  if (!markerReady) {
+    log.warn(`processContainerData - ${appId} volume not mounted; skipping syncthing configuration this cycle`);
+    return;
+  }
 
   // Get and process app locations
   let locations = await appLocation(installedAppName);
@@ -362,7 +388,7 @@ async function syncthingAppsCore(state, installedAppsFn, getGlobalStateFn) {
           const folderPath = folder.path;
 
           // eslint-disable-next-line no-await-in-loop
-          const mountSafety = await verifyFolderMountSafety(appId, folderPath);
+          const mountSafety = await verifySendReceiveFolderSafety(appId, folderPath);
 
           if (!mountSafety.isSafe) {
             unsafeFoldersCount += 1;

--- a/ZelBack/src/services/appMonitoring/syncthingMonitorHelpers.js
+++ b/ZelBack/src/services/appMonitoring/syncthingMonitorHelpers.js
@@ -1,14 +1,14 @@
 // Syncthing Monitor - Helper Functions
 const axios = require('axios');
-const util = require('util');
 const log = require('../../lib/log');
+const serviceHelper = require('../serviceHelper');
+const volumeService = require('../utils/volumeService');
 const {
   DEVICE_ID_REQUEST_TIMEOUT_MS,
   SYNCTHING_RESCAN_INTERVAL_SECONDS,
   SYNCTHING_MAX_CONFLICTS,
 } = require('./syncthingMonitorConstants');
 
-const cmdAsync = util.promisify(require('child_process').exec);
 const { normalizeSocketAddress, extractIp, extractPort, socketAddressesMatch } = require('../utils/socketAddressUtils');
 
 /**
@@ -201,13 +201,26 @@ function createSyncthingFolderConfig(id, label, path, devices, type = 'sendrecei
 }
 
 /**
- * Ensure .stfolder directory exists
+ * Ensure the .stfolder marker exists - ONLY inside the mounted volume. The
+ * marker is syncthing's own guard against syncing a missing folder: creating
+ * it on the bare mountpoint re-arms syncthing onto the host filesystem and
+ * defeats that guard (this exact leak re-armed a sync onto the rootfs in the
+ * 2026-07-01 data-loss incident).
  * @param {string} folder - Folder path
- * @returns {Promise<void>}
+ * @returns {Promise<boolean>} True if the marker exists in a mounted volume
  */
 async function ensureStfolderExists(folder) {
-  const execDIRst = `[ ! -d \\"${folder}/.stfolder\\" ] && sudo mkdir -p ${folder}/.stfolder`;
-  await cmdAsync(execDIRst);
+  const mounted = await volumeService.isPathMounted(folder);
+  if (!mounted) {
+    log.error(`ensureStfolderExists - ${folder} is not a mountpoint; refusing to create .stfolder on the bare directory`);
+    return false;
+  }
+  const mkdir = await serviceHelper.runCommand('mkdir', { runAsRoot: true, params: ['-p', `${folder}/.stfolder`] });
+  if (mkdir.error) {
+    log.error(`ensureStfolderExists - failed to create .stfolder in ${folder}: ${mkdir.error.message}`);
+    return false;
+  }
+  return true;
 }
 
 /**

--- a/ZelBack/src/services/appNetwork/portManager.js
+++ b/ZelBack/src/services/appNetwork/portManager.js
@@ -290,6 +290,10 @@ async function restoreAppsPortsSupport() {
 
     // UPNP
     if (isUPNP) {
+      // one shared recovery pause per cycle: every failing mapping still gets
+      // its retry, but a router-wide outage must not stack per-app pauses
+      // (N apps -> N x 30s of serial delay, outgrowing the restore interval)
+      let retryDelayElapsed = false;
       // map application ports
       // eslint-disable-next-line no-restricted-syntax
       for (const application of currentAppsPorts) {
@@ -299,8 +303,11 @@ async function restoreAppsPortsSupport() {
           // eslint-disable-next-line no-await-in-loop
           let upnpOk = await upnpService.mapUpnpPort(serviceHelper.ensureNumber(port), `Flux_App_${application.name}`);
           if (!upnpOk) {
-            // eslint-disable-next-line no-await-in-loop
-            await serviceHelper.delay(UPNP_MAP_RETRY_DELAY_MS);
+            if (!retryDelayElapsed) {
+              // eslint-disable-next-line no-await-in-loop
+              await serviceHelper.delay(UPNP_MAP_RETRY_DELAY_MS);
+              retryDelayElapsed = true;
+            }
             // eslint-disable-next-line no-await-in-loop
             upnpOk = await upnpService.mapUpnpPort(serviceHelper.ensureNumber(port), `Flux_App_${application.name}`);
           }

--- a/ZelBack/src/services/appNetwork/portManager.js
+++ b/ZelBack/src/services/appNetwork/portManager.js
@@ -16,6 +16,19 @@ const { localAppsInformation, globalAppsInformation } = require('../utils/appCon
 // Global cache for failed nodes
 const failedNodesTestPortsCache = new Map();
 
+// A single UPnP map failure is routine on consumer routers (busy router, a
+// node network blip) and the app itself keeps running regardless - it must
+// NEVER escalate straight to a force-removal + network broadcast. Removal
+// requires the failure to be sustained: consecutive restore cycles AND a
+// minimum wall-clock window, measured on the monotonic clock.
+const UPNP_REMOVAL_MIN_CONSECUTIVE_CYCLES = 3;
+const UPNP_REMOVAL_MIN_WINDOW_MS = 30 * 60 * 1000;
+const UPNP_MAP_RETRY_DELAY_MS = 30 * 1000;
+// appName -> { cycles, firstFailureAtMs } (monotonic ms)
+const upnpMapFailures = new Map();
+
+const monotonicMs = () => Number(process.hrtime.bigint() / 1000000n);
+
 /**
  * Check if ports in array are unique
  * @param {number[]} portsArray - Array of port numbers
@@ -228,7 +241,7 @@ async function restoreFluxPortsSupport() {
   try {
     const isUPNP = upnpService.isUPNP();
 
-    const userconfig = globalThis.userconfig;
+    const { userconfig } = globalThis;
     const apiPort = userconfig.initial.apiport || config.server.apiport;
     const homePort = +apiPort - 1;
     const apiPortSSL = +apiPort + 1;
@@ -280,22 +293,52 @@ async function restoreAppsPortsSupport() {
       // map application ports
       // eslint-disable-next-line no-restricted-syntax
       for (const application of currentAppsPorts) {
+        let failedPort = null;
         // eslint-disable-next-line no-restricted-syntax
         for (const port of application.ports) {
           // eslint-disable-next-line no-await-in-loop
-          const upnpOk = await upnpService.mapUpnpPort(serviceHelper.ensureNumber(port), `Flux_App_${application.name}`);
+          let upnpOk = await upnpService.mapUpnpPort(serviceHelper.ensureNumber(port), `Flux_App_${application.name}`);
           if (!upnpOk) {
-            log.warn(`REMOVAL REASON: UPNP port mapping failure - ${application.name} failed to map port ${port} via UPNP (portManager)`);
-            // Import locally to avoid circular dependency
-            // eslint-disable-next-line global-require
-            const appUninstaller = require('../appLifecycle/appUninstaller');
             // eslint-disable-next-line no-await-in-loop
-            await appUninstaller.removeAppLocally(application.name, null, true, true, true).catch((error) => log.error(error)); // remove entire app
+            await serviceHelper.delay(UPNP_MAP_RETRY_DELAY_MS);
             // eslint-disable-next-line no-await-in-loop
-            await serviceHelper.delay(3 * 60 * 1000); // 3 mins
+            upnpOk = await upnpService.mapUpnpPort(serviceHelper.ensureNumber(port), `Flux_App_${application.name}`);
+          }
+          if (!upnpOk) {
+            failedPort = port;
             break;
           }
         }
+
+        if (failedPort === null) {
+          upnpMapFailures.delete(application.name);
+          // eslint-disable-next-line no-continue
+          continue;
+        }
+
+        const now = monotonicMs();
+        const tracker = upnpMapFailures.get(application.name) || { cycles: 0, firstFailureAtMs: now };
+        tracker.cycles += 1;
+        upnpMapFailures.set(application.name, tracker);
+        const sustainedMs = now - tracker.firstFailureAtMs;
+
+        if (tracker.cycles < UPNP_REMOVAL_MIN_CONSECUTIVE_CYCLES || sustainedMs < UPNP_REMOVAL_MIN_WINDOW_MS) {
+          log.warn(`restoreAppsPortsSupport - ${application.name} failed to map port ${failedPort} via UPNP `
+            + `(failure ${tracker.cycles}, ${Math.round(sustainedMs / 60000)}m sustained); not removing - removal requires `
+            + `${UPNP_REMOVAL_MIN_CONSECUTIVE_CYCLES} consecutive cycles over ${UPNP_REMOVAL_MIN_WINDOW_MS / 60000}m`);
+          // eslint-disable-next-line no-continue
+          continue;
+        }
+
+        log.warn(`REMOVAL REASON: UPNP port mapping failure - ${application.name} failed to map port ${failedPort} via UPNP for ${tracker.cycles} consecutive cycles over ${Math.round(sustainedMs / 60000)}m (portManager)`);
+        upnpMapFailures.delete(application.name);
+        // Import locally to avoid circular dependency
+        // eslint-disable-next-line global-require
+        const appUninstaller = require('../appLifecycle/appUninstaller');
+        // eslint-disable-next-line no-await-in-loop
+        await appUninstaller.removeAppLocally(application.name, null, true, true, true).catch((error) => log.error(error)); // remove entire app
+        // eslint-disable-next-line no-await-in-loop
+        await serviceHelper.delay(3 * 60 * 1000); // 3 mins
       }
     }
   } catch (error) {
@@ -596,7 +639,7 @@ async function checkInstallingAppPortAvailable(portsToTest = []) {
  */
 async function callOtherNodeToKeepUpnpPortsOpen() {
   try {
-    const userconfig = globalThis.userconfig;
+    const { userconfig } = globalThis;
     const apiPort = userconfig.initial.apiport || config.server.apiport;
     const localSocketAddr = await fluxNetworkHelper.getLocalSocketAddress();
     if (!localSocketAddr) {
@@ -704,4 +747,5 @@ module.exports = {
   checkInstallingAppPortAvailable,
   callOtherNodeToKeepUpnpPortsOpen,
   failedNodesTestPortsCache,
+  upnpMapFailures,
 };

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -66,14 +66,16 @@ const apiPort = userconfig.initial.apiport || config.server.apiport;
 const development = userconfig.initial.development || false;
 const fluxTransactionCollection = config.database.daemon.collections.fluxTransactions;
 
-const bootDelayMultiplier = config.fluxapps.bootDelayMultiplier;
+const { bootDelayMultiplier } = config.fluxapps;
 function bootDelay(ms) { return Math.round(ms * bootDelayMultiplier); }
 
-const portRestoreIntervalMs = config.fluxapps.portRestoreIntervalMs;
-const cpuCheckIntervalMs = config.fluxapps.cpuCheckIntervalMs;
-const imageComplianceIntervalMs = config.fluxapps.imageComplianceIntervalMs;
-const forceRemovalIntervalMs = config.fluxapps.forceRemovalIntervalMs;
-const tempMsgTtlS = config.fluxapps.tempMsgTtlS;
+const {
+  portRestoreIntervalMs,
+  cpuCheckIntervalMs,
+  imageComplianceIntervalMs,
+  forceRemovalIntervalMs,
+  tempMsgTtlS,
+} = config.fluxapps;
 
 // State objects for monitoring services
 const dosState = {
@@ -356,7 +358,8 @@ async function startFluxFunctions() {
       fluxCommunication.startDiscovery();
       log.info('Flux Discovery started');
     }
-    // Cleanup and fix crontab mount entries (add wait logic, remove stale entries, ensure mounts are active)
+    // Mount every installed app's data volume (derived from the installed-apps
+    // DB) and drop the superseded legacy @reboot remount crontab entries
     log.info('crontab and mounts cleanup...');
     await crontabAndMountsCleanup.cleanupCrontabAndMounts().catch((error) => {
       log.error(`Crontab and mounts cleanup service error: ${error.message}`);
@@ -419,7 +422,7 @@ async function startFluxFunctions() {
 
     // Services that read from zelappsinformation wait for the orchestrator
     // to finish rebuilding it rather than guessing a setTimeout delay.
-    async function startDbDependentServices() {
+    const startDbDependentServices = async () => {
       await globalState.waitForDbReady();
       log.info('DB ready - starting db-dependent services');
       advancedWorkflows.checkAndRemoveEnterpriseAppsOnNonArcane();
@@ -433,7 +436,7 @@ async function startFluxFunctions() {
       setInterval(() => {
         portManager.restorePortsSupport();
       }, portRestoreIntervalMs);
-    }
+    };
     startDbDependentServices();
     log.info('Starting setting Node Geolocation');
     geolocationService.setNodeGeolocation();

--- a/ZelBack/src/services/utils/appConstants.js
+++ b/ZelBack/src/services/utils/appConstants.js
@@ -5,6 +5,14 @@ const path = require('path');
 const fluxDirPath = process.env.FLUXOS_PATH || path.join(process.env.HOME, 'zelflux');
 const appsFolderPath = process.env.FLUX_APPS_FOLDER || path.join(fluxDirPath, 'ZelApps');
 const appsFolder = path.join(appsFolderPath, '/');
+// Backing FLUXFSVOL images live here when the host volume is the root
+// filesystem (the directory ships with the repo - see appvolumes/.gitkeep).
+const appVolumesPath = path.join(fluxDirPath, 'appvolumes');
+// The path used to be assembled by string concatenation without a separator,
+// landing images in a glued '<fluxDir>appvolumes' sibling directory (e.g.
+// ~/zelfluxappvolumes). Volumes created by older FluxOS still live there, so
+// discovery must keep checking it.
+const legacyAppVolumesPath = `${fluxDirPath}appvolumes`;
 
 // Database collections - Daemon
 const scannedHeightCollection = config.database.daemon.collections.scannedHeight;
@@ -87,6 +95,8 @@ module.exports = {
   fluxDirPath,
   appsFolderPath,
   appsFolder,
+  appVolumesPath,
+  legacyAppVolumesPath,
 
   // Database collections
   scannedHeightCollection,

--- a/ZelBack/src/services/utils/volumeService.js
+++ b/ZelBack/src/services/utils/volumeService.js
@@ -1,9 +1,130 @@
 const fs = require('fs').promises;
+const path = require('node:path');
+const util = require('node:util');
+const df = require('node-df');
 const dockerService = require('../dockerService');
 const serviceHelper = require('../serviceHelper');
 const mountParser = require('./mountParser');
 const log = require('../../lib/log');
-const { appsFolder } = require('./appConstants');
+const { appsFolder, appVolumesPath, legacyAppVolumesPath } = require('./appConstants');
+
+const dfAsync = util.promisify(df);
+
+/**
+ * Whether a path currently has a filesystem mounted on it.
+ * @param {string} dirPath Directory path to check.
+ * @returns {Promise<boolean>} True if the path is a mountpoint.
+ */
+async function isPathMounted(dirPath) {
+  const result = await serviceHelper.runCommand('mountpoint', { params: ['-q', dirPath], logError: false });
+  return !result.error;
+}
+
+/**
+ * Locates the backing FLUXFSVOL image for an app component deterministically,
+ * without consulting the crontab (whose entries can silently vanish - relying
+ * on them once orphaned images on removal and left volumes unmounted after
+ * reboot). Candidates mirror where createAppVolume places images: the root of
+ * each eligible host volume, or the appvolumes directory (proper and legacy
+ * glued layout) when the root filesystem hosts them.
+ * @param {string} appId Docker app identifier (e.g. fluxcomp_app).
+ * @returns {Promise<string|null>} Absolute path of the image, or null.
+ */
+async function getVolumeFilePath(appId) {
+  const volumeFileName = `${appId}FLUXFSVOL`;
+  const candidates = [];
+
+  try {
+    const dfres = await dfAsync({});
+    dfres.forEach((volume) => {
+      const eligible = (volume.filesystem.includes('/dev/') && !volume.filesystem.includes('loop') && !volume.mount.includes('boot'))
+        || (volume.filesystem.includes('loop') && volume.mount === '/');
+      if (eligible && volume.mount !== '/') {
+        candidates.push(path.join(volume.mount, volumeFileName));
+      }
+    });
+  } catch (error) {
+    log.warn(`getVolumeFilePath - df failed (${error.message}), falling back to appvolumes locations only`);
+  }
+
+  candidates.push(path.join(appVolumesPath, volumeFileName));
+  candidates.push(path.join(legacyAppVolumesPath, volumeFileName));
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const candidate of candidates) {
+    // eslint-disable-next-line no-await-in-loop
+    const exists = await fs.access(candidate).then(() => true).catch(() => false);
+    if (exists) return candidate;
+  }
+
+  return null;
+}
+
+/**
+ * Ensures an app component's data volume is loop-mounted at its app dir - the
+ * level-based desired state FluxOS itself owns (a rw mount replays a dirty
+ * ext4 journal automatically). Idempotent: a mounted volume is a no-op. Never
+ * deletes anything: content found on the bare mountpoint is shadowed by the
+ * mount, loudly, so it stays recoverable underneath.
+ * @param {string} identifier Component identifier (comp_app), app name, or docker app id.
+ * @returns {Promise<{mounted: boolean, alreadyMounted?: boolean, reason?: string}>}
+ */
+async function ensureAppVolumeMounted(identifier) {
+  const appId = dockerService.getAppIdentifier(identifier);
+  const mountPoint = path.join(appsFolder, appId);
+
+  if (await isPathMounted(mountPoint)) {
+    return { mounted: true, alreadyMounted: true };
+  }
+
+  const volumeFile = await getVolumeFilePath(appId);
+  if (!volumeFile) {
+    return { mounted: false, reason: 'volume_file_missing' };
+  }
+
+  let mountPointEntries;
+  try {
+    mountPointEntries = await fs.readdir(mountPoint);
+  } catch (error) {
+    const mkdir = await serviceHelper.runCommand('mkdir', { runAsRoot: true, params: ['-p', mountPoint] });
+    if (mkdir.error) {
+      return { mounted: false, reason: `mount_point_unavailable: ${mkdir.error.message}` };
+    }
+    mountPointEntries = [];
+  }
+
+  if (mountPointEntries.length === 0) {
+    // An empty bare mountpoint is locked immutable before mounting so writes
+    // through it while the volume is unmounted fail with EPERM instead of
+    // silently landing on the host filesystem (bypassing the app's quota and
+    // getting orphaned under the next mount). The mounted volume shadows the
+    // flag. Both fleet filesystems (ext4, XFS) support it, so a failure is an
+    // anomaly - but the flag is defense-in-depth on top of the mount itself,
+    // so it must never block bringing the app's volume up.
+    const chattr = await serviceHelper.runCommand('chattr', { runAsRoot: true, params: ['+i', mountPoint], logError: false });
+    if (chattr.error) {
+      log.error(`ensureAppVolumeMounted - could not set ${mountPoint} immutable (unexpected on ext4/XFS): ${chattr.error.message}`);
+    }
+  } else {
+    log.warn(`ensureAppVolumeMounted - ${mountPoint} is not mounted but holds ${mountPointEntries.length} entries; they were written while unmounted and will be shadowed by the volume`);
+  }
+
+  const mountRes = await serviceHelper.runCommand('mount', {
+    runAsRoot: true, params: ['-o', 'loop', volumeFile, mountPoint], logError: false,
+  });
+  if (mountRes.error) {
+    // another actor (e.g. a legacy @reboot job on its last boot) may have
+    // mounted in between - that is success, not an error
+    if (await isPathMounted(mountPoint)) {
+      return { mounted: true, alreadyMounted: true };
+    }
+    log.error(`ensureAppVolumeMounted - failed to mount ${volumeFile} at ${mountPoint}: ${mountRes.error.message}`);
+    return { mounted: false, reason: `mount_failed: ${mountRes.error.message}` };
+  }
+
+  log.info(`ensureAppVolumeMounted - mounted ${volumeFile} at ${mountPoint}`);
+  return { mounted: true, alreadyMounted: false };
+}
 
 async function verifyAppVolumeMount(appName, isComponent, componentName) {
   const identifier = isComponent ? `${componentName}_${appName}` : appName;
@@ -68,6 +189,14 @@ async function ensureMountPathsExist(appSpecifications, appName, isComponent, fu
   const identifier = isComponent ? `${appSpecifications.name}_${appName}` : appName;
   const appId = dockerService.getAppIdentifier(identifier);
 
+  // Structure created on the bare app dir would land on the host filesystem
+  // instead of the app's volume, so the volume must be mounted first - and it
+  // is level-based desired state, so mount it rather than merely assert.
+  const volumeMount = await ensureAppVolumeMounted(identifier);
+  if (!volumeMount.mounted) {
+    throw new Error(`Data volume for ${appId} is not mounted (${volumeMount.reason}); refusing to create mount paths on the bare directory`);
+  }
+
   let parsedMounts;
   try {
     parsedMounts = mountParser.parseContainerData(appSpecifications.containerData);
@@ -125,6 +254,14 @@ async function ensureMountPathsExist(appSpecifications, appName, isComponent, fu
       }
 
       const componentAppId = dockerService.getAppIdentifier(componentIdentifier);
+
+      // the referenced component's own volume must back anything we create there
+      // eslint-disable-next-line no-await-in-loop
+      const refVolumeMount = await ensureAppVolumeMounted(componentIdentifier);
+      if (!refVolumeMount.mounted) {
+        throw new Error(`Data volume for referenced component ${componentAppId} is not mounted (${refVolumeMount.reason})`);
+      }
+
       const fullPath = mount.subdir === 'appdata'
         ? `${appsFolder}${componentAppId}/appdata`
         : `${appsFolder}${componentAppId}/${mount.subdir}`;
@@ -148,4 +285,7 @@ async function ensureMountPathsExist(appSpecifications, appName, isComponent, fu
 module.exports = {
   verifyAppVolumeMount,
   ensureMountPathsExist,
+  isPathMounted,
+  getVolumeFilePath,
+  ensureAppVolumeMounted,
 };

--- a/ZelBack/src/services/utils/volumeService.js
+++ b/ZelBack/src/services/utils/volumeService.js
@@ -61,6 +61,51 @@ async function getVolumeFilePath(appId) {
 }
 
 /**
+ * Derives the docker app identifiers of an app's components from the
+ * FLUXFSVOL images present on disk - the image filename embeds the component
+ * identifier (flux<component>_<app>FLUXFSVOL; legacy single-component apps
+ * flux<app>FLUXFSVOL). Ground truth for apps whose local spec cannot
+ * enumerate components: enterprise specs are stored with compose emptied and
+ * decryption needs fluxbenchd, while the images need nothing.
+ * @param {string} appName Application name.
+ * @returns {Promise<string[]>} Docker app identifiers whose images exist on disk.
+ */
+async function getComponentAppIdsFromVolumeFiles(appName) {
+  const appIds = new Set();
+  const searchDirs = new Set([appVolumesPath, legacyAppVolumesPath]);
+
+  try {
+    const dfres = await dfAsync({});
+    dfres.forEach((volume) => {
+      const eligible = (volume.filesystem.includes('/dev/') && !volume.filesystem.includes('loop') && !volume.mount.includes('boot'))
+        || (volume.filesystem.includes('loop') && volume.mount === '/');
+      if (eligible && volume.mount !== '/') {
+        searchDirs.add(volume.mount);
+      }
+    });
+  } catch (error) {
+    log.warn(`getComponentAppIdsFromVolumeFiles - df failed (${error.message}), searching appvolumes locations only`);
+  }
+
+  const escapedName = appName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const componentImage = new RegExp(`^flux\\w+_${escapedName}FLUXFSVOL$`);
+  const legacyImage = `flux${appName}FLUXFSVOL`;
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const dir of searchDirs) {
+    // eslint-disable-next-line no-await-in-loop
+    const entries = await fs.readdir(dir).catch(() => []);
+    entries.forEach((entry) => {
+      if (componentImage.test(entry) || entry === legacyImage) {
+        appIds.add(entry.slice(0, -'FLUXFSVOL'.length));
+      }
+    });
+  }
+
+  return [...appIds];
+}
+
+/**
  * Ensures an app component's data volume is loop-mounted at its app dir - the
  * level-based desired state FluxOS itself owns (a rw mount replays a dirty
  * ext4 journal automatically). Idempotent: a mounted volume is a no-op. Never
@@ -287,5 +332,6 @@ module.exports = {
   ensureMountPathsExist,
   isPathMounted,
   getVolumeFilePath,
+  getComponentAppIdsFromVolumeFiles,
   ensureAppVolumeMounted,
 };

--- a/ZelBack/src/services/utils/volumeService.js
+++ b/ZelBack/src/services/utils/volumeService.js
@@ -37,9 +37,9 @@ async function getVolumeFilePath(appId) {
   try {
     const dfres = await dfAsync({});
     dfres.forEach((volume) => {
-      const eligible = (volume.filesystem.includes('/dev/') && !volume.filesystem.includes('loop') && !volume.mount.includes('boot'))
-        || (volume.filesystem.includes('loop') && volume.mount === '/');
-      if (eligible && volume.mount !== '/') {
+      const eligible = volume.filesystem.includes('/dev/') && !volume.filesystem.includes('loop')
+        && !volume.mount.includes('boot') && volume.mount !== '/';
+      if (eligible) {
         candidates.push(path.join(volume.mount, volumeFileName));
       }
     });
@@ -77,9 +77,9 @@ async function getComponentAppIdsFromVolumeFiles(appName) {
   try {
     const dfres = await dfAsync({});
     dfres.forEach((volume) => {
-      const eligible = (volume.filesystem.includes('/dev/') && !volume.filesystem.includes('loop') && !volume.mount.includes('boot'))
-        || (volume.filesystem.includes('loop') && volume.mount === '/');
-      if (eligible && volume.mount !== '/') {
+      const eligible = volume.filesystem.includes('/dev/') && !volume.filesystem.includes('loop')
+        && !volume.mount.includes('boot') && volume.mount !== '/';
+      if (eligible) {
         searchDirs.add(volume.mount);
       }
     });

--- a/test-infra/config/shared.js
+++ b/test-infra/config/shared.js
@@ -30,8 +30,12 @@ module.exports = {
   },
   confirmation: {
     pollIntervalMs: 5000,
-    daemonStaleMs: 10000,
-    daemonExpiredMs: 20000,
+    // The stale/expired verdicts remove every local app, so the fleet default
+    // must ride out multi-second process stalls under parallel-gate load
+    // (production is minutes-scale). Suites that exercise the stale/expiry
+    // removal flows override these per-env to fast values.
+    daemonStaleMs: 300000,
+    daemonExpiredMs: 600000,
   },
   github: {
     rawBaseUrl: 'http://198.18.0.6:3000',

--- a/test-infra/runner/framework/app-helper.js
+++ b/test-infra/runner/framework/app-helper.js
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { authenticate, signBtcMessage } from '../auth.js';
 import { appOwnerKey } from './keys.js';
 import { buildEnterpriseBlob } from './enterprise-helper.js';
+import { REGISTRY_REPO_HOST } from './subnet-config.js';
 import * as daemon from './daemon-control.js';
 import { waitFor } from './wait.js';
 
@@ -18,7 +19,12 @@ const defaultSpec = {
     {
       name: 'e2eTestApp',
       description: 'nginx test container',
-      repotag: 'nginx:alpine',
+      // the harness registry, NEVER a bare Docker Hub reference: registration
+      // verifies the repotag against the registry it names, and a hub repotag
+      // makes the suite depend on live internet + hub rate limits (429s broke
+      // suites 07/08/09 in the 2026-07-02 gate). Suites using this default
+      // must push it once per env: pushImage('nginx', 'alpine').
+      repotag: `${REGISTRY_REPO_HOST}/nginx:alpine`,
       ports: [31111],
       domains: [''],
       environmentParameters: [],

--- a/test-infra/runner/framework/app-helper.js
+++ b/test-infra/runner/framework/app-helper.js
@@ -46,9 +46,23 @@ const defaultSpec = {
   enterprise: '',
 };
 
-export function buildAppSpec({ enterprise = false, ...overrides } = {}) {
+// Every repotag must name the harness registry: anything else is verified or
+// pulled over live internet, silently coupling the suite to Docker Hub uptime
+// and rate limits (429s failed suites 07/08/09 in the 2026-07-02 gate). A test
+// that deliberately needs an external/unreachable repotag opts out explicitly.
+export function assertHermeticRepotags(spec, allowExternalRepotag) {
+  if (allowExternalRepotag) return;
+  for (const comp of spec.compose || []) {
+    if (comp.repotag && !comp.repotag.startsWith(`${REGISTRY_REPO_HOST}/`)) {
+      throw new Error(`spec repotag leaves the harness: ${comp.repotag} - push to the env registry (${REGISTRY_REPO_HOST}/...) or pass allowExternalRepotag: true for an external-by-design test`);
+    }
+  }
+}
+
+export function buildAppSpec({ enterprise = false, allowExternalRepotag = false, ...overrides } = {}) {
   const ownerKey = appOwnerKey();
   const spec = { ...defaultSpec, owner: ownerKey.zelid, ...overrides };
+  assertHermeticRepotags(spec, allowExternalRepotag);
 
   if (overrides.compose) {
     spec.compose = overrides.compose;

--- a/test-infra/runner/framework/app-helper.js
+++ b/test-infra/runner/framework/app-helper.js
@@ -18,13 +18,13 @@ const defaultSpec = {
   compose: [
     {
       name: 'e2eTestApp',
-      description: 'nginx test container',
+      description: 'default pause test container',
       // the harness registry, NEVER a bare Docker Hub reference: registration
       // verifies the repotag against the registry it names, and a hub repotag
       // makes the suite depend on live internet + hub rate limits (429s broke
-      // suites 07/08/09 in the 2026-07-02 gate). Suites using this default
-      // must push it once per env: pushImage('nginx', 'alpine').
-      repotag: `${REGISTRY_REPO_HOST}/nginx:alpine`,
+      // suites 07/08/09 in the 2026-07-02 gate). The env registry is seeded
+      // with this image at bootstrap (test-env.js).
+      repotag: `${REGISTRY_REPO_HOST}/e2e-pause:v1`,
       ports: [31111],
       domains: [''],
       environmentParameters: [],

--- a/test-infra/runner/framework/reconciler-suite.js
+++ b/test-infra/runner/framework/reconciler-suite.js
@@ -13,6 +13,7 @@ import { authenticate } from '../auth.js';
 import { fluxTeamKey } from './keys.js';
 import {
   waitForDaemonReady, waitForNodeStatus, waitForBlockProcessed, waitForAppInstalled, waitFor,
+  waitForReconcileActuated,
 } from './wait.js';
 import { REGISTRY_REPO_HOST, getSubnetConfig } from './subnet-config.js';
 import { setSynced } from './syncthing-control.js';
@@ -20,12 +21,13 @@ import { execInContainer } from './container.js';
 
 // A folder the suite pins "synced" (setSynced reports a non-zero global index)
 // must also HOLD data on disk, like any really-synced folder. Seeded apps write
-// nothing themselves, and an index that claims bytes over an empty disk is
-// exactly the phantom-index state the mount-safety guard demotes - the guard
-// and the pinned-synced re-promotion then fight forever (demote <-> promote),
-// which bit suite 61's leak test on its first runs. Call AFTER the app has
-// first reached running: the sync layer's first-run reset clears local appdata
-// at install and would delete anything written earlier.
+// nothing themselves, and an index that claims bytes over an empty disk is the
+// phantom-index state the mount-safety guard refuses to promote (and demotes) -
+// the stub never rescans, so the disagreement never converges and the app never
+// (re)starts. Call AFTER the sync layer's first-run reset (the dataCleared
+// actuation): the reset clears local appdata at install and deletes anything
+// written earlier. seedSyncthingApp runs this ordering itself; only suites
+// installing through another path need to call it directly.
 export async function seedSyncScopedData(env, name, index) {
   const dataFile = `/mnt/appdata/flux-apps/flux${name}_${name}/appdata/seed-data`;
   const r = await execInContainer(env.clients[index].container, `sh -c 'echo seeded > ${dataFile}'`);
@@ -199,11 +201,18 @@ export async function waitForInstanceCount(env, appName, target, {
 // peer list to itself and makes the subject win a spurious single-peer election and
 // cold-start. Pinning the peer synced keeps it the stable running source the subject
 // must defer to.
+//
+// Every install here waits out the sync layer's first-run reset (dataCleared) and
+// then writes sync-scoped disk data, so a folder any test later pins synced already
+// holds the data its index claims (see seedSyncScopedData). Whether/when to pin the
+// SUBJECT synced stays the caller's choice.
 export async function seedSyncthingApp(env, {
   name, mode = 'r', forceNonLeader = false, index = 0,
 }) {
   await pushImage(name, 'v1');
   const app = await buildSeedableSyncthingApp({ name, mode });
+  const folder = `flux${name}_${name}`;
+  const identifier = `${name}_${name}`;
 
   const peerIndex = forceNonLeader ? (index === 0 ? env.clients.length - 1 : 0) : null;
   if (forceNonLeader) {
@@ -212,16 +221,22 @@ export async function seedSyncthingApp(env, {
     // broadcast (surfaced as network:apprunning) before installing it, so its first
     // leader-election sees a running peer and takes the sync-gated follower path.
     const afterId = env.clients[index].getLastEventId();
+    const peerInstallAfter = env.clients[peerIndex].getLastEventId();
     await installOnNodes(env, app, [peerIndex]);
-    await setSynced({ ip: getSubnetConfig().nodeIp(peerIndex + 1), folder: `flux${name}_${name}` });
+    await waitForReconcileActuated(env.clients[peerIndex], identifier, 'dataCleared', 60000, { afterId: peerInstallAfter });
+    await seedSyncScopedData(env, name, peerIndex);
+    await setSynced({ ip: getSubnetConfig().nodeIp(peerIndex + 1), folder });
     await env.clients[index].waitForEvent(
       'network:apprunning', (d) => d.apps?.some((a) => a.name === name), 60000, { afterId },
     );
   }
 
+  const installAfter = env.clients[index].getLastEventId();
   await installOnNodes(env, app, [index]);
+  await waitForReconcileActuated(env.clients[index], identifier, 'dataCleared', 60000, { afterId: installAfter });
+  await seedSyncScopedData(env, name, index);
   return {
-    app, index, peerIndex, folder: `flux${name}_${name}`, identifier: `${name}_${name}`,
+    app, index, peerIndex, folder, identifier,
   };
 }
 

--- a/test-infra/runner/framework/reconciler-suite.js
+++ b/test-infra/runner/framework/reconciler-suite.js
@@ -16,6 +16,21 @@ import {
 } from './wait.js';
 import { REGISTRY_REPO_HOST, getSubnetConfig } from './subnet-config.js';
 import { setSynced } from './syncthing-control.js';
+import { execInContainer } from './container.js';
+
+// A folder the suite pins "synced" (setSynced reports a non-zero global index)
+// must also HOLD data on disk, like any really-synced folder. Seeded apps write
+// nothing themselves, and an index that claims bytes over an empty disk is
+// exactly the phantom-index state the mount-safety guard demotes - a seeded
+// r: leader left idle for a few monitor cycles would be demoted and held
+// mid-suite (bit suite 61's leak test on its first run).
+async function seedSyncScopedData(env, name, index) {
+  const dataFile = `/mnt/appdata/flux-apps/flux${name}_${name}/appdata/seed-data`;
+  const r = await execInContainer(env.clients[index].container, `sh -c 'echo seeded > ${dataFile}'`);
+  if (r.exitCode !== 0) {
+    throw new Error(`seedSyncScopedData: could not write ${dataFile} on node ${index}: ${r.output}`);
+  }
+}
 
 // Seed a pre-built app's global spec into the given nodes' DBs (so a local install
 // can resolve it).
@@ -196,6 +211,7 @@ export async function seedSyncthingApp(env, {
     // leader-election sees a running peer and takes the sync-gated follower path.
     const afterId = env.clients[index].getLastEventId();
     await installOnNodes(env, app, [peerIndex]);
+    await seedSyncScopedData(env, name, peerIndex);
     await setSynced({ ip: getSubnetConfig().nodeIp(peerIndex + 1), folder: `flux${name}_${name}` });
     await env.clients[index].waitForEvent(
       'network:apprunning', (d) => d.apps?.some((a) => a.name === name), 60000, { afterId },
@@ -203,6 +219,7 @@ export async function seedSyncthingApp(env, {
   }
 
   await installOnNodes(env, app, [index]);
+  await seedSyncScopedData(env, name, index);
   return {
     app, index, peerIndex, folder: `flux${name}_${name}`, identifier: `${name}_${name}`,
   };

--- a/test-infra/runner/framework/reconciler-suite.js
+++ b/test-infra/runner/framework/reconciler-suite.js
@@ -21,10 +21,12 @@ import { execInContainer } from './container.js';
 // A folder the suite pins "synced" (setSynced reports a non-zero global index)
 // must also HOLD data on disk, like any really-synced folder. Seeded apps write
 // nothing themselves, and an index that claims bytes over an empty disk is
-// exactly the phantom-index state the mount-safety guard demotes - a seeded
-// r: leader left idle for a few monitor cycles would be demoted and held
-// mid-suite (bit suite 61's leak test on its first run).
-async function seedSyncScopedData(env, name, index) {
+// exactly the phantom-index state the mount-safety guard demotes - the guard
+// and the pinned-synced re-promotion then fight forever (demote <-> promote),
+// which bit suite 61's leak test on its first runs. Call AFTER the app has
+// first reached running: the sync layer's first-run reset clears local appdata
+// at install and would delete anything written earlier.
+export async function seedSyncScopedData(env, name, index) {
   const dataFile = `/mnt/appdata/flux-apps/flux${name}_${name}/appdata/seed-data`;
   const r = await execInContainer(env.clients[index].container, `sh -c 'echo seeded > ${dataFile}'`);
   if (r.exitCode !== 0) {
@@ -214,7 +216,6 @@ export async function seedSyncthingApp(env, {
     // leader-election sees a running peer and takes the sync-gated follower path.
     const afterId = env.clients[index].getLastEventId();
     await installOnNodes(env, app, [peerIndex]);
-    await seedSyncScopedData(env, name, peerIndex);
     await setSynced({ ip: getSubnetConfig().nodeIp(peerIndex + 1), folder: `flux${name}_${name}` });
     await env.clients[index].waitForEvent(
       'network:apprunning', (d) => d.apps?.some((a) => a.name === name), 60000, { afterId },
@@ -222,7 +223,6 @@ export async function seedSyncthingApp(env, {
   }
 
   await installOnNodes(env, app, [index]);
-  await seedSyncScopedData(env, name, index);
   return {
     app, index, peerIndex, folder: `flux${name}_${name}`, identifier: `${name}_${name}`,
   };

--- a/test-infra/runner/framework/reconciler-suite.js
+++ b/test-infra/runner/framework/reconciler-suite.js
@@ -198,10 +198,13 @@ export async function waitForInstanceCount(env, appName, target, {
 // cold-start. Pinning the peer synced keeps it the stable running source the subject
 // must defer to.
 export async function seedSyncthingApp(env, {
-  name, mode = 'r', forceNonLeader = false, index = 0,
+  name, mode = 'r', forceNonLeader = false, index = 0, spawnable = true,
 }) {
   await pushImage(name, 'v1');
-  const app = await buildSeedableSyncthingApp({ name, mode });
+  // spawnable: false seeds a near-expiry spec the spawner permanently ignores
+  // (see buildSeedableApp) - for suites that hold/kill their only instance and
+  // must not have the network respawn it mid-assertion.
+  const app = await buildSeedableSyncthingApp({ name, mode, ...(spawnable ? {} : { expire: 50 }) });
 
   const peerIndex = forceNonLeader ? (index === 0 ? env.clients.length - 1 : 0) : null;
   if (forceNonLeader) {

--- a/test-infra/runner/framework/reconciler-suite.js
+++ b/test-infra/runner/framework/reconciler-suite.js
@@ -200,13 +200,10 @@ export async function waitForInstanceCount(env, appName, target, {
 // cold-start. Pinning the peer synced keeps it the stable running source the subject
 // must defer to.
 export async function seedSyncthingApp(env, {
-  name, mode = 'r', forceNonLeader = false, index = 0, spawnable = true,
+  name, mode = 'r', forceNonLeader = false, index = 0,
 }) {
   await pushImage(name, 'v1');
-  // spawnable: false seeds a near-expiry spec the spawner permanently ignores
-  // (see buildSeedableApp) - for suites that hold/kill their only instance and
-  // must not have the network respawn it mid-assertion.
-  const app = await buildSeedableSyncthingApp({ name, mode, ...(spawnable ? {} : { expire: 50 }) });
+  const app = await buildSeedableSyncthingApp({ name, mode });
 
   const peerIndex = forceNonLeader ? (index === 0 ? env.clients.length - 1 : 0) : null;
   if (forceNonLeader) {

--- a/test-infra/runner/framework/seed-helper.js
+++ b/test-infra/runner/framework/seed-helper.js
@@ -3,6 +3,7 @@ import { buildEnterpriseBlob } from './enterprise-helper.js';
 import { signBtcMessage } from '../auth.js';
 import { appOwnerKey } from './keys.js';
 import { REGISTRY_REPO_HOST } from './subnet-config.js';
+import { assertHermeticRepotags } from './app-helper.js';
 
 function sha256(data) {
   return createHash('sha256').update(data).digest('hex');
@@ -21,6 +22,7 @@ export async function buildSeedableApp({
   staticip = false,
   enterprise = '',
   expire = 22000,
+  allowExternalRepotag = false,
 }) {
   const ownerKey = appOwnerKey();
   const appOwner = owner ?? ownerKey.zelid;
@@ -33,7 +35,10 @@ export async function buildSeedableApp({
     compose: compose ?? [{
       name,
       description: 'seeded component',
-      repotag: 'nginx:alpine',
+      // harness registry, never bare Docker Hub: hub repotags make installs
+      // pull over live internet (rate-limit flakes); the env registry is
+      // seeded with this image at bootstrap (test-env.js)
+      repotag: `${REGISTRY_REPO_HOST}/nginx:alpine`,
       ports: [31111],
       domains: [''],
       environmentParameters: [],
@@ -86,6 +91,7 @@ export async function buildSeedableApp({
     createdAt: new Date(),
   };
 
+  assertHermeticRepotags(spec, allowExternalRepotag);
   const specWithMeta = { ...spec, hash, height };
 
   return { spec: specWithMeta, permanentMessage, hashEntry, hash, txid };
@@ -374,7 +380,7 @@ export async function buildSeedableEnterpriseApp({ name, compose, contacts = [],
   const components = compose ?? [{
     name,
     description: 'seeded enterprise component',
-    repotag: 'nginx:alpine',
+    repotag: `${REGISTRY_REPO_HOST}/nginx:alpine`,
     ports: [31131],
     domains: [''],
     environmentParameters: [],

--- a/test-infra/runner/framework/seed-helper.js
+++ b/test-infra/runner/framework/seed-helper.js
@@ -20,6 +20,11 @@ export async function buildSeedableApp({
   owner = null,
   staticip = false,
   enterprise = '',
+  // Targeted suites that deliberately hold/kill their only instance seed a
+  // near-expiry spec (expire < newMinBlocksAllowance = 100): the spawner's
+  // pipeline permanently ignores it, so the network cannot "heal" the app
+  // back mid-assertion. With the block ticker off it never actually expires.
+  expire = 22000,
 }) {
   const ownerKey = appOwnerKey();
   const appOwner = owner ?? ownerKey.zelid;
@@ -47,7 +52,7 @@ export async function buildSeedableApp({
     instances,
     contacts: [],
     geolocation: [],
-    expire: 22000,
+    expire,
     nodes: [],
     staticip,
     enterprise,

--- a/test-infra/runner/framework/seed-helper.js
+++ b/test-infra/runner/framework/seed-helper.js
@@ -38,7 +38,7 @@ export async function buildSeedableApp({
       // harness registry, never bare Docker Hub: hub repotags make installs
       // pull over live internet (rate-limit flakes); the env registry is
       // seeded with this image at bootstrap (test-env.js)
-      repotag: `${REGISTRY_REPO_HOST}/nginx:alpine`,
+      repotag: `${REGISTRY_REPO_HOST}/e2e-pause:v1`,
       ports: [31111],
       domains: [''],
       environmentParameters: [],
@@ -380,7 +380,7 @@ export async function buildSeedableEnterpriseApp({ name, compose, contacts = [],
   const components = compose ?? [{
     name,
     description: 'seeded enterprise component',
-    repotag: `${REGISTRY_REPO_HOST}/nginx:alpine`,
+    repotag: `${REGISTRY_REPO_HOST}/e2e-pause:v1`,
     ports: [31131],
     domains: [''],
     environmentParameters: [],

--- a/test-infra/runner/framework/seed-helper.js
+++ b/test-infra/runner/framework/seed-helper.js
@@ -20,10 +20,6 @@ export async function buildSeedableApp({
   owner = null,
   staticip = false,
   enterprise = '',
-  // Targeted suites that deliberately hold/kill their only instance seed a
-  // near-expiry spec (expire < newMinBlocksAllowance = 100): the spawner's
-  // pipeline permanently ignores it, so the network cannot "heal" the app
-  // back mid-assertion. With the block ticker off it never actually expires.
   expire = 22000,
 }) {
   const ownerKey = appOwnerKey();

--- a/test-infra/runner/framework/test-env.js
+++ b/test-infra/runner/framework/test-env.js
@@ -11,6 +11,7 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import http from 'node:http';
 import { nodeClient } from './node-client.js';
+import { execInContainer } from './container.js';
 import { HttpPollWaitStrategy } from './http-wait-strategy.js';
 import { TcpPollWaitStrategy } from './tcp-wait-strategy.js';
 import { getSubnetConfig, REGISTRY_ALIAS, REGISTRY_REPO_HOST } from './subnet-config.js';
@@ -243,6 +244,19 @@ function makeEnvShell(networkName) {
       for (const client of clients) {
         if (client) client.disconnectEventStream();
       }
+      // FluxOS sets app mountpoints immutable (chattr +i) so an unmounted app
+      // dir rejects writes. The flag lives on the BARE dir under the loop mount
+      // and survives into the node's named volume - Docker then cannot delete
+      // the volume (EPERM) and every run leaks its node volumes. Unmount to
+      // expose the bare dirs and strip the flag while the node is still
+      // running; containers going down makes this the last chance to exec.
+      await Promise.all(clients.map(async (client) => {
+        if (!client?.container) return;
+        await execInContainer(
+          client.container,
+          'for d in /mnt/appdata/flux-apps/*/; do umount -l "$d" 2>/dev/null; done; chattr -R -i /mnt/appdata 2>/dev/null; true',
+        ).catch((e) => warn('immutable-flag sweep', e));
+      }));
       for (const c of [...started].reverse()) {
         await c.stop().catch((e) => warn('container stop', e));
       }

--- a/test-infra/runner/framework/test-env.js
+++ b/test-infra/runner/framework/test-env.js
@@ -263,7 +263,28 @@ function makeEnvShell(networkName) {
       await closeDb();
       const cleanupClient = await getContainerRuntimeClient();
       for (const volName of volumeNames) {
-        await cleanupClient.container.dockerode.getVolume(volName).remove().catch((e) => warn(`volume ${volName}`, e));
+        const volume = cleanupClient.container.dockerode.getVolume(volName);
+        try {
+          await volume.remove();
+        } catch (firstErr) {
+          // The in-container sweep above misses nodes that crashed or never got
+          // a client (boot failure), and their immutable app dirs EPERM the
+          // volume delete. Strip the flags from the volume side with a
+          // throwaway container and retry, so even a wedged fleet cleans up.
+          try {
+            const helper = await cleanupClient.container.dockerode.createContainer({
+              Image: 'flux-e2e-fluxos-01',
+              Entrypoint: ['bash', '-c', 'chattr -R -i /v 2>/dev/null; true'],
+              HostConfig: { Binds: [`${volName}:/v`], CapAdd: ['LINUX_IMMUTABLE'] },
+            });
+            await helper.start();
+            await helper.wait();
+            await helper.remove({ force: true }).catch(() => {});
+            await volume.remove();
+          } catch (retryErr) {
+            warn(`volume ${volName}`, firstErr);
+          }
+        }
       }
       await removeNetwork(networkName);
       for (const cfg of nodeConfigs) {

--- a/test-infra/runner/framework/test-env.js
+++ b/test-infra/runner/framework/test-env.js
@@ -254,7 +254,7 @@ function makeEnvShell(networkName) {
         if (!client?.container) return;
         await execInContainer(
           client.container,
-          'for d in /mnt/appdata/flux-apps/*/; do umount -l "$d" 2>/dev/null; done; chattr -R -i /mnt/appdata 2>/dev/null; true',
+          'for d in /mnt/appdata/flux-apps/*/; do umount -l "$d" 2>/dev/null; done; chattr -R -i /mnt/appdata/flux-apps 2>/dev/null; true',
         ).catch((e) => warn('immutable-flag sweep', e));
       }));
       for (const c of [...started].reverse()) {
@@ -274,7 +274,7 @@ function makeEnvShell(networkName) {
           try {
             const helper = await cleanupClient.container.dockerode.createContainer({
               Image: 'flux-e2e-fluxos-01',
-              Entrypoint: ['bash', '-c', 'chattr -R -i /v 2>/dev/null; true'],
+              Entrypoint: ['bash', '-c', 'chattr -R -i /v/flux-apps 2>/dev/null; true'],
               HostConfig: { Binds: [`${volName}:/v`], CapAdd: ['LINUX_IMMUTABLE'] },
             });
             await helper.start();

--- a/test-infra/runner/framework/test-env.js
+++ b/test-infra/runner/framework/test-env.js
@@ -619,7 +619,7 @@ async function _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, conf
   // defaults BY CONSTRUCTION - no per-suite push incantation. The image is
   // synthesized in memory (static pause binary + marker; see registry-helper),
   // so this costs milliseconds and never contacts Docker Hub.
-  await pushImage('nginx', 'alpine');
+  await pushImage('e2e-pause', 'v1');
 
   const rtClient = await getContainerRuntimeClient();
   const { getReaper: getReaperFn } = await import('testcontainers');

--- a/test-infra/runner/framework/test-env.js
+++ b/test-infra/runner/framework/test-env.js
@@ -17,6 +17,7 @@ import { TcpPollWaitStrategy } from './tcp-wait-strategy.js';
 import { getSubnetConfig, REGISTRY_ALIAS, REGISTRY_REPO_HOST } from './subnet-config.js';
 import { closeDb } from './db-client.js';
 import { stubPeerClient } from './stub-peer-helper.js';
+import { pushImage } from './registry-helper.js';
 import { MongoClient } from 'mongodb';
 import { authenticate } from '../auth.js';
 import { fluxTeamKey, nodeKey } from './keys.js';
@@ -612,6 +613,13 @@ async function _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, conf
     .start();
   started.push(registry);
   containers.registry = registry;
+
+  // Seed the default spec image so every env's registry can satisfy
+  // registration verification and installs for buildAppSpec/buildSeedableApp
+  // defaults BY CONSTRUCTION - no per-suite push incantation. The image is
+  // synthesized in memory (static pause binary + marker; see registry-helper),
+  // so this costs milliseconds and never contacts Docker Hub.
+  await pushImage('nginx', 'alpine');
 
   const rtClient = await getContainerRuntimeClient();
   const { getReaper: getReaperFn } = await import('testcontainers');

--- a/test-infra/runner/tests/07-hash-sync.js
+++ b/test-infra/runner/tests/07-hash-sync.js
@@ -7,7 +7,6 @@ import { waitForDaemonReady, waitForBlockProcessed, waitFor, waitForNodeStatus }
 import { advanceBlock, startTicker } from '../framework/daemon-control.js';
 import { dbClient } from '../framework/db-client.js';
 import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
-import { pushImage } from '../framework/registry-helper.js';
 
 async function bootAndPeer(env) {
   for (const client of env.clients) {
@@ -51,9 +50,6 @@ describe('Hash sync: late-joining node', function () {
   before(async function () {
     this.timeout(300000);
     env = await createTestEnv({ hookCtx: this, nodes: 10, deferredNodes: 1, tickerAutostart: false });
-    // the default spec's repotag points at the harness registry; the image
-    // must exist there for registration verification to pass
-    await pushImage('nginx', 'alpine');
     await bootAndPeer(env);
 
     ({ appHash } = await registerApp(env));
@@ -103,7 +99,6 @@ describe('Hash sync: network partition', function () {
   before(async function () {
     this.timeout(300000);
     env = await createTestEnv({ hookCtx: this, nodes: 10, tickerAutostart: false });
-    await pushImage('nginx', 'alpine');
     await bootAndPeer(env);
 
     await env.disconnectNode(env.lastNodeIndex);
@@ -153,7 +148,6 @@ describe('Hash sync: stale state recovery', function () {
   before(async function () {
     this.timeout(300000);
     env = await createTestEnv({ hookCtx: this, nodes: 10, tickerAutostart: false });
-    await pushImage('nginx', 'alpine');
     await bootAndPeer(env);
     ({ appHash } = await registerApp(env));
 

--- a/test-infra/runner/tests/07-hash-sync.js
+++ b/test-infra/runner/tests/07-hash-sync.js
@@ -7,6 +7,7 @@ import { waitForDaemonReady, waitForBlockProcessed, waitFor, waitForNodeStatus }
 import { advanceBlock, startTicker } from '../framework/daemon-control.js';
 import { dbClient } from '../framework/db-client.js';
 import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
+import { pushImage } from '../framework/registry-helper.js';
 
 async function bootAndPeer(env) {
   for (const client of env.clients) {
@@ -50,6 +51,9 @@ describe('Hash sync: late-joining node', function () {
   before(async function () {
     this.timeout(300000);
     env = await createTestEnv({ hookCtx: this, nodes: 10, deferredNodes: 1, tickerAutostart: false });
+    // the default spec's repotag points at the harness registry; the image
+    // must exist there for registration verification to pass
+    await pushImage('nginx', 'alpine');
     await bootAndPeer(env);
 
     ({ appHash } = await registerApp(env));
@@ -99,6 +103,7 @@ describe('Hash sync: network partition', function () {
   before(async function () {
     this.timeout(300000);
     env = await createTestEnv({ hookCtx: this, nodes: 10, tickerAutostart: false });
+    await pushImage('nginx', 'alpine');
     await bootAndPeer(env);
 
     await env.disconnectNode(env.lastNodeIndex);
@@ -148,6 +153,7 @@ describe('Hash sync: stale state recovery', function () {
   before(async function () {
     this.timeout(300000);
     env = await createTestEnv({ hookCtx: this, nodes: 10, tickerAutostart: false });
+    await pushImage('nginx', 'alpine');
     await bootAndPeer(env);
     ({ appHash } = await registerApp(env));
 

--- a/test-infra/runner/tests/08-app-registration.js
+++ b/test-infra/runner/tests/08-app-registration.js
@@ -8,17 +8,14 @@ import { startTicker, advanceBlock } from '../framework/daemon-control.js';
 import { waitForDaemonReady, waitFor, waitForBlockProcessed, waitForNodeStatus } from '../framework/wait.js';
 import { dbClient } from '../framework/db-client.js';
 import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
-import { pushImage } from '../framework/registry-helper.js';
 
 let env;
 
 describe('App registration', function () {
+  dumpLogsOnFailure(() => env);
   before(async function () {
     this.timeout(300000);
     env = await createTestEnv({ hookCtx: this, nodes: 10, tickerAutostart: false });
-    // the default spec's repotag points at the harness registry; the image
-    // must exist there for registration verification to pass
-    await pushImage('nginx', 'alpine');
     await Promise.all(env.clients.map((c) => waitForDaemonReady(c)));
     await Promise.all(env.clients.map((c) => waitForNodeStatus(c, (d) => d.confirmed === true, 30000)));
     await advanceBlock();

--- a/test-infra/runner/tests/08-app-registration.js
+++ b/test-infra/runner/tests/08-app-registration.js
@@ -8,6 +8,7 @@ import { startTicker, advanceBlock } from '../framework/daemon-control.js';
 import { waitForDaemonReady, waitFor, waitForBlockProcessed, waitForNodeStatus } from '../framework/wait.js';
 import { dbClient } from '../framework/db-client.js';
 import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
+import { pushImage } from '../framework/registry-helper.js';
 
 let env;
 
@@ -15,6 +16,9 @@ describe('App registration', function () {
   before(async function () {
     this.timeout(300000);
     env = await createTestEnv({ hookCtx: this, nodes: 10, tickerAutostart: false });
+    // the default spec's repotag points at the harness registry; the image
+    // must exist there for registration verification to pass
+    await pushImage('nginx', 'alpine');
     await Promise.all(env.clients.map((c) => waitForDaemonReady(c)));
     await Promise.all(env.clients.map((c) => waitForNodeStatus(c, (d) => d.confirmed === true, 30000)));
     await advanceBlock();

--- a/test-infra/runner/tests/09-app-spawning.js
+++ b/test-infra/runner/tests/09-app-spawning.js
@@ -6,6 +6,7 @@ import { buildAppSpec, registerAndConfirm } from '../framework/app-helper.js';
 import { startTicker, advanceBlock } from '../framework/daemon-control.js';
 import { waitForDaemonReady, waitForBlockProcessed, waitFor, waitForAppInstalled, waitForAppSpecStored, waitForNodeStatus } from '../framework/wait.js';
 import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
+import { pushImage } from '../framework/registry-helper.js';
 
 let env;
 
@@ -16,6 +17,9 @@ describe('App spawning', function () {
   before(async function () {
     this.timeout(300000);
     env = await createTestEnv({ hookCtx: this, nodes: 10, tickerAutostart: false });
+    // the default spec's repotag points at the harness registry; the image
+    // must exist there for registration verification to pass
+    await pushImage('nginx', 'alpine');
     for (const client of env.clients) await waitForDaemonReady(client);
     await Promise.all(env.clients.map((c) => waitForNodeStatus(c, (d) => d.confirmed === true, 30000)));
     await advanceBlock();

--- a/test-infra/runner/tests/09-app-spawning.js
+++ b/test-infra/runner/tests/09-app-spawning.js
@@ -6,7 +6,6 @@ import { buildAppSpec, registerAndConfirm } from '../framework/app-helper.js';
 import { startTicker, advanceBlock } from '../framework/daemon-control.js';
 import { waitForDaemonReady, waitForBlockProcessed, waitFor, waitForAppInstalled, waitForAppSpecStored, waitForNodeStatus } from '../framework/wait.js';
 import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
-import { pushImage } from '../framework/registry-helper.js';
 
 let env;
 
@@ -17,9 +16,6 @@ describe('App spawning', function () {
   before(async function () {
     this.timeout(300000);
     env = await createTestEnv({ hookCtx: this, nodes: 10, tickerAutostart: false });
-    // the default spec's repotag points at the harness registry; the image
-    // must exist there for registration verification to pass
-    await pushImage('nginx', 'alpine');
     for (const client of env.clients) await waitForDaemonReady(client);
     await Promise.all(env.clients.map((c) => waitForNodeStatus(c, (d) => d.confirmed === true, 30000)));
     await advanceBlock();

--- a/test-infra/runner/tests/17-confirmation-service.js
+++ b/test-infra/runner/tests/17-confirmation-service.js
@@ -2,13 +2,11 @@ import { describe, it, before, after, afterEach } from 'mocha';
 import { expect } from 'chai';
 import { createTestEnv } from '../framework/test-env.js';
 import {
-  waitForDaemonReady, waitForNodeStatus, waitForMessageCapabilityChanged,
-  waitForDaemonUnreachable, waitForDaemonRecovered, waitFor,
+  waitForDaemonReady, waitForNodeStatus, waitForMessageCapabilityChanged, waitFor,
 } from '../framework/wait.js';
 import {
-  advanceBlock, setNodeStatus, clearAllNodeStatus, clearNodeStatus,
-  enableRpcFailure, disableRpcFailure, disableAllRpcFailure,
-  removeFromNodeList, restoreToNodeList, resetNodeList,
+  advanceBlock, enableRpcFailure, disableAllRpcFailure,
+  removeFromNodeList, resetNodeList,
 } from '../framework/daemon-control.js';
 import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
 
@@ -68,7 +66,14 @@ describe('Confirmation service: RPC failure windows', function () {
 
   before(async function () {
     this.timeout(120000);
-    env = await createTestEnv({ hookCtx: this, nodes: 1, tickerAutostart: false });
+    // fast stale/expiry windows: this describe exercises those flows directly
+    // (the fleet default is stall-proof and would take minutes here)
+    env = await createTestEnv({
+      hookCtx: this,
+      nodes: 1,
+      tickerAutostart: false,
+      configOverrides: { confirmation: { daemonStaleMs: 10000, daemonExpiredMs: 20000 } },
+    });
     await waitForDaemonReady(env.clients[0]);
     await waitForNodeStatus(env.clients[0], (d) => d.confirmed === true, 30000);
   });

--- a/test-infra/runner/tests/24-node-status-removal.js
+++ b/test-infra/runner/tests/24-node-status-removal.js
@@ -1,5 +1,4 @@
 import { describe, it, before, after } from 'mocha';
-import { expect } from 'chai';
 import { createTestEnv } from '../framework/test-env.js';
 import { pushImage } from '../framework/registry-helper.js';
 import { dbClient } from '../framework/db-client.js';
@@ -110,7 +109,14 @@ describe('Daemon stale removes installed apps', function () {
 
   before(async function () {
     this.timeout(300000);
-    env = await createTestEnv({ hookCtx: this, nodes: 10, tickerAutostart: false });
+    // fast stale window: this suite exercises the stale-removal flow directly
+    // (the fleet default is stall-proof and would take minutes here)
+    env = await createTestEnv({
+      hookCtx: this,
+      nodes: 10,
+      tickerAutostart: false,
+      configOverrides: { confirmation: { daemonStaleMs: 10000, daemonExpiredMs: 20000 } },
+    });
     await bootAndPeer(env);
     installedOnIndex = await seedAndWaitForInstall(env, appName);
   });

--- a/test-infra/runner/tests/35-reconciler-masterslave-election.js
+++ b/test-infra/runner/tests/35-reconciler-masterslave-election.js
@@ -12,7 +12,7 @@ import { getSubnetConfig } from '../framework/subnet-config.js';
 import {
   waitFor, waitForReconcileActuated, waitForReconcilerDesiredChanged, assertNoEvent,
 } from '../framework/wait.js';
-import { bootAndPeer, installOnNodes } from '../framework/reconciler-suite.js';
+import { bootAndPeer, installOnNodes, seedSyncScopedData } from '../framework/reconciler-suite.js';
 import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
 
 const subnet = getSubnetConfig();
@@ -52,13 +52,20 @@ describe('reconciler enforces masterSlave g: election', function () {
     await pushImage(appName, 'v1');
     const app = await buildSeedableSyncthingApp({ name: appName, mode: 'g' });
     // targeted install on two specific nodes — deterministic g: holders
+    const installAfters = [0, 1].map((i) => env.clients[i].getLastEventId());
     holders = await installOnNodes(env, app, [0, 1]);
     // This suite exercises the FDM election/failover of a READY g: app, so pin both
     // holders' folders to a genuinely synced state (they promote to sendreceive and
     // become election-eligible). An empty global is correctly no longer treated as
     // synced, so without real data neither holder would ever become ready — that
-    // sourceless cold-start path is covered separately by suite 51.
+    // sourceless cold-start path is covered separately by suite 51. A synced index
+    // also requires matching data on disk (the promote gate refuses a claimed-bytes
+    // index over an empty volume), written after each holder's first-run reset.
     const folder = `flux${appName}_${appName}`;
+    await Promise.all(holders.map(async (i, k) => {
+      await waitForReconcileActuated(env.clients[i], identifier, 'dataCleared', 60000, { afterId: installAfters[k] });
+      await seedSyncScopedData(env, appName, i);
+    }));
     await Promise.all(holders.map((i) => setSynced({ ip: subnet.nodeIp(i + 1), folder })));
   });
 
@@ -107,7 +114,6 @@ describe('reconciler enforces masterSlave g: election', function () {
     await waitForDown(b, appName, 'operator-stopped primary down');
 
     // keep b elected; the election must NOT override the operator stop
-    const afterId = b.getLastEventId();
     await electMaster(appName, b.ip);
     await assertNoEvent(b, 'reconciler:actuated', (d) => d.identifier === identifier && d.action === 'started', 15000);
     expect(await isUp(b, appName)).to.equal(false);

--- a/test-infra/runner/tests/60-volume-mount-ownership.js
+++ b/test-infra/runner/tests/60-volume-mount-ownership.js
@@ -65,6 +65,7 @@ async function installPlainApp(env, name, index, port) {
   await pushImage(name, 'v1');
   const app = await buildSeedableApp({
     name,
+    expire: 50, // spawner must never respawn a deliberately-held test app
     compose: [{
       name,
       description: 'test container',
@@ -104,7 +105,7 @@ describe('FluxOS-owned volume mounting (no crontab) + inert unmounted app dirs',
     await bootAndPeer(env);
     await resetSyncState();
 
-    await seedSyncthingApp(env, { name: syncName, mode: 'r', index: 0 });
+    await seedSyncthingApp(env, { name: syncName, mode: 'r', index: 0, spawnable: false });
     // pin the folder synced so the leader promotes and the app runs steadily
     await setSynced({ ip: subnet.nodeIp(1), folder: appId(syncName) });
     await installPlainApp(env, rebootName, 1, 31201);
@@ -114,6 +115,7 @@ describe('FluxOS-owned volume mounting (no crontab) + inert unmounted app dirs',
     await pushImage(entName, 'v1');
     const entApp = await buildSeedableEnterpriseApp({
       name: entName,
+      expire: 50, // spawner must never respawn a deliberately-held test app
       compose: [{
         name: entName,
         description: 'test container',

--- a/test-infra/runner/tests/60-volume-mount-ownership.js
+++ b/test-infra/runner/tests/60-volume-mount-ownership.js
@@ -65,7 +65,6 @@ async function installPlainApp(env, name, index, port) {
   await pushImage(name, 'v1');
   const app = await buildSeedableApp({
     name,
-    expire: 50, // spawner must never respawn a deliberately-held test app
     compose: [{
       name,
       description: 'test container',
@@ -109,7 +108,7 @@ describe('FluxOS-owned volume mounting (no crontab) + inert unmounted app dirs',
     // index claiming bytes over an empty disk is the phantom state the guard
     // demotes, and the demote/hold would latch the app down mid-suite
     const syncInstallAfter = env.clients[0].getLastEventId();
-    await seedSyncthingApp(env, { name: syncName, mode: 'r', index: 0, spawnable: false });
+    await seedSyncthingApp(env, { name: syncName, mode: 'r', index: 0 });
     await waitForReconcileActuated(env.clients[0], syncIdentifier, 'dataCleared', 60000, { afterId: syncInstallAfter });
     await seedSyncScopedData(env, syncName, 0);
     // pin the folder synced so the leader promotes and the app runs steadily
@@ -121,7 +120,6 @@ describe('FluxOS-owned volume mounting (no crontab) + inert unmounted app dirs',
     await pushImage(entName, 'v1');
     const entApp = await buildSeedableEnterpriseApp({
       name: entName,
-      expire: 50, // spawner must never respawn a deliberately-held test app
       compose: [{
         name: entName,
         description: 'test container',
@@ -285,6 +283,10 @@ describe('FluxOS-owned volume mounting (no crontab) + inert unmounted app dirs',
     expect(row, 'enterprise app row present in local DB').to.exist;
     expect(row.compose, 'compose stored empty for enterprise').to.deep.equal([]);
     expect(row.enterprise, 'enterprise blob stored').to.be.a('string').and.not.equal('');
+    // a local row stored without height is force-removed by the expiry sweep's
+    // missing-height check - the install path must preserve it through the
+    // enterprise decrypt+format
+    expect(row.height, 'local row must keep spec height').to.be.a('number').greaterThan(0);
 
     // the incident state: no remount entry exists anywhere
     await execInContainer(client.container, 'crontab -r 2>/dev/null || true');

--- a/test-infra/runner/tests/60-volume-mount-ownership.js
+++ b/test-infra/runner/tests/60-volume-mount-ownership.js
@@ -7,7 +7,7 @@ import { buildSeedableApp, buildSeedableEnterpriseApp } from '../framework/seed-
 import {
   waitFor, waitForReconcileActuated, waitForAppRemoved, assertNoEvent,
 } from '../framework/wait.js';
-import { bootAndPeer, seedSyncthingApp, installOnNodes } from '../framework/reconciler-suite.js';
+import { bootAndPeer, seedSyncthingApp, seedSyncScopedData, installOnNodes } from '../framework/reconciler-suite.js';
 import { setSynced, resetSyncState } from '../framework/syncthing-control.js';
 import { getSubnetConfig, REGISTRY_REPO_HOST } from '../framework/subnet-config.js';
 import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
@@ -133,6 +133,11 @@ describe('FluxOS-owned volume mounting (no crontab) + inert unmounted app dirs',
       }],
     });
     await installOnNodes(env, entApp, [4]);
+
+    // the pinned-synced r: app needs real disk content once it is up (post
+    // first-run reset), or the phantom guard fights the re-promotion all suite
+    await waitFor(() => isUp(env.clients[0], syncName), { timeout: 90000, interval: 2000, label: 'sync app running' });
+    await seedSyncScopedData(env, syncName, 0);
   });
 
   after(async function () {

--- a/test-infra/runner/tests/60-volume-mount-ownership.js
+++ b/test-infra/runner/tests/60-volume-mount-ownership.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { createTestEnv } from '../framework/test-env.js';
 import { execInContainer, getAppContainerStatus, restartFluxos } from '../framework/container.js';
 import { pushImage } from '../framework/registry-helper.js';
-import { buildSeedableApp } from '../framework/seed-helper.js';
+import { buildSeedableApp, buildSeedableEnterpriseApp } from '../framework/seed-helper.js';
 import {
   waitFor, waitForReconcileActuated, waitForAppRemoved, assertNoEvent,
 } from '../framework/wait.js';
@@ -27,6 +27,12 @@ import { fluxTeamKey } from '../framework/keys.js';
 //    recreated on the bare dir
 //  - uninstall deletes the backing image WITHOUT a crontab entry to parse
 //    (old code orphaned the image when the entry was missing)
+//  - a legacy @reboot entry whose volume CANNOT be mounted is KEPT - it is the
+//    remaining safety net; removing entries on the strength of a possibly
+//    blind inventory is how they kept vanishing in production
+//  - all of the above hold for ENTERPRISE apps, whose local row stores compose
+//    EMPTY (components only inside the encrypted blob) - the inventory that
+//    took that as "not installed" ate their remount entries on every start
 
 const subnet = getSubnetConfig();
 
@@ -88,6 +94,7 @@ describe('FluxOS-owned volume mounting (no crontab) + inert unmounted app dirs',
   const rebootName = `e2evolboot${ts}`; // plain app on node 1 (reboot remount regression)
   const inertName = `e2evolinert${ts}`; // plain app on node 2 (missing image stays inert)
   const rmName = `e2evolrm${ts}`; // plain app on node 3 (uninstall deletes image)
+  const entName = `e2evolent${ts}`; // ENTERPRISE app on node 4 (reboot remount for the encrypted-compose class)
   const syncIdentifier = `${syncName}_${syncName}`;
   const inertIdentifier = `${inertName}_${inertName}`;
 
@@ -103,6 +110,27 @@ describe('FluxOS-owned volume mounting (no crontab) + inert unmounted app dirs',
     await installPlainApp(env, rebootName, 1, 31201);
     await installPlainApp(env, inertName, 2, 31301);
     await installPlainApp(env, rmName, 3, 31401);
+
+    await pushImage(entName, 'v1');
+    const entApp = await buildSeedableEnterpriseApp({
+      name: entName,
+      compose: [{
+        name: entName,
+        description: 'test container',
+        repotag: `${REGISTRY_REPO_HOST}/${entName}:v1`,
+        ports: [31501],
+        domains: [''],
+        environmentParameters: [],
+        commands: [],
+        containerPorts: [80],
+        containerData: '/appdata',
+        cpu: 0.1,
+        ram: 100,
+        hdd: 1,
+        repoauth: '',
+      }],
+    });
+    await installOnNodes(env, entApp, [4]);
   });
 
   after(async function () {
@@ -195,6 +223,28 @@ describe('FluxOS-owned volume mounting (no crontab) + inert unmounted app dirs',
     expect(probe.stdout.trim()).to.equal('0');
   });
 
+  it('keeps a legacy @reboot entry across FluxOS restart while its volume cannot be mounted', async function () {
+    this.timeout(240000);
+    // continues on node 2: the previous test deleted the app's backing image,
+    // so its volume cannot mount. A legacy entry seeded now must SURVIVE the
+    // startup cleanup - it is only superseded once the FluxOS-owned mount
+    // demonstrably works, and here it demonstrably cannot.
+    const client = env.clients[2];
+    const c2 = client.container;
+    const entry = `@reboot while [ ! -f ${volFile(inertName)} ]; do sleep 5; done && sudo mount -o loop ${volFile(inertName)} ${appDir(inertName)} #${appId(inertName)}`;
+    await execInContainer(c2, `(crontab -l 2>/dev/null; echo '${entry}') | crontab -`);
+    expect(await crontabVolumeEntries(c2)).to.equal(1);
+
+    const afterId = client.getLastEventId();
+    await restartFluxos(c2);
+    // the reconciler reporting the unavailable volume proves startup (and the
+    // crontab cleanup pass that precedes reconciliation) has completed
+    await waitForReconcileActuated(client, inertIdentifier, 'volumeUnavailable', 120000, { afterId });
+
+    expect(await crontabVolumeEntries(c2)).to.equal(1);
+    expect(await isUp(client, inertName)).to.equal(false);
+  });
+
   it('uninstall deletes the discovered backing image with NO crontab entry to parse (orphan regression)', async function () {
     this.timeout(180000);
     const client = env.clients[3];
@@ -210,5 +260,33 @@ describe('FluxOS-owned volume mounting (no crontab) + inert unmounted app dirs',
 
     await waitFor(async () => !(await fileExists(client.container, volFile(rmName))), { timeout: 30000, interval: 2000, label: 'backing image deleted' });
     expect(await fileExists(client.container, appDir(rmName))).to.equal(false);
+  });
+
+  it('remounts an ENTERPRISE app volume after a reboot with an empty crontab (incident app class)', async function () {
+    this.timeout(300000);
+    let client = env.clients[4];
+    const dir = appDir(entName);
+    await waitFor(() => isUp(client, entName), { timeout: 120000, interval: 2000, label: 'enterprise app running' });
+    expect(await isMountpoint(client.container, dir)).to.equal(true);
+
+    // the local row must be in the production enterprise shape: compose emptied,
+    // components only inside the encrypted blob - the exact shape the blind
+    // inventory took for "not installed"
+    const installed = await client.getInstalledApps();
+    const row = installed.data.find((a) => a.name === entName);
+    expect(row, 'enterprise app row present in local DB').to.exist;
+    expect(row.compose, 'compose stored empty for enterprise').to.deep.equal([]);
+    expect(row.enterprise, 'enterprise blob stored').to.be.a('string').and.not.equal('');
+
+    // the incident state: no remount entry exists anywhere
+    await execInContainer(client.container, 'crontab -r 2>/dev/null || true');
+
+    env.setBootId(4, `entreboot-${Date.now()}`);
+    await env.restartNode(4);
+    client = env.clients[4];
+
+    await waitFor(() => isMountpoint(client.container, dir), { timeout: 150000, interval: 3000, label: 'enterprise volume remounted after reboot' });
+    await waitFor(() => isUp(client, entName), { timeout: 120000, interval: 3000, label: 'enterprise app running after reboot' });
+    expect(await crontabVolumeEntries(client.container)).to.equal(0);
   });
 });

--- a/test-infra/runner/tests/60-volume-mount-ownership.js
+++ b/test-infra/runner/tests/60-volume-mount-ownership.js
@@ -215,8 +215,13 @@ describe('FluxOS-owned volume mounting (no crontab) + inert unmounted app dirs',
     await waitFor(() => isUp(client, inertName), { timeout: 60000, interval: 2000, label: 'running before image loss' });
 
     const afterId = client.getLastEventId();
+    // Demolish the volume BEFORE stopping the container: the die event triggers
+    // an immediate reconcile, so the broken state must fully exist when it
+    // fires (a die over a still-healthy volume gets re-mounted and restarted by
+    // the self-heal instead of reported unavailable). The lazy unmount detaches
+    // the host dir under the running container without emitting any event.
     const r = await execInContainer(client.container,
-      `docker stop ${appId(inertName)} >/dev/null 2>&1; umount ${dir} && rm -f ${volFile(inertName)}`);
+      `umount -l ${dir} && rm -f ${volFile(inertName)} && docker stop ${appId(inertName)} >/dev/null 2>&1`);
     expect(r.exitCode, `teardown failed: ${r.output}`).to.equal(0);
 
     // the reconciler must report the unavailable volume and never start

--- a/test-infra/runner/tests/60-volume-mount-ownership.js
+++ b/test-infra/runner/tests/60-volume-mount-ownership.js
@@ -105,7 +105,13 @@ describe('FluxOS-owned volume mounting (no crontab) + inert unmounted app dirs',
     await bootAndPeer(env);
     await resetSyncState();
 
+    // first-run reset first, real data on disk second, pin synced LAST - an
+    // index claiming bytes over an empty disk is the phantom state the guard
+    // demotes, and the demote/hold would latch the app down mid-suite
+    const syncInstallAfter = env.clients[0].getLastEventId();
     await seedSyncthingApp(env, { name: syncName, mode: 'r', index: 0, spawnable: false });
+    await waitForReconcileActuated(env.clients[0], syncIdentifier, 'dataCleared', 60000, { afterId: syncInstallAfter });
+    await seedSyncScopedData(env, syncName, 0);
     // pin the folder synced so the leader promotes and the app runs steadily
     await setSynced({ ip: subnet.nodeIp(1), folder: appId(syncName) });
     await installPlainApp(env, rebootName, 1, 31201);
@@ -133,11 +139,6 @@ describe('FluxOS-owned volume mounting (no crontab) + inert unmounted app dirs',
       }],
     });
     await installOnNodes(env, entApp, [4]);
-
-    // the pinned-synced r: app needs real disk content once it is up (post
-    // first-run reset), or the phantom guard fights the re-promotion all suite
-    await waitFor(() => isUp(env.clients[0], syncName), { timeout: 90000, interval: 2000, label: 'sync app running' });
-    await seedSyncScopedData(env, syncName, 0);
   });
 
   after(async function () {

--- a/test-infra/runner/tests/60-volume-mount-ownership.js
+++ b/test-infra/runner/tests/60-volume-mount-ownership.js
@@ -1,0 +1,214 @@
+import { describe, it, before, after } from 'mocha';
+import { expect } from 'chai';
+import { createTestEnv } from '../framework/test-env.js';
+import { execInContainer, getAppContainerStatus, restartFluxos } from '../framework/container.js';
+import { pushImage } from '../framework/registry-helper.js';
+import { buildSeedableApp } from '../framework/seed-helper.js';
+import {
+  waitFor, waitForReconcileActuated, waitForAppRemoved, assertNoEvent,
+} from '../framework/wait.js';
+import { bootAndPeer, seedSyncthingApp, installOnNodes } from '../framework/reconciler-suite.js';
+import { setSynced, resetSyncState } from '../framework/syncthing-control.js';
+import { getSubnetConfig, REGISTRY_REPO_HOST } from '../framework/subnet-config.js';
+import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
+import { authenticate } from '../auth.js';
+import { fluxTeamKey } from '../framework/keys.js';
+
+// FluxOS owns app volume mounting (no @reboot crontab), and an unmounted app
+// dir is inert. These are the incident regressions:
+//  - install creates NO crontab entry, and the volume is loop-mounted for real
+//  - a machine reboot with an EMPTY crontab (the incident state: the entry had
+//    silently vanished) still remounts the volume - old code only remounted
+//    from crontab entries, so the app dir silently degraded to a bare host dir
+//  - a legacy @reboot entry left by an older FluxOS is removed on start
+//  - writes to an unmounted app dir fail (chattr +i) instead of landing on the
+//    host filesystem, and FluxOS self-heals the mount without a restart
+//  - an app whose backing image is GONE stays inert: no start, no structure
+//    recreated on the bare dir
+//  - uninstall deletes the backing image WITHOUT a crontab entry to parse
+//    (old code orphaned the image when the entry was missing)
+
+const subnet = getSubnetConfig();
+
+const appId = (name) => `flux${name}_${name}`;
+const appDir = (name) => `/mnt/appdata/flux-apps/${appId(name)}`;
+const volFile = (name) => `/mnt/appdata/${appId(name)}FLUXFSVOL`;
+
+async function isMountpoint(container, dir) {
+  const r = await execInContainer(container, `mountpoint -q ${dir}`);
+  return r.exitCode === 0;
+}
+
+async function fileExists(container, path) {
+  const r = await execInContainer(container, `test -e ${path}`);
+  return r.exitCode === 0;
+}
+
+async function crontabVolumeEntries(container) {
+  const r = await execInContainer(container, 'crontab -l 2>/dev/null | grep -c FLUXFSVOL || true');
+  return parseInt(r.stdout.trim(), 10) || 0;
+}
+
+async function isUp(client, appName) {
+  const status = await getAppContainerStatus(client.container, appName);
+  return !!(status && status.status.startsWith('Up'));
+}
+
+// targeted install of a plain (non-sync) app on one node
+async function installPlainApp(env, name, index, port) {
+  await pushImage(name, 'v1');
+  const app = await buildSeedableApp({
+    name,
+    compose: [{
+      name,
+      description: 'test container',
+      repotag: `${REGISTRY_REPO_HOST}/${name}:v1`,
+      ports: [port],
+      domains: [''],
+      environmentParameters: [],
+      commands: [],
+      containerPorts: [80],
+      containerData: '/appdata',
+      cpu: 0.1,
+      ram: 100,
+      hdd: 1,
+      repoauth: '',
+    }],
+  });
+  await installOnNodes(env, app, [index]);
+  return app;
+}
+
+describe('FluxOS-owned volume mounting (no crontab) + inert unmounted app dirs', function () {
+  let env;
+  dumpLogsOnFailure(() => env);
+
+  const ts = Date.now();
+  const syncName = `e2evolsync${ts}`; // r: app on node 0 (invariants, self-heal, legacy cleanup)
+  const rebootName = `e2evolboot${ts}`; // plain app on node 1 (reboot remount regression)
+  const inertName = `e2evolinert${ts}`; // plain app on node 2 (missing image stays inert)
+  const rmName = `e2evolrm${ts}`; // plain app on node 3 (uninstall deletes image)
+  const syncIdentifier = `${syncName}_${syncName}`;
+  const inertIdentifier = `${inertName}_${inertName}`;
+
+  before(async function () {
+    this.timeout(480000);
+    env = await createTestEnv({ hookCtx: this, nodes: 10, tickerAutostart: false });
+    await bootAndPeer(env);
+    await resetSyncState();
+
+    await seedSyncthingApp(env, { name: syncName, mode: 'r', index: 0 });
+    // pin the folder synced so the leader promotes and the app runs steadily
+    await setSynced({ ip: subnet.nodeIp(1), folder: appId(syncName) });
+    await installPlainApp(env, rebootName, 1, 31201);
+    await installPlainApp(env, inertName, 2, 31301);
+    await installPlainApp(env, rmName, 3, 31401);
+  });
+
+  after(async function () {
+    this.timeout(30000);
+    await resetSyncState().catch(() => {});
+    await env?.teardown();
+  });
+
+  it('install loop-mounts the volume and creates NO @reboot crontab entry', async function () {
+    this.timeout(120000);
+    const c0 = env.clients[0].container;
+    await waitFor(() => isMountpoint(c0, appDir(syncName)), { timeout: 30000, interval: 2000, label: 'volume mounted after install' });
+    expect(await fileExists(c0, volFile(syncName))).to.equal(true);
+    expect(await crontabVolumeEntries(c0)).to.equal(0);
+    expect(await crontabVolumeEntries(env.clients[1].container)).to.equal(0);
+    await waitFor(() => isUp(env.clients[0], syncName), { timeout: 90000, interval: 2000, label: 'r: app running' });
+  });
+
+  it('rejects writes to the unmounted app dir (EPERM) and self-heals the mount without a restart', async function () {
+    this.timeout(120000);
+    const client = env.clients[0];
+    const dir = appDir(syncName);
+
+    // stop the container (releases the bind), unmount, then immediately probe a
+    // write on the bare dir - all in ONE shell so the monitor's 3s repair cycle
+    // cannot remount in between. The immutable mountpoint must refuse the write.
+    const r = await execInContainer(client.container,
+      `docker stop ${appId(syncName)} >/dev/null 2>&1; umount ${dir} || exit 9; touch ${dir}/leak-probe 2>/dev/null; echo TOUCH_EXIT:$?`);
+    expect(r.exitCode, `umount failed: ${r.output}`).to.not.equal(9);
+    const touchExit = r.output.match(/TOUCH_EXIT:(\d+)/)?.[1];
+    expect(touchExit, `expected the bare-dir write to fail, got: ${r.output}`).to.not.equal('0');
+
+    // FluxOS remounts the volume (reconciler / monitor repair) and restarts the app
+    await waitFor(() => isMountpoint(client.container, dir), { timeout: 60000, interval: 2000, label: 'volume remounted (self-heal)' });
+    await waitFor(() => isUp(client, syncName), { timeout: 90000, interval: 2000, label: 'app running again after self-heal' });
+  });
+
+  it('removes a legacy @reboot mount entry on FluxOS start and leaves the mount intact', async function () {
+    this.timeout(180000);
+    const client = env.clients[0];
+    const c0 = client.container;
+    const entry = `@reboot while [ ! -f ${volFile(syncName)} ]; do sleep 5; done && sudo mount -o loop ${volFile(syncName)} ${appDir(syncName)} #${appId(syncName)}`;
+    await execInContainer(c0, `(crontab -l 2>/dev/null; echo '${entry}') | crontab -`);
+    expect(await crontabVolumeEntries(c0)).to.equal(1);
+
+    await restartFluxos(c0);
+
+    await waitFor(async () => (await crontabVolumeEntries(c0)) === 0, { timeout: 120000, interval: 3000, label: 'legacy crontab entry removed' });
+    expect(await isMountpoint(c0, appDir(syncName))).to.equal(true);
+    await waitFor(() => isUp(client, syncName), { timeout: 90000, interval: 2000, label: 'app running after FluxOS restart' });
+  });
+
+  it('remounts the volume after a machine reboot with an EMPTY crontab (incident regression)', async function () {
+    this.timeout(300000);
+    let client = env.clients[1];
+    const dir = appDir(rebootName);
+    await waitFor(() => isUp(client, rebootName), { timeout: 60000, interval: 2000, label: 'running before reboot' });
+    expect(await isMountpoint(client.container, dir)).to.equal(true);
+
+    // the incident state: no remount entry exists anywhere
+    await execInContainer(client.container, 'crontab -r 2>/dev/null || true');
+
+    env.setBootId(1, `volreboot-${Date.now()}`);
+    await env.restartNode(1);
+    client = env.clients[1];
+
+    await waitFor(() => isMountpoint(client.container, dir), { timeout: 150000, interval: 3000, label: 'volume remounted after reboot without crontab' });
+    await waitFor(() => isUp(client, rebootName), { timeout: 120000, interval: 3000, label: 'app running after reboot' });
+    expect(await crontabVolumeEntries(client.container)).to.equal(0);
+  });
+
+  it('holds an app inert when its backing image is missing: no start, nothing written to the bare dir', async function () {
+    this.timeout(180000);
+    const client = env.clients[2];
+    const dir = appDir(inertName);
+    await waitFor(() => isUp(client, inertName), { timeout: 60000, interval: 2000, label: 'running before image loss' });
+
+    const afterId = client.getLastEventId();
+    const r = await execInContainer(client.container,
+      `docker stop ${appId(inertName)} >/dev/null 2>&1; umount ${dir} && rm -f ${volFile(inertName)}`);
+    expect(r.exitCode, `teardown failed: ${r.output}`).to.equal(0);
+
+    // the reconciler must report the unavailable volume and never start
+    await waitForReconcileActuated(client, inertIdentifier, 'volumeUnavailable', 90000, { afterId });
+    await assertNoEvent(client, 'reconciler:actuated', (d) => d.identifier === inertIdentifier && d.action === 'started', 15000);
+    expect(await isUp(client, inertName)).to.equal(false);
+
+    // nothing recreated structure on the bare mountpoint (it stays empty)
+    const probe = await execInContainer(client.container, `find ${dir} -mindepth 1 2>/dev/null | head -5 | wc -l`);
+    expect(probe.stdout.trim()).to.equal('0');
+  });
+
+  it('uninstall deletes the discovered backing image with NO crontab entry to parse (orphan regression)', async function () {
+    this.timeout(180000);
+    const client = env.clients[3];
+    expect(await fileExists(client.container, volFile(rmName))).to.equal(true);
+    // old code recovered the image path by parsing the crontab entry; make sure
+    // there is none, as in the incident
+    await execInContainer(client.container, 'crontab -r 2>/dev/null || true');
+
+    const auth = await authenticate(client.url, fluxTeamKey());
+    const res = await fetch(`${client.url}/apps/appremove/${rmName}`, { headers: { zelidauth: auth.zelidauth } });
+    await res.text(); // streamed progress; completion is confirmed via the event
+    await waitForAppRemoved(client, rmName, 120000);
+
+    await waitFor(async () => !(await fileExists(client.container, volFile(rmName))), { timeout: 30000, interval: 2000, label: 'backing image deleted' });
+    expect(await fileExists(client.container, appDir(rmName))).to.equal(false);
+  });
+});

--- a/test-infra/runner/tests/61-syncthing-mount-safety.js
+++ b/test-infra/runner/tests/61-syncthing-mount-safety.js
@@ -123,6 +123,12 @@ describe('syncthing mount-safety guard demotes unsafe sendreceive folders', func
     this.timeout(120000);
     const client = env.clients[0];
     const dir = appDir(leakName);
+
+    // premise, asserted so drift fails fast instead of timing out downstream: a
+    // genuinely running sendreceive leader (an idle seeded leader with an empty
+    // disk would already have been phantom-demoted - see seedSyncScopedData)
+    expect(await folderType(ip0, leakFolder), 'leak folder must start sendreceive').to.equal('sendreceive');
+    expect(await isUp(client, leakName), 'leak app must start running').to.equal(true);
     const afterId = client.getLastEventId();
 
     // recreate the incident state: volume unmounted and unrepairable (image

--- a/test-infra/runner/tests/61-syncthing-mount-safety.js
+++ b/test-infra/runner/tests/61-syncthing-mount-safety.js
@@ -145,26 +145,22 @@ describe('syncthing mount-safety guard demotes unsafe sendreceive folders', func
     // recreate the incident state: volume unmounted and unrepairable (image
     // gone), with data leaked onto the bare host dir. chattr -i first - the
     // leak predates the immutable-mountpoint fix on real incident nodes.
+    // Deliberately do NOT stop the container: a die event triggers an
+    // immediate reconcile, whose level-based mount ownership re-mounts the
+    // volume and restarts the app before the image can be removed (the
+    // self-heal beat this test's teardown in every earlier run). A lazy
+    // unmount detaches the dir under the running container instead; stopping
+    // the app is then the GUARD's job, which is exactly what this test is for.
     const r = await execInContainer(client.container,
-      `L() { grep "${appId(leakName)}" /proc/self/mountinfo; }; echo "PRE:"; L; docker stop ${appId(leakName)} >/dev/null 2>&1; echo "POSTSTOP:"; L; umount ${dir}; U=$?; echo "UMOUNT_RC:$U POSTUMOUNT:"; L; losetup -a | grep "${appId(leakName)}"; [ $U -eq 0 ] && chattr -i ${dir} && touch ${dir}/leaked.db && rm -f ${volFile(leakName)} && echo SETUP_OK`);
-    console.log(`      [setup trace]\n${r.output.trim().split('\n').map((l) => `        ${l}`).join('\n')}`);
-    expect(r.output, `leak-state setup failed: ${r.output}`).to.include('SETUP_OK');
+      `umount -l ${dir} && chattr -i ${dir} && touch ${dir}/leaked.db && rm -f ${volFile(leakName)}`);
+    expect(r.exitCode, `leak-state setup failed: ${r.output}`).to.equal(0);
 
-    // ground truth for the mount views: layers per /proc in the exec namespace
-    // vs the FluxOS process's namespace (they have diverged in past runs)
-    const probe = await execInContainer(client.container,
-      `FPID=$(cat /tmp/fluxos.pid); echo EXEC_LAYERS:$(grep -c "${appId(leakName)}" /proc/self/mountinfo); echo FLUX_LAYERS:$(grep -c "${appId(leakName)}" /proc/$FPID/mountinfo); echo DIR:$(ls -a ${dir} | tr "\n" ",")`);
-    console.log(`      [mount-probe after setup] ${probe.output.trim().replace(/\n/g, ' | ')}`);
-
-    // content must NOT buy a pass: the folder is demoted and the container held
-    await new Promise((resolve) => { setTimeout(resolve, 9000); });
-    const probe2 = await execInContainer(client.container,
-      `FPID=$(cat /tmp/fluxos.pid); echo EXEC_LAYERS:$(grep -c "${appId(leakName)}" /proc/self/mountinfo); echo FLUX_LAYERS:$(grep -c "${appId(leakName)}" /proc/$FPID/mountinfo)`);
-    console.log(`      [mount-probe +9s] ${probe2.output.trim().replace(/\n/g, ' | ')}`);
+    // content must NOT buy a pass: the folder is demoted and the container
+    // stopped by the mount-safety hold (no help from the test this time)
     await waitFor(async () => (await folderType(ip0, leakFolder)) === 'receiveonly', { timeout: 60000, interval: 3000, label: 'leaked folder demoted to receiveonly' });
     await waitForReconcilerDesiredChanged(client, leakIdentifier, 'stopped', 60000, { afterId });
+    await waitFor(async () => !(await isUp(client, leakName)), { timeout: 60000, interval: 2000, label: 'leak app container held (stopped)' });
     await assertNoEvent(client, 'reconciler:actuated', (d) => d.identifier === leakIdentifier && d.action === 'started', 15000);
-    expect(await isUp(client, leakName)).to.equal(false);
   });
 
   it('never recreates the .stfolder marker on the bare unmounted dir', async function () {

--- a/test-infra/runner/tests/61-syncthing-mount-safety.js
+++ b/test-infra/runner/tests/61-syncthing-mount-safety.js
@@ -146,8 +146,9 @@ describe('syncthing mount-safety guard demotes unsafe sendreceive folders', func
     // gone), with data leaked onto the bare host dir. chattr -i first - the
     // leak predates the immutable-mountpoint fix on real incident nodes.
     const r = await execInContainer(client.container,
-      `docker stop ${appId(leakName)} >/dev/null 2>&1; umount ${dir} && chattr -i ${dir} && touch ${dir}/leaked.db && rm -f ${volFile(leakName)}`);
-    expect(r.exitCode, `leak-state setup failed: ${r.output}`).to.equal(0);
+      `L() { grep "${appId(leakName)}" /proc/self/mountinfo; }; echo "PRE:"; L; docker stop ${appId(leakName)} >/dev/null 2>&1; echo "POSTSTOP:"; L; umount ${dir}; U=$?; echo "UMOUNT_RC:$U POSTUMOUNT:"; L; losetup -a | grep "${appId(leakName)}"; [ $U -eq 0 ] && chattr -i ${dir} && touch ${dir}/leaked.db && rm -f ${volFile(leakName)} && echo SETUP_OK`);
+    console.log(`      [setup trace]\n${r.output.trim().split('\n').map((l) => `        ${l}`).join('\n')}`);
+    expect(r.output, `leak-state setup failed: ${r.output}`).to.include('SETUP_OK');
 
     // ground truth for the mount views: layers per /proc in the exec namespace
     // vs the FluxOS process's namespace (they have diverged in past runs)

--- a/test-infra/runner/tests/61-syncthing-mount-safety.js
+++ b/test-infra/runner/tests/61-syncthing-mount-safety.js
@@ -6,7 +6,7 @@ import {
   setSyncState, setSynced, setSyncing, getSyncthingState, resetSyncState,
 } from '../framework/syncthing-control.js';
 import {
-  waitFor, waitForReconcilerDesiredChanged, assertNoEvent,
+  waitFor, waitForReconcilerDesiredChanged, waitForReconcileActuated, assertNoEvent,
 } from '../framework/wait.js';
 import { bootAndPeer, seedSyncthingApp, seedSyncScopedData } from '../framework/reconciler-suite.js';
 import { getSubnetConfig } from '../framework/subnet-config.js';
@@ -66,23 +66,27 @@ describe('syncthing mount-safety guard demotes unsafe sendreceive folders', func
     await resetSyncState();
 
     // both apps are r: leaders on their own nodes: they seed, promote to
-    // sendreceive and start - the state every test here begins from
+    // sendreceive and start - the state every test here begins from.
+    // Order matters: the sync layer's first-run reset clears local appdata, so
+    // wait for it, put real data on disk, and only THEN pin the index synced -
+    // if the index ever claims bytes over an empty disk, the phantom guard
+    // (correctly) demotes and holds, and the app never reaches the premise.
+    const leakInstallAfter = env.clients[0].getLastEventId();
     await seedSyncthingApp(env, { name: leakName, mode: 'r', index: 0, spawnable: false });
+    await waitForReconcileActuated(env.clients[0], leakIdentifier, 'dataCleared', 60000, { afterId: leakInstallAfter });
+    await seedSyncScopedData(env, leakName, 0);
     await setSynced({ ip: ip0, folder: leakFolder });
+
+    const phantomInstallAfter = env.clients[1].getLastEventId();
     await seedSyncthingApp(env, { name: phantomName, mode: 'r', index: 1, spawnable: false });
+    await waitForReconcileActuated(env.clients[1], phantomIdentifier, 'dataCleared', 60000, { afterId: phantomInstallAfter });
+    await seedSyncScopedData(env, phantomName, 1);
     await setSynced({ ip: ip1, folder: phantomFolder });
 
     await waitFor(async () => (await folderType(ip0, leakFolder)) === 'sendreceive', { timeout: 90000, interval: 3000, label: `${leakFolder} sendreceive` });
     await waitFor(async () => (await folderType(ip1, phantomFolder)) === 'sendreceive', { timeout: 90000, interval: 3000, label: `${phantomFolder} sendreceive` });
     await waitFor(() => isUp(env.clients[0], leakName), { timeout: 90000, interval: 2000, label: 'leak app running' });
     await waitFor(() => isUp(env.clients[1], phantomName), { timeout: 90000, interval: 2000, label: 'phantom app running' });
-
-    // now that the first-run reset has run and the apps are up, give each
-    // pinned-synced folder real disk content - index and disk must agree or
-    // the phantom guard (correctly) fights the pinned-synced re-promotion
-    // for the rest of the suite
-    await seedSyncScopedData(env, leakName, 0);
-    await seedSyncScopedData(env, phantomName, 1);
   });
 
   after(async function () {

--- a/test-infra/runner/tests/61-syncthing-mount-safety.js
+++ b/test-infra/runner/tests/61-syncthing-mount-safety.js
@@ -72,13 +72,13 @@ describe('syncthing mount-safety guard demotes unsafe sendreceive folders', func
     // if the index ever claims bytes over an empty disk, the phantom guard
     // (correctly) demotes and holds, and the app never reaches the premise.
     const leakInstallAfter = env.clients[0].getLastEventId();
-    await seedSyncthingApp(env, { name: leakName, mode: 'r', index: 0, spawnable: false });
+    await seedSyncthingApp(env, { name: leakName, mode: 'r', index: 0 });
     await waitForReconcileActuated(env.clients[0], leakIdentifier, 'dataCleared', 60000, { afterId: leakInstallAfter });
     await seedSyncScopedData(env, leakName, 0);
     await setSynced({ ip: ip0, folder: leakFolder });
 
     const phantomInstallAfter = env.clients[1].getLastEventId();
-    await seedSyncthingApp(env, { name: phantomName, mode: 'r', index: 1, spawnable: false });
+    await seedSyncthingApp(env, { name: phantomName, mode: 'r', index: 1 });
     await waitForReconcileActuated(env.clients[1], phantomIdentifier, 'dataCleared', 60000, { afterId: phantomInstallAfter });
     await seedSyncScopedData(env, phantomName, 1);
     await setSynced({ ip: ip1, folder: phantomFolder });

--- a/test-infra/runner/tests/61-syncthing-mount-safety.js
+++ b/test-infra/runner/tests/61-syncthing-mount-safety.js
@@ -149,7 +149,17 @@ describe('syncthing mount-safety guard demotes unsafe sendreceive folders', func
       `docker stop ${appId(leakName)} >/dev/null 2>&1; umount ${dir} && chattr -i ${dir} && touch ${dir}/leaked.db && rm -f ${volFile(leakName)}`);
     expect(r.exitCode, `leak-state setup failed: ${r.output}`).to.equal(0);
 
+    // ground truth for the mount views: layers per /proc in the exec namespace
+    // vs the FluxOS process's namespace (they have diverged in past runs)
+    const probe = await execInContainer(client.container,
+      `FPID=$(cat /tmp/fluxos.pid); echo EXEC_LAYERS:$(grep -c "${appId(leakName)}" /proc/self/mountinfo); echo FLUX_LAYERS:$(grep -c "${appId(leakName)}" /proc/$FPID/mountinfo); echo DIR:$(ls -a ${dir} | tr "\n" ",")`);
+    console.log(`      [mount-probe after setup] ${probe.output.trim().replace(/\n/g, ' | ')}`);
+
     // content must NOT buy a pass: the folder is demoted and the container held
+    await new Promise((resolve) => { setTimeout(resolve, 9000); });
+    const probe2 = await execInContainer(client.container,
+      `FPID=$(cat /tmp/fluxos.pid); echo EXEC_LAYERS:$(grep -c "${appId(leakName)}" /proc/self/mountinfo); echo FLUX_LAYERS:$(grep -c "${appId(leakName)}" /proc/$FPID/mountinfo)`);
+    console.log(`      [mount-probe +9s] ${probe2.output.trim().replace(/\n/g, ' | ')}`);
     await waitFor(async () => (await folderType(ip0, leakFolder)) === 'receiveonly', { timeout: 60000, interval: 3000, label: 'leaked folder demoted to receiveonly' });
     await waitForReconcilerDesiredChanged(client, leakIdentifier, 'stopped', 60000, { afterId });
     await assertNoEvent(client, 'reconciler:actuated', (d) => d.identifier === leakIdentifier && d.action === 'started', 15000);

--- a/test-infra/runner/tests/61-syncthing-mount-safety.js
+++ b/test-infra/runner/tests/61-syncthing-mount-safety.js
@@ -8,7 +8,7 @@ import {
 import {
   waitFor, waitForReconcilerDesiredChanged, assertNoEvent,
 } from '../framework/wait.js';
-import { bootAndPeer, seedSyncthingApp } from '../framework/reconciler-suite.js';
+import { bootAndPeer, seedSyncthingApp, seedSyncScopedData } from '../framework/reconciler-suite.js';
 import { getSubnetConfig } from '../framework/subnet-config.js';
 import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
 
@@ -76,6 +76,13 @@ describe('syncthing mount-safety guard demotes unsafe sendreceive folders', func
     await waitFor(async () => (await folderType(ip1, phantomFolder)) === 'sendreceive', { timeout: 90000, interval: 3000, label: `${phantomFolder} sendreceive` });
     await waitFor(() => isUp(env.clients[0], leakName), { timeout: 90000, interval: 2000, label: 'leak app running' });
     await waitFor(() => isUp(env.clients[1], phantomName), { timeout: 90000, interval: 2000, label: 'phantom app running' });
+
+    // now that the first-run reset has run and the apps are up, give each
+    // pinned-synced folder real disk content - index and disk must agree or
+    // the phantom guard (correctly) fights the pinned-synced re-promotion
+    // for the rest of the suite
+    await seedSyncScopedData(env, leakName, 0);
+    await seedSyncScopedData(env, phantomName, 1);
   });
 
   after(async function () {

--- a/test-infra/runner/tests/61-syncthing-mount-safety.js
+++ b/test-infra/runner/tests/61-syncthing-mount-safety.js
@@ -1,0 +1,156 @@
+import { describe, it, before, after } from 'mocha';
+import { expect } from 'chai';
+import { createTestEnv } from '../framework/test-env.js';
+import { execInContainer, getAppContainerStatus } from '../framework/container.js';
+import {
+  setSyncState, setSynced, setSyncing, getSyncthingState, resetSyncState,
+} from '../framework/syncthing-control.js';
+import {
+  waitFor, waitForReconcilerDesiredChanged, assertNoEvent,
+} from '../framework/wait.js';
+import { bootAndPeer, seedSyncthingApp } from '../framework/reconciler-suite.js';
+import { getSubnetConfig } from '../framework/subnet-config.js';
+import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
+
+// The syncthing mount-safety guard gates on the MOUNTPOINT, not on content
+// (the deletion-propagation incident regressions):
+//  - a sendreceive folder whose app dir is unmounted with leaked content must
+//    be demoted to receiveonly and its container held - content used to buy a
+//    pass, which let a stale sendreceive folder broadcast deletions to the
+//    healthy master
+//  - a sendreceive folder whose index claims data over an empty (mounted)
+//    volume - the stale "phantom" index - must be demoted before it can
+//    broadcast every missing file as a deletion
+//  - a legitimately empty folder (index empty too - the cold-start seed) must
+//    NOT be demoted
+//  - the .stfolder marker must never (re)appear on the bare unmounted dir -
+//    recreating it there re-arms syncthing onto the host filesystem and
+//    defeats syncthing's own missing-marker guard
+
+const subnet = getSubnetConfig();
+
+const appId = (name) => `flux${name}_${name}`;
+const appDir = (name) => `/mnt/appdata/flux-apps/${appId(name)}`;
+const volFile = (name) => `/mnt/appdata/${appId(name)}FLUXFSVOL`;
+
+async function isUp(client, appName) {
+  const status = await getAppContainerStatus(client.container, appName);
+  return !!(status && status.status.startsWith('Up'));
+}
+
+// the folder type as the (stub) syncthing daemon has it configured for a node
+async function folderType(nodeIp, folderId) {
+  const state = await getSyncthingState();
+  const node = state.nodes.find((n) => n.ip === nodeIp);
+  return node?.folders?.find((f) => f.id === folderId)?.type ?? null;
+}
+
+describe('syncthing mount-safety guard demotes unsafe sendreceive folders', function () {
+  let env;
+  dumpLogsOnFailure(() => env);
+
+  const ts = Date.now();
+  const leakName = `e2eleak${ts}`; // node 0: unmounted dir with leaked content
+  const phantomName = `e2ephantom${ts}`; // node 1: phantom index over empty volume
+  const leakFolder = appId(leakName);
+  const phantomFolder = appId(phantomName);
+  const leakIdentifier = `${leakName}_${leakName}`;
+  const phantomIdentifier = `${phantomName}_${phantomName}`;
+  const ip0 = subnet.nodeIp(1);
+  const ip1 = subnet.nodeIp(2);
+
+  before(async function () {
+    this.timeout(480000);
+    env = await createTestEnv({ hookCtx: this, nodes: 10, tickerAutostart: false });
+    await bootAndPeer(env);
+    await resetSyncState();
+
+    // both apps are r: leaders on their own nodes: they seed, promote to
+    // sendreceive and start - the state every test here begins from
+    await seedSyncthingApp(env, { name: leakName, mode: 'r', index: 0 });
+    await setSynced({ ip: ip0, folder: leakFolder });
+    await seedSyncthingApp(env, { name: phantomName, mode: 'r', index: 1 });
+    await setSynced({ ip: ip1, folder: phantomFolder });
+
+    await waitFor(async () => (await folderType(ip0, leakFolder)) === 'sendreceive', { timeout: 90000, interval: 3000, label: `${leakFolder} sendreceive` });
+    await waitFor(async () => (await folderType(ip1, phantomFolder)) === 'sendreceive', { timeout: 90000, interval: 3000, label: `${phantomFolder} sendreceive` });
+    await waitFor(() => isUp(env.clients[0], leakName), { timeout: 90000, interval: 2000, label: 'leak app running' });
+    await waitFor(() => isUp(env.clients[1], phantomName), { timeout: 90000, interval: 2000, label: 'phantom app running' });
+  });
+
+  after(async function () {
+    this.timeout(30000);
+    await resetSyncState().catch(() => {});
+    await env?.teardown();
+  });
+
+  it('does NOT demote a legitimately empty folder whose index is empty too (cold-start seed)', async function () {
+    this.timeout(60000);
+    const client = env.clients[1];
+    // wipe the app's data inside the MOUNTED volume and report an empty index:
+    // disk and index agree, so there is nothing a sendreceive folder could
+    // wrongly delete - the guard must leave it alone
+    await execInContainer(client.container, `sh -c 'rm -rf ${appDir(phantomName)}/appdata/* 2>/dev/null; true'`);
+    await setSyncState({ ip: ip1, folder: phantomFolder, state: 'idle', globalBytes: 0, inSyncBytes: 0 });
+
+    // several 3s monitor cycles must pass without a demotion
+    await assertNoEvent(client, 'reconciler:desiredChanged', (d) => d.identifier === phantomIdentifier && d.state === 'stopped', 15000);
+    expect(await folderType(ip1, phantomFolder)).to.equal('sendreceive');
+  });
+
+  it('demotes a sendreceive folder whose index claims data over an empty volume (phantom index)', async function () {
+    this.timeout(120000);
+    const client = env.clients[1];
+    const afterId = client.getLastEventId();
+
+    // the stale-index state: the index claims fully-synced data while the
+    // mounted volume holds none - in sendreceive, syncthing would broadcast
+    // every "missing" file as a deletion
+    await setSyncState({ ip: ip1, folder: phantomFolder, state: 'idle', globalBytes: 100000, inSyncBytes: 100000 });
+
+    await waitFor(async () => (await folderType(ip1, phantomFolder)) === 'receiveonly', { timeout: 60000, interval: 3000, label: 'phantom folder demoted to receiveonly' });
+    await waitForReconcilerDesiredChanged(client, phantomIdentifier, 'stopped', 60000, { afterId });
+
+    // park the folder mid-sync BEFORE asserting the stop: the stub's static
+    // "fully synced" index would otherwise let the receiveonly machinery
+    // re-promote (in production the demotion's folder restart rescans and
+    // corrects the index; the stub has no disk to rescan)
+    await setSyncing({ ip: ip1, folder: phantomFolder, percent: 40 });
+    await waitFor(async () => !(await isUp(client, phantomName)), { timeout: 60000, interval: 2000, label: 'phantom app container held (stopped)' });
+  });
+
+  it('demotes a sendreceive folder over an unmounted dir even when it HAS content (leak regression)', async function () {
+    this.timeout(120000);
+    const client = env.clients[0];
+    const dir = appDir(leakName);
+    const afterId = client.getLastEventId();
+
+    // recreate the incident state: volume unmounted and unrepairable (image
+    // gone), with data leaked onto the bare host dir. chattr -i first - the
+    // leak predates the immutable-mountpoint fix on real incident nodes.
+    const r = await execInContainer(client.container,
+      `docker stop ${appId(leakName)} >/dev/null 2>&1; umount ${dir} && chattr -i ${dir} && touch ${dir}/leaked.db && rm -f ${volFile(leakName)}`);
+    expect(r.exitCode, `leak-state setup failed: ${r.output}`).to.equal(0);
+
+    // content must NOT buy a pass: the folder is demoted and the container held
+    await waitFor(async () => (await folderType(ip0, leakFolder)) === 'receiveonly', { timeout: 60000, interval: 3000, label: 'leaked folder demoted to receiveonly' });
+    await waitForReconcilerDesiredChanged(client, leakIdentifier, 'stopped', 60000, { afterId });
+    await assertNoEvent(client, 'reconciler:actuated', (d) => d.identifier === leakIdentifier && d.action === 'started', 15000);
+    expect(await isUp(client, leakName)).to.equal(false);
+  });
+
+  it('never recreates the .stfolder marker on the bare unmounted dir', async function () {
+    this.timeout(60000);
+    const client = env.clients[0];
+    const dir = appDir(leakName);
+
+    // give the monitor several cycles; the marker must not reappear on the
+    // bare dir (old code recreated it every cycle, re-arming sync onto the
+    // host filesystem), and FluxOS must not add anything else there either
+    await new Promise((resolve) => { setTimeout(resolve, 12000); });
+    const marker = await execInContainer(client.container, `test -d ${dir}/.stfolder`);
+    expect(marker.exitCode).to.not.equal(0);
+    const entries = await execInContainer(client.container, `find ${dir} -mindepth 1 2>/dev/null`);
+    expect(entries.stdout.trim()).to.equal(`${dir}/leaked.db`);
+  });
+});

--- a/test-infra/runner/tests/61-syncthing-mount-safety.js
+++ b/test-infra/runner/tests/61-syncthing-mount-safety.js
@@ -67,9 +67,9 @@ describe('syncthing mount-safety guard demotes unsafe sendreceive folders', func
 
     // both apps are r: leaders on their own nodes: they seed, promote to
     // sendreceive and start - the state every test here begins from
-    await seedSyncthingApp(env, { name: leakName, mode: 'r', index: 0 });
+    await seedSyncthingApp(env, { name: leakName, mode: 'r', index: 0, spawnable: false });
     await setSynced({ ip: ip0, folder: leakFolder });
-    await seedSyncthingApp(env, { name: phantomName, mode: 'r', index: 1 });
+    await seedSyncthingApp(env, { name: phantomName, mode: 'r', index: 1, spawnable: false });
     await setSynced({ ip: ip1, folder: phantomFolder });
 
     await waitFor(async () => (await folderType(ip0, leakFolder)) === 'sendreceive', { timeout: 90000, interval: 3000, label: `${leakFolder} sendreceive` });

--- a/tests/unit/appReconciler.test.js
+++ b/tests/unit/appReconciler.test.js
@@ -176,6 +176,23 @@ describe('appReconciler tests', () => {
       expect(deferredLoud, 'should log the volume defer loudly').to.equal(true);
     });
 
+    it('honors a pending stop even when the data volume cannot be mounted (mount-safety hold)', async () => {
+      // a stop takes nothing from the app dir; deferring it left the incident's
+      // container running over the gutted volume with the hold unenforceable
+      stubs.volumeService.ensureAppVolumeMounted.resolves({ mounted: false, reason: 'volume_file_missing' });
+      stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: true, Status: 'running', ExitCode: 0 } });
+      try {
+        appReconciler.setControllerDesired('www_App', 'stopped', 'mount safety block: unmounted_with_content');
+        // setControllerDesired enqueues its own reconcile; wait for it to land
+        await new Promise((resolve) => { setTimeout(resolve, 50); });
+        expect(stubs.dockerService.appDockerStop.calledWith('www_App')).to.be.true;
+        expect(stubs.dockerService.appDockerStart.called).to.be.false;
+        expect(stubs.dockerOperations.appDeleteDataInMountPoint.called).to.be.false;
+      } finally {
+        appReconciler.clearControllerDesired('www_App');
+      }
+    });
+
     it('mounts an unmounted volume and proceeds with the start', async () => {
       stubs.volumeService.ensureAppVolumeMounted.resolves({ mounted: true, alreadyMounted: false });
       await appReconciler.reconcile('www_App');

--- a/tests/unit/appReconciler.test.js
+++ b/tests/unit/appReconciler.test.js
@@ -40,7 +40,10 @@ describe('appReconciler tests', () => {
         waitForBootContainerStateSettled: () => Promise.resolve(),
       },
       appInspector: { startAppMonitoring: sinon.stub() },
-      volumeService: { ensureMountPathsExist: sinon.stub().resolves() },
+      volumeService: {
+        ensureMountPathsExist: sinon.stub().resolves(),
+        ensureAppVolumeMounted: sinon.stub().resolves({ mounted: true, alreadyMounted: true }),
+      },
       appsRuntimeState: {
         isOperatorStopped: sinon.stub().resolves(false),
         restartWaitMs: sinon.stub().resolves(0),
@@ -157,6 +160,45 @@ describe('appReconciler tests', () => {
       expect(stubs.appsRuntimeState.recordRestart.calledOnceWith('www_App')).to.be.true;
       expect(stubs.dockerService.appDockerStart.calledOnceWith('www_App')).to.be.true;
       expect(stubs.appInspector.startAppMonitoring.calledOnce).to.be.true;
+    });
+
+    it('defers ALL actuation when the data volume cannot be mounted', async () => {
+      // the app dir without its volume is an ordinary host dir: a start there
+      // writes to the host filesystem instead of the volume - the reconciler
+      // must keep the component inert and retry, never actuate
+      stubs.volumeService.ensureAppVolumeMounted.resolves({ mounted: false, reason: 'mount_failed: bad superblock' });
+      stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: true, Status: 'running', ExitCode: 0 } });
+      await appReconciler.reconcile('www_App');
+      expect(stubs.dockerService.appDockerStart.called).to.be.false;
+      expect(stubs.dockerService.appDockerStop.called).to.be.false;
+      expect(stubs.dockerOperations.appDeleteDataInMountPoint.called).to.be.false;
+      const deferredLoud = stubs.log.error.getCalls().some((c) => /data volume not mounted/.test(c.args[0]));
+      expect(deferredLoud, 'should log the volume defer loudly').to.equal(true);
+    });
+
+    it('mounts an unmounted volume and proceeds with the start', async () => {
+      stubs.volumeService.ensureAppVolumeMounted.resolves({ mounted: true, alreadyMounted: false });
+      await appReconciler.reconcile('www_App');
+      expect(stubs.dockerService.appDockerStart.calledOnceWith('www_App')).to.be.true;
+      sinon.assert.callOrder(stubs.volumeService.ensureAppVolumeMounted, stubs.dockerService.appDockerStart);
+    });
+
+    it('records a tampering event once (not per retry) when the backing image is missing', async () => {
+      stubs.volumeService.ensureAppVolumeMounted.resolves({ mounted: false, reason: 'volume_file_missing' });
+      await appReconciler.reconcile('www_App');
+      await appReconciler.reconcile('www_App');
+      const volumeEvents = stubs.appTamperingDetectionService.recordEvent.getCalls()
+        .filter((c) => c.args[1] === 'volume_missing');
+      expect(volumeEvents).to.have.lengthOf(1);
+      expect(volumeEvents[0].args[0]).to.equal('App');
+    });
+
+    it('ensures the volume is mounted before actuating a pending data wipe', async () => {
+      appReconciler.requestStopAndClearData('www_App', 'test wipe');
+      // requestStopAndClearData enqueues its own reconcile; wait for it to land
+      await new Promise((resolve) => { setTimeout(resolve, 50); });
+      expect(stubs.dockerOperations.appDeleteDataInMountPoint.calledOnce).to.be.true;
+      sinon.assert.callOrder(stubs.volumeService.ensureAppVolumeMounted, stubs.dockerOperations.appDeleteDataInMountPoint);
     });
 
     it('ensures mount paths exist (recreating any syncthing-cleaned source) before starting', async () => {

--- a/tests/unit/appUninstaller.test.js
+++ b/tests/unit/appUninstaller.test.js
@@ -59,8 +59,10 @@ describe('appUninstaller tests', () => {
       config: configStub,
       '../verificationHelper': verificationHelperStub,
       '../messageHelper': messageHelperStub,
+      '../utils/volumeService': { getVolumeFilePath: sinon.stub().resolves(null), isPathMounted: sinon.stub().resolves(false) },
       '../serviceHelper': {
         ensureString: sinon.stub().returnsArg(0),
+        runCommand: sinon.stub().resolves({ error: null, stdout: '', stderr: '' }),
         ensureBoolean: sinon.stub().returnsArg(0),
       },
       '../dbHelper': dbHelperStub,
@@ -246,8 +248,10 @@ describe('appUninstaller tests', () => {
         config: configStub,
         '../verificationHelper': verificationHelperStub,
         '../messageHelper': messageHelperStub,
+        '../utils/volumeService': { getVolumeFilePath: sinon.stub().resolves(null), isPathMounted: sinon.stub().resolves(false) },
         '../serviceHelper': {
           ensureString: sinon.stub().returnsArg(0),
+          runCommand: sinon.stub().resolves({ error: null, stdout: '', stderr: '' }),
           ensureBoolean: sinon.stub().returnsArg(0),
           delay: sinon.stub().resolves(),
         },
@@ -322,8 +326,10 @@ describe('appUninstaller tests', () => {
         config: configStub,
         '../verificationHelper': verificationHelperStub,
         '../messageHelper': messageHelperStub,
+        '../utils/volumeService': { getVolumeFilePath: sinon.stub().resolves(null), isPathMounted: sinon.stub().resolves(false) },
         '../serviceHelper': {
           ensureString: sinon.stub().returnsArg(0),
+          runCommand: sinon.stub().resolves({ error: null, stdout: '', stderr: '' }),
           ensureBoolean: sinon.stub().returnsArg(0),
         },
         '../dbHelper': {
@@ -419,8 +425,10 @@ describe('appUninstaller tests', () => {
         config: configStub,
         '../verificationHelper': verificationHelperStub,
         '../messageHelper': messageHelperStub,
+        '../utils/volumeService': { getVolumeFilePath: sinon.stub().resolves(null), isPathMounted: sinon.stub().resolves(false) },
         '../serviceHelper': {
           ensureString: sinon.stub().returnsArg(0),
+          runCommand: sinon.stub().resolves({ error: null, stdout: '', stderr: '' }),
           ensureBoolean: sinon.stub().returnsArg(0),
           ensureNumber: sinon.stub().returnsArg(0),
           delay: sinon.stub().resolves(),
@@ -609,8 +617,10 @@ describe('appUninstaller tests', () => {
         config: configStub,
         '../verificationHelper': verificationHelperStub,
         '../messageHelper': messageHelperStub,
+        '../utils/volumeService': { getVolumeFilePath: sinon.stub().resolves(null), isPathMounted: sinon.stub().resolves(false) },
         '../serviceHelper': {
           ensureString: sinon.stub().returnsArg(0),
+          runCommand: sinon.stub().resolves({ error: null, stdout: '', stderr: '' }),
           ensureBoolean: sinon.stub().returnsArg(0),
           delay: sinon.stub().resolves(),
         },
@@ -695,8 +705,10 @@ describe('appUninstaller tests', () => {
         config: configStub,
         '../verificationHelper': verificationHelperStub,
         '../messageHelper': messageHelperStub,
+        '../utils/volumeService': { getVolumeFilePath: sinon.stub().resolves(null), isPathMounted: sinon.stub().resolves(false) },
         '../serviceHelper': {
           ensureString: sinon.stub().returnsArg(0),
+          runCommand: sinon.stub().resolves({ error: null, stdout: '', stderr: '' }),
           ensureBoolean: sinon.stub().returnsArg(0),
         },
         '../dbHelper': {

--- a/tests/unit/crontabAndMountsCleanup.test.js
+++ b/tests/unit/crontabAndMountsCleanup.test.js
@@ -10,14 +10,6 @@ const crontabMock = {
   load: sinon.stub(),
 };
 
-const cmdAsyncMock = sinon.stub();
-
-const nodecmdMock = {
-  run: (cmd, callback) => {
-    cmdAsyncMock(cmd).then((result) => callback(null, result)).catch((err) => callback(err));
-  },
-};
-
 const logMock = {
   info: sinon.stub(),
   warn: sinon.stub(),
@@ -33,29 +25,22 @@ const dockerServiceMock = {
   getAppIdentifier: sinon.stub(),
 };
 
-const appUninstallerMock = {
-  removeAppLocally: sinon.stub(),
+const volumeServiceMock = {
+  ensureAppVolumeMounted: sinon.stub(),
 };
 
-const isPathMountedMock = sinon.stub();
-
-const fsMock = {
-  promises: {
-    access: sinon.stub(),
-    stat: sinon.stub(),
-  },
+const appTamperingDetectionServiceMock = {
+  recordEvent: sinon.stub(),
 };
 
 // Load module with mocked dependencies
 const crontabAndMountsCleanup = proxyquire('../../ZelBack/src/services/appLifecycle/crontabAndMountsCleanup', {
   crontab: crontabMock,
-  'node-cmd': nodecmdMock,
   '../../lib/log': logMock,
   '../dbHelper': dbHelperMock,
   '../dockerService': dockerServiceMock,
-  './appUninstaller': appUninstallerMock,
-  '../appMonitoring/syncthingFolderStateMachine': { isPathMounted: isPathMountedMock },
-  'node:fs': fsMock,
+  '../utils/volumeService': volumeServiceMock,
+  '../appTamperingDetectionService': appTamperingDetectionServiceMock,
 });
 
 describe('crontabAndMountsCleanup tests', () => {
@@ -63,164 +48,26 @@ describe('crontabAndMountsCleanup tests', () => {
     // Reset only this file's own stubs (a global sinon.reset() would wipe stub
     // behaviour set up at module load by other test files in the same run)
     crontabMock.load.reset();
-    cmdAsyncMock.reset();
     logMock.info.reset();
     logMock.warn.reset();
     logMock.error.reset();
     dbHelperMock.databaseConnection.reset();
     dbHelperMock.findInDatabase.reset();
     dockerServiceMock.getAppIdentifier.reset();
-    appUninstallerMock.removeAppLocally.reset();
-    isPathMountedMock.reset();
-    fsMock.promises.access.reset();
-    fsMock.promises.stat.reset();
+    volumeServiceMock.ensureAppVolumeMounted.reset();
+    appTamperingDetectionServiceMock.recordEvent.reset();
+    appTamperingDetectionServiceMock.recordEvent.resolves();
   });
 
-  describe('extractAppNameFromAppId', () => {
-    it('should extract app name from simple app id', () => {
-      const result = crontabAndMountsCleanup.extractAppNameFromAppId('fluxmyapp');
-      expect(result).to.equal('myapp');
-    });
-
-    it('should extract app name from component app id', () => {
-      const result = crontabAndMountsCleanup.extractAppNameFromAppId('fluxwp_wordpress123');
-      expect(result).to.equal('wordpress123');
-    });
-
-    it('should handle multiple underscores in app name', () => {
-      const result = crontabAndMountsCleanup.extractAppNameFromAppId('fluxmysql_my_app_name');
-      expect(result).to.equal('my_app_name');
-    });
-
-    it('should handle app id without underscore', () => {
-      const result = crontabAndMountsCleanup.extractAppNameFromAppId('fluxsimpleapp');
-      expect(result).to.equal('simpleapp');
-    });
-  });
-
-  describe('hasWaitLogic', () => {
-    it('should return true for command with wait logic', () => {
-      const command = 'while [ ! -f /dat/fluxwpFLUXFSVOL ]; do sleep 5; done && sudo mount -o loop /dat/fluxwpFLUXFSVOL /mount/point';
-      const result = crontabAndMountsCleanup.hasWaitLogic(command);
-      expect(result).to.be.true;
-    });
-
-    it('should return false for command without wait logic', () => {
-      const command = 'sudo mount -o loop /dat/fluxwpFLUXFSVOL /mount/point';
-      const result = crontabAndMountsCleanup.hasWaitLogic(command);
-      expect(result).to.be.false;
-    });
-
-    it('should return false for partially matching command', () => {
-      const command = 'while [ ! -f /dat/fluxwpFLUXFSVOL ]; sudo mount -o loop /dat/fluxwpFLUXFSVOL /mount/point';
-      const result = crontabAndMountsCleanup.hasWaitLogic(command);
-      expect(result).to.be.false;
-    });
-  });
-
-  describe('extractVolumeFile', () => {
-    it('should extract volume file from simple mount command', () => {
-      const command = 'sudo mount -o loop /dat/fluxwpFLUXFSVOL /mount/point';
-      const result = crontabAndMountsCleanup.extractVolumeFile(command);
-      expect(result).to.equal('/dat/fluxwpFLUXFSVOL');
-    });
-
-    it('should extract volume file from command with wait logic', () => {
-      const command = 'while [ ! -f /dat/fluxwp_wordpress123FLUXFSVOL ]; do sleep 5; done && sudo mount -o loop /dat/fluxwp_wordpress123FLUXFSVOL /mount/point';
-      const result = crontabAndMountsCleanup.extractVolumeFile(command);
-      expect(result).to.equal('/dat/fluxwp_wordpress123FLUXFSVOL');
-    });
-
-    it('should return null for command without FLUXFSVOL', () => {
-      const command = 'sudo mount -o loop /dat/somefile /mount/point';
-      const result = crontabAndMountsCleanup.extractVolumeFile(command);
-      expect(result).to.be.null;
-    });
-
-    it('should handle different volume paths', () => {
-      const command = 'sudo mount -o loop /home/user/zelflux/appvolumes/fluxappFLUXFSVOL /path/to/mount';
-      const result = crontabAndMountsCleanup.extractVolumeFile(command);
-      expect(result).to.equal('/home/user/zelflux/appvolumes/fluxappFLUXFSVOL');
-    });
-  });
-
-  describe('extractMountPoint', () => {
-    it('should extract mount point from simple command', () => {
-      const command = 'sudo mount -o loop /dat/fluxwpFLUXFSVOL /dat/var/lib/fluxos/flux-apps/fluxwp';
-      const result = crontabAndMountsCleanup.extractMountPoint(command);
-      expect(result).to.equal('/dat/var/lib/fluxos/flux-apps/fluxwp');
-    });
-
-    it('should extract mount point from command with wait logic', () => {
-      const command = 'while [ ! -f /dat/fluxwpFLUXFSVOL ]; do sleep 5; done && sudo mount -o loop /dat/fluxwpFLUXFSVOL /dat/var/lib/fluxos/flux-apps/fluxwp';
-      const result = crontabAndMountsCleanup.extractMountPoint(command);
-      expect(result).to.equal('/dat/var/lib/fluxos/flux-apps/fluxwp');
-    });
-
-    it('should return null for invalid command', () => {
-      const command = 'sudo mount -o loop /dat/somefile';
-      const result = crontabAndMountsCleanup.extractMountPoint(command);
-      expect(result).to.be.null;
-    });
-  });
-
-  describe('extractAppIdFromJob', () => {
-    it('should extract appId from comment if it contains flux', () => {
-      const comment = 'fluxwp_wordpress123';
-      const command = 'sudo mount -o loop /dat/fluxwp_wordpress123FLUXFSVOL /mount/point';
-      const result = crontabAndMountsCleanup.extractAppIdFromJob(comment, command);
-      expect(result).to.equal('fluxwp_wordpress123');
-    });
-
-    it('should extract appId from command if comment does not contain flux', () => {
-      const comment = 'someotherjob';
-      const command = 'sudo mount -o loop /dat/fluxwp_wordpress123FLUXFSVOL /mount/point';
-      const result = crontabAndMountsCleanup.extractAppIdFromJob(comment, command);
-      expect(result).to.equal('fluxwp_wordpress123');
-    });
-
-    it('should return null if cannot extract appId', () => {
-      const comment = 'otherjob';
-      const command = 'some other command without FLUXFSVOL pattern';
-      const result = crontabAndMountsCleanup.extractAppIdFromJob(comment, command);
-      expect(result).to.be.null;
-    });
-
-    it('should prefer comment over command extraction', () => {
-      const comment = 'fluxmysql_app1';
-      const command = 'sudo mount -o loop /dat/fluxwp_app2FLUXFSVOL /mount/point';
-      const result = crontabAndMountsCleanup.extractAppIdFromJob(comment, command);
-      expect(result).to.equal('fluxmysql_app1');
-    });
-  });
-
-  describe('addWaitLogicToCommand', () => {
-    it('should add wait logic to simple mount command', () => {
-      const oldCommand = 'sudo mount -o loop /dat/fluxwpFLUXFSVOL /dat/var/lib/fluxos/flux-apps/fluxwp';
-      const result = crontabAndMountsCleanup.addWaitLogicToCommand(oldCommand);
-      expect(result).to.equal('while [ ! -f /dat/fluxwpFLUXFSVOL ]; do sleep 5; done && sudo mount -o loop /dat/fluxwpFLUXFSVOL /dat/var/lib/fluxos/flux-apps/fluxwp');
-    });
-
-    it('should return original command if volume file cannot be extracted', () => {
-      const oldCommand = 'sudo mount /dat/somefile /mount/point';
-      const result = crontabAndMountsCleanup.addWaitLogicToCommand(oldCommand);
-      expect(result).to.equal(oldCommand);
-      expect(logMock.warn.called).to.be.true;
-    });
-
-    it('should return original command if mount point cannot be extracted', () => {
-      const oldCommand = 'sudo mount -o loop /dat/fluxwpFLUXFSVOL';
-      const result = crontabAndMountsCleanup.addWaitLogicToCommand(oldCommand);
-      expect(result).to.equal(oldCommand);
-      expect(logMock.warn.called).to.be.true;
-    });
-  });
+  const stubInstalledApps = (apps) => {
+    const mockDb = { db: sinon.stub().returns({}) };
+    dbHelperMock.databaseConnection.returns(mockDb);
+    dbHelperMock.findInDatabase.resolves(apps);
+  };
 
   describe('getInstalledAppIds', () => {
     it('should return empty set when no apps installed', async () => {
-      const mockDb = { db: sinon.stub().returns({}) };
-      dbHelperMock.databaseConnection.returns(mockDb);
-      dbHelperMock.findInDatabase.resolves([]);
+      stubInstalledApps([]);
 
       const result = await crontabAndMountsCleanup.getInstalledAppIds();
       expect(result).to.be.instanceOf(Set);
@@ -228,11 +75,7 @@ describe('crontabAndMountsCleanup tests', () => {
     });
 
     it('should handle legacy apps (version <= 3)', async () => {
-      const mockDb = { db: sinon.stub().returns({}) };
-      dbHelperMock.databaseConnection.returns(mockDb);
-      dbHelperMock.findInDatabase.resolves([
-        { name: 'myapp', version: 3 },
-      ]);
+      stubInstalledApps([{ name: 'myapp', version: 3 }]);
       dockerServiceMock.getAppIdentifier.withArgs('myapp').returns('fluxmyapp');
 
       const result = await crontabAndMountsCleanup.getInstalledAppIds();
@@ -241,9 +84,7 @@ describe('crontabAndMountsCleanup tests', () => {
     });
 
     it('should handle newer apps with compose (version > 3)', async () => {
-      const mockDb = { db: sinon.stub().returns({}) };
-      dbHelperMock.databaseConnection.returns(mockDb);
-      dbHelperMock.findInDatabase.resolves([
+      stubInstalledApps([
         {
           name: 'wordpress123',
           version: 4,
@@ -275,107 +116,121 @@ describe('crontabAndMountsCleanup tests', () => {
     });
 
     it('should handle null response from database', async () => {
-      const mockDb = { db: sinon.stub().returns({}) };
-      dbHelperMock.databaseConnection.returns(mockDb);
-      dbHelperMock.findInDatabase.resolves(null);
+      stubInstalledApps(null);
 
       const result = await crontabAndMountsCleanup.getInstalledAppIds();
       expect(result.size).to.equal(0);
     });
   });
 
-  describe('ensureAppMounted', () => {
-    it('should return success if already mounted', async () => {
-      isPathMountedMock.resolves(true);
-
-      const result = await crontabAndMountsCleanup.ensureAppMounted(
-        'fluxwp_app1',
-        '/dat/fluxwp_app1FLUXFSVOL',
-        '/mount/point',
-      );
-
-      expect(result.mounted).to.be.true;
-      expect(result.error).to.be.null;
-      expect(logMock.info.calledWithMatch(/already mounted/)).to.be.true;
+  describe('isVolumeMountJob', () => {
+    it('should match a plain mount command', () => {
+      expect(crontabAndMountsCleanup.isVolumeMountJob('sudo mount -o loop /dat/fluxwpFLUXFSVOL /mount/point')).to.be.true;
     });
 
-    it('should return error if volume file does not exist', async () => {
-      isPathMountedMock.resolves(false);
-      fsMock.promises.access.rejects(new Error('ENOENT'));
-
-      const result = await crontabAndMountsCleanup.ensureAppMounted(
-        'fluxwp_app1',
-        '/dat/fluxwp_app1FLUXFSVOL',
-        '/mount/point',
-      );
-
-      expect(result.mounted).to.be.false;
-      expect(result.error).to.equal('Volume file does not exist');
+    it('should match a mount command with wait logic', () => {
+      expect(crontabAndMountsCleanup.isVolumeMountJob('while [ ! -f /dat/fluxwpFLUXFSVOL ]; do sleep 5; done && sudo mount -o loop /dat/fluxwpFLUXFSVOL /mount/point')).to.be.true;
     });
 
-    it('should create mount point if it does not exist', async () => {
-      isPathMountedMock.resolves(false);
-      fsMock.promises.access.resolves();
-      fsMock.promises.stat.rejects(new Error('ENOENT'));
-      cmdAsyncMock.resolves('');
-
-      const result = await crontabAndMountsCleanup.ensureAppMounted(
-        'fluxwp_app1',
-        '/dat/fluxwp_app1FLUXFSVOL',
-        '/mount/point',
-      );
-
-      expect(result.mounted).to.be.true;
-      expect(cmdAsyncMock.calledWithMatch(/sudo mkdir -p/)).to.be.true;
-      expect(cmdAsyncMock.calledWithMatch(/sudo mount -o loop/)).to.be.true;
+    it('should not match unrelated commands', () => {
+      expect(crontabAndMountsCleanup.isVolumeMountJob('sudo apt update')).to.be.false;
     });
 
-    it('should execute mount command successfully', async () => {
-      isPathMountedMock.resolves(false);
-      fsMock.promises.access.resolves();
-      fsMock.promises.stat.resolves({ isDirectory: () => true });
-      cmdAsyncMock.resolves('');
+    it('should not match loop mounts of non-FLUXFSVOL files', () => {
+      expect(crontabAndMountsCleanup.isVolumeMountJob('sudo mount -o loop /dat/somefile /mount/point')).to.be.false;
+    });
+  });
 
-      const result = await crontabAndMountsCleanup.ensureAppMounted(
-        'fluxwp_app1',
-        '/dat/fluxwp_app1FLUXFSVOL',
-        '/mount/point',
-      );
+  describe('ensureInstalledAppVolumesMounted', () => {
+    it('should mount every installed app volume derived from the DB', async () => {
+      stubInstalledApps([
+        { name: 'app1', version: 3 },
+        { name: 'wordpress123', version: 4, compose: [{ name: 'wp' }] },
+      ]);
+      dockerServiceMock.getAppIdentifier.withArgs('app1').returns('fluxapp1');
+      dockerServiceMock.getAppIdentifier.withArgs('wp_wordpress123').returns('fluxwp_wordpress123');
+      volumeServiceMock.ensureAppVolumeMounted.withArgs('fluxapp1').resolves({ mounted: true, alreadyMounted: false });
+      volumeServiceMock.ensureAppVolumeMounted.withArgs('fluxwp_wordpress123').resolves({ mounted: true, alreadyMounted: true });
 
-      expect(result.mounted).to.be.true;
-      expect(result.error).to.be.null;
-      expect(cmdAsyncMock.calledWith('sudo mount -o loop /dat/fluxwp_app1FLUXFSVOL /mount/point')).to.be.true;
+      const result = await crontabAndMountsCleanup.ensureInstalledAppVolumesMounted();
+
+      expect(result.mounted).to.deep.equal(['fluxapp1']);
+      expect(result.alreadyMounted).to.deep.equal(['fluxwp_wordpress123']);
+      expect(result.failed).to.have.lengthOf(0);
     });
 
-    it('should return error if mount command fails', async () => {
-      isPathMountedMock.resolves(false);
-      fsMock.promises.access.resolves();
-      fsMock.promises.stat.resolves({ isDirectory: () => true });
-      cmdAsyncMock.rejects(new Error('mount: permission denied'));
+    it('should record a tampering event when a volume cannot be mounted', async () => {
+      stubInstalledApps([{ name: 'app1', version: 3 }]);
+      dockerServiceMock.getAppIdentifier.withArgs('app1').returns('fluxapp1');
+      volumeServiceMock.ensureAppVolumeMounted.resolves({ mounted: false, reason: 'volume_file_missing' });
 
-      const result = await crontabAndMountsCleanup.ensureAppMounted(
-        'fluxwp_app1',
-        '/dat/fluxwp_app1FLUXFSVOL',
-        '/mount/point',
-      );
+      const result = await crontabAndMountsCleanup.ensureInstalledAppVolumesMounted();
 
-      expect(result.mounted).to.be.false;
-      expect(result.error).to.include('mount: permission denied');
+      expect(result.failed).to.deep.equal([{ appId: 'fluxapp1', reason: 'volume_file_missing' }]);
+      expect(appTamperingDetectionServiceMock.recordEvent.calledWith('fluxapp1', 'mount_vanished')).to.be.true;
+    });
+  });
+
+  describe('removeLegacyMountCrontabEntries', () => {
+    let mockCrontab;
+    let mockJobs;
+
+    const makeJob = (command, comment) => ({
+      isValid: () => true,
+      command: () => command,
+      comment: () => comment,
     });
 
-    it('should return error if mount point is not a directory', async () => {
-      isPathMountedMock.resolves(false);
-      fsMock.promises.access.resolves();
-      fsMock.promises.stat.resolves({ isDirectory: () => false });
+    beforeEach(() => {
+      mockJobs = [];
+      mockCrontab = {
+        jobs: () => mockJobs,
+        remove: sinon.stub(),
+        save: sinon.stub(),
+      };
+      crontabMock.load.callsFake((callback) => callback(null, mockCrontab));
+    });
 
-      const result = await crontabAndMountsCleanup.ensureAppMounted(
-        'fluxwp_app1',
-        '/dat/fluxwp_app1FLUXFSVOL',
-        '/mount/point',
-      );
+    it('should remove every FLUXFSVOL mount entry, installed or not', async () => {
+      const plainJob = makeJob('sudo mount -o loop /dat/fluxapp1FLUXFSVOL /mount/app1', 'fluxapp1');
+      const waitJob = makeJob('while [ ! -f /dat/fluxapp2FLUXFSVOL ]; do sleep 5; done && sudo mount -o loop /dat/fluxapp2FLUXFSVOL /mount/app2', 'fluxapp2');
+      mockJobs = [plainJob, waitJob];
 
-      expect(result.mounted).to.be.false;
-      expect(result.error).to.include('not a directory');
+      const result = await crontabAndMountsCleanup.removeLegacyMountCrontabEntries();
+
+      expect(mockCrontab.remove.calledWith(plainJob)).to.be.true;
+      expect(mockCrontab.remove.calledWith(waitJob)).to.be.true;
+      expect(result.removed).to.deep.equal(['fluxapp1', 'fluxapp2']);
+      expect(mockCrontab.save.called).to.be.true;
+    });
+
+    it('should leave non-mount jobs untouched and not save', async () => {
+      mockJobs = [makeJob('sudo apt update', 'system-update')];
+
+      const result = await crontabAndMountsCleanup.removeLegacyMountCrontabEntries();
+
+      expect(mockCrontab.remove.called).to.be.false;
+      expect(mockCrontab.save.called).to.be.false;
+      expect(result.removed).to.have.lengthOf(0);
+    });
+
+    it('should handle crontab load errors without throwing', async () => {
+      crontabMock.load.callsFake((callback) => callback(new Error('Crontab load failed')));
+
+      const result = await crontabAndMountsCleanup.removeLegacyMountCrontabEntries();
+
+      expect(result.removed).to.have.lengthOf(0);
+      expect(logMock.warn.called).to.be.true;
+    });
+
+    it('should report a save failure as an error', async () => {
+      mockJobs = [makeJob('sudo mount -o loop /dat/fluxapp1FLUXFSVOL /mount/app1', 'fluxapp1')];
+      mockCrontab.save.throws(new Error('crontab: permission denied'));
+
+      const result = await crontabAndMountsCleanup.removeLegacyMountCrontabEntries();
+
+      expect(result.errors).to.have.lengthOf(1);
+      expect(result.errors[0].error).to.include('permission denied');
     });
   });
 
@@ -388,227 +243,73 @@ describe('crontabAndMountsCleanup tests', () => {
       mockCrontab = {
         jobs: () => mockJobs,
         remove: sinon.stub(),
-        create: sinon.stub(),
         save: sinon.stub(),
       };
       crontabMock.load.callsFake((callback) => callback(null, mockCrontab));
     });
 
-    it('should return empty results when no crontab jobs', async () => {
-      const mockDb = { db: sinon.stub().returns({}) };
-      dbHelperMock.databaseConnection.returns(mockDb);
-      dbHelperMock.findInDatabase.resolves([]);
+    it('should mount installed app volumes even when the crontab is empty', async () => {
+      // the incident regression: the old implementation derived mounts from
+      // crontab entries, so a silently emptied crontab meant nothing was ever
+      // remounted after a reboot
+      stubInstalledApps([{ name: 'myapp', version: 3 }]);
+      dockerServiceMock.getAppIdentifier.withArgs('myapp').returns('fluxmyapp');
+      volumeServiceMock.ensureAppVolumeMounted.resolves({ mounted: true, alreadyMounted: false });
       mockJobs = [];
 
       const result = await crontabAndMountsCleanup.cleanupCrontabAndMounts();
 
-      expect(result.crontab.updated).to.have.lengthOf(0);
-      expect(result.crontab.removed).to.have.lengthOf(0);
-      expect(result.crontab.unchanged).to.have.lengthOf(0);
-      expect(result.mounts.mounted).to.have.lengthOf(0);
-    });
-
-    it('should remove jobs for uninstalled apps', async () => {
-      const mockDb = { db: sinon.stub().returns({}) };
-      dbHelperMock.databaseConnection.returns(mockDb);
-      dbHelperMock.findInDatabase.resolves([]); // No apps installed
-
-      const oldJob = {
-        isValid: () => true,
-        command: () => 'sudo mount -o loop /dat/fluxwp_oldappFLUXFSVOL /mount/point',
-        comment: () => 'fluxwp_oldapp',
-      };
-      mockJobs = [oldJob];
-
-      const result = await crontabAndMountsCleanup.cleanupCrontabAndMounts();
-
-      expect(mockCrontab.remove.calledWith(oldJob)).to.be.true;
-      expect(result.crontab.removed).to.include('fluxwp_oldapp');
-      expect(mockCrontab.save.called).to.be.true;
-    });
-
-    it('should update jobs without wait logic', async () => {
-      const mockDb = { db: sinon.stub().returns({}) };
-      dbHelperMock.databaseConnection.returns(mockDb);
-      dbHelperMock.findInDatabase.resolves([{ name: 'myapp', version: 3 }]);
-      dockerServiceMock.getAppIdentifier.withArgs('myapp').returns('fluxmyapp');
-
-      const oldJob = {
-        isValid: () => true,
-        command: () => 'sudo mount -o loop /dat/fluxmyappFLUXFSVOL /mount/point',
-        comment: () => 'fluxmyapp',
-      };
-      mockJobs = [oldJob];
-
-      const newJob = { isValid: () => true };
-      mockCrontab.create.returns(newJob);
-
-      isPathMountedMock.resolves(true); // Already mounted
-
-      const result = await crontabAndMountsCleanup.cleanupCrontabAndMounts();
-
-      expect(mockCrontab.remove.calledWith(oldJob)).to.be.true;
-      expect(mockCrontab.create.calledWithMatch(/while \[ ! -f/, '@reboot', 'fluxmyapp')).to.be.true;
-      expect(result.crontab.updated).to.include('fluxmyapp');
-      expect(mockCrontab.save.called).to.be.true;
-    });
-
-    it('should keep jobs that already have wait logic', async () => {
-      const mockDb = { db: sinon.stub().returns({}) };
-      dbHelperMock.databaseConnection.returns(mockDb);
-      dbHelperMock.findInDatabase.resolves([{ name: 'myapp', version: 3 }]);
-      dockerServiceMock.getAppIdentifier.withArgs('myapp').returns('fluxmyapp');
-
-      const goodJob = {
-        isValid: () => true,
-        command: () => 'while [ ! -f /dat/fluxmyappFLUXFSVOL ]; do sleep 5; done && sudo mount -o loop /dat/fluxmyappFLUXFSVOL /mount/point',
-        comment: () => 'fluxmyapp',
-      };
-      mockJobs = [goodJob];
-
-      isPathMountedMock.resolves(true);
-
-      const result = await crontabAndMountsCleanup.cleanupCrontabAndMounts();
-
-      expect(mockCrontab.remove.called).to.be.false;
-      expect(mockCrontab.create.called).to.be.false;
-      expect(result.crontab.unchanged).to.include('fluxmyapp');
-      expect(mockCrontab.save.called).to.be.false; // No changes, no save
-    });
-
-    it('should uninstall app if crontab update fails', async () => {
-      const mockDb = { db: sinon.stub().returns({}) };
-      dbHelperMock.databaseConnection.returns(mockDb);
-      dbHelperMock.findInDatabase.resolves([{ name: 'myapp', version: 3 }]);
-      dockerServiceMock.getAppIdentifier.withArgs('myapp').returns('fluxmyapp');
-
-      const oldJob = {
-        isValid: () => true,
-        command: () => 'sudo mount -o loop /dat/fluxmyappFLUXFSVOL /mount/point',
-        comment: () => 'fluxmyapp',
-      };
-      mockJobs = [oldJob];
-
-      // Create returns invalid job
-      mockCrontab.create.returns({ isValid: () => false });
-      appUninstallerMock.removeAppLocally.resolves();
-
-      const result = await crontabAndMountsCleanup.cleanupCrontabAndMounts();
-
-      expect(appUninstallerMock.removeAppLocally.calledWith('myapp', null, true, false, true)).to.be.true;
-      expect(result.crontab.errors).to.have.lengthOf(1);
-      expect(result.crontab.errors[0].action).to.equal('update');
-    });
-
-    it('should verify and create missing mounts', async () => {
-      const mockDb = { db: sinon.stub().returns({}) };
-      dbHelperMock.databaseConnection.returns(mockDb);
-      dbHelperMock.findInDatabase.resolves([{ name: 'myapp', version: 3 }]);
-      dockerServiceMock.getAppIdentifier.withArgs('myapp').returns('fluxmyapp');
-
-      const goodJob = {
-        isValid: () => true,
-        command: () => 'while [ ! -f /dat/fluxmyappFLUXFSVOL ]; do sleep 5; done && sudo mount -o loop /dat/fluxmyappFLUXFSVOL /mount/point',
-        comment: () => 'fluxmyapp',
-      };
-      mockJobs = [goodJob];
-
-      // First call: not mounted (for ensureAppMounted check)
-      // Second call: mounted (for result verification)
-      isPathMountedMock.onFirstCall().resolves(false);
-      isPathMountedMock.onSecondCall().resolves(true);
-      fsMock.promises.access.resolves();
-      fsMock.promises.stat.resolves({ isDirectory: () => true });
-      cmdAsyncMock.resolves('');
-
-      const result = await crontabAndMountsCleanup.cleanupCrontabAndMounts();
-
+      expect(volumeServiceMock.ensureAppVolumeMounted.calledWith('fluxmyapp')).to.be.true;
       expect(result.mounts.mounted).to.include('fluxmyapp');
-      expect(cmdAsyncMock.calledWithMatch(/sudo mount -o loop/)).to.be.true;
     });
 
-    it('should handle multiple apps correctly', async () => {
-      const mockDb = { db: sinon.stub().returns({}) };
-      dbHelperMock.databaseConnection.returns(mockDb);
-      dbHelperMock.findInDatabase.resolves([
-        { name: 'app1', version: 3 },
-        { name: 'app2', version: 3 },
-      ]);
-      dockerServiceMock.getAppIdentifier.withArgs('app1').returns('fluxapp1');
-      dockerServiceMock.getAppIdentifier.withArgs('app2').returns('fluxapp2');
-
-      const job1 = {
-        isValid: () => true,
-        command: () => 'sudo mount -o loop /dat/fluxapp1FLUXFSVOL /mount/app1',
-        comment: () => 'fluxapp1',
-      };
-      const job2 = {
-        isValid: () => true,
-        command: () => 'while [ ! -f /dat/fluxapp2FLUXFSVOL ]; do sleep 5; done && sudo mount -o loop /dat/fluxapp2FLUXFSVOL /mount/app2',
-        comment: () => 'fluxapp2',
-      };
-      const job3Stale = {
-        isValid: () => true,
-        command: () => 'sudo mount -o loop /dat/fluxoldappFLUXFSVOL /mount/oldapp',
-        comment: () => 'fluxoldapp',
-      };
-      mockJobs = [job1, job2, job3Stale];
-
-      const newJob = { isValid: () => true };
-      mockCrontab.create.returns(newJob);
-      isPathMountedMock.resolves(true);
-
-      const result = await crontabAndMountsCleanup.cleanupCrontabAndMounts();
-
-      expect(result.crontab.updated).to.include('fluxapp1'); // Updated (no wait logic)
-      expect(result.crontab.unchanged).to.include('fluxapp2'); // Unchanged (already has wait logic)
-      expect(result.crontab.removed).to.include('fluxoldapp'); // Removed (not installed)
-      expect(mockCrontab.save.called).to.be.true;
-    });
-
-    it('should skip non-mount jobs', async () => {
-      const mockDb = { db: sinon.stub().returns({}) };
-      dbHelperMock.databaseConnection.returns(mockDb);
-      dbHelperMock.findInDatabase.resolves([]);
-
-      const nonMountJob = {
-        isValid: () => true,
-        command: () => 'sudo apt update',
-        comment: () => 'system-update',
-      };
-      mockJobs = [nonMountJob];
-
-      const result = await crontabAndMountsCleanup.cleanupCrontabAndMounts();
-
-      expect(mockCrontab.remove.called).to.be.false;
-      expect(result.crontab.removed).to.have.lengthOf(0);
-    });
-
-    it('should handle crontab load errors', async () => {
+    it('should mount volumes even when the crontab cannot be loaded at all', async () => {
+      stubInstalledApps([{ name: 'myapp', version: 3 }]);
+      dockerServiceMock.getAppIdentifier.withArgs('myapp').returns('fluxmyapp');
+      volumeServiceMock.ensureAppVolumeMounted.resolves({ mounted: true, alreadyMounted: false });
       crontabMock.load.callsFake((callback) => callback(new Error('Crontab load failed')));
 
       const result = await crontabAndMountsCleanup.cleanupCrontabAndMounts();
 
-      expect(result.crontab.errors).to.have.lengthOf(1);
-      expect(logMock.error.called).to.be.true;
+      expect(result.mounts.mounted).to.include('fluxmyapp');
+      expect(result.crontab.removed).to.have.lengthOf(0);
     });
 
-    it('should skip invalid jobs', async () => {
-      const mockDb = { db: sinon.stub().returns({}) };
-      dbHelperMock.databaseConnection.returns(mockDb);
-      dbHelperMock.findInDatabase.resolves([]);
-
-      const invalidJob = {
-        isValid: () => false,
-        command: () => 'sudo mount -o loop /dat/fluxappFLUXFSVOL /mount/point',
-        comment: () => 'fluxapp',
+    it('should remove legacy mount entries of installed apps too', async () => {
+      stubInstalledApps([{ name: 'myapp', version: 3 }]);
+      dockerServiceMock.getAppIdentifier.withArgs('myapp').returns('fluxmyapp');
+      volumeServiceMock.ensureAppVolumeMounted.resolves({ mounted: true, alreadyMounted: true });
+      const legacyJob = {
+        isValid: () => true,
+        command: () => 'while [ ! -f /dat/fluxmyappFLUXFSVOL ]; do sleep 5; done && sudo mount -o loop /dat/fluxmyappFLUXFSVOL /mount/point',
+        comment: () => 'fluxmyapp',
       };
-      mockJobs = [invalidJob];
+      mockJobs = [legacyJob];
 
       const result = await crontabAndMountsCleanup.cleanupCrontabAndMounts();
 
-      expect(mockCrontab.remove.called).to.be.false;
-      expect(result.crontab.removed).to.have.lengthOf(0);
+      expect(mockCrontab.remove.calledWith(legacyJob)).to.be.true;
+      expect(result.crontab.removed).to.include('fluxmyapp');
+      expect(result.mounts.alreadyMounted).to.include('fluxmyapp');
+    });
+
+    it('should never remove an app because of crontab state', async () => {
+      // the old implementation force-removed apps when a crontab rewrite
+      // failed; the new one must take no app-lifecycle action at all
+      stubInstalledApps([{ name: 'myapp', version: 3 }]);
+      dockerServiceMock.getAppIdentifier.withArgs('myapp').returns('fluxmyapp');
+      volumeServiceMock.ensureAppVolumeMounted.resolves({ mounted: true, alreadyMounted: true });
+      mockJobs = [{
+        isValid: () => true,
+        command: () => 'sudo mount -o loop /dat/fluxmyappFLUXFSVOL /mount/point',
+        comment: () => 'fluxmyapp',
+      }];
+      mockCrontab.save.throws(new Error('crontab: permission denied'));
+
+      const result = await crontabAndMountsCleanup.cleanupCrontabAndMounts();
+
+      expect(result.crontab.errors).to.have.lengthOf(1);
+      expect(result.mounts.failed).to.have.lengthOf(0);
     });
   });
 });

--- a/tests/unit/crontabAndMountsCleanup.test.js
+++ b/tests/unit/crontabAndMountsCleanup.test.js
@@ -27,6 +27,12 @@ const dockerServiceMock = {
 
 const volumeServiceMock = {
   ensureAppVolumeMounted: sinon.stub(),
+  getComponentAppIdsFromVolumeFiles: sinon.stub(),
+  isPathMounted: sinon.stub(),
+};
+
+const enterpriseHelperMock = {
+  checkAndDecryptAppSpecs: sinon.stub(),
 };
 
 const appTamperingDetectionServiceMock = {
@@ -40,6 +46,7 @@ const crontabAndMountsCleanup = proxyquire('../../ZelBack/src/services/appLifecy
   '../dbHelper': dbHelperMock,
   '../dockerService': dockerServiceMock,
   '../utils/volumeService': volumeServiceMock,
+  '../utils/enterpriseHelper': enterpriseHelperMock,
   '../appTamperingDetectionService': appTamperingDetectionServiceMock,
 });
 
@@ -55,6 +62,9 @@ describe('crontabAndMountsCleanup tests', () => {
     dbHelperMock.findInDatabase.reset();
     dockerServiceMock.getAppIdentifier.reset();
     volumeServiceMock.ensureAppVolumeMounted.reset();
+    volumeServiceMock.getComponentAppIdsFromVolumeFiles.reset();
+    volumeServiceMock.isPathMounted.reset();
+    enterpriseHelperMock.checkAndDecryptAppSpecs.reset();
     appTamperingDetectionServiceMock.recordEvent.reset();
     appTamperingDetectionServiceMock.recordEvent.resolves();
   });
@@ -106,13 +116,19 @@ describe('crontabAndMountsCleanup tests', () => {
       expect(result.size).to.equal(3);
     });
 
-    it('should handle database errors gracefully', async () => {
+    it('should throw on database errors instead of reporting an empty install set', async () => {
+      // an empty set means "nothing installed" to callers; a failed
+      // enumeration must never masquerade as that
       dbHelperMock.databaseConnection.throws(new Error('DB connection failed'));
 
-      const result = await crontabAndMountsCleanup.getInstalledAppIds();
-      expect(result).to.be.instanceOf(Set);
-      expect(result.size).to.equal(0);
-      expect(logMock.error.called).to.be.true;
+      let thrown = null;
+      try {
+        await crontabAndMountsCleanup.getInstalledAppIds();
+      } catch (error) {
+        thrown = error;
+      }
+      expect(thrown).to.be.an('error');
+      expect(thrown.message).to.include('DB connection failed');
     });
 
     it('should handle null response from database', async () => {
@@ -120,6 +136,73 @@ describe('crontabAndMountsCleanup tests', () => {
 
       const result = await crontabAndMountsCleanup.getInstalledAppIds();
       expect(result.size).to.equal(0);
+    });
+
+    it('should decrypt enterprise apps (compose stored empty) to enumerate components', async () => {
+      // enterprise specs are stored locally with compose: [] - the incident
+      // regression treated them as "not installed" and ate their crontab entries
+      const enterpriseApp = {
+        name: 'hermesagent123', version: 8, compose: [], enterprise: 'encryptedblob',
+      };
+      stubInstalledApps([enterpriseApp]);
+      enterpriseHelperMock.checkAndDecryptAppSpecs.resolves({
+        ...enterpriseApp, compose: [{ name: 'hermes' }],
+      });
+      dockerServiceMock.getAppIdentifier.withArgs('hermes_hermesagent123').returns('fluxhermes_hermesagent123');
+
+      const result = await crontabAndMountsCleanup.getInstalledAppIds();
+
+      expect(enterpriseHelperMock.checkAndDecryptAppSpecs.calledWith(enterpriseApp)).to.be.true;
+      expect(result.has('fluxhermes_hermesagent123')).to.be.true;
+      expect(result.size).to.equal(1);
+    });
+
+    it('should derive enterprise components from volume images when decryption fails', async () => {
+      stubInstalledApps([{
+        name: 'hermesagent123', version: 8, compose: [], enterprise: 'encryptedblob',
+      }]);
+      enterpriseHelperMock.checkAndDecryptAppSpecs.rejects(new Error('fluxbenchd unavailable'));
+      volumeServiceMock.getComponentAppIdsFromVolumeFiles.withArgs('hermesagent123').resolves(['fluxhermes_hermesagent123']);
+
+      const result = await crontabAndMountsCleanup.getInstalledAppIds();
+
+      expect(result.has('fluxhermes_hermesagent123')).to.be.true;
+      expect(logMock.warn.called).to.be.true;
+    });
+
+    it('should derive enterprise components from volume images when decryption yields no compose', async () => {
+      stubInstalledApps([{
+        name: 'hermesagent123', version: 8, compose: [], enterprise: 'encryptedblob',
+      }]);
+      enterpriseHelperMock.checkAndDecryptAppSpecs.resolvesArg(0);
+      volumeServiceMock.getComponentAppIdsFromVolumeFiles.withArgs('hermesagent123').resolves(['fluxhermes_hermesagent123']);
+
+      const result = await crontabAndMountsCleanup.getInstalledAppIds();
+
+      expect(result.has('fluxhermes_hermesagent123')).to.be.true;
+    });
+
+    it('should not attempt decryption for apps with plaintext compose', async () => {
+      stubInstalledApps([{ name: 'wordpress123', version: 4, compose: [{ name: 'wp' }] }]);
+      dockerServiceMock.getAppIdentifier.withArgs('wp_wordpress123').returns('fluxwp_wordpress123');
+
+      await crontabAndMountsCleanup.getInstalledAppIds();
+
+      expect(enterpriseHelperMock.checkAndDecryptAppSpecs.called).to.be.false;
+    });
+  });
+
+  describe('extractMountPoint', () => {
+    it('should extract the mountpoint from a plain mount command', () => {
+      expect(crontabAndMountsCleanup.extractMountPoint('sudo mount -o loop /dat/fluxwpFLUXFSVOL /dat/var/lib/fluxos/flux-apps/fluxwp')).to.equal('/dat/var/lib/fluxos/flux-apps/fluxwp');
+    });
+
+    it('should extract the mountpoint from a wait-logic command', () => {
+      expect(crontabAndMountsCleanup.extractMountPoint('while [ ! -f /dat/fluxwpFLUXFSVOL ]; do sleep 5; done && sudo mount -o loop /dat/fluxwpFLUXFSVOL /mnt/wp')).to.equal('/mnt/wp');
+    });
+
+    it('should return null for unparseable commands', () => {
+      expect(crontabAndMountsCleanup.extractMountPoint('sudo apt update')).to.be.null;
     });
   });
 
@@ -189,19 +272,47 @@ describe('crontabAndMountsCleanup tests', () => {
         save: sinon.stub(),
       };
       crontabMock.load.callsFake((callback) => callback(null, mockCrontab));
+      volumeServiceMock.isPathMounted.resolves(true);
     });
 
-    it('should remove every FLUXFSVOL mount entry, installed or not', async () => {
+    it('should remove every mounted FLUXFSVOL entry, installed or not', async () => {
       const plainJob = makeJob('sudo mount -o loop /dat/fluxapp1FLUXFSVOL /mount/app1', 'fluxapp1');
       const waitJob = makeJob('while [ ! -f /dat/fluxapp2FLUXFSVOL ]; do sleep 5; done && sudo mount -o loop /dat/fluxapp2FLUXFSVOL /mount/app2', 'fluxapp2');
       mockJobs = [plainJob, waitJob];
 
       const result = await crontabAndMountsCleanup.removeLegacyMountCrontabEntries();
 
+      expect(volumeServiceMock.isPathMounted.calledWith('/mount/app1')).to.be.true;
+      expect(volumeServiceMock.isPathMounted.calledWith('/mount/app2')).to.be.true;
       expect(mockCrontab.remove.calledWith(plainJob)).to.be.true;
       expect(mockCrontab.remove.calledWith(waitJob)).to.be.true;
       expect(result.removed).to.deep.equal(['fluxapp1', 'fluxapp2']);
       expect(mockCrontab.save.called).to.be.true;
+    });
+
+    it('should keep entries whose volume is not currently mounted', async () => {
+      // the entry is only superseded once the FluxOS-owned mount demonstrably
+      // works; until then it is the remaining safety net for the next boot
+      const job = makeJob('sudo mount -o loop /dat/fluxapp1FLUXFSVOL /mount/app1', 'fluxapp1');
+      mockJobs = [job];
+      volumeServiceMock.isPathMounted.withArgs('/mount/app1').resolves(false);
+
+      const result = await crontabAndMountsCleanup.removeLegacyMountCrontabEntries();
+
+      expect(mockCrontab.remove.called).to.be.false;
+      expect(mockCrontab.save.called).to.be.false;
+      expect(result.kept).to.deep.equal(['fluxapp1']);
+      expect(result.removed).to.have.lengthOf(0);
+    });
+
+    it('should keep entries whose mountpoint cannot be parsed', async () => {
+      const job = makeJob('mount -o loop somethingFLUXFSVOL', 'fluxweird');
+      mockJobs = [job];
+
+      const result = await crontabAndMountsCleanup.removeLegacyMountCrontabEntries();
+
+      expect(mockCrontab.remove.called).to.be.false;
+      expect(result.kept).to.deep.equal(['fluxweird']);
     });
 
     it('should leave non-mount jobs untouched and not save', async () => {
@@ -246,6 +357,40 @@ describe('crontabAndMountsCleanup tests', () => {
         save: sinon.stub(),
       };
       crontabMock.load.callsFake((callback) => callback(null, mockCrontab));
+      volumeServiceMock.isPathMounted.resolves(true);
+    });
+
+    it('should abort without touching the crontab when the install set cannot be enumerated', async () => {
+      // a failed enumeration must not cascade into destructive crontab edits -
+      // that is precisely how remount entries kept vanishing in production
+      dbHelperMock.databaseConnection.throws(new Error('DB connection failed'));
+      mockJobs = [{
+        isValid: () => true,
+        command: () => 'sudo mount -o loop /dat/fluxmyappFLUXFSVOL /mount/point',
+        comment: () => 'fluxmyapp',
+      }];
+
+      const result = await crontabAndMountsCleanup.cleanupCrontabAndMounts();
+
+      expect(mockCrontab.remove.called).to.be.false;
+      expect(mockCrontab.save.called).to.be.false;
+      expect(result.crontab.removed).to.have.lengthOf(0);
+      expect(result.mounts.mounted).to.have.lengthOf(0);
+      expect(logMock.error.called).to.be.true;
+    });
+
+    it('should mount an enterprise app volume via disk-derived components when decryption fails', async () => {
+      stubInstalledApps([{
+        name: 'hermesagent123', version: 8, compose: [], enterprise: 'encryptedblob',
+      }]);
+      enterpriseHelperMock.checkAndDecryptAppSpecs.rejects(new Error('fluxbenchd unavailable'));
+      volumeServiceMock.getComponentAppIdsFromVolumeFiles.withArgs('hermesagent123').resolves(['fluxhermes_hermesagent123']);
+      volumeServiceMock.ensureAppVolumeMounted.withArgs('fluxhermes_hermesagent123').resolves({ mounted: true, alreadyMounted: false });
+
+      const result = await crontabAndMountsCleanup.cleanupCrontabAndMounts();
+
+      expect(result.mounts.mounted).to.include('fluxhermes_hermesagent123');
+      expect(result.mounts.failed).to.have.lengthOf(0);
     });
 
     it('should mount installed app volumes even when the crontab is empty', async () => {

--- a/tests/unit/portManager.test.js
+++ b/tests/unit/portManager.test.js
@@ -6,6 +6,8 @@ const portManager = require('../../ZelBack/src/services/appNetwork/portManager')
 const upnpService = require('../../ZelBack/src/services/upnpService');
 const fluxNetworkHelper = require('../../ZelBack/src/services/fluxNetworkHelper');
 const verificationHelper = require('../../ZelBack/src/services/verificationHelper');
+const serviceHelper = require('../../ZelBack/src/services/serviceHelper');
+const appUninstaller = require('../../ZelBack/src/services/appLifecycle/appUninstaller');
 const { requireMongo } = require('./dbTestHelper');
 
 describe('portManager tests', () => {
@@ -496,6 +498,9 @@ describe('portManager tests', () => {
       sinon.stub(fluxNetworkHelper, 'isFirewallActive').resolves(false);
       sinon.stub(fluxNetworkHelper, 'allowPort').resolves(true);
       sinon.stub(upnpService, 'mapUpnpPort').resolves(true);
+      sinon.stub(serviceHelper, 'delay').resolves();
+      sinon.stub(appUninstaller, 'removeAppLocally').resolves();
+      portManager.upnpMapFailures.clear();
     });
 
     it('should setup firewall for app ports when active', async () => {
@@ -519,6 +524,71 @@ describe('portManager tests', () => {
 
       // Should not throw
       await portManager.restoreAppsPortsSupport();
+    });
+
+    it('should NOT remove an app on a single UPNP mapping failure', async () => {
+      // the incident regression: one failed map used to escalate straight to
+      // removeAppLocally(force, sendMessage) - a transient router blip nuked
+      // a running app and broadcast its removal to the network
+      upnpService.isUPNP.returns(true);
+      upnpService.mapUpnpPort.resolves(false);
+
+      await portManager.restoreAppsPortsSupport();
+
+      sinon.assert.notCalled(appUninstaller.removeAppLocally);
+      expect(portManager.upnpMapFailures.get('App1').cycles).to.equal(1);
+    });
+
+    it('should retry a failed port within the cycle and record no failure on recovery', async () => {
+      upnpService.isUPNP.returns(true);
+      upnpService.mapUpnpPort.onFirstCall().resolves(false);
+      upnpService.mapUpnpPort.resolves(true);
+
+      await portManager.restoreAppsPortsSupport();
+
+      sinon.assert.notCalled(appUninstaller.removeAppLocally);
+      expect(portManager.upnpMapFailures.has('App1')).to.be.false;
+    });
+
+    it('should not remove before the sustained window even after enough failing cycles', async () => {
+      upnpService.isUPNP.returns(true);
+      upnpService.mapUpnpPort.resolves(false);
+
+      await portManager.restoreAppsPortsSupport();
+      await portManager.restoreAppsPortsSupport();
+      await portManager.restoreAppsPortsSupport();
+
+      // 3 consecutive cycles, but wall-clock window not yet elapsed
+      sinon.assert.notCalled(appUninstaller.removeAppLocally);
+      expect(portManager.upnpMapFailures.get('App1').cycles).to.equal(3);
+    });
+
+    it('should remove and broadcast only after sustained failure (cycles AND window)', async () => {
+      upnpService.isUPNP.returns(true);
+      upnpService.mapUpnpPort.resolves(false);
+      const nowMonotonicMs = Number(process.hrtime.bigint() / 1000000n);
+      portManager.upnpMapFailures.set('App1', {
+        cycles: 2,
+        firstFailureAtMs: nowMonotonicMs - (31 * 60 * 1000),
+      });
+
+      await portManager.restoreAppsPortsSupport();
+
+      sinon.assert.calledWith(appUninstaller.removeAppLocally, 'App1', null, true, true, true);
+      expect(portManager.upnpMapFailures.has('App1')).to.be.false;
+    });
+
+    it('should clear the failure tracker once mapping succeeds again', async () => {
+      upnpService.isUPNP.returns(true);
+      upnpService.mapUpnpPort.resolves(false);
+      await portManager.restoreAppsPortsSupport();
+      expect(portManager.upnpMapFailures.get('App1').cycles).to.equal(1);
+
+      upnpService.mapUpnpPort.resolves(true);
+      await portManager.restoreAppsPortsSupport();
+
+      expect(portManager.upnpMapFailures.has('App1')).to.be.false;
+      sinon.assert.notCalled(appUninstaller.removeAppLocally);
     });
   });
 

--- a/tests/unit/portManager.test.js
+++ b/tests/unit/portManager.test.js
@@ -578,6 +578,24 @@ describe('portManager tests', () => {
       expect(portManager.upnpMapFailures.has('App1')).to.be.false;
     });
 
+    it('should pay the retry pause at most once per cycle across failing apps', async () => {
+      const collection = config.database.appslocal.collections.appsInformation;
+      await dbHelper.insertManyToDatabase(database, collection, [
+        { name: 'App2', version: 3, ports: [30002] },
+      ]);
+      upnpService.isUPNP.returns(true);
+      upnpService.mapUpnpPort.resolves(false);
+
+      await portManager.restoreAppsPortsSupport();
+
+      // both apps still get their retry attempt and their strike, but the
+      // recovery pause is shared - not stacked per app
+      sinon.assert.calledOnce(serviceHelper.delay);
+      expect(upnpService.mapUpnpPort.callCount).to.equal(4);
+      expect(portManager.upnpMapFailures.get('App1').cycles).to.equal(1);
+      expect(portManager.upnpMapFailures.get('App2').cycles).to.equal(1);
+    });
+
     it('should clear the failure tracker once mapping succeeds again', async () => {
       upnpService.isUPNP.returns(true);
       upnpService.mapUpnpPort.resolves(false);

--- a/tests/unit/syncthingFolderStateMachine.test.js
+++ b/tests/unit/syncthingFolderStateMachine.test.js
@@ -24,10 +24,23 @@ const dockerServiceMock = {
 
 const serviceHelperMock = {
   delay: sinon.stub().resolves(),
+  runCommand: sinon.stub().resolves({ error: null, stdout: '', stderr: '' }),
 };
 
-const nodecmdMock = {
-  run: sinon.stub(),
+const volumeServiceMock = {
+  isPathMounted: sinon.stub(),
+  ensureAppVolumeMounted: sinon.stub(),
+};
+
+const fsMock = {
+  promises: {
+    stat: sinon.stub(),
+    readdir: sinon.stub(),
+  },
+};
+
+const appTamperingDetectionServiceMock = {
+  recordEvent: sinon.stub().resolves(),
 };
 
 const appReconcilerMock = {
@@ -37,12 +50,21 @@ const appReconcilerMock = {
 };
 const appUninstallerMock = { removeAppLocally: sinon.stub().resolves() };
 
+// a directory entry as fs.readdir({ withFileTypes: true }) returns it
+const dirent = (name, isFile = true) => ({
+  name,
+  isFile: () => isFile,
+  isDirectory: () => !isFile,
+});
+
 // Load module with mocked dependencies
 const stateMachine = proxyquire('../../ZelBack/src/services/appMonitoring/syncthingFolderStateMachine', {
   '../dockerService': dockerServiceMock,
   '../syncthingService': syncthingServiceMock,
   '../serviceHelper': serviceHelperMock,
-  'node-cmd': nodecmdMock,
+  '../utils/volumeService': volumeServiceMock,
+  '../appTamperingDetectionService': appTamperingDetectionServiceMock,
+  'node:fs': fsMock,
   // stub new collaborators so the unit test doesn't load the real module graph
   './appReconciler': appReconcilerMock,
   '../appLifecycle/appUninstaller': appUninstallerMock,
@@ -68,35 +90,25 @@ describe('syncthingFolderStateMachine tests', () => {
     dockerServiceMock.getAppIdentifier.reset();
     serviceHelperMock.delay.reset();
     serviceHelperMock.delay.resolves();
-    nodecmdMock.run.reset();
+    serviceHelperMock.runCommand.reset();
+    serviceHelperMock.runCommand.resolves({ error: null, stdout: '', stderr: '' });
+    volumeServiceMock.isPathMounted.reset();
+    volumeServiceMock.ensureAppVolumeMounted.reset();
+    fsMock.promises.stat.reset();
+    fsMock.promises.readdir.reset();
+    appTamperingDetectionServiceMock.recordEvent.reset();
+    appTamperingDetectionServiceMock.recordEvent.resolves();
     appUninstallerMock.removeAppLocally.reset();
     appUninstallerMock.removeAppLocally.resolves();
     appReconcilerMock.setControllerDesired.reset();
     appReconcilerMock.requestStopAndClearData.reset();
     appReconcilerMock.enqueue.reset();
 
-    // Mock successful file system operations for safety checks
+    // Default filesystem state: app dir exists, is a mountpoint, holds files.
     // This makes verifyFolderMountSafety return isSafe: true
-    // nodecmd.run callback signature: (err, data, stderr)
-    nodecmdMock.run.callsFake((cmd, callback) => {
-      if (cmd.includes('test -d')) {
-        // Directory exists
-        callback(null, 'exists', '');
-      } else if (cmd.includes('mountpoint')) {
-        // Not a mount point (exit code 1) - this causes an error
-        const err = new Error('not a mountpoint');
-        err.code = 1;
-        callback(err, '', '');
-      } else if (cmd.includes('find')) {
-        // Has files (return count > 0)
-        callback(null, '10\n', '');
-      } else if (cmd.includes('chmod')) {
-        // Permission changes succeed
-        callback(null, '', '');
-      } else {
-        callback(null, '', '');
-      }
-    });
+    fsMock.promises.stat.resolves({ isDirectory: () => true });
+    volumeServiceMock.isPathMounted.resolves(true);
+    fsMock.promises.readdir.resolves([dirent('state.db'), dirent('config.yaml')]);
   });
 
   describe('isDesignatedLeader', () => {
@@ -989,6 +1001,157 @@ describe('syncthingFolderStateMachine tests', () => {
       sinon.assert.calledTwice(syncthingServiceMock.systemPause);
       sinon.assert.calledTwice(syncthingServiceMock.systemResume);
       expect(syncthingServiceMock.systemResume.secondCall.args[0].params.device).to.equal('DEVICE_B');
+    });
+  });
+
+  describe('verifyFolderMountSafety', () => {
+    it('is unsafe when the dir is not mounted even if it has content', async () => {
+      // the deletion-propagation regression: syncthing had pulled the master's
+      // data onto the BARE dir, so content used to buy a pass while unmounted -
+      // and the stale sendreceive folder then broadcast deletions to the master
+      volumeServiceMock.isPathMounted.resolves(false);
+      fsMock.promises.readdir.resolves([dirent('leaked.db')]);
+
+      const result = await stateMachine.verifyFolderMountSafety('test-app', '/apps/test-app');
+
+      expect(result.isSafe).to.be.false;
+      expect(result.reason).to.equal('unmounted_with_content');
+      expect(result.hasContent).to.be.true;
+      sinon.assert.calledWith(appTamperingDetectionServiceMock.recordEvent, 'test-app', 'mount_vanished');
+    });
+
+    it('is unsafe when the dir is not mounted and empty', async () => {
+      volumeServiceMock.isPathMounted.resolves(false);
+      fsMock.promises.readdir.resolves([]);
+
+      const result = await stateMachine.verifyFolderMountSafety('test-app', '/apps/test-app');
+
+      expect(result.isSafe).to.be.false;
+      expect(result.reason).to.equal('empty_unmounted_directory');
+    });
+
+    it('is safe when mounted with content', async () => {
+      const result = await stateMachine.verifyFolderMountSafety('test-app', '/apps/test-app');
+
+      expect(result.isSafe).to.be.true;
+      expect(result.isMounted).to.be.true;
+    });
+
+    it('is unsafe when the base directory is missing', async () => {
+      fsMock.promises.stat.rejects(new Error('ENOENT'));
+
+      const result = await stateMachine.verifyFolderMountSafety('test-app', '/apps/test-app');
+
+      expect(result.isSafe).to.be.false;
+      expect(result.reason).to.equal('base_directory_missing');
+    });
+  });
+
+  describe('verifySendReceiveFolderSafety', () => {
+    it('is unsafe when the index claims data but the disk holds no sync-scoped files', async () => {
+      // stale ("phantom") index over a fresh empty volume: only FluxOS's own
+      // housekeeping (.stignore, backup/) on disk, yet the index claims bytes -
+      // sendreceive would broadcast every "missing" file as a deletion
+      fsMock.promises.readdir.resolves([dirent('.stignore'), dirent('backup', false)]);
+      syncthingServiceMock.getDbStatus.resolves({
+        status: 'success',
+        data: { globalBytes: 500000, inSyncBytes: 500000, state: 'idle' },
+      });
+
+      const result = await stateMachine.verifySendReceiveFolderSafety('test-app', '/apps/test-app');
+
+      expect(result.isSafe).to.be.false;
+      expect(result.reason).to.equal('phantom_index_empty_disk');
+    });
+
+    it('is safe on an empty disk when the index is empty too (cold-start seed)', async () => {
+      fsMock.promises.readdir.resolves([dirent('.stignore')]);
+      syncthingServiceMock.getDbStatus.resolves({
+        status: 'success',
+        data: { globalBytes: 0, inSyncBytes: 0, state: 'idle' },
+      });
+
+      const result = await stateMachine.verifySendReceiveFolderSafety('test-app', '/apps/test-app');
+
+      expect(result.isSafe).to.be.true;
+    });
+
+    it('is safe when the disk holds real data matching a non-empty index', async () => {
+      syncthingServiceMock.getDbStatus.resolves({
+        status: 'success',
+        data: { globalBytes: 500000, inSyncBytes: 500000, state: 'idle' },
+      });
+
+      const result = await stateMachine.verifySendReceiveFolderSafety('test-app', '/apps/test-app');
+
+      expect(result.isSafe).to.be.true;
+    });
+
+    it('falls back to the mount-level verdict when the sync status is unreadable', async () => {
+      syncthingServiceMock.getDbStatus.rejects(new Error('syncthing down'));
+
+      const result = await stateMachine.verifySendReceiveFolderSafety('test-app', '/apps/test-app');
+
+      expect(result.isSafe).to.be.true;
+    });
+  });
+
+  describe('manageFolderSyncState mount safety on a sendreceive folder', () => {
+    let mockParams;
+
+    beforeEach(() => {
+      mockParams = {
+        appId: 'test-app',
+        syncFolder: { type: 'sendreceive', path: '/apps/test-app' },
+        containerDataFlags: 'g',
+        syncthingAppsFirstRun: false,
+        receiveOnlySyncthingAppsCache: new Map(),
+        appLocation: sinon.stub().resolves([]),
+        localSocketAddr: '10.0.0.1:16127',
+        syncthingFolder: { id: 'test-app', type: 'sendreceive' },
+        installedAppName: 'test-app',
+      };
+      dockerServiceMock.dockerContainerInspect.resolves({ State: { Running: true } });
+    });
+
+    it('mounts an unmounted volume and proceeds when the re-verify passes', async () => {
+      volumeServiceMock.isPathMounted.onFirstCall().resolves(false);
+      volumeServiceMock.isPathMounted.resolves(true);
+      volumeServiceMock.ensureAppVolumeMounted.resolves({ mounted: true, alreadyMounted: false });
+
+      const result = await stateMachine.manageFolderSyncState(mockParams);
+
+      sinon.assert.calledWith(volumeServiceMock.ensureAppVolumeMounted, 'test-app');
+      expect(result.skipUpdate).to.be.true;
+      sinon.assert.neverCalledWith(appReconcilerMock.setControllerDesired, 'test-app', 'stopped');
+    });
+
+    it('demotes to receiveonly and holds the container when the volume cannot be mounted', async () => {
+      volumeServiceMock.isPathMounted.resolves(false);
+      volumeServiceMock.ensureAppVolumeMounted.resolves({ mounted: false, reason: 'volume_file_missing' });
+
+      const result = await stateMachine.manageFolderSyncState(mockParams);
+
+      expect(result.syncthingFolder.type).to.equal('receiveonly');
+      expect(result.cache.mountSafetyBlocked).to.be.true;
+      sinon.assert.calledWith(appReconcilerMock.setControllerDesired, 'test-app', 'stopped');
+    });
+
+    it('still demotes after a successful mount when the index is phantom over an empty volume', async () => {
+      volumeServiceMock.isPathMounted.onFirstCall().resolves(false);
+      volumeServiceMock.isPathMounted.resolves(true);
+      volumeServiceMock.ensureAppVolumeMounted.resolves({ mounted: true, alreadyMounted: false });
+      fsMock.promises.readdir.resolves([dirent('.stignore')]);
+      syncthingServiceMock.getDbStatus.resolves({
+        status: 'success',
+        data: { globalBytes: 500000, inSyncBytes: 500000, state: 'idle' },
+      });
+
+      const result = await stateMachine.manageFolderSyncState(mockParams);
+
+      expect(result.syncthingFolder.type).to.equal('receiveonly');
+      expect(result.cache.blockedReason).to.equal('phantom_index_empty_disk');
+      sinon.assert.calledWith(appReconcilerMock.setControllerDesired, 'test-app', 'stopped');
     });
   });
 });

--- a/tests/unit/syncthingFolderStateMachine.test.js
+++ b/tests/unit/syncthingFolderStateMachine.test.js
@@ -584,6 +584,78 @@ describe('syncthingFolderStateMachine tests', () => {
       sinon.assert.calledWith(appReconcilerMock.setControllerDesired, 'test-app', 'running');
     });
 
+    // Pre-flip safety: completion metrics come from the index, and a stale index
+    // claims bytes the disk does not hold. A folder must pass the sendreceive
+    // safety verification BEFORE it flips - promoting first and demoting a cycle
+    // later leaves a window where sendreceive broadcasts the missing files as
+    // deletions.
+    it('does not promote a synced folder whose index claims data over an empty disk', async () => {
+      mockParams.receiveOnlySyncthingAppsCache.set('test-app', {
+        restarted: false,
+        numberOfExecutions: 1,
+      });
+      mockParams.appLocation.resolves([
+        { ip: '10.0.0.0:16127', runningSince: null, broadcastedAt: 1000 },
+        { ip: '10.0.0.1:16127', runningSince: null, broadcastedAt: 1000 },
+      ]);
+      syncthingServiceMock.getDbStatus.resolves({
+        status: 'success',
+        data: { globalBytes: 1000, inSyncBytes: 1000, state: 'idle' },
+      });
+      // only syncthing housekeeping on disk - no sync-scoped files
+      fsMock.promises.readdir.resolves([dirent('.stignore'), dirent('backup', false)]);
+
+      const result = await stateMachine.manageFolderSyncState(mockParams);
+
+      expect(result.syncthingFolder.type).to.equal('receiveonly');
+      expect(result.cache.restarted).to.not.equal(true);
+      sinon.assert.neverCalledWith(appReconcilerMock.setControllerDesired, sinon.match.any, 'running');
+    });
+
+    it('does not let an elected leader seed when the index claims data over an empty disk', async () => {
+      mockParams.receiveOnlySyncthingAppsCache.set('test-app', {
+        restarted: false,
+        numberOfExecutions: 1,
+        leaderStreak: 5,
+      });
+      mockParams.appLocation.resolves([
+        { ip: '10.0.0.1:16127', runningSince: null, broadcastedAt: 1000 },
+      ]);
+      syncthingServiceMock.getDbStatus.resolves({
+        status: 'success',
+        data: { globalBytes: 1000, inSyncBytes: 1000, state: 'idle' },
+      });
+      fsMock.promises.readdir.resolves([dirent('.stignore'), dirent('backup', false)]);
+
+      const result = await stateMachine.manageFolderSyncState(mockParams);
+
+      expect(result.syncthingFolder.type).to.equal('receiveonly');
+      expect(result.cache.restarted).to.not.equal(true);
+      sinon.assert.neverCalledWith(appReconcilerMock.setControllerDesired, sinon.match.any, 'running');
+    });
+
+    it('still lets the leader seed a cold start (empty index over an empty disk)', async () => {
+      mockParams.receiveOnlySyncthingAppsCache.set('test-app', {
+        restarted: false,
+        numberOfExecutions: 1,
+        leaderStreak: 5,
+      });
+      mockParams.appLocation.resolves([
+        { ip: '10.0.0.1:16127', runningSince: null, broadcastedAt: 1000 },
+      ]);
+      syncthingServiceMock.getDbStatus.resolves({
+        status: 'success',
+        data: { globalBytes: 0, inSyncBytes: 0, state: 'idle' },
+      });
+      fsMock.promises.readdir.resolves([dirent('.stignore')]);
+
+      const result = await stateMachine.manageFolderSyncState(mockParams);
+
+      expect(result.syncthingFolder.type).to.equal('sendreceive');
+      expect(result.cache.restarted).to.be.true;
+      sinon.assert.calledWith(appReconcilerMock.setControllerDesired, 'test-app', 'running');
+    });
+
     it('should NOT start on unsynced data while sync is still progressing (no force-start)', async () => {
       // not the leader, sync at 50% and still progressing (not stalled)
       mockParams.receiveOnlySyncthingAppsCache.set('test-app', {

--- a/tests/unit/syncthingMonitor.test.js
+++ b/tests/unit/syncthingMonitor.test.js
@@ -52,6 +52,10 @@ const volumeServiceMock = {
   ensureAppVolumeMounted: sinon.stub().resolves({ mounted: true, alreadyMounted: true }),
 };
 
+const appReconcilerMock = {
+  setControllerDesired: sinon.stub(),
+};
+
 const syncthingMonitorHelpersMock = {
   sortAndFilterLocations: sinon.stub((locs) => locs),
   buildDeviceConfiguration: sinon.stub().resolves([]),
@@ -96,6 +100,7 @@ const syncthingMonitor = proxyquire('../../ZelBack/src/services/appMonitoring/sy
   '../syncthingService': syncthingServiceMock,
   '../appQuery/appQueryService': appQueryServiceMock,
   '../utils/volumeService': volumeServiceMock,
+  './appReconciler': appReconcilerMock,
   './syncthingFolderStateMachine': syncthingFolderStateMachineMock,
   './syncthingMonitorHelpers': syncthingMonitorHelpersMock,
   './syncthingHealthMonitor': syncthingHealthMonitorMock,
@@ -147,6 +152,12 @@ describe('syncthingMonitor tests', () => {
     syncthingEventsConsumerMock.start.reset();
     syncthingEventsConsumerMock.stop.reset();
     syncthingEventsConsumerMock.stop.resolves();
+
+    volumeServiceMock.ensureAppVolumeMounted.reset();
+    volumeServiceMock.ensureAppVolumeMounted.resolves({ mounted: true, alreadyMounted: true });
+    appReconcilerMock.setControllerDesired.reset();
+    syncthingFolderStateMachineMock.verifyFolderMountSafety.reset();
+    syncthingFolderStateMachineMock.verifyFolderMountSafety.resolves({ isSafe: true, isMounted: true, fileCount: 1 });
 
     // Default stub behaviors
     syncthingServiceMock.getConfigFolders.resolves({ data: [] });
@@ -304,6 +315,52 @@ describe('syncthingMonitor tests', () => {
       sinon.assert.notCalled(syncthingServiceMock.systemRestart);
 
       syncthingFolderStateMachineMock.verifySendReceiveFolderSafety.resolves({ isSafe: true, isMounted: true, fileCount: 1 });
+    });
+
+    it('demotes a sendreceive folder over an unrepairable mount while skipping the cycle', async function () {
+      // repair fails (no backing image) -> the cycle is skipped, but a folder
+      // left sendreceive over the bad mount could still broadcast its disk
+      // state - it must be demoted and its container held before bailing
+      mockInstalledAppsFn.resolves({
+        status: 'success',
+        data: [{ name: 'testapp', version: 3, containerData: 'g:/appdata' }],
+      });
+      syncthingFolderStateMachineMock.verifyFolderMountSafety.resolves({ isSafe: false, isMounted: false, reason: 'unmounted_with_content' });
+      volumeServiceMock.ensureAppVolumeMounted.resolves({ mounted: false, reason: 'volume_file_missing' });
+      syncthingServiceMock.getConfigFolders.resolves({ data: [{ id: 'testapp', type: 'sendreceive' }] });
+      syncthingServiceMock.adjustConfigFolders.resolves();
+
+      monitorControl = syncthingMonitor.syncthingApps(
+        mockState,
+        mockInstalledAppsFn,
+        mockGetGlobalStateFn,
+      );
+      await clock.tickAsync(100);
+
+      sinon.assert.calledWithExactly(syncthingServiceMock.adjustConfigFolders, 'patch', { type: 'receiveonly' }, 'testapp');
+      sinon.assert.calledWith(appReconcilerMock.setControllerDesired, 'testapp', 'stopped');
+      // the cycle itself was skipped - per-app processing never ran
+      sinon.assert.notCalled(syncthingServiceMock.getDeviceId);
+    });
+
+    it('does not re-patch an unsafe folder that is already receiveonly', async function () {
+      mockInstalledAppsFn.resolves({
+        status: 'success',
+        data: [{ name: 'testapp', version: 3, containerData: 'g:/appdata' }],
+      });
+      syncthingFolderStateMachineMock.verifyFolderMountSafety.resolves({ isSafe: false, isMounted: false, reason: 'empty_unmounted_directory' });
+      volumeServiceMock.ensureAppVolumeMounted.resolves({ mounted: false, reason: 'volume_file_missing' });
+      syncthingServiceMock.getConfigFolders.resolves({ data: [{ id: 'testapp', type: 'receiveonly' }] });
+
+      monitorControl = syncthingMonitor.syncthingApps(
+        mockState,
+        mockInstalledAppsFn,
+        mockGetGlobalStateFn,
+      );
+      await clock.tickAsync(100);
+
+      sinon.assert.notCalled(syncthingServiceMock.adjustConfigFolders);
+      sinon.assert.notCalled(appReconcilerMock.setControllerDesired);
     });
 
     it('should start the events consumer (edge accelerator) and stop it on shutdown', async () => {

--- a/tests/unit/syncthingMonitor.test.js
+++ b/tests/unit/syncthingMonitor.test.js
@@ -45,6 +45,11 @@ const syncthingFolderStateMachineMock = {
   getFolderSyncCompletion: sinon.stub(),
   isDesignatedLeader: sinon.stub(),
   verifyFolderMountSafety: sinon.stub().resolves({ isSafe: true, isMounted: true, fileCount: 1 }),
+  verifySendReceiveFolderSafety: sinon.stub().resolves({ isSafe: true, isMounted: true, fileCount: 1 }),
+};
+
+const volumeServiceMock = {
+  ensureAppVolumeMounted: sinon.stub().resolves({ mounted: true, alreadyMounted: true }),
 };
 
 const syncthingMonitorHelpersMock = {
@@ -57,7 +62,7 @@ const syncthingMonitorHelpersMock = {
     devices,
     type: type || 'sendreceive',
   })),
-  ensureStfolderExists: sinon.stub().resolves(),
+  ensureStfolderExists: sinon.stub().resolves(true),
   getContainerFolderPath: sinon.stub().returns(''),
   getContainerDataFlags: sinon.stub().returns(''),
   requiresSyncing: sinon.stub().returns(false),
@@ -90,6 +95,7 @@ const syncthingMonitor = proxyquire('../../ZelBack/src/services/appMonitoring/sy
   '../fluxNetworkHelper': fluxNetworkHelperMock,
   '../syncthingService': syncthingServiceMock,
   '../appQuery/appQueryService': appQueryServiceMock,
+  '../utils/volumeService': volumeServiceMock,
   './syncthingFolderStateMachine': syncthingFolderStateMachineMock,
   './syncthingMonitorHelpers': syncthingMonitorHelpersMock,
   './syncthingHealthMonitor': syncthingHealthMonitorMock,
@@ -281,7 +287,7 @@ describe('syncthingMonitor tests', () => {
         data: [{ id: 'fluxcomp_testapp', path: '/apps/fluxcomp_testapp', type: 'sendreceive' }],
       });
       syncthingServiceMock.adjustConfigFolders.resolves(); // beforeEach reset() wipes behavior; restore it
-      syncthingFolderStateMachineMock.verifyFolderMountSafety.resolves({ isSafe: false, reason: 'not mounted' });
+      syncthingFolderStateMachineMock.verifySendReceiveFolderSafety.resolves({ isSafe: false, reason: 'not mounted' });
 
       monitorControl = syncthingMonitor.syncthingApps(
         mockState,
@@ -297,7 +303,7 @@ describe('syncthingMonitor tests', () => {
       sinon.assert.calledWithExactly(syncthingServiceMock.adjustConfigFolders, 'patch', { type: 'receiveonly' }, 'fluxcomp_testapp');
       sinon.assert.notCalled(syncthingServiceMock.systemRestart);
 
-      syncthingFolderStateMachineMock.verifyFolderMountSafety.resolves({ isSafe: true, isMounted: true, fileCount: 1 });
+      syncthingFolderStateMachineMock.verifySendReceiveFolderSafety.resolves({ isSafe: true, isMounted: true, fileCount: 1 });
     });
 
     it('should start the events consumer (edge accelerator) and stop it on shutdown', async () => {

--- a/tests/unit/syncthingMonitorHelpers.test.js
+++ b/tests/unit/syncthingMonitorHelpers.test.js
@@ -4,6 +4,8 @@ process.env.NODE_CONFIG_DIR = `${process.cwd()}/tests/unit/globalconfig`;
 const { expect } = require('chai');
 const sinon = require('sinon');
 const axios = require('axios');
+const serviceHelper = require('../../ZelBack/src/services/serviceHelper');
+const volumeService = require('../../ZelBack/src/services/utils/volumeService');
 const helpers = require('../../ZelBack/src/services/appMonitoring/syncthingMonitorHelpers');
 
 describe('syncthingMonitorHelpers tests', () => {
@@ -374,6 +376,39 @@ describe('syncthingMonitorHelpers tests', () => {
 
       expect(result).to.be.null;
       expect(cache.has('10.0.0.1:16127')).to.be.false;
+    });
+  });
+
+  describe('ensureStfolderExists', () => {
+    it('refuses to create the marker on an unmounted dir (the rootfs-leak regression)', async () => {
+      // a .stfolder created on the bare mountpoint re-arms syncthing onto the
+      // host filesystem and defeats syncthing's own missing-marker guard
+      sandbox.stub(volumeService, 'isPathMounted').resolves(false);
+      const runCommand = sandbox.stub(serviceHelper, 'runCommand');
+
+      const result = await helpers.ensureStfolderExists('/apps/fluxcomp_app');
+
+      expect(result).to.be.false;
+      sinon.assert.notCalled(runCommand);
+    });
+
+    it('creates the marker inside a mounted volume', async () => {
+      sandbox.stub(volumeService, 'isPathMounted').resolves(true);
+      const runCommand = sandbox.stub(serviceHelper, 'runCommand').resolves({ error: null, stdout: '', stderr: '' });
+
+      const result = await helpers.ensureStfolderExists('/apps/fluxcomp_app');
+
+      expect(result).to.be.true;
+      sinon.assert.calledWith(runCommand, 'mkdir', sinon.match({ runAsRoot: true, params: ['-p', '/apps/fluxcomp_app/.stfolder'] }));
+    });
+
+    it('reports failure when the marker cannot be created', async () => {
+      sandbox.stub(volumeService, 'isPathMounted').resolves(true);
+      sandbox.stub(serviceHelper, 'runCommand').resolves({ error: new Error('EPERM'), stdout: '', stderr: '' });
+
+      const result = await helpers.ensureStfolderExists('/apps/fluxcomp_app');
+
+      expect(result).to.be.false;
     });
   });
 });

--- a/tests/unit/volumeService.test.js
+++ b/tests/unit/volumeService.test.js
@@ -7,51 +7,270 @@ chai.use(chaiAsPromised);
 const { expect } = chai;
 
 describe('volumeService tests', () => {
-  describe('ensureMountPathsExist tests', () => {
-    const APPS_FOLDER = '/test/apps/folder/';
-    let dockerServiceStub;
-    let serviceHelperStub;
-    let mountParserStub;
-    let fsStub;
-    let logStub;
-    let volumeService;
+  const APPS_FOLDER = '/test/apps/folder/';
+  const APP_VOLUMES = '/test/flux/appvolumes';
+  const LEGACY_APP_VOLUMES = '/test/fluxappvolumes';
+  let dockerServiceStub;
+  let serviceHelperStub;
+  let mountParserStub;
+  let fsStub;
+  let dfStub;
+  let logStub;
+  let volumeService;
 
+  beforeEach(() => {
+    dockerServiceStub = { getAppIdentifier: sinon.stub() };
+    // runCommand defaults to success ({ error: null }); tests override as needed
+    serviceHelperStub = { runCommand: sinon.stub().resolves({ error: null, stdout: '', stderr: '' }) };
+    mountParserStub = {
+      parseContainerData: sinon.stub(),
+      getRequiredLocalPaths: sinon.stub(),
+      MountType: {
+        PRIMARY: 'primary',
+        DIRECTORY: 'directory',
+        FILE: 'file',
+        COMPONENT_PRIMARY: 'component_primary',
+        COMPONENT_DIRECTORY: 'component_directory',
+        COMPONENT_FILE: 'component_file',
+      },
+    };
+    fsStub = { promises: { access: sinon.stub(), readdir: sinon.stub().resolves([]) } };
+    dfStub = sinon.stub().callsArgWith(1, null, []); // node-df callback style: (options, cb)
+    logStub = {
+      info: sinon.stub(), warn: sinon.stub(), error: sinon.stub(), debug: sinon.stub(),
+    };
+
+    volumeService = proxyquire('../../ZelBack/src/services/utils/volumeService', {
+      '../dockerService': dockerServiceStub,
+      '../serviceHelper': serviceHelperStub,
+      './mountParser': mountParserStub,
+      './appConstants': { appsFolder: APPS_FOLDER, appVolumesPath: APP_VOLUMES, legacyAppVolumesPath: LEGACY_APP_VOLUMES },
+      '../../lib/log': logStub,
+      'node-df': dfStub,
+      fs: { promises: fsStub.promises },
+    });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  const callsFor = (cmd) => serviceHelperStub.runCommand.getCalls().filter((c) => c.args[0] === cmd);
+
+  // per-command dispatcher for runCommand; unlisted commands succeed
+  const dispatchRunCommand = (behaviours) => {
+    serviceHelperStub.runCommand.callsFake(async (cmd, options) => {
+      const behaviour = behaviours[cmd];
+      if (!behaviour) return { error: null, stdout: '', stderr: '' };
+      return behaviour(options);
+    });
+  };
+
+  describe('isPathMounted tests', () => {
+    it('should return true when mountpoint -q succeeds', async () => {
+      const result = await volumeService.isPathMounted('/some/dir');
+      expect(result).to.be.true;
+      const probe = callsFor('mountpoint');
+      expect(probe).to.have.lengthOf(1);
+      expect(probe[0].args[1].params).to.deep.equal(['-q', '/some/dir']);
+    });
+
+    it('should return false when mountpoint -q fails', async () => {
+      serviceHelperStub.runCommand.resolves({ error: new Error('not a mountpoint'), stdout: '', stderr: '' });
+      const result = await volumeService.isPathMounted('/some/dir');
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('getVolumeFilePath tests', () => {
+    it('should find the image at the root of an eligible df volume', async () => {
+      dfStub.callsArgWith(1, null, [
+        { filesystem: '/dev/sda1', mount: '/dat' },
+        { filesystem: 'tmpfs', mount: '/run' },
+      ]);
+      fsStub.promises.access.rejects(new Error('ENOENT'));
+      fsStub.promises.access.withArgs('/dat/fluxapp1FLUXFSVOL').resolves();
+
+      const result = await volumeService.getVolumeFilePath('fluxapp1');
+      expect(result).to.equal('/dat/fluxapp1FLUXFSVOL');
+    });
+
+    it('should not look for images at the root filesystem itself', async () => {
+      dfStub.callsArgWith(1, null, [{ filesystem: '/dev/sda1', mount: '/' }]);
+      fsStub.promises.access.rejects(new Error('ENOENT'));
+
+      await volumeService.getVolumeFilePath('fluxapp1');
+      const checked = fsStub.promises.access.getCalls().map((c) => c.args[0]);
+      expect(checked).to.not.include('/fluxapp1FLUXFSVOL');
+    });
+
+    it('should find the image in the appvolumes directory', async () => {
+      fsStub.promises.access.rejects(new Error('ENOENT'));
+      fsStub.promises.access.withArgs(`${APP_VOLUMES}/fluxapp1FLUXFSVOL`).resolves();
+
+      const result = await volumeService.getVolumeFilePath('fluxapp1');
+      expect(result).to.equal(`${APP_VOLUMES}/fluxapp1FLUXFSVOL`);
+    });
+
+    it('should find an image left at the legacy glued appvolumes location', async () => {
+      fsStub.promises.access.rejects(new Error('ENOENT'));
+      fsStub.promises.access.withArgs(`${LEGACY_APP_VOLUMES}/fluxapp1FLUXFSVOL`).resolves();
+
+      const result = await volumeService.getVolumeFilePath('fluxapp1');
+      expect(result).to.equal(`${LEGACY_APP_VOLUMES}/fluxapp1FLUXFSVOL`);
+    });
+
+    it('should return null when the image exists nowhere', async () => {
+      fsStub.promises.access.rejects(new Error('ENOENT'));
+
+      const result = await volumeService.getVolumeFilePath('fluxapp1');
+      expect(result).to.be.null;
+    });
+
+    it('should still check appvolumes locations when df fails', async () => {
+      dfStub.callsArgWith(1, new Error('df failed'), null);
+      fsStub.promises.access.rejects(new Error('ENOENT'));
+      fsStub.promises.access.withArgs(`${APP_VOLUMES}/fluxapp1FLUXFSVOL`).resolves();
+
+      const result = await volumeService.getVolumeFilePath('fluxapp1');
+      expect(result).to.equal(`${APP_VOLUMES}/fluxapp1FLUXFSVOL`);
+    });
+  });
+
+  describe('ensureAppVolumeMounted tests', () => {
     beforeEach(() => {
-      dockerServiceStub = { getAppIdentifier: sinon.stub() };
-      // runCommand defaults to success ({ error: null }); tests override as needed
-      serviceHelperStub = { runCommand: sinon.stub().resolves({ error: null, stdout: '', stderr: '' }) };
-      mountParserStub = {
-        parseContainerData: sinon.stub(),
-        getRequiredLocalPaths: sinon.stub(),
-        MountType: {
-          PRIMARY: 'primary',
-          DIRECTORY: 'directory',
-          FILE: 'file',
-          COMPONENT_PRIMARY: 'component_primary',
-          COMPONENT_DIRECTORY: 'component_directory',
-          COMPONENT_FILE: 'component_file',
-        },
-      };
-      fsStub = { promises: { access: sinon.stub() } };
-      logStub = {
-        info: sinon.stub(), warn: sinon.stub(), error: sinon.stub(), debug: sinon.stub(),
-      };
+      dockerServiceStub.getAppIdentifier.returns('fluxapp1');
+      dfStub.callsArgWith(1, null, [{ filesystem: '/dev/sda1', mount: '/dat' }]);
+    });
 
-      volumeService = proxyquire('../../ZelBack/src/services/utils/volumeService', {
-        '../dockerService': dockerServiceStub,
-        '../serviceHelper': serviceHelperStub,
-        './mountParser': mountParserStub,
-        './appConstants': { appsFolder: APPS_FOLDER },
-        '../../lib/log': logStub,
-        fs: { promises: fsStub.promises },
+    it('should be a no-op when the app dir is already a mountpoint', async () => {
+      const result = await volumeService.ensureAppVolumeMounted('app1');
+
+      expect(result).to.deep.equal({ mounted: true, alreadyMounted: true });
+      expect(callsFor('mount')).to.have.lengthOf(0);
+    });
+
+    it('should mount the discovered image and set the empty mountpoint immutable first', async () => {
+      dispatchRunCommand({
+        mountpoint: async () => ({ error: new Error('not mounted'), stdout: '', stderr: '' }),
       });
+      fsStub.promises.access.rejects(new Error('ENOENT'));
+      fsStub.promises.access.withArgs('/dat/fluxapp1FLUXFSVOL').resolves();
+      fsStub.promises.readdir.resolves([]);
+
+      const result = await volumeService.ensureAppVolumeMounted('app1');
+
+      expect(result).to.deep.equal({ mounted: true, alreadyMounted: false });
+      const chattr = callsFor('chattr');
+      expect(chattr).to.have.lengthOf(1);
+      expect(chattr[0].args[1].params).to.deep.equal(['+i', `${APPS_FOLDER}fluxapp1`]);
+      const mount = callsFor('mount');
+      expect(mount).to.have.lengthOf(1);
+      expect(mount[0].args[1].params).to.deep.equal(['-o', 'loop', '/dat/fluxapp1FLUXFSVOL', `${APPS_FOLDER}fluxapp1`]);
+      // the flag must be set BEFORE the mount shadows the bare dir
+      expect(chattr[0].calledBefore(mount[0])).to.be.true;
     });
 
-    afterEach(() => {
-      sinon.restore();
+    it('should not set the immutable flag over leaked content, but still mount (shadowing it)', async () => {
+      dispatchRunCommand({
+        mountpoint: async () => ({ error: new Error('not mounted'), stdout: '', stderr: '' }),
+      });
+      fsStub.promises.access.rejects(new Error('ENOENT'));
+      fsStub.promises.access.withArgs('/dat/fluxapp1FLUXFSVOL').resolves();
+      fsStub.promises.readdir.resolves(['leaked.db']);
+
+      const result = await volumeService.ensureAppVolumeMounted('app1');
+
+      expect(result.mounted).to.be.true;
+      expect(callsFor('chattr')).to.have.lengthOf(0);
+      expect(callsFor('mount')).to.have.lengthOf(1);
+      expect(logStub.warn.calledWithMatch(/shadowed/)).to.be.true;
     });
 
-    const callsFor = (cmd) => serviceHelperStub.runCommand.getCalls().filter((c) => c.args[0] === cmd);
+    it('should create a missing mountpoint directory before mounting', async () => {
+      dispatchRunCommand({
+        mountpoint: async () => ({ error: new Error('not mounted'), stdout: '', stderr: '' }),
+      });
+      fsStub.promises.access.rejects(new Error('ENOENT'));
+      fsStub.promises.access.withArgs('/dat/fluxapp1FLUXFSVOL').resolves();
+      fsStub.promises.readdir.rejects(new Error('ENOENT'));
+
+      const result = await volumeService.ensureAppVolumeMounted('app1');
+
+      expect(result.mounted).to.be.true;
+      const mkdir = callsFor('mkdir');
+      expect(mkdir).to.have.lengthOf(1);
+      expect(mkdir[0].args[1].params).to.deep.equal(['-p', `${APPS_FOLDER}fluxapp1`]);
+    });
+
+    it('should report volume_file_missing when no image exists anywhere', async () => {
+      dispatchRunCommand({
+        mountpoint: async () => ({ error: new Error('not mounted'), stdout: '', stderr: '' }),
+      });
+      fsStub.promises.access.rejects(new Error('ENOENT'));
+
+      const result = await volumeService.ensureAppVolumeMounted('app1');
+
+      expect(result).to.deep.equal({ mounted: false, reason: 'volume_file_missing' });
+      expect(callsFor('mount')).to.have.lengthOf(0);
+    });
+
+    it('should treat a lost mount race as success when the dir turns out mounted', async () => {
+      let mountpointCalls = 0;
+      dispatchRunCommand({
+        mountpoint: async () => {
+          mountpointCalls += 1;
+          // unmounted on the first probe; mounted on the re-probe after our own mount fails
+          return mountpointCalls === 1
+            ? { error: new Error('not mounted'), stdout: '', stderr: '' }
+            : { error: null, stdout: '', stderr: '' };
+        },
+        mount: async () => ({ error: new Error('already mounted'), stdout: '', stderr: '' }),
+      });
+      fsStub.promises.access.rejects(new Error('ENOENT'));
+      fsStub.promises.access.withArgs('/dat/fluxapp1FLUXFSVOL').resolves();
+      fsStub.promises.readdir.resolves([]);
+
+      const result = await volumeService.ensureAppVolumeMounted('app1');
+
+      expect(result).to.deep.equal({ mounted: true, alreadyMounted: true });
+    });
+
+    it('should report mount_failed when the mount fails and the dir stays unmounted', async () => {
+      dispatchRunCommand({
+        mountpoint: async () => ({ error: new Error('not mounted'), stdout: '', stderr: '' }),
+        mount: async () => ({ error: new Error('bad superblock'), stdout: '', stderr: '' }),
+      });
+      fsStub.promises.access.rejects(new Error('ENOENT'));
+      fsStub.promises.access.withArgs('/dat/fluxapp1FLUXFSVOL').resolves();
+      fsStub.promises.readdir.resolves([]);
+
+      const result = await volumeService.ensureAppVolumeMounted('app1');
+
+      expect(result.mounted).to.be.false;
+      expect(result.reason).to.include('mount_failed');
+      expect(result.reason).to.include('bad superblock');
+    });
+  });
+
+  describe('ensureMountPathsExist tests', () => {
+    // the app dir reads as an already-mounted volume unless a test overrides it
+    const mountCommands = () => serviceHelperStub.runCommand.getCalls().filter((c) => ['mkdir', 'touch', 'chmod', 'mount', 'chattr'].includes(c.args[0]));
+
+    it('should refuse to create paths when the volume is missing (bare dir would take the writes)', async () => {
+      dockerServiceStub.getAppIdentifier.returns('fluxwebserver_testapp');
+      mountParserStub.parseContainerData.returns({ allMounts: [] });
+      mountParserStub.getRequiredLocalPaths.returns([{ name: 'appdata', isFile: false }]);
+      dispatchRunCommand({
+        mountpoint: async () => ({ error: new Error('not mounted'), stdout: '', stderr: '' }),
+      });
+      fsStub.promises.access.rejects(new Error('ENOENT')); // no volume image anywhere
+
+      await expect(
+        volumeService.ensureMountPathsExist({ name: 'webserver', containerData: '/data' }, 'testapp', true, null),
+      ).to.be.rejectedWith(/not mounted.*refusing to create/);
+      expect(callsFor('mkdir')).to.have.lengthOf(0);
+    });
 
     it('should skip creating paths that already exist', async () => {
       dockerServiceStub.getAppIdentifier.returns('fluxwebserver_testapp');
@@ -65,7 +284,7 @@ describe('volumeService tests', () => {
       await volumeService.ensureMountPathsExist({ name: 'webserver', containerData: '/data|f:config.yaml:/etc/config.yaml' }, 'testapp', true, null);
 
       expect(fsStub.promises.access.callCount).to.equal(2);
-      expect(serviceHelperStub.runCommand.called).to.be.false; // nothing created
+      expect(mountCommands()).to.have.lengthOf(0); // nothing created
     });
 
     it('should create a missing file as root via touch + chmod (no shell, args passed as params)', async () => {
@@ -126,7 +345,7 @@ describe('volumeService tests', () => {
       await volumeService.ensureMountPathsExist({ name: 'webserver', containerData: '/data|m:logs:/var/log|f:config.yaml:/etc/config.yaml|m:cache:/var/cache' }, 'testapp', true, null);
 
       // logs (mkdir) + config.yaml (touch+chmod) + cache (mkdir) = 4 commands
-      expect(serviceHelperStub.runCommand.callCount).to.equal(4);
+      expect(mountCommands()).to.have.lengthOf(4);
       expect(callsFor('mkdir')).to.have.lengthOf(2);
       expect(callsFor('touch')).to.have.lengthOf(1);
       expect(callsFor('chmod')).to.have.lengthOf(1);
@@ -157,7 +376,9 @@ describe('volumeService tests', () => {
       mountParserStub.parseContainerData.returns({ allMounts: [] });
       mountParserStub.getRequiredLocalPaths.returns([{ name: 'logs', isFile: false }]);
       fsStub.promises.access.rejects(new Error('ENOENT')); // missing → must create
-      serviceHelperStub.runCommand.resolves({ error: new Error('mkdir failed'), stdout: '', stderr: '' });
+      dispatchRunCommand({
+        mkdir: async () => ({ error: new Error('mkdir failed'), stdout: '', stderr: '' }),
+      });
 
       await expect(
         volumeService.ensureMountPathsExist({ name: 'webserver', containerData: '/data' }, 'testapp', true, null),
@@ -181,7 +402,7 @@ describe('volumeService tests', () => {
       await volumeService.ensureMountPathsExist({ name: 'backup', containerData: '/data|0:/database' }, 'testapp', true, fullAppSpecs);
 
       expect(fsStub.promises.access.callCount).to.be.at.least(1);
-      expect(serviceHelperStub.runCommand.called).to.be.false;
+      expect(mountCommands()).to.have.lengthOf(0);
     });
 
     it('should throw when a component-reference mount has no full app specifications', async () => {


### PR DESCRIPTION
This PR remediates the root causes of a production data-loss incident involving a two-instance syncthing-replicated (`g:`) application, plus additional defects found while building integration coverage for the fixes.

**The problems being solved**

1. **After a reboot, nothing reliably re-mounted an app's data volume.** Remounting was delegated to a root `@reboot` crontab entry that FluxOS itself could delete and that nothing ever re-asserted — a node could come back broadcasting an app as "running" while its data volume was never mounted.
2. **An unmounted app directory silently accepted writes.** The bare mountpoint was an ordinary writable directory, so container binds and syncthing pulls landed on the host filesystem (bypassing the app's quota), and a syncthing folder left `sendreceive` with a stale index could broadcast the "missing" files as deletions — wiping the healthy replica.
3. **A single transient UPnP port-mapping failure force-removed the entire app** and broadcast the removal network-wide, triggering a re-placement that came up empty.
4. **Enterprise apps were invisible to the startup crontab/mount inventory** (their components live in the encrypted blob), so every FluxOS restart deleted their remount entries; separately, their local-install path lost `height`/`hash`, which the expiry sweep eventually punishes with a forced, broadcast removal.
5. **Volume deletion at uninstall depended on parsing the crontab entry** — when the entry was missing, the multi-GB volume image was orphaned on disk.

**Volume mounting (the core change)**
- FluxOS now owns app data-volume mounting end to end: volumes are mounted from the installed-apps database and deterministic image discovery at startup, by the reconciler before any actuation, and by the syncthing monitor's repair path. The legacy `@reboot` crontab entries are no longer created; existing entries are removed only once the FluxOS-owned mount demonstrably covers them (an entry whose volume cannot mount is kept as the remaining safety net).
- Volume deletion at uninstall derives the image path deterministically instead of parsing the crontab, eliminating orphaned volume images when entries are missing.
- An unmounted app directory is now physically inert: the bare mountpoint is set immutable (`chattr +i`), so writes while the volume is unmounted fail loudly instead of silently landing on the host filesystem (and bypassing the app's quota).

**Syncthing mount-safety**
- The mount-safety guard gates on the mountpoint, not directory content: a `sendreceive` folder over an unmounted directory is demoted to `receiveonly` and its container held, regardless of content. Content on a bare directory means data already leaked to the host filesystem — it must never buy a pass (in the incident, a stale `sendreceive` folder broadcast deletions that gutted the healthy replica).
- A stale ("phantom") index claiming data over an empty mounted volume is demoted before it can broadcast the missing files as deletions.
- Promotion to `sendreceive` — including the cold-start leader seed — requires that same verification to pass *before* the flip, so a folder whose index claims data the disk does not hold (or whose directory is not a mountpoint) is never promoted at all; the per-cycle check above covers folders that degrade while already `sendreceive`. A legitimately empty cold-start seed (an empty index over an empty disk) still seeds.
- The demotion also runs from the monitor's skip path (previously unreachable when the mount was unrepairable), and the `.stfolder` marker can only ever be created inside a mounted volume.
- The reconciler now honors a pending stop even while a volume is unavailable — previously the volume-unavailable defer blocked the very stop the mount-safety hold requested, leaving the container running over a missing volume.

**Enterprise app lifecycle**
- Enterprise apps store `compose: []` locally (components live in the encrypted blob). The crontab/mount inventory never decrypted, so every FluxOS restart classified enterprise apps as uninstalled and deleted their remount entries. The inventory now decrypts like every other consumer, with a decryption-free fallback that derives component ids from the volume-image filenames; a failed database enumeration aborts the sweep instead of reading as "nothing installed".
- The local-install path preserved neither `height` nor `hash` through the enterprise decrypt+format step; since the expiry sweep force-removes any installed app without a height, locally-installed enterprise apps were eventually removed (with broadcast). Both fields now survive, mirroring the existing pattern in `registryManager`.

**UPnP**
- `restoreAppsPortsSupport` no longer force-removes (and broadcasts removal of) an app on a single UPnP mapping failure; removal requires sustained failure across multiple cycles and a minimum monotonic duration.

**Tests**
- Unit coverage across the touched services (crontab/mount cleanup, reconciler, installer, port manager, syncthing state machine), with the key guards mutation-verified.
- Two new integration suites: `60-volume-mount-ownership` (install/reboot/uninstall/enterprise volume lifecycle, immutable-mountpoint enforcement, legacy-entry handling) and `61-syncthing-mount-safety` (demotion of unsafe `sendreceive` folders, phantom-index handling, cold-start non-demotion, marker discipline).
- Harness hardening: hermetic image registry (no live-internet dependencies; enforced at spec construction), deterministic seeded-sync state (a folder pinned synced holds matching data on disk), stall-tolerant confirmation-staleness defaults with the fast windows scoped to the suites that test those flows, and teardown that cannot leak volumes.
- The **full integration harness — all 54 suites — has been run against this branch and passes in its entirety** (including the two new suites).

Written against `57dc362dd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
