### PR TITLE
fix: syncthing monitor verifies at decision points, never as steady-state churn

### DIFF
--- a/ZelBack/src/services/appMonitoring/syncthingEventsConsumer.js
+++ b/ZelBack/src/services/appMonitoring/syncthingEventsConsumer.js
@@ -50,6 +50,11 @@ const controller = new FluxController();
 // folderId -> { time, errors } from the last FolderErrors event
 const folderErrorsByFolder = new Map();
 
+// folder ids seen in FolderErrors since the last drain - the monitor pass
+// drains this to mount-verify exactly the flagged folders (targeted reaction,
+// never a steady-state sweep)
+const erroredFolderIdsSinceLastDrain = new Set();
+
 /**
  * One long-poll iteration: fetch events after `since`, detect lost-events
  * conditions, surface folder activity to the monitor.
@@ -100,6 +105,7 @@ async function pollOnce() {
     }
     if (event.type === 'FolderErrors') {
       folderErrorsByFolder.set(folder, { time: event.time, errors: event.data.errors || [] });
+      erroredFolderIdsSinceLastDrain.add(folder);
       fluxEventBus.publish('syncthing:folderErrors', { folder, time: event.time, errors: event.data.errors || [] });
     }
     if (callbacks.onFolderActivity) callbacks.onFolderActivity(folder, event.type);
@@ -177,9 +183,21 @@ function getFolderErrors(folderId) {
   return folderErrorsByFolder.get(folderId);
 }
 
+/**
+ * Folder ids flagged by FolderErrors since the last drain; draining clears
+ * the accumulator. Consumed by the monitor pass for targeted mount verifies.
+ * @returns {string[]} Folder ids
+ */
+function drainErroredFolderIds() {
+  const ids = [...erroredFolderIdsSinceLastDrain];
+  erroredFolderIdsSinceLastDrain.clear();
+  return ids;
+}
+
 module.exports = {
   start,
   stop,
   isRunning,
   getFolderErrors,
+  drainErroredFolderIds,
 };

--- a/ZelBack/src/services/appMonitoring/syncthingFolderStateMachine.js
+++ b/ZelBack/src/services/appMonitoring/syncthingFolderStateMachine.js
@@ -24,6 +24,46 @@ const {
 
 const { isPathMounted } = volumeService;
 
+const monotonicMs = () => Number(process.hrtime.bigint() / 1000000n);
+
+// Per-folder mount-safety observation log gate: a persistent condition writes
+// one line when first seen (re-logged at most every OBSERVATION_RELOG_MS while
+// it lasts) and one recovery line when it clears - never a line per monitor
+// pass. Process-lifetime state, bounded by the folder ids ever observed; it
+// only dedupes log lines, so a stale entry for a removed app costs nothing.
+// appId -> { observation, lastLoggedMs }
+const mountSafetyObservations = new Map();
+const OBSERVATION_RELOG_MS = 5 * 60 * 1000;
+
+/**
+ * Logs a mount-safety observation only when it changes for the folder (with a
+ * periodic re-log while a non-ok observation persists) and logs recovery when
+ * the folder returns to ok.
+ * @param {string} appId - App/folder identifier
+ * @param {string} observation - Stable key for the observed condition ('ok' when healthy)
+ * @param {Function} [logFn] - Log method for the observation line (unused for 'ok')
+ * @param {string} [message] - The observation line
+ */
+function noteSafetyObservation(appId, observation, logFn, message) {
+  const now = monotonicMs();
+  const previous = mountSafetyObservations.get(appId);
+  if (previous && previous.observation === observation) {
+    if (observation !== 'ok' && now - previous.lastLoggedMs >= OBSERVATION_RELOG_MS) {
+      previous.lastLoggedMs = now;
+      logFn(message);
+    }
+    return;
+  }
+  mountSafetyObservations.set(appId, { observation, lastLoggedMs: now });
+  if (observation === 'ok') {
+    if (previous && previous.observation !== 'ok') {
+      log.info(`verifyFolderMountSafety - ${appId} recovered (was: ${previous.observation})`);
+    }
+    return;
+  }
+  logFn(message);
+}
+
 /**
  * Counts regular files under a directory (recursive, early exit at `limit`),
  * optionally skipping file names and directory subtrees. Pure fs - no child
@@ -118,7 +158,7 @@ async function verifyFolderMountSafety(appId, folderPath) {
     if (!baseDirExists) {
       result.isSafe = false;
       result.reason = 'base_directory_missing';
-      log.warn(`verifyFolderMountSafety - ${appId} base directory does not exist: ${baseDir}`);
+      noteSafetyObservation(appId, result.reason, log.warn, `verifyFolderMountSafety - ${appId} base directory does not exist: ${baseDir}`);
       await appTamperingDetectionService.recordEvent(appId, 'mount_vanished', `Base directory missing: ${baseDir}`);
       return result;
     }
@@ -139,19 +179,20 @@ async function verifyFolderMountSafety(appId, folderPath) {
     if (!result.isMounted) {
       result.isSafe = false;
       result.reason = result.hasContent ? 'unmounted_with_content' : 'empty_unmounted_directory';
-      log.error(`verifyFolderMountSafety - CRITICAL: ${appId} directory is not a mountpoint (${result.fileCount} file(s) present)! Missing loop mount.`);
+      noteSafetyObservation(appId, result.reason, log.error, `verifyFolderMountSafety - CRITICAL: ${appId} directory is not a mountpoint (${result.fileCount} file(s) present)! Missing loop mount.`);
       if (result.hasContent) {
         await appTamperingDetectionService.recordEvent(appId, 'mount_vanished', `App dir not mounted but holds ${result.fileCount} file(s) - data leaked onto the host filesystem`);
       }
       return result;
     }
 
-    // If mounted but empty, be cautious (could be race condition)
+    // Mounted but empty is legitimate (a folder the app never writes to, a
+    // fresh volume awaiting its first sync) - note it once, allow it, and let
+    // the sync machinery decide what emptiness means for this folder
     if (!result.hasContent) {
-      // Give a small grace period - maybe syncing hasn't completed yet
-      // But this is still suspicious
-      log.warn(`verifyFolderMountSafety - ${appId} is mounted but has no content (0 files). Potential data loss risk.`);
-      // We'll allow it but log warning - Syncthing should handle this
+      noteSafetyObservation(appId, 'mounted_empty', log.warn, `verifyFolderMountSafety - ${appId} is mounted but has no content (0 files). Potential data loss risk.`);
+    } else {
+      noteSafetyObservation(appId, 'ok');
     }
 
     return result;
@@ -793,6 +834,7 @@ async function manageFolderSyncState(params) {
     localSocketAddr,
     syncthingFolder,
     installedAppName,
+    mountVerifyNeeded = true,
   } = params;
 
   // Check if folder already exists and is in sendreceive mode
@@ -800,48 +842,52 @@ async function manageFolderSyncState(params) {
 
   // If already syncing in sendreceive mode, ensure container is running
   if (folderAlreadySyncing) {
-    // CRITICAL SAFETY CHECK: Verify mount is properly initialized before trusting sendreceive mode
-    // This prevents data loss when loop mounts aren't ready after reboot
-    const folderPath = syncFolder.path || `${appsFolder}${appId}/appdata`;
-    let mountSafety = await verifySendReceiveFolderSafety(appId, folderPath);
+    // Mount safety of a live sendreceive folder is verified at decision points
+    // (startup, FolderErrors from syncthing) - not per pass: the .stfolder
+    // marker inside the volume turns storage loss into FolderErrors, and the
+    // caller flags exactly those folders here
+    if (mountVerifyNeeded) {
+      const folderPath = syncFolder.path || `${appsFolder}${appId}/appdata`;
+      let mountSafety = await verifySendReceiveFolderSafety(appId, folderPath);
 
-    if (!mountSafety.isSafe && !mountSafety.isMounted) {
-      // The detection is actionable: the backing image normally still exists,
-      // and FluxOS owns the mount - repair instead of just blocking. The
-      // re-verify still holds the folder back (receiveonly) if the freshly
-      // mounted volume disagrees with the index (phantom-index case).
-      const mountAttempt = await volumeService.ensureAppVolumeMounted(appId);
-      if (mountAttempt.mounted) {
-        log.info(`manageFolderSyncState - ${appId} volume was not mounted; mounted it, re-verifying folder safety`);
-        mountSafety = await verifySendReceiveFolderSafety(appId, folderPath);
+      if (!mountSafety.isSafe && !mountSafety.isMounted) {
+        // The detection is actionable: the backing image normally still exists,
+        // and FluxOS owns the mount - repair instead of just blocking. The
+        // re-verify still holds the folder back (receiveonly) if the freshly
+        // mounted volume disagrees with the index (phantom-index case).
+        const mountAttempt = await volumeService.ensureAppVolumeMounted(appId);
+        if (mountAttempt.mounted) {
+          log.info(`manageFolderSyncState - ${appId} volume was not mounted; mounted it, re-verifying folder safety`);
+          mountSafety = await verifySendReceiveFolderSafety(appId, folderPath);
+        }
+      }
+
+      if (!mountSafety.isSafe) {
+        // DANGER: Mount not ready! Switch to receiveonly to prevent data propagation
+        log.error(`manageFolderSyncState - SAFETY BLOCK: ${appId} mount not safe (${mountSafety.reason}). Switching to receiveonly mode to prevent data loss.`);
+        log.error(`manageFolderSyncState - Mount status: mounted=${mountSafety.isMounted}, hasContent=${mountSafety.hasContent}, files=${mountSafety.fileCount}`);
+
+        // Update folder to receiveonly mode to prevent this node from sending "empty" state to peers
+        syncthingFolder.type = 'receiveonly';
+        const cache = {
+          numberOfExecutions: 0,
+          mountSafetyBlocked: true,
+          blockedReason: mountSafety.reason,
+          blockedAt: Date.now(),
+        };
+        receiveOnlySyncthingAppsCache.set(appId, cache);
+
+        // Hold the container too: its binds point at the same unsafe dir. The
+        // reconciler is the actuator; the receiveonly machinery flips the
+        // verdict back to running once the folder is verifiably synced.
+        appReconciler.setControllerDesired(appId, 'stopped', `mount safety block: ${mountSafety.reason}`);
+
+        // Return with skipUpdate=false so the folder config gets updated to receiveonly
+        return { syncthingFolder, cache, skipUpdate: false };
       }
     }
 
-    if (!mountSafety.isSafe) {
-      // DANGER: Mount not ready! Switch to receiveonly to prevent data propagation
-      log.error(`manageFolderSyncState - SAFETY BLOCK: ${appId} mount not safe (${mountSafety.reason}). Switching to receiveonly mode to prevent data loss.`);
-      log.error(`manageFolderSyncState - Mount status: mounted=${mountSafety.isMounted}, hasContent=${mountSafety.hasContent}, files=${mountSafety.fileCount}`);
-
-      // Update folder to receiveonly mode to prevent this node from sending "empty" state to peers
-      syncthingFolder.type = 'receiveonly';
-      const cache = {
-        numberOfExecutions: 0,
-        mountSafetyBlocked: true,
-        blockedReason: mountSafety.reason,
-        blockedAt: Date.now(),
-      };
-      receiveOnlySyncthingAppsCache.set(appId, cache);
-
-      // Hold the container too: its binds point at the same unsafe dir. The
-      // reconciler is the actuator; the receiveonly machinery flips the
-      // verdict back to running once the folder is verifiably synced.
-      appReconciler.setControllerDesired(appId, 'stopped', `mount safety block: ${mountSafety.reason}`);
-
-      // Return with skipUpdate=false so the folder config gets updated to receiveonly
-      return { syncthingFolder, cache, skipUpdate: false };
-    }
-
-    // Mount is safe, proceed normally
+    // Mount is safe (verified) or not in question (steady state)
     await ensureContainerRunning(appId, containerDataFlags);
     // Ensure cache entry exists so health monitor can track this folder
     const existingCache = receiveOnlySyncthingAppsCache.get(appId);

--- a/ZelBack/src/services/appMonitoring/syncthingMonitor.js
+++ b/ZelBack/src/services/appMonitoring/syncthingMonitor.js
@@ -15,7 +15,10 @@ const {
   ERROR_RETRY_DELAY_MS,
   SYNC_STATE_LOG_INTERVAL_MS,
   HEALTH_CHECK_INTERVAL_MS,
+  EARLY_EVAL_DEBOUNCE_MS,
+  EARLY_EVAL_MIN_GAP_MS,
 } = require('./syncthingMonitorConstants');
+const { createMonitorAccelerator } = require('./syncthingMonitorAccelerator');
 const {
   sortAndFilterLocations,
   buildDeviceConfiguration,
@@ -105,6 +108,26 @@ async function checkAppFolderMounts(appsInstalled) {
   return unmountedApps;
 }
 
+/**
+ * Installed apps having at least one component whose docker app identifier is
+ * in the given folder-id list (syncthing folder ids ARE the app identifiers).
+ * @param {Array} appsInstalled - List of installed apps
+ * @param {string[]} folderIds - Syncthing folder ids to match
+ * @returns {Array} Matching installed apps
+ */
+function appsMatchingFolderIds(appsInstalled, folderIds) {
+  if (folderIds.length === 0) return [];
+  const wanted = new Set(folderIds);
+  return appsInstalled.filter((installedApp) => {
+    if (installedApp.version <= 3) {
+      return wanted.has(dockerService.getAppIdentifier(installedApp.name));
+    }
+    return (installedApp.compose || []).some(
+      (component) => wanted.has(dockerService.getAppIdentifier(`${component.name}_${installedApp.name}`)),
+    );
+  });
+}
+
 // Helper function to get app locations
 async function appLocation(appName) {
   try {
@@ -135,6 +158,7 @@ async function processContainerData(params) {
     localSocketAddr,
     localDeviceId,
     state,
+    erroredFolderIds,
     allFoldersResp,
     allDevicesResp,
     devicesConfiguration,
@@ -202,6 +226,7 @@ async function processContainerData(params) {
       localSocketAddr,
       syncthingFolder,
       installedAppName,
+      mountVerifyNeeded: state.syncthingAppsFirstRun || erroredFolderIds.has(appId),
     });
 
     // Update cache if provided
@@ -324,11 +349,20 @@ async function syncthingAppsCore(state, installedAppsFn, getGlobalStateFn) {
     // Decrypt enterprise apps (version 8 with encrypted content)
     appsInstalled.data = await decryptEnterpriseApps(appsInstalled.data);
 
-    // CRITICAL: Check if app folder mounts are ready before processing
-    // This prevents syncthing operations when loop devices aren't mounted after reboot
-    // (checkAppFolderMounts repairs an unmounted volume itself when the backing
-    // image still exists, so reaching this branch means repair failed too)
-    const unmountedApps = await checkAppFolderMounts(appsInstalled.data);
+    // Mount safety is verified at decision points and in reaction to
+    // syncthing's own storage signal - never as a steady-state sweep. The full
+    // sweep runs on the first pass after process start (the reboot case: loop
+    // mounts may not be up yet, and the sweep repairs them). After that, a
+    // vanished mount takes the folder's .stfolder marker with it, syncthing
+    // halts the folder and raises FolderErrors, and only the flagged folders
+    // are verified here (checkAppFolderMounts repairs an unmounted volume
+    // itself when the backing image still exists, so a non-empty unmountedApps
+    // means repair failed too).
+    const erroredFolderIds = new Set(syncthingEventsConsumer.drainErroredFolderIds());
+    const appsToVerify = state.syncthingAppsFirstRun
+      ? appsInstalled.data
+      : appsMatchingFolderIds(appsInstalled.data, [...erroredFolderIds]);
+    const unmountedApps = appsToVerify.length > 0 ? await checkAppFolderMounts(appsToVerify) : [];
     if (unmountedApps.length > 0) {
       const unmountedList = unmountedApps.map((app) => app.appId).join(', ');
       log.warn(`syncthingAppsCore - Skipping processing: ${unmountedApps.length} app folders not mounted yet: ${unmountedList}`);
@@ -448,6 +482,7 @@ async function syncthingAppsCore(state, installedAppsFn, getGlobalStateFn) {
       localSocketAddr,
       localDeviceId,
       state,
+      erroredFolderIds,
       allFoldersResp,
       allDevicesResp,
       devicesConfiguration,
@@ -621,6 +656,7 @@ async function syncthingAppsCore(state, installedAppsFn, getGlobalStateFn) {
 function syncthingApps(state, installedAppsFn, getGlobalStateFn) {
   let intervalId = null;
   let isRunning = false;
+  let accelerator; // assigned below; runMonitoring only executes after assignment
 
   const runMonitoring = async () => {
     if (isRunning) {
@@ -629,6 +665,7 @@ function syncthingApps(state, installedAppsFn, getGlobalStateFn) {
     }
 
     isRunning = true;
+    accelerator.notePassStarted();
     try {
       await syncthingAppsCore(
         state,
@@ -640,8 +677,23 @@ function syncthingApps(state, installedAppsFn, getGlobalStateFn) {
       log.error(error.stack);
     } finally {
       isRunning = false;
+      accelerator.notePassEnded();
     }
   };
+
+  // Edge accelerator: folder events for folders the state machine is actively
+  // transitioning (plus FolderErrors and resync requests) trigger an early run
+  // of the SAME monitoring pass the interval drives - events never carry
+  // decisions, and steady-state folder activity never accelerates anything.
+  accelerator = createMonitorAccelerator({
+    run: runMonitoring,
+    isFolderInTransition: (folderId) => {
+      const entry = state.receiveOnlySyncthingAppsCache.get(folderId);
+      return Boolean(entry && !entry.restarted);
+    },
+    debounceMs: EARLY_EVAL_DEBOUNCE_MS,
+    minGapMs: EARLY_EVAL_MIN_GAP_MS,
+  });
 
   // Run immediately on start
   runMonitoring();
@@ -649,21 +701,9 @@ function syncthingApps(state, installedAppsFn, getGlobalStateFn) {
   // Then run at regular intervals (the LEVEL: ground truth, self-healing)
   intervalId = setInterval(runMonitoring, MONITOR_INTERVAL_MS);
 
-  // Edge accelerator: syncthing folder events trigger an early run of the SAME
-  // monitoring pass the interval drives - events never carry decisions. Debounced
-  // so an event burst coalesces into one evaluation; if the stream dies, behavior
-  // degrades to the interval cadence (latency, never correctness).
-  let earlyEvaluationTimer = null;
-  const requestEarlyEvaluation = () => {
-    if (earlyEvaluationTimer) return;
-    earlyEvaluationTimer = setTimeout(() => {
-      earlyEvaluationTimer = null;
-      runMonitoring();
-    }, 2000);
-  };
   syncthingEventsConsumer.start({
-    onFolderActivity: () => requestEarlyEvaluation(),
-    onResync: () => requestEarlyEvaluation(),
+    onFolderActivity: (folder, eventType) => accelerator.onFolderActivity(folder, eventType),
+    onResync: () => accelerator.onResync(),
   });
 
   // Return control object for graceful shutdown
@@ -672,10 +712,7 @@ function syncthingApps(state, installedAppsFn, getGlobalStateFn) {
       if (intervalId) {
         clearInterval(intervalId);
         intervalId = null;
-        if (earlyEvaluationTimer) {
-          clearTimeout(earlyEvaluationTimer);
-          earlyEvaluationTimer = null;
-        }
+        accelerator.stop();
         syncthingEventsConsumer.stop();
         log.info('syncthingApps - Monitoring service stopped');
       }

--- a/ZelBack/src/services/appMonitoring/syncthingMonitorAccelerator.js
+++ b/ZelBack/src/services/appMonitoring/syncthingMonitorAccelerator.js
@@ -1,0 +1,80 @@
+// Edge accelerator for the syncthing monitor. Folder-activity events request
+// an early run of the same monitoring pass the interval drives - events never
+// carry decisions. Two guards keep a continuous event stream (a large install
+// sync, a busy app writing into its own folder) from degenerating into
+// back-to-back full passes:
+//   - activity only counts for folders the state machine is actively
+//     transitioning, or for FolderErrors (syncthing's own signal that a
+//     folder's storage went bad - e.g. the .stfolder marker vanished with its
+//     mount); steady-state folders belong to the level pass
+//   - early runs keep a minimum gap from the end of the last completed pass
+// A request landing while a pass is running is remembered and re-armed when
+// the pass ends. If the event stream dies entirely, behavior degrades to the
+// interval cadence - latency, never correctness.
+
+const monotonicMs = () => Number(process.hrtime.bigint() / 1000000n);
+
+/**
+ * @param {object} options
+ * @param {Function} options.run Runs one monitoring pass (fire and forget).
+ * @param {Function} options.isFolderInTransition (folderId) => boolean.
+ * @param {number} options.debounceMs Coalescing window for event bursts.
+ * @param {number} options.minGapMs Minimum gap from the last completed pass.
+ * @returns {{onFolderActivity: Function, onResync: Function,
+ *   notePassStarted: Function, notePassEnded: Function, stop: Function}}
+ */
+function createMonitorAccelerator({
+  run, isFolderInTransition, debounceMs, minGapMs,
+}) {
+  let timer = null;
+  let pending = false;
+  let passRunning = false;
+  let lastPassEndedAtMs = 0;
+
+  function request() {
+    if (timer) return;
+    if (passRunning) {
+      pending = true;
+      return;
+    }
+    const sinceLastPass = monotonicMs() - lastPassEndedAtMs;
+    const delay = Math.max(debounceMs, minGapMs - sinceLastPass);
+    timer = setTimeout(() => {
+      timer = null;
+      run();
+    }, delay);
+  }
+
+  return {
+    onFolderActivity(folderId, eventType) {
+      if (eventType === 'FolderErrors' || isFolderInTransition(folderId)) {
+        request();
+      }
+    },
+    onResync() {
+      request();
+    },
+    notePassStarted() {
+      passRunning = true;
+    },
+    notePassEnded() {
+      passRunning = false;
+      lastPassEndedAtMs = monotonicMs();
+      if (pending) {
+        pending = false;
+        request();
+      }
+    },
+    stop() {
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      pending = false;
+    },
+  };
+}
+
+module.exports = {
+  createMonitorAccelerator,
+};

--- a/ZelBack/src/services/appMonitoring/syncthingMonitorConstants.js
+++ b/ZelBack/src/services/appMonitoring/syncthingMonitorConstants.js
@@ -39,6 +39,12 @@ const CLOCK_SKEW_TOLERANCE_MS = 5000; // 5 seconds tolerance for timestamp compa
 // flip a follower into self-promoting (and starting the app). Tunable for tests.
 const LEADER_CONFIRM_COUNT = config.syncthing.leaderConfirmCount ?? 2;
 
+// Edge-accelerator pacing: event bursts coalesce for the debounce window, and
+// early runs keep a minimum gap from the last completed pass so a continuous
+// event stream cannot drive back-to-back full passes. Tunable for tests.
+const EARLY_EVAL_DEBOUNCE_MS = config.syncthing.earlyEvalDebounceMs ?? 2 * 1000;
+const EARLY_EVAL_MIN_GAP_MS = config.syncthing.earlyEvalMinGapMs ?? 10 * 1000;
+
 // Sync completion thresholds
 const SYNC_COMPLETE_PERCENTAGE = 100;
 
@@ -62,6 +68,8 @@ module.exports = {
   STALL_REMOVE_MIN_NUDGES,
   ACTIVE_FOLDER_STATES,
   CLOCK_SKEW_TOLERANCE_MS,
+  EARLY_EVAL_DEBOUNCE_MS,
+  EARLY_EVAL_MIN_GAP_MS,
   LEADER_CONFIRM_COUNT,
   SYNC_COMPLETE_PERCENTAGE,
   HEALTH_NUDGE_THRESHOLD_MS,

--- a/ZelBack/src/services/appMonitoring/syncthingMonitorHelpers.js
+++ b/ZelBack/src/services/appMonitoring/syncthingMonitorHelpers.js
@@ -1,5 +1,7 @@
 // Syncthing Monitor - Helper Functions
 const axios = require('axios');
+const fs = require('node:fs/promises');
+const path = require('node:path');
 const log = require('../../lib/log');
 const serviceHelper = require('../serviceHelper');
 const volumeService = require('../utils/volumeService');
@@ -215,11 +217,18 @@ async function ensureStfolderExists(folder) {
     log.error(`ensureStfolderExists - ${folder} is not a mountpoint; refusing to create .stfolder on the bare directory`);
     return false;
   }
-  const mkdir = await serviceHelper.runCommand('mkdir', { runAsRoot: true, params: ['-p', `${folder}/.stfolder`] });
+  // creation is a one-time setup act: when the marker is already present in
+  // the mounted volume there is nothing to do (and nothing to log)
+  const marker = path.join(folder, '.stfolder');
+  const exists = await fs.stat(marker).then((stats) => stats.isDirectory()).catch(() => false);
+  if (exists) return true;
+
+  const mkdir = await serviceHelper.runCommand('mkdir', { runAsRoot: true, params: ['-p', marker] });
   if (mkdir.error) {
     log.error(`ensureStfolderExists - failed to create .stfolder in ${folder}: ${mkdir.error.message}`);
     return false;
   }
+  log.info(`ensureStfolderExists - created .stfolder in ${folder}`);
   return true;
 }
 

--- a/ZelBack/src/services/utils/volumeService.js
+++ b/ZelBack/src/services/utils/volumeService.js
@@ -11,13 +11,27 @@ const { appsFolder, appVolumesPath, legacyAppVolumesPath } = require('./appConst
 const dfAsync = util.promisify(df);
 
 /**
- * Whether a path currently has a filesystem mounted on it.
+ * Whether a path currently has a filesystem mounted on it. Reads
+ * /proc/self/mountinfo - one silent file read instead of forking
+ * mountpoint(1), so callers can probe freely without process-spawn cost or
+ * log noise. Falls back to the mountpoint binary if the read fails.
  * @param {string} dirPath Directory path to check.
  * @returns {Promise<boolean>} True if the path is a mountpoint.
  */
 async function isPathMounted(dirPath) {
-  const result = await serviceHelper.runCommand('mountpoint', { params: ['-q', dirPath], logError: false });
-  return !result.error;
+  const mountinfo = await fs.readFile('/proc/self/mountinfo', 'utf8').catch(() => null);
+  if (mountinfo === null) {
+    const result = await serviceHelper.runCommand('mountpoint', { params: ['-q', dirPath], logError: false });
+    return !result.error;
+  }
+  const target = path.resolve(dirPath);
+  // field 5 of each mountinfo line is the mount point, with space/tab/newline/
+  // backslash octal-escaped
+  const unescapeMount = (s) => s.replace(/\\(\d{3})/g, (_, oct) => String.fromCharCode(parseInt(oct, 8)));
+  return mountinfo.split('\n').some((line) => {
+    const fields = line.split(' ');
+    return fields.length > 4 && unescapeMount(fields[4]) === target;
+  });
 }
 
 /**

--- a/test-infra/runner/tests/61-syncthing-mount-safety.js
+++ b/test-infra/runner/tests/61-syncthing-mount-safety.js
@@ -4,7 +4,9 @@ import { createTestEnv } from '../framework/test-env.js';
 import { execInContainer, getAppContainerStatus } from '../framework/container.js';
 import {
   setSyncState, setSynced, setSyncing, getSyncthingState, resetSyncState,
+  injectSyncthingEvent,
 } from '../framework/syncthing-control.js';
+import { countPattern } from '../framework/log-reader.js';
 import {
   waitFor, waitForReconcilerDesiredChanged, waitForReconcileActuated, assertNoEvent,
 } from '../framework/wait.js';
@@ -26,6 +28,13 @@ import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
 //  - the .stfolder marker must never (re)appear on the bare unmounted dir -
 //    recreating it there re-arms syncthing onto the host filesystem and
 //    defeats syncthing's own missing-marker guard
+//
+// Mount safety is verified at decision points (startup, promotion) and in
+// reaction to FolderErrors - syncthing's own storage-went-bad signal, raised
+// natively when a vanished mount takes the .stfolder marker with it. The stub
+// has no disk watcher, so these tests inject the FolderErrors event that real
+// syncthing would raise. Steady state runs no probes and writes no per-pass
+// log lines - asserted here before any state is broken.
 
 const subnet = getSubnetConfig();
 
@@ -95,6 +104,26 @@ describe('syncthing mount-safety guard demotes unsafe sendreceive folders', func
     await env?.teardown();
   });
 
+  it('steady state runs no mount probes and writes no per-pass observation lines', async function () {
+    this.timeout(60000);
+    // both apps are healthy, promoted and running - four-plus monitor cycles
+    // must pass without a forked mount probe, a marker re-assertion, or a
+    // repeated safety observation on either node
+    await new Promise((resolve) => { setTimeout(resolve, 13000); });
+    // eslint-disable-next-line no-restricted-syntax
+    for (const client of [env.clients[0], env.clients[1]]) {
+      // eslint-disable-next-line no-await-in-loop
+      const probes = await countPattern(client.container, 'Run Cmd: mountpoint', { since: '13s' });
+      // eslint-disable-next-line no-await-in-loop
+      const markerAsserts = await countPattern(client.container, 'mkdir -p .*stfolder', { since: '13s' });
+      // eslint-disable-next-line no-await-in-loop
+      const observationSpam = await countPattern(client.container, 'mounted but has no content', { since: '13s' });
+      expect(probes, 'mountpoint execs in steady state').to.equal(0);
+      expect(markerAsserts, '.stfolder re-assertions in steady state').to.equal(0);
+      expect(observationSpam, 'per-pass observation warns in steady state').to.equal(0);
+    }
+  });
+
   it('does NOT demote a legitimately empty folder whose index is empty too (cold-start seed)', async function () {
     this.timeout(60000);
     const client = env.clients[1];
@@ -118,6 +147,9 @@ describe('syncthing mount-safety guard demotes unsafe sendreceive folders', func
     // mounted volume holds none - in sendreceive, syncthing would broadcast
     // every "missing" file as a deletion
     await setSyncState({ ip: ip1, folder: phantomFolder, state: 'idle', globalBytes: 100000, inSyncBytes: 100000 });
+    // flag the folder: steady state is never swept, so the verify (which
+    // includes the phantom-index check) runs when syncthing flags the folder
+    await injectSyncthingEvent({ ip: ip1, type: 'FolderErrors', data: { folder: phantomFolder, errors: [{ error: 'pull failed' }] } });
 
     await waitFor(async () => (await folderType(ip1, phantomFolder)) === 'receiveonly', { timeout: 60000, interval: 3000, label: 'phantom folder demoted to receiveonly' });
     await waitForReconcilerDesiredChanged(client, phantomIdentifier, 'stopped', 60000, { afterId });
@@ -154,6 +186,11 @@ describe('syncthing mount-safety guard demotes unsafe sendreceive folders', func
     const r = await execInContainer(client.container,
       `umount -l ${dir} && chattr -i ${dir} && touch ${dir}/leaked.db && rm -f ${volFile(leakName)}`);
     expect(r.exitCode, `leak-state setup failed: ${r.output}`).to.equal(0);
+
+    // the vanished mount took the .stfolder marker with it - real syncthing
+    // raises FolderErrors for the folder; the stub has no disk watcher, so
+    // inject the same signal
+    await injectSyncthingEvent({ ip: ip0, type: 'FolderErrors', data: { folder: leakFolder, errors: [{ error: 'folder marker missing' }] } });
 
     // content must NOT buy a pass: the folder is demoted and the container
     // stopped by the mount-safety hold (no help from the test this time)

--- a/test-infra/runner/tests/61-syncthing-mount-safety.js
+++ b/test-infra/runner/tests/61-syncthing-mount-safety.js
@@ -6,7 +6,6 @@ import {
   setSyncState, setSynced, setSyncing, getSyncthingState, resetSyncState,
   injectSyncthingEvent,
 } from '../framework/syncthing-control.js';
-import { countPattern } from '../framework/log-reader.js';
 import {
   waitFor, waitForReconcilerDesiredChanged, waitForReconcileActuated, assertNoEvent,
 } from '../framework/wait.js';
@@ -108,20 +107,20 @@ describe('syncthing mount-safety guard demotes unsafe sendreceive folders', func
     this.timeout(60000);
     // both apps are healthy, promoted and running - four-plus monitor cycles
     // must pass without a forked mount probe, a marker re-assertion, or a
-    // repeated safety observation on either node
+    // repeated safety observation on either node. The harness's in-memory log
+    // collectors give each node's lines; only lines from the quiet window count.
+    const linesFor = (index) => env.nodeDiagnostics().find((n) => n.index === index)?.lines ?? [];
+    const startAt = [linesFor(0).length, linesFor(1).length];
     await new Promise((resolve) => { setTimeout(resolve, 13000); });
-    // eslint-disable-next-line no-restricted-syntax
-    for (const client of [env.clients[0], env.clients[1]]) {
-      // eslint-disable-next-line no-await-in-loop
-      const probes = await countPattern(client.container, 'Run Cmd: mountpoint', { since: '13s' });
-      // eslint-disable-next-line no-await-in-loop
-      const markerAsserts = await countPattern(client.container, 'mkdir -p .*stfolder', { since: '13s' });
-      // eslint-disable-next-line no-await-in-loop
-      const observationSpam = await countPattern(client.container, 'mounted but has no content', { since: '13s' });
-      expect(probes, 'mountpoint execs in steady state').to.equal(0);
-      expect(markerAsserts, '.stfolder re-assertions in steady state').to.equal(0);
-      expect(observationSpam, 'per-pass observation warns in steady state').to.equal(0);
-    }
+    [0, 1].forEach((nodeIndex) => {
+      const fresh = linesFor(nodeIndex).slice(startAt[nodeIndex]);
+      const probes = fresh.filter((l) => l.includes('Run Cmd: mountpoint')).length;
+      const markerAsserts = fresh.filter((l) => /mkdir -p .*stfolder/.test(l)).length;
+      const observationSpam = fresh.filter((l) => l.includes('mounted but has no content')).length;
+      expect(probes, `node ${nodeIndex} mountpoint execs in steady state`).to.equal(0);
+      expect(markerAsserts, `node ${nodeIndex} .stfolder re-assertions in steady state`).to.equal(0);
+      expect(observationSpam, `node ${nodeIndex} per-pass observation warns in steady state`).to.equal(0);
+    });
   });
 
   it('does NOT demote a legitimately empty folder whose index is empty too (cold-start seed)', async function () {

--- a/tests/unit/syncthingEventsConsumer.test.js
+++ b/tests/unit/syncthingEventsConsumer.test.js
@@ -94,6 +94,21 @@ describe('syncthingEventsConsumer tests', () => {
     expect(secondCallQuery.since).to.equal(6);
   });
 
+  it('accumulates FolderErrors folder ids for the monitor to drain; draining clears', async () => {
+    syncthingServiceMock.getEvents.onFirstCall().resolves(eventsResponse([
+      { id: 7, time: 't', type: 'FolderErrors', data: { folder: 'fluxcomp_bad', errors: [{ error: 'folder marker missing' }] } },
+      { id: 8, time: 't', type: 'FolderSummary', data: { folder: 'fluxcomp_ok', summary: {} } },
+    ]));
+    syncthingServiceMock.getEvents.onSecondCall().callsFake(parkForever);
+
+    consumer.start({ onFolderActivity, onResync });
+    await new Promise((resolve) => { setImmediate(() => { setImmediate(resolve); }); });
+
+    // only the FolderErrors folder accumulates - plain activity never does
+    expect(consumer.drainErroredFolderIds()).to.deep.equal(['fluxcomp_bad']);
+    expect(consumer.drainErroredFolderIds()).to.deep.equal([]);
+  });
+
   it('treats an id regression as a lost-events signal (defensive: a conforming server never returns ids below since)', async () => {
     syncthingServiceMock.getEvents.onFirstCall().resolves(eventsResponse([
       { id: 100, time: 't', type: 'FolderSummary', data: { folder: 'fluxa', summary: {} } },

--- a/tests/unit/syncthingFolderStateMachine.test.js
+++ b/tests/unit/syncthingFolderStateMachine.test.js
@@ -1119,6 +1119,75 @@ describe('syncthingFolderStateMachine tests', () => {
     });
   });
 
+  describe('mount-safety observation logging', () => {
+    // eslint-disable-next-line global-require
+    const log = require('../../ZelBack/src/lib/log');
+    let sandbox;
+
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+      sandbox.spy(log, 'warn');
+      sandbox.spy(log, 'error');
+      sandbox.spy(log, 'info');
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    const callsMentioning = (spy, appId) => spy.getCalls().filter((c) => String(c.args[0]).includes(appId));
+
+    it('logs a persistent mounted-but-empty observation once, not per pass', async () => {
+      fsMock.promises.readdir.resolves([]); // mounted, no content
+
+      await stateMachine.verifyFolderMountSafety('obs-empty-app', '/apps/obs-empty-app');
+      await stateMachine.verifyFolderMountSafety('obs-empty-app', '/apps/obs-empty-app');
+      await stateMachine.verifyFolderMountSafety('obs-empty-app', '/apps/obs-empty-app');
+
+      expect(callsMentioning(log.warn, 'obs-empty-app')).to.have.lengthOf(1);
+    });
+
+    it('logs recovery once when the observation returns to ok', async () => {
+      fsMock.promises.readdir.resolves([]);
+      await stateMachine.verifyFolderMountSafety('obs-recover-app', '/apps/obs-recover-app');
+
+      fsMock.promises.readdir.resolves([dirent('state.db')]);
+      await stateMachine.verifyFolderMountSafety('obs-recover-app', '/apps/obs-recover-app');
+      await stateMachine.verifyFolderMountSafety('obs-recover-app', '/apps/obs-recover-app');
+
+      const recoveries = callsMentioning(log.info, 'obs-recover-app').filter((c) => String(c.args[0]).includes('recovered'));
+      expect(recoveries).to.have.lengthOf(1);
+    });
+
+    it('logs again when the observation changes to a different condition', async () => {
+      fsMock.promises.readdir.resolves([]); // mounted empty -> warn
+      await stateMachine.verifyFolderMountSafety('obs-change-app', '/apps/obs-change-app');
+      expect(callsMentioning(log.warn, 'obs-change-app')).to.have.lengthOf(1);
+
+      volumeServiceMock.isPathMounted.resolves(false); // unmounted now -> error
+      await stateMachine.verifyFolderMountSafety('obs-change-app', '/apps/obs-change-app');
+      await stateMachine.verifyFolderMountSafety('obs-change-app', '/apps/obs-change-app');
+
+      expect(callsMentioning(log.error, 'obs-change-app')).to.have.lengthOf(1);
+    });
+
+    it('re-logs a persisting unsafe observation after the relog interval', async () => {
+      const clock = sinon.useFakeTimers({ toFake: ['hrtime'] });
+      try {
+        fsMock.promises.readdir.resolves([]);
+        await stateMachine.verifyFolderMountSafety('obs-relog-app', '/apps/obs-relog-app');
+        expect(callsMentioning(log.warn, 'obs-relog-app')).to.have.lengthOf(1);
+
+        clock.tick(6 * 60 * 1000); // past the 5-minute relog interval
+        await stateMachine.verifyFolderMountSafety('obs-relog-app', '/apps/obs-relog-app');
+
+        expect(callsMentioning(log.warn, 'obs-relog-app')).to.have.lengthOf(2);
+      } finally {
+        clock.restore();
+      }
+    });
+  });
+
   describe('verifySendReceiveFolderSafety', () => {
     it('is unsafe when the index claims data but the disk holds no sync-scoped files', async () => {
       // stale ("phantom") index over a fresh empty volume: only FluxOS's own

--- a/tests/unit/syncthingMonitor.test.js
+++ b/tests/unit/syncthingMonitor.test.js
@@ -89,6 +89,7 @@ const syncthingEventsConsumerMock = {
   stop: sinon.stub().resolves(),
   isRunning: sinon.stub().returns(false),
   getFolderErrors: sinon.stub(),
+  drainErroredFolderIds: sinon.stub().returns([]),
 };
 
 // Load module with mocked dependencies
@@ -152,6 +153,8 @@ describe('syncthingMonitor tests', () => {
     syncthingEventsConsumerMock.start.reset();
     syncthingEventsConsumerMock.stop.reset();
     syncthingEventsConsumerMock.stop.resolves();
+    syncthingEventsConsumerMock.drainErroredFolderIds.reset();
+    syncthingEventsConsumerMock.drainErroredFolderIds.returns([]);
 
     volumeServiceMock.ensureAppVolumeMounted.reset();
     volumeServiceMock.ensureAppVolumeMounted.resolves({ mounted: true, alreadyMounted: true });
@@ -318,6 +321,7 @@ describe('syncthingMonitor tests', () => {
     });
 
     it('demotes a sendreceive folder over an unrepairable mount while skipping the cycle', async function () {
+      // syncthing raised FolderErrors for the folder (storage went bad), the
       // repair fails (no backing image) -> the cycle is skipped, but a folder
       // left sendreceive over the bad mount could still broadcast its disk
       // state - it must be demoted and its container held before bailing
@@ -325,6 +329,7 @@ describe('syncthingMonitor tests', () => {
         status: 'success',
         data: [{ name: 'testapp', version: 3, containerData: 'g:/appdata' }],
       });
+      syncthingEventsConsumerMock.drainErroredFolderIds.returns(['testapp']);
       syncthingFolderStateMachineMock.verifyFolderMountSafety.resolves({ isSafe: false, isMounted: false, reason: 'unmounted_with_content' });
       volumeServiceMock.ensureAppVolumeMounted.resolves({ mounted: false, reason: 'volume_file_missing' });
       syncthingServiceMock.getConfigFolders.resolves({ data: [{ id: 'testapp', type: 'sendreceive' }] });
@@ -348,6 +353,7 @@ describe('syncthingMonitor tests', () => {
         status: 'success',
         data: [{ name: 'testapp', version: 3, containerData: 'g:/appdata' }],
       });
+      syncthingEventsConsumerMock.drainErroredFolderIds.returns(['testapp']);
       syncthingFolderStateMachineMock.verifyFolderMountSafety.resolves({ isSafe: false, isMounted: false, reason: 'empty_unmounted_directory' });
       volumeServiceMock.ensureAppVolumeMounted.resolves({ mounted: false, reason: 'volume_file_missing' });
       syncthingServiceMock.getConfigFolders.resolves({ data: [{ id: 'testapp', type: 'receiveonly' }] });
@@ -387,12 +393,14 @@ describe('syncthingMonitor tests', () => {
       sinon.assert.calledOnce(syncthingEventsConsumerMock.stop);
     });
 
-    it('should run an early evaluation (debounced) when folder events arrive', async () => {
+    it('should run an early evaluation for a folder in active transition', async () => {
       // events never decide anything - they only run the SAME monitoring pass
-      // earlier than the interval would
+      // earlier than the interval would, and only for folders the state
+      // machine is actively transitioning
       mockInstalledAppsFn.resolves({ status: 'success', data: [] });
       syncthingServiceMock.getDeviceId.resolves('DEVICE-ID');
       fluxNetworkHelperMock.getLocalSocketAddress.resolves('10.0.0.1:16127');
+      mockState.receiveOnlySyncthingAppsCache.set('fluxcomp_app1', { numberOfExecutions: 3 });
 
       monitorControl = syncthingMonitor.syncthingApps(
         mockState,
@@ -410,7 +418,98 @@ describe('syncthingMonitor tests', () => {
       handlers.onFolderActivity('fluxcomp_app1', 'FolderSummary');
       handlers.onFolderActivity('fluxcomp_app1', 'StateChanged'); // coalesces
 
-      await clock.tickAsync(2500); // past the debounce, well before the interval
+      // a continuous event stream must not drive back-to-back passes: nothing
+      // fires before the min gap from the last completed pass
+      await clock.tickAsync(2500);
+      expect(mockInstalledAppsFn.callCount).to.equal(runsAfterStart);
+
+      // past the min gap, before the interval
+      await clock.tickAsync(8500);
+      expect(mockInstalledAppsFn.callCount).to.equal(runsAfterStart + 1);
+    });
+
+    it('does not sweep mounts in steady state (no FolderErrors, not first run)', async () => {
+      // an unsafe mount exists, but nothing flagged it - the steady-state pass
+      // must not go looking: syncthing's .stfolder marker converts real
+      // storage loss into FolderErrors, which is the only trigger
+      mockInstalledAppsFn.resolves({
+        status: 'success',
+        data: [{ name: 'testapp', version: 3, containerData: 'g:/appdata' }],
+      });
+      syncthingFolderStateMachineMock.verifyFolderMountSafety.resolves({ isSafe: false, isMounted: false, reason: 'empty_unmounted_directory' });
+      syncthingServiceMock.getConfigFolders.resolves({ data: [{ id: 'testapp', type: 'sendreceive' }] });
+      syncthingServiceMock.getDeviceId.resolves('DEVICE-ID');
+      fluxNetworkHelperMock.getLocalSocketAddress.resolves('10.0.0.1:16127');
+
+      monitorControl = syncthingMonitor.syncthingApps(
+        mockState,
+        mockInstalledAppsFn,
+        mockGetGlobalStateFn,
+      );
+      await clock.tickAsync(100);
+
+      sinon.assert.notCalled(syncthingFolderStateMachineMock.verifyFolderMountSafety);
+      sinon.assert.neverCalledWith(syncthingServiceMock.adjustConfigFolders, 'patch', { type: 'receiveonly' }, 'testapp');
+      // and the pass itself proceeded - it was not skipped
+      sinon.assert.called(syncthingServiceMock.getDeviceId);
+    });
+
+    it('should NOT accelerate on activity from steady-state folders', async () => {
+      // a healthy folder (synced, or simply a busy app writing into it) emits
+      // events continuously - those belong to the level pass, never the
+      // accelerator, or a busy g: app degenerates the 30s cadence into
+      // back-to-back full passes
+      mockInstalledAppsFn.resolves({ status: 'success', data: [] });
+      syncthingServiceMock.getDeviceId.resolves('DEVICE-ID');
+      fluxNetworkHelperMock.getLocalSocketAddress.resolves('10.0.0.1:16127');
+      // a completed transition (restarted) is steady state too
+      mockState.receiveOnlySyncthingAppsCache.set('fluxcomp_done', { restarted: true });
+
+      monitorControl = syncthingMonitor.syncthingApps(
+        mockState,
+        mockInstalledAppsFn,
+        mockGetGlobalStateFn,
+        mockAppDockerStopFn,
+        mockAppDockerRestartFn,
+        mockAppDeleteDataFn,
+        mockRemoveAppLocallyFn,
+      );
+      await clock.tickAsync(100); // initial run completes
+      const runsAfterStart = mockInstalledAppsFn.callCount;
+
+      const handlers = syncthingEventsConsumerMock.start.firstCall.args[0];
+      handlers.onFolderActivity('fluxcomp_untracked', 'FolderSummary');
+      handlers.onFolderActivity('fluxcomp_done', 'FolderSummary');
+      handlers.onFolderActivity('fluxcomp_done', 'StateChanged');
+
+      await clock.tickAsync(15000); // well past debounce and min gap
+
+      expect(mockInstalledAppsFn.callCount).to.equal(runsAfterStart);
+    });
+
+    it('should accelerate on FolderErrors regardless of folder state', async () => {
+      // FolderErrors is syncthing's own storage-went-bad signal (e.g. the
+      // .stfolder marker vanished with its mount) - always worth an early pass
+      mockInstalledAppsFn.resolves({ status: 'success', data: [] });
+      syncthingServiceMock.getDeviceId.resolves('DEVICE-ID');
+      fluxNetworkHelperMock.getLocalSocketAddress.resolves('10.0.0.1:16127');
+
+      monitorControl = syncthingMonitor.syncthingApps(
+        mockState,
+        mockInstalledAppsFn,
+        mockGetGlobalStateFn,
+        mockAppDockerStopFn,
+        mockAppDockerRestartFn,
+        mockAppDeleteDataFn,
+        mockRemoveAppLocallyFn,
+      );
+      await clock.tickAsync(100); // initial run completes
+      const runsAfterStart = mockInstalledAppsFn.callCount;
+
+      const handlers = syncthingEventsConsumerMock.start.firstCall.args[0];
+      handlers.onFolderActivity('fluxcomp_untracked', 'FolderErrors');
+
+      await clock.tickAsync(11000);
 
       expect(mockInstalledAppsFn.callCount).to.equal(runsAfterStart + 1);
     });

--- a/tests/unit/syncthingMonitorAccelerator.test.js
+++ b/tests/unit/syncthingMonitorAccelerator.test.js
@@ -1,0 +1,106 @@
+// Set NODE_CONFIG_DIR before any requires
+process.env.NODE_CONFIG_DIR = `${process.cwd()}/tests/unit/globalconfig`;
+
+const sinon = require('sinon');
+const { createMonitorAccelerator } = require('../../ZelBack/src/services/appMonitoring/syncthingMonitorAccelerator');
+
+describe('syncthingMonitorAccelerator tests', () => {
+  let clock;
+  let run;
+  let inTransition;
+  let accelerator;
+
+  const DEBOUNCE = 2000;
+  const MIN_GAP = 10000;
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers();
+    run = sinon.stub();
+    inTransition = sinon.stub().returns(false);
+    accelerator = createMonitorAccelerator({
+      run,
+      isFolderInTransition: inTransition,
+      debounceMs: DEBOUNCE,
+      minGapMs: MIN_GAP,
+    });
+  });
+
+  afterEach(() => {
+    accelerator.stop();
+    clock.restore();
+  });
+
+  it('ignores activity from folders not in transition', () => {
+    accelerator.onFolderActivity('fluxsteady_app', 'FolderSummary');
+    clock.tick(MIN_GAP * 3);
+    sinon.assert.notCalled(run);
+  });
+
+  it('runs for a folder in transition, honoring the min gap from the last pass', () => {
+    inTransition.returns(true);
+
+    // a pass just completed
+    accelerator.notePassStarted();
+    accelerator.notePassEnded();
+
+    accelerator.onFolderActivity('fluxsyncing_app', 'FolderSummary');
+    clock.tick(MIN_GAP - 1);
+    sinon.assert.notCalled(run);
+    clock.tick(1);
+    sinon.assert.calledOnce(run);
+  });
+
+  it('runs on FolderErrors regardless of transition state', () => {
+    accelerator.notePassStarted();
+    accelerator.notePassEnded();
+
+    accelerator.onFolderActivity('fluxany_app', 'FolderErrors');
+    clock.tick(MIN_GAP);
+    sinon.assert.calledOnce(run);
+  });
+
+  it('waits only the debounce when the last pass ended long ago', () => {
+    accelerator.notePassStarted();
+    accelerator.notePassEnded();
+    clock.tick(MIN_GAP * 2); // idle for a while
+
+    accelerator.onFolderActivity('fluxany_app', 'FolderErrors');
+    clock.tick(DEBOUNCE - 1);
+    sinon.assert.notCalled(run);
+    clock.tick(1);
+    sinon.assert.calledOnce(run);
+  });
+
+  it('coalesces an event burst into one run', () => {
+    accelerator.notePassStarted();
+    accelerator.notePassEnded();
+    clock.tick(MIN_GAP * 2);
+
+    for (let i = 0; i < 25; i += 1) {
+      accelerator.onFolderActivity('fluxany_app', 'FolderErrors');
+    }
+    clock.tick(MIN_GAP * 2);
+    sinon.assert.calledOnce(run);
+  });
+
+  it('remembers a request landing during a pass and re-arms when the pass ends', () => {
+    accelerator.notePassStarted();
+    accelerator.onFolderActivity('fluxany_app', 'FolderErrors');
+    clock.tick(MIN_GAP * 2); // nothing may fire while the pass runs
+    sinon.assert.notCalled(run);
+
+    accelerator.notePassEnded();
+    clock.tick(MIN_GAP);
+    sinon.assert.calledOnce(run);
+  });
+
+  it('stop() cancels a pending run', () => {
+    accelerator.notePassStarted();
+    accelerator.notePassEnded();
+    accelerator.onFolderActivity('fluxany_app', 'FolderErrors');
+
+    accelerator.stop();
+    clock.tick(MIN_GAP * 3);
+    sinon.assert.notCalled(run);
+  });
+});

--- a/tests/unit/syncthingMonitorHelpers.test.js
+++ b/tests/unit/syncthingMonitorHelpers.test.js
@@ -4,6 +4,7 @@ process.env.NODE_CONFIG_DIR = `${process.cwd()}/tests/unit/globalconfig`;
 const { expect } = require('chai');
 const sinon = require('sinon');
 const axios = require('axios');
+const fsp = require('node:fs/promises');
 const serviceHelper = require('../../ZelBack/src/services/serviceHelper');
 const volumeService = require('../../ZelBack/src/services/utils/volumeService');
 const helpers = require('../../ZelBack/src/services/appMonitoring/syncthingMonitorHelpers');
@@ -394,12 +395,24 @@ describe('syncthingMonitorHelpers tests', () => {
 
     it('creates the marker inside a mounted volume', async () => {
       sandbox.stub(volumeService, 'isPathMounted').resolves(true);
+      sandbox.stub(fsp, 'stat').rejects(new Error('ENOENT'));
       const runCommand = sandbox.stub(serviceHelper, 'runCommand').resolves({ error: null, stdout: '', stderr: '' });
 
       const result = await helpers.ensureStfolderExists('/apps/fluxcomp_app');
 
       expect(result).to.be.true;
       sinon.assert.calledWith(runCommand, 'mkdir', sinon.match({ runAsRoot: true, params: ['-p', '/apps/fluxcomp_app/.stfolder'] }));
+    });
+
+    it('does not recreate an existing marker (creation is one-time setup, not a per-pass ritual)', async () => {
+      sandbox.stub(volumeService, 'isPathMounted').resolves(true);
+      sandbox.stub(fsp, 'stat').resolves({ isDirectory: () => true });
+      const runCommand = sandbox.stub(serviceHelper, 'runCommand');
+
+      const result = await helpers.ensureStfolderExists('/apps/fluxcomp_app');
+
+      expect(result).to.be.true;
+      sinon.assert.notCalled(runCommand);
     });
 
     it('reports failure when the marker cannot be created', async () => {

--- a/tests/unit/volumeService.test.js
+++ b/tests/unit/volumeService.test.js
@@ -34,7 +34,10 @@ describe('volumeService tests', () => {
         COMPONENT_FILE: 'component_file',
       },
     };
-    fsStub = { promises: { access: sinon.stub(), readdir: sinon.stub().resolves([]) } };
+    // readFile rejecting drives isPathMounted onto its mountpoint-command
+    // fallback, so tests can keep expressing mountedness via runCommand; the
+    // isPathMounted describe covers the mountinfo path with real fixtures
+    fsStub = { promises: { access: sinon.stub(), readdir: sinon.stub().resolves([]), readFile: sinon.stub().rejects(new Error('no mountinfo')) } };
     dfStub = sinon.stub().callsArgWith(1, null, []); // node-df callback style: (options, cb)
     logStub = {
       info: sinon.stub(), warn: sinon.stub(), error: sinon.stub(), debug: sinon.stub(),
@@ -66,8 +69,41 @@ describe('volumeService tests', () => {
     });
   };
 
+  // one /proc/self/mountinfo line per mounted path (field 5 is the mount point)
+  const mountinfoWith = (...paths) => paths
+    .map((p, i) => `${400 + i} 29 7:${i} / ${p} rw,relatime shared:${i} - ext4 /dev/loop${i} rw`)
+    .join('\n');
+
   describe('isPathMounted tests', () => {
-    it('should return true when mountpoint -q succeeds', async () => {
+    it('should return true when mountinfo lists the path as a mount point', async () => {
+      fsStub.promises.readFile.resolves(mountinfoWith('/dat', '/some/dir'));
+      const result = await volumeService.isPathMounted('/some/dir');
+      expect(result).to.be.true;
+      // no process spawned - this is the whole point of the mountinfo read
+      expect(callsFor('mountpoint')).to.have.lengthOf(0);
+    });
+
+    it('should return false when mountinfo does not list the path', async () => {
+      fsStub.promises.readFile.resolves(mountinfoWith('/dat', '/some/dir/deeper'));
+      const result = await volumeService.isPathMounted('/some/dir');
+      expect(result).to.be.false;
+      expect(callsFor('mountpoint')).to.have.lengthOf(0);
+    });
+
+    it('should normalize a trailing slash on the queried path', async () => {
+      fsStub.promises.readFile.resolves(mountinfoWith('/some/dir'));
+      const result = await volumeService.isPathMounted('/some/dir/');
+      expect(result).to.be.true;
+    });
+
+    it('should decode octal-escaped characters in mount points', async () => {
+      // mountinfo escapes spaces as \040
+      fsStub.promises.readFile.resolves(mountinfoWith('/some/dir\\040with\\040space'));
+      const result = await volumeService.isPathMounted('/some/dir with space');
+      expect(result).to.be.true;
+    });
+
+    it('should fall back to the mountpoint command when mountinfo is unreadable', async () => {
       const result = await volumeService.isPathMounted('/some/dir');
       expect(result).to.be.true;
       const probe = callsFor('mountpoint');
@@ -75,7 +111,7 @@ describe('volumeService tests', () => {
       expect(probe[0].args[1].params).to.deep.equal(['-q', '/some/dir']);
     });
 
-    it('should return false when mountpoint -q fails', async () => {
+    it('should return false from the fallback when mountpoint -q fails', async () => {
       serviceHelperStub.runCommand.resolves({ error: new Error('not a mountpoint'), stdout: '', stderr: '' });
       const result = await volumeService.isPathMounted('/some/dir');
       expect(result).to.be.false;
@@ -144,10 +180,14 @@ describe('volumeService tests', () => {
     });
 
     it('should be a no-op when the app dir is already a mountpoint', async () => {
+      // the mountedness comes from mountinfo - proving the composition once
+      fsStub.promises.readFile.resolves(mountinfoWith(`${APPS_FOLDER}fluxapp1`));
+
       const result = await volumeService.ensureAppVolumeMounted('app1');
 
       expect(result).to.deep.equal({ mounted: true, alreadyMounted: true });
       expect(callsFor('mount')).to.have.lengthOf(0);
+      expect(callsFor('mountpoint')).to.have.lengthOf(0);
     });
 
     it('should mount the discovered image and set the empty mountpoint immutable first', async () => {


### PR DESCRIPTION
## The problem being solved

On any node running an actively-writing `g:` application, the syncthing monitor degenerated into permanent maximum-rate churn:

- **Process-spawn churn**: every monitoring pass forked `mountpoint(1)` per app folder (some folders twice) and re-ran `sudo mkdir -p .../.stfolder` per syncthing folder — observed live at **3–4 shell commands per second, sustained indefinitely** (880 mountpoint forks and 206 mkdirs in ten minutes on a node with six apps).
- **Event-storm degeneration**: the monitor's edge accelerator re-armed on *any* folder event. A large install sync — or simply a busy app writing into its own synced folder — emits events continuously, so the "debounced" accelerator drove the full monitoring pass every ~2 seconds forever, instead of the intended 30-second level cadence.
- **Log spam**: un-rate-limited per-pass observations ("mounted but has no content … Potential data loss risk") wrote the same warning line every pass — 110 times in ten minutes for one legitimately-empty folder — burying real signals.
- **Architectural mismatch**: mount safety was re-verified for every folder on every pass, even though syncthing already has a native storage-loss signal: the `.stfolder` marker lives *inside* the mounted volume, so a vanished mount takes the marker with it and syncthing halts the folder and raises `FolderErrors` — no deletion broadcast. (The historical failure of that mechanism was FluxOS re-creating the marker on the bare directory each pass; that was fixed in #1761's mount-gated marker creation.)

## The design

Mount safety is verified **at decision points and in reaction to syncthing's own signals — never as a steady-state sweep**:

- **Startup** (first monitor pass after process start — the reboot case): full sweep with repair, unchanged.
- **Promotion flips** (receiveonly → sendreceive): the pre-flip safety gate, unchanged.
- **`FolderErrors` reaction**: the events consumer now accumulates flagged folder ids; the next pass mount-verifies exactly those folders (with repair, demote-to-receiveonly and container hold on failure). A plain app's bad mount no longer gates syncthing processing of unrelated folders.
- **The edge accelerator** (extracted into `syncthingMonitorAccelerator.js`) only reacts to folders the state machine is actively transitioning, plus `FolderErrors` and resync requests; early runs keep a minimum gap from the last completed pass (both knobs tunable via `config.syncthing`); a request landing mid-pass re-arms when the pass ends instead of being dropped. Steady-state folder activity never accelerates anything.
- **`isPathMounted` reads `/proc/self/mountinfo`** — one silent file read instead of a process fork, with octal-escape decoding and a `mountpoint(1)` fallback if the read fails.
- **`.stfolder` is created once** (mount-gated exactly as before); an existing marker is never re-asserted.
- **Observations log on change**: a persistent condition writes one line when first seen, a re-log at most every 5 minutes while it lasts, and one recovery line when it clears.

One deliberate contract change: a phantom index arising **mid-run** is caught at the next decision point (startup, promotion, flagged verify) rather than by per-cycle re-verification. The phantom hazard windows are precisely those decision points; steady-state paranoia was the churn.

## Results

- **Unit**: 168 tests across the six affected suites, including new coverage for the accelerator (scoping, min-gap, burst coalescing, mid-pass re-arm), the FolderErrors drain, marker create-once, observation gating, and a steady-state-no-sweep guard. The five key behaviors are mutation-verified (each fix reverted individually makes its guard test fail).
- **Live verification: this branch is deployed and running on a production node with real apps** — a three-component WordPress (wp + mysql + operator, its data folder syncthing-synced and actively written to by the running site: the exact workload that drove the old code to maximum-rate churn), Folding@home (`g:`, legitimately-empty folder — the observation-spam case), and a blockbook instance. Measured since restart: `mountpoint` forks **880/10min → 0**, marker re-assertions **206/10min → 0**, repeated observation warns **110/10min → 1** (a single change-gated line at boot for the empty folder). All app containers ran untouched across the deploy.
- **The mountinfo reader** was validated against live node mountinfo (loop mounts, trailing slashes, octal escapes; ~0.8 ms per probe, zero forks).
- **Extended soak: ~18 hours in production, spanning 11 FluxOS process restarts** (routine watchdog update-check restarts — the watchdog restarts FluxOS each cycle while a node runs a version ahead of the published release, as this pre-release deployment does; not crashes or instability) — zero `mountpoint` forks, zero marker re-assertions, and the empty-folder observation logged exactly once per process start (1:1 with firstRun sweeps). The change-gated logging contract holds across process lifecycles, not just at deploy time.
- **Same-hour A/B against an unpatched node**: over an identical idle hour on the same version base, an unpatched node (4 apps, all healthy) logged **123 forked `mountpoint` probes and 120 identical "data loss risk" warnings**; the patched node logged **zero of each** — the only `.stfolder` creations on either node were genuine new-install decision points. The unpatched base cadence is steady churn even without the event-storm degeneration described above.
- **Enterprise masterSlave app installed live on the patched node** (v8 encrypted-spec app, two `g:` components): accelerator early-runs fired at the 10s min-gap *only* while the folders were in active transition, interleaved with the 30s level passes; held-until-synced promotion ran through the pre-flip gate (112.6MB synced, then flipped to sendreceive); the standby containers were correctly held. A FluxOS restart then showed the firstRun decision-point sweep verifying both folders and steady state returning to silence. Every new mechanism in this PR observed on a workload class the original deployment didn't include.
- **Integration**: suite 61 gains a steady-state-quiet test (zero probes/re-assertions/warns over four-plus monitor cycles on healthy nodes) and its demote tests now inject the `FolderErrors` event real syncthing raises natively (the stub has no disk watcher). Suite 60 is unchanged: its self-heal path rides the reconciler, and its crontab/reboot tests use the intact startup sweeps.

## Merge gate

- [x] Unit suites green (168/168), key behaviors mutation-verified
- [x] Targeted syncthing/mount-family integration subset (15 suites) — all green (one new harness test needed a plumbing fix, `96a8dafbc`; all product-behavior tests passed first run)
- [x] **Full integration harness — 52/52 green** (full 52-suite parallel gate, run at `96a8dafbc`)

Written against `7022b2287`; harness-test fix `96a8dafbc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




