### PR TITLE
fix(reconciler): heal containers running detached from their docker network

### DIFF
--- a/ZelBack/src/services/appManagement/appsRuntimeState.js
+++ b/ZelBack/src/services/appManagement/appsRuntimeState.js
@@ -191,29 +191,80 @@ async function setNetworkHealRemoval(identifier, removed) {
 /**
  * Whether the reconciler removed this container itself for a network heal.
  *
+ * Deliberately does NOT reuse getState: getState swallows a read failure and
+ * returns null, which here would read as "not a heal removal" - the DESTRUCTIVE
+ * direction (the caller would treat its own removal as a vanished container,
+ * record a false tampering event and, on a failed recreate, uninstall the app).
+ * A read failure must be a failure, so the caller can defer instead of guess.
+ *
  * @param {string} identifier
- * @returns {Promise<boolean>}
+ * @returns {Promise<boolean>} - throws if the state cannot be read
  */
-async function isNetworkHealRemoval(identifier) {
-  const state = await getState(identifier);
+async function isNetworkHealRemoval(rawIdentifier) {
+  const identifier = canonical(rawIdentifier);
+  const database = collection();
+  const state = await dbHelper.findOneInDatabase(database, appsRuntimeState, { identifier }, { projection: { _id: 0 } });
   return state?.networkHealRemoval === true;
 }
 
 /**
- * Clears the heal-removal flag. Reads first so the healthy steady state (every
- * reconcile of every attached container) costs a lookup, not a write.
+ * Appends a network-heal attempt to its OWN durable ladder. Kept separate from
+ * restartHistory: sharing it would cross-contaminate in both directions - a heal
+ * that recreates a g: component (created, not started) would then have the very
+ * container it just fixed held down by the crash ladder its own attempts grew,
+ * and a crash-looping container could not be healed for up to the 30m cap.
  *
  * @param {string} identifier
  */
-async function clearNetworkHealRemoval(identifier) {
+async function recordNetworkHealAttempt(identifier) {
+  // No catch: pacing that silently fails to persist means the next pass sees an
+  // empty ladder, waits 0, and hammers the destructive heal. The caller defers.
+  const state = await getState(identifier);
+  const history = (state && state.networkHealHistory) || [];
+  history.push(Date.now());
+  if (history.length > MAX_HISTORY) {
+    history.splice(0, history.length - MAX_HISTORY);
+  }
+  await setFields(identifier, { networkHealHistory: history });
+}
+
+/**
+ * How long (ms) before the next network-heal attempt is allowed - 0 means now.
+ * Same ladder shape as the crash backoff (immediate, 30s, 5m, 15m, 30m cap), so
+ * a container that keeps coming back detached is retried forever but at a
+ * decaying rate. The ladder is reset by clearNetworkHeal once the container is
+ * seen healthy, so a later, unrelated episode starts from the bottom again.
+ *
+ * @param {string} identifier
+ * @returns {Promise<number>}
+ */
+async function networkHealWaitMs(identifier) {
+  const state = await getState(identifier);
+  const history = (state && state.networkHealHistory) || [];
+  if (history.length === 0) return 0;
+  const last = history[history.length - 1];
+  const index = Math.min(history.length, BACKOFF_DELAYS_MS.length - 1);
+  return Math.max(0, BACKOFF_DELAYS_MS[index] - (Date.now() - last));
+}
+
+/**
+ * Drops all network-heal state (the removal flag and the heal ladder) once the
+ * container is healthy again. Reads first so the healthy steady state - every
+ * reconcile of every attached container - costs a lookup, not a write.
+ *
+ * @param {string} identifier
+ */
+async function clearNetworkHeal(identifier) {
   try {
-    if (!(await isNetworkHealRemoval(identifier))) return;
-    await setFields(identifier, { networkHealRemoval: false });
+    const state = await getState(identifier);
+    if (!state) return;
+    if (state.networkHealRemoval !== true && !(state.networkHealHistory || []).length) return;
+    await setFields(identifier, { networkHealRemoval: false, networkHealHistory: [] });
   } catch (err) {
-    // A stale `true` only ever makes the reconciler MORE conservative (it keeps
+    // A stale flag only ever makes the reconciler MORE conservative (it keeps
     // recreating instead of escalating to an uninstall), so a failed clear is safe
     // to log and move on from - unlike a failed set, which must abort the remove.
-    log.error(`appsRuntimeState - failed to clear network heal removal for ${identifier}: ${err.message}`);
+    log.error(`appsRuntimeState - failed to clear network heal state for ${identifier}: ${err.message}`);
   }
 }
 
@@ -278,6 +329,7 @@ async function prepareCollection() {
           // likewise, a heal-removal anywhere means a heal may be mid-flight: keep
           // the reconciler on the recreate path rather than the uninstall path
           networkHealRemoval: twins.some((t) => t.networkHealRemoval === true),
+          networkHealHistory: [...new Set(twins.flatMap((t) => t.networkHealHistory || []))].sort((a, b) => a - b).slice(-MAX_HISTORY),
           restartHistory: [...new Set(twins.flatMap((t) => t.restartHistory || []))].sort((a, b) => a - b).slice(-MAX_HISTORY),
           updatedAt: Math.max(...twins.map((t) => t.updatedAt || 0)),
         };
@@ -308,7 +360,9 @@ module.exports = {
   restartWaitMs,
   setNetworkHealRemoval,
   isNetworkHealRemoval,
-  clearNetworkHealRemoval,
+  recordNetworkHealAttempt,
+  networkHealWaitMs,
+  clearNetworkHeal,
   recordExit,
   remove,
   BACKOFF_DELAYS_MS,

--- a/ZelBack/src/services/appManagement/appsRuntimeState.js
+++ b/ZelBack/src/services/appManagement/appsRuntimeState.js
@@ -170,6 +170,54 @@ async function restartWaitMs(identifier, lastFinishedAtMs = null) {
 }
 
 /**
+ * The network-detach heal force-removes a container in order to recreate it with
+ * a fresh endpoint. Between those two steps the container is legitimately absent,
+ * and that fact MUST be durable: if FluxOS restarts in that window, the next
+ * reconcile would otherwise see a missing container with no heal in flight, call
+ * it vanished (a false tampering signal) and, on a failed recreate, uninstall the
+ * whole app. This flag is the reconciler's memory of "I removed this on purpose";
+ * it is set before the remove and cleared once the container is seen running AND
+ * attached again (see appReconciler).
+ *
+ * @param {string} identifier
+ * @param {boolean} removed
+ */
+async function setNetworkHealRemoval(identifier, removed) {
+  // No catch: the flag is what keeps a failed heal from escalating to an app
+  // uninstall. If it cannot be persisted, the caller must not remove the container.
+  await setFields(identifier, { networkHealRemoval: removed });
+}
+
+/**
+ * Whether the reconciler removed this container itself for a network heal.
+ *
+ * @param {string} identifier
+ * @returns {Promise<boolean>}
+ */
+async function isNetworkHealRemoval(identifier) {
+  const state = await getState(identifier);
+  return state?.networkHealRemoval === true;
+}
+
+/**
+ * Clears the heal-removal flag. Reads first so the healthy steady state (every
+ * reconcile of every attached container) costs a lookup, not a write.
+ *
+ * @param {string} identifier
+ */
+async function clearNetworkHealRemoval(identifier) {
+  try {
+    if (!(await isNetworkHealRemoval(identifier))) return;
+    await setFields(identifier, { networkHealRemoval: false });
+  } catch (err) {
+    // A stale `true` only ever makes the reconciler MORE conservative (it keeps
+    // recreating instead of escalating to an uninstall), so a failed clear is safe
+    // to log and move on from - unlike a failed set, which must abort the remove.
+    log.error(`appsRuntimeState - failed to clear network heal removal for ${identifier}: ${err.message}`);
+  }
+}
+
+/**
  * Records the last observed exit for diagnostics / tampering signals.
  *
  * @param {string} identifier
@@ -227,6 +275,9 @@ async function prepareCollection() {
           identifier,
           // a lock anywhere is a lock: never auto-start a deliberately stopped app
           operatorStopped: twins.some((t) => t.operatorStopped === true),
+          // likewise, a heal-removal anywhere means a heal may be mid-flight: keep
+          // the reconciler on the recreate path rather than the uninstall path
+          networkHealRemoval: twins.some((t) => t.networkHealRemoval === true),
           restartHistory: [...new Set(twins.flatMap((t) => t.restartHistory || []))].sort((a, b) => a - b).slice(-MAX_HISTORY),
           updatedAt: Math.max(...twins.map((t) => t.updatedAt || 0)),
         };
@@ -255,6 +306,9 @@ module.exports = {
   isOperatorStopped,
   recordRestart,
   restartWaitMs,
+  setNetworkHealRemoval,
+  isNetworkHealRemoval,
+  clearNetworkHealRemoval,
   recordExit,
   remove,
   BACKOFF_DELAYS_MS,

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -374,13 +374,13 @@ async function recreateForNetworkHeal(identifier) {
 }
 
 /**
- * One heal cycle for a running-but-detached container: record the signal,
- * force-remove the broken container (keeping bind-mounted data), then recreate
- * it with a fresh endpoint. Force-remove is required because the recreate path
- * (appDockerCreate) 409s on an existing container name.
+ * One heal cycle for a running-but-detached container: force-remove the broken
+ * container (keeping bind-mounted data), then recreate it with a fresh endpoint.
+ * Force-remove is required because the recreate path (appDockerCreate) 409s on an
+ * existing container name. The durable network_detached signal is recorded once
+ * per episode by the caller, not here (this runs up to MAX times per episode).
  */
-async function attemptNetworkHeal(identifier, mainAppName) {
-  await appTamperingDetectionService.recordEvent(mainAppName, 'network_detached', `Container ${identifier} running with no network endpoint on its own network`);
+async function attemptNetworkHeal(identifier) {
   fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkDetached' });
   // Stop the per-minute stats monitor before removing the container (mirrors the
   // uninstaller). Otherwise its interval runs against a gone container - and, if
@@ -597,8 +597,14 @@ async function reconcile(rawIdentifier) {
     }
     st.tries += 1;
     networkHealState.set(identifier, st);
+    // Record the durable anomaly signal ONCE per episode (first attempt), not on
+    // every retry - it feeds a node-level tampering-event count, so a per-retry
+    // record would inflate it 3x for a single detachment.
+    if (st.tries === 1) {
+      await appTamperingDetectionService.recordEvent(mainAppName, 'network_detached', `Container ${identifier} running with no network endpoint on its own network`);
+    }
     log.warn(`appReconciler - ${identifier} running but not attached to its docker network (recreate ${st.tries}/${MAX_NETWORK_HEAL_ATTEMPTS}); clearing the stale endpoint`);
-    await attemptNetworkHeal(identifier, mainAppName);
+    await attemptNetworkHeal(identifier);
     return;
   }
 

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -122,10 +122,13 @@ const volumeMissingNoted = new Set();
 //     instant. A settle + re-read guarantees the time separation the confirmation
 //     is for: a transient inspect (dockerd mid-restart, the brief pre-IP window)
 //     never destroys a healthy container.
-//   - Paced, not capped: heal attempts walk the SAME durable backoff ladder as
-//     crash restarts (appsRuntimeState), up to its 30m cap. A hard attempt cap
-//     would park the heal in a terminal state until the FluxOS process restarts,
-//     which is not level-based - a reconciler keeps trying at a bounded rate.
+//   - Paced, not capped: heal attempts walk their own durable ladder in
+//     appsRuntimeState (same shape as the crash backoff, up to a 30m cap, but a
+//     SEPARATE history - sharing one would let a heal's attempts hold down the
+//     very container it just recreated, and would block the heal of a container
+//     that happens to be crash-looping). A hard attempt cap would park the heal in
+//     a terminal state until the FluxOS process restarts, which is not level-based
+//     - a reconciler keeps trying at a bounded rate.
 //     Retrying forever is also convergent at the network level: while the
 //     container is broken or absent this node stops advertising it in apprunning,
 //     its location record expires on TTL and the app is re-placed elsewhere, all
@@ -139,6 +142,19 @@ const volumeMissingNoted = new Set();
 // reconcile read the absence as tampering and, on a failed recreate, uninstall the
 // app). That lives in appsRuntimeState.networkHealRemoval, not here.
 const NETWORK_DETACH_CONFIRM_MS = 3000;
+// ...and the detach must ALSO have persisted for this long since we first saw it.
+// A dockerd restart with live-restore can answer an inspect before libnetwork has
+// re-populated endpoint IPs on running containers - and the event-stream reconnect
+// sweep enqueues every component at exactly that moment, so a short confirm alone
+// would rebuild every container on the node. This is wall-clock since the first
+// sighting, NOT a count of reconcile passes (two passes can land in the same
+// instant), so it is a real settle window whatever the trigger cadence.
+const DETACHED_PERSIST_MS = 60 * 1000;
+// id -> ms epoch of the first detached sighting of the current episode
+const detachedSince = new Map();
+// One container detached is a stale endpoint. Several at once is the daemon, not
+// the containers - refuse to force-remove the whole node's workload on that read.
+const DETACH_STORM_THRESHOLD = 3;
 // a pruned network cannot be repaired by recreating the container - re-check on a
 // slow pace so a restored network is picked up without an hour's wait
 const NETWORK_PRUNED_RETRY_MS = 5 * 60 * 1000;
@@ -386,35 +402,82 @@ async function recreateMissing(identifier) {
  * Deliberately NOT recreateMissing: a failure here must not escalate to
  * uninstalling the whole app (the trigger is a transient host-networking
  * conflict, not tampering). On failure we just re-arm a retry; the next pass
- * paces it on the backoff ladder. For a g: component recreateMissingContainers
+ * paces it on the heal ladder. For a g: component recreateMissingContainers
  * creates but does not start - the normal reconcile flow starts it on a later
  * pass. The durable heal-removal flag is NOT cleared here: only seeing the
- * container running AND attached proves the heal worked.
+ * container back proves the heal worked.
  */
 async function recreateForNetworkHeal(identifier) {
+  const mainAppName = identifier.split('_')[1] || identifier;
   try {
-    await containerHealthMonitor.recreateMissingContainers(identifier);
+    // softOnly: a hard install would REFORMAT the app's data volume (createAppVolume
+    // fallocates + mke2fs). We removed a live container whose data was intact, so a
+    // recreate that cannot verify the volume must fail and be retried - never wipe it.
+    await containerHealthMonitor.recreateMissingContainers(identifier, { softOnly: true });
     appInspector.startAppMonitoring(identifier, globalState.appsMonitored);
     log.info(`appReconciler - recreated ${identifier} to clear a detached network endpoint`);
     fluxEventBus.publish('reconciler:actuated', { identifier, action: 'recreated', reason: 'networkDetached' });
     notifyContainerStarted(identifier);
     scheduleRetry(identifier, POST_START_VERIFY_MS); // verify it came up attached
   } catch (err) {
+    // Same diagnostics the vanished path emits - minus the uninstall escalation.
+    // Without these a heal-removed container whose recreate keeps failing (e.g. its
+    // network was pruned in the meantime) would loop with no operator-visible signal.
     log.error(`appReconciler - failed to recreate ${identifier} after network detach: ${err.message}; will retry (app NOT uninstalled)`);
     fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkHealRecreateFailed', reason: err.message });
+    await appTamperingDetectionService.recordEvent(mainAppName, 'recreation_failed', `Container recreation failure after network detach: ${err.message}`).catch(() => {});
+    if (appTamperingDetectionService.isNetworkMissingError(err.message) && !networkPrunedNoted.has(identifier)) {
+      networkPrunedNoted.add(identifier);
+      await appTamperingDetectionService.recordEvent(mainAppName, 'network_pruned', `Docker network missing while recreating ${identifier}: ${err.message}`).catch(() => {});
+    }
     scheduleRetry(identifier, MANAGED_RETRY_MS);
   }
 }
 
 /**
- * Drops all bookkeeping for a healed/healthy container: the record-once tampering
- * markers and the durable "I removed this on purpose" flag. Called when a running
- * container is seen properly attached - the only proof a heal actually worked.
+ * Drops all bookkeeping for a healthy container: the in-memory episode markers and
+ * the durable heal state (the "I removed this on purpose" flag and the heal ladder).
+ * Called whenever the container is seen to EXIST and not be detached - existing is
+ * what makes the removal flag stale, so this must not be gated on `running`, or the
+ * flag would leak on every path that leaves the container stopped (a g: component
+ * awaiting its controller, an operator stop) and would then divert a later, genuine
+ * disappearance away from the vanished path forever.
  */
 async function clearNetworkHealState(identifier) {
   networkDetachedNoted.delete(identifier);
   networkPrunedNoted.delete(identifier);
-  await appsRuntimeState.clearNetworkHealRemoval(identifier);
+  detachedSince.delete(identifier);
+  await appsRuntimeState.clearNetworkHeal(identifier);
+}
+
+/**
+ * Whether a detached container can actually be recreated after we destroy it.
+ * The heal removes FIRST and recreates second, so every precondition of the
+ * recreate must hold BEFORE the remove - otherwise we turn a partially-alive
+ * container into a permanently gone one. Returns null when it is safe to proceed,
+ * or a reason string.
+ */
+async function networkHealBlocker(identifier, spec) {
+  // recreateMissingContainers throws unconditionally on a spec with no compose
+  // array (v1-3 apps, which getLocalComponentSpec explicitly supports). Removing
+  // such a container destroys it forever: the recreate can never succeed, and the
+  // heal - by design - never escalates to an uninstall that would re-place the app.
+  if (!(spec.appSpec.version >= 4 && Array.isArray(spec.appSpec.compose) && spec.appSpec.compose.length)) {
+    return 'the app has no compose spec, so its container cannot be recreated';
+  }
+  // The recreate refuses to reformat (softOnly), so an unverifiable volume means it
+  // would fail AFTER we destroyed the container. Check the same thing the recreate
+  // checks, before committing.
+  const mainAppName = identifier.split('_')[1] || identifier;
+  const componentName = identifier.split('_')[0];
+  const isComponent = identifier.includes('_');
+  const volumeMounted = await volumeService
+    .verifyAppVolumeMount(mainAppName, true, isComponent ? componentName : spec.comp.name)
+    .catch(() => false);
+  if (!volumeMounted) {
+    return 'its data volume cannot be verified as mounted, so the recreate would fail';
+  }
+  return null;
 }
 
 /**
@@ -425,7 +488,7 @@ async function clearNetworkHealState(identifier) {
  * existing container name; `docker network connect` on a live container does not
  * restore published host ports, so only a recreate fully heals it.
  */
-async function healDetachedNetwork(identifier, mainAppName) {
+async function healDetachedNetwork(identifier, mainAppName, spec) {
   // Confirm in-pass: a detached read can be transient (dockerd mid-restart, the
   // brief window before an endpoint gets its IP). Settle, then look again, and
   // only destroy on a state that survived the gap.
@@ -444,6 +507,32 @@ async function healDetachedNetwork(identifier, mainAppName) {
     return;
   }
   const { networkMode } = confirmed.attachment;
+
+  // The detach must also have PERSISTED. A dockerd restart (live-restore) can serve
+  // a successful inspect before libnetwork has re-populated endpoint IPs, and the
+  // reconnect sweep enqueues everything at that moment - without a real settle
+  // window we would rebuild every container on the node.
+  if (!detachedSince.has(identifier)) {
+    detachedSince.set(identifier, Date.now());
+    log.warn(`appReconciler - ${identifier} detached; waiting for it to persist before healing`);
+    scheduleRetry(identifier, DETACHED_PERSIST_MS);
+    return;
+  }
+  const detachedFor = Date.now() - detachedSince.get(identifier);
+  if (detachedFor < DETACHED_PERSIST_MS) {
+    scheduleRetry(identifier, DETACHED_PERSIST_MS - detachedFor);
+    return;
+  }
+
+  // Several containers detached at once is a daemon-level fault, not N stale
+  // endpoints. Force-removing the node's whole workload on that read is never the
+  // right answer - say so loudly and wait for the daemon to settle instead.
+  if (detachedSince.size >= DETACH_STORM_THRESHOLD) {
+    log.error(`appReconciler - ${detachedSince.size} containers look detached at once; treating this as a docker-level fault and NOT recreating any of them (including ${identifier})`);
+    fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkDetachStorm', count: detachedSince.size });
+    scheduleRetry(identifier, NETWORK_PRUNED_RETRY_MS);
+    return;
+  }
 
   // Only a stale endpoint (network present, container not attached) is heal-able.
   // If the network itself is gone the recreate would fail on a missing NetworkMode,
@@ -469,39 +558,70 @@ async function healDetachedNetwork(identifier, mainAppName) {
   }
   networkPrunedNoted.delete(identifier);
 
-  // Paced on the durable crash-backoff ladder (0, 30s, 5m, 15m, 30m cap), shared
-  // with restarts: a component that keeps needing intervention gets progressively
-  // slower attention, and the pacing survives a FluxOS restart. No attempt cap -
-  // the reconciler never parks in a terminal state.
-  const wait = await appsRuntimeState.restartWaitMs(identifier);
+  // Never destroy what we cannot rebuild: every precondition of the recreate must
+  // hold BEFORE the remove, or the heal turns a half-alive container into a gone one.
+  const blocker = await networkHealBlocker(identifier, spec);
+  if (blocker) {
+    log.error(`appReconciler - ${identifier} runs detached but must NOT be recreated: ${blocker}; leaving the container in place (app NOT touched)`);
+    fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkHealBlocked', reason: blocker });
+    scheduleRetry(identifier, NETWORK_PRUNED_RETRY_MS);
+    return;
+  }
+
+  // Paced on its OWN durable ladder (0, 30s, 5m, 15m, 30m cap), not the crash one:
+  // a container that keeps coming back detached is retried forever but at a decaying
+  // rate, without holding down (or being held down by) the restart backoff.
+  const wait = await appsRuntimeState.networkHealWaitMs(identifier);
   if (wait > 0) {
     log.warn(`appReconciler - ${identifier} still detached, backing off ${Math.round(wait / 1000)}s before the next heal attempt`);
     scheduleRetry(identifier, wait);
     return;
   }
 
-  if (!networkDetachedNoted.has(identifier)) {
-    networkDetachedNoted.add(identifier);
-    await appTamperingDetectionService.recordEvent(mainAppName, 'network_detached', `Container ${identifier} running with no network endpoint on its own network`);
+  // The ONLY ownership sample was at reconcile entry, and everything above this
+  // point - the settle, two inspects, the network probe, the volume check - has
+  // taken seconds. A redeploy/backup/uninstall may have taken the container over in
+  // the meantime, and force-removing it from under them is exactly what
+  // isManagedElsewhere exists to prevent. Re-check at actuation time (the same
+  // re-read-before-acting discipline the controller verdict and recreateMissing use).
+  if (isManagedElsewhere(identifier)) {
+    log.info(`appReconciler - ${identifier} was taken over by another operation during the heal confirmation; aborting the recreate`);
+    scheduleRetry(identifier, MANAGED_RETRY_MS);
+    return;
   }
+
   log.warn(`appReconciler - ${identifier} running but not attached to its docker network; clearing the stale endpoint`);
   fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkDetached' });
 
-  await appsRuntimeState.recordRestart(identifier);
-  // Durable, and BEFORE the remove: if FluxOS restarts in the window between the
-  // remove and the recreate, this is the only thing that tells the next process the
-  // absence was ours - without it, the vanished path records a false tampering event
-  // and can uninstall the whole app on a failed recreate. A throw here aborts the
-  // remove, which is the safe direction (a detached container still half-serves).
-  await appsRuntimeState.setNetworkHealRemoval(identifier, true);
+  try {
+    // Record the anomaly (once per episode) and the durable "I removed this on
+    // purpose" flag BEFORE the remove: if FluxOS restarts in the window between the
+    // remove and the recreate, the flag is the only thing that tells the next process
+    // the absence was ours - without it, the vanished path records a false tampering
+    // event and can uninstall the whole app on a failed recreate. The marker is only
+    // set AFTER a successful record, so a failed write does not suppress the event.
+    if (!networkDetachedNoted.has(identifier)) {
+      await appTamperingDetectionService.recordEvent(mainAppName, 'network_detached', `Container ${identifier} running with no network endpoint on its own network`);
+      networkDetachedNoted.add(identifier);
+    }
+    await appsRuntimeState.recordNetworkHealAttempt(identifier);
+    await appsRuntimeState.setNetworkHealRemoval(identifier, true);
+  } catch (err) {
+    // These writes are what make the remove safe and paced, so a failure must abort
+    // it - and must re-arm a retry, or the container stays broken until the hourly
+    // sweep (every other failure path here paces its own retry).
+    log.error(`appReconciler - cannot record the network heal of ${identifier} (${err.message}); not removing the container, will retry`);
+    scheduleRetry(identifier, MANAGED_RETRY_MS);
+    return;
+  }
 
   // Stop the per-minute stats monitor before removing the container (mirrors the
   // uninstaller). Otherwise its interval runs against a gone container, leaking and
   // error-spamming. The recreate re-establishes it via startAppMonitoring.
   appInspector.stopAppMonitoring(identifier, true, globalState.appsMonitored);
   try {
-    // v=false: Flux data lives on bind mounts, so nothing is lost; the recreate
-    // reuses it via a soft install.
+    // v=false: Flux data lives on bind mounts; the recreate reuses them via a soft
+    // install (enforced: recreateForNetworkHeal passes softOnly).
     await dockerService.appDockerForceRemove(identifier, false);
   } catch (err) {
     // The container is still there (or partially removed): put monitoring back so a
@@ -540,6 +660,7 @@ async function reconcile(rawIdentifier) {
     // is dropped by the uninstaller via appsRuntimeState.remove)
     networkDetachedNoted.delete(identifier);
     networkPrunedNoted.delete(identifier);
+    detachedSince.delete(identifier);
     return;
   }
 
@@ -616,6 +737,16 @@ async function reconcile(rawIdentifier) {
     return;
   }
 
+  // The heal state says "this container is absent because I removed it". The moment
+  // the container exists and is not detached, that is stale - whatever its run state,
+  // and whatever the desired state below turns out to be. Clearing here (rather than
+  // only on the running+attached path) is what stops the flag leaking on every branch
+  // that leaves a container stopped (awaiting-controller g:, operator stop), which
+  // would otherwise divert a later, genuine disappearance away from the vanished path.
+  if (actual.exists && !dockerService.isContainerDetachedFromNetwork(actual.attachment)) {
+    await clearNetworkHealState(identifier);
+  }
+
   // Pending data wipe: the sync layer flagged this component's local appdata as
   // stale/to-be-reset and to be cleared before it runs again. This is the highest-
   // priority data action and is resolved here, inside the per-key single-flight and
@@ -678,29 +809,44 @@ async function reconcile(rawIdentifier) {
     // Verify the attachment (from the inspect dockerActual already did) before
     // trusting "running"; heal by recreating, confirmed in-pass and paced.
     if (!dockerService.isContainerDetachedFromNetwork(actual.attachment)) {
-      // running AND attached - already where we want it, and the only proof that
-      // any earlier heal actually worked.
-      await clearNetworkHealState(identifier);
-      return;
+      return; // running and properly attached (heal state was cleared above)
     }
-    await healDetachedNetwork(identifier, mainAppName);
+    await healDetachedNetwork(identifier, mainAppName, spec);
     return;
   }
 
   if (!actual.exists) {
     // Durable, so it survives a FluxOS restart mid-heal: if WE removed this
     // container to clear a stale endpoint, its absence is not tampering. Keep
-    // recreating it - paced on the backoff ladder, never escalating to the vanished
+    // recreating it - paced on the heal ladder, never escalating to the vanished
     // path's uninstall-on-failure. Only a container that vanished by other means
     // takes that path.
-    if (await appsRuntimeState.isNetworkHealRemoval(identifier)) {
-      const wait = await appsRuntimeState.restartWaitMs(identifier);
+    let healRemoved;
+    try {
+      healRemoved = await appsRuntimeState.isNetworkHealRemoval(identifier);
+    } catch (err) {
+      // We cannot tell whether we removed this container ourselves. Guessing "no" is
+      // the destructive guess: it records a false tampering event and can uninstall
+      // the whole app on a failed recreate. Defer until the state is readable.
+      log.warn(`appReconciler - cannot read the heal state of the missing ${identifier} (${err.message}); deferring rather than treating it as vanished`);
+      scheduleRetry(identifier, MANAGED_RETRY_MS);
+      return;
+    }
+    if (healRemoved) {
+      const wait = await appsRuntimeState.networkHealWaitMs(identifier);
       if (wait > 0) {
         log.warn(`appReconciler - ${identifier} awaiting recreation after a network heal, backing off ${Math.round(wait / 1000)}s`);
         scheduleRetry(identifier, wait);
         return;
       }
-      await appsRuntimeState.recordRestart(identifier);
+      try {
+        await appsRuntimeState.recordNetworkHealAttempt(identifier);
+      } catch (err) {
+        // unpaced retries would hammer the recreate; defer instead
+        log.error(`appReconciler - cannot pace the heal recreate of ${identifier} (${err.message}); will retry`);
+        scheduleRetry(identifier, MANAGED_RETRY_MS);
+        return;
+      }
       await recreateForNetworkHeal(identifier);
       return;
     }

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -575,6 +575,21 @@ async function reconcile(rawIdentifier) {
       }
       return;
     }
+    // Only heal a stale endpoint (network present, container not attached). If the
+    // network itself is gone, a recreate would fail on a missing NetworkMode, so
+    // removing the container would only take it from partially-alive to removed-
+    // and-unrecreatable. That is a different fault (network restore) - record it
+    // and leave the container in place rather than destroying it.
+    if (!(await dockerService.dockerNetworkExists(actual.attachment.networkMode))) {
+      if (!st.gaveUp) {
+        st.gaveUp = true;
+        networkHealState.set(identifier, st);
+        log.error(`appReconciler - ${identifier} detached because its network ${actual.attachment.networkMode} is missing; not recreating (needs network restore, app NOT touched)`);
+        await appTamperingDetectionService.recordEvent(mainAppName, 'network_pruned', `Network ${actual.attachment.networkMode} missing while ${identifier} runs detached`);
+        fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkPruned' });
+      }
+      return;
+    }
     st.tries += 1;
     networkHealState.set(identifier, st);
     log.warn(`appReconciler - ${identifier} running but not attached to its docker network (recreate ${st.tries}/${MAX_NETWORK_HEAL_ATTEMPTS}); clearing the stale endpoint`);

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -107,6 +107,14 @@ const VOLUME_MOUNT_RETRY_MS = 30 * 1000;
 // event, so the paced retries don't re-record it every cycle
 const volumeMissingNoted = new Set();
 
+// A running container attached to NO network (stale libnetwork endpoint from an
+// earlier failed start) is healed by recreating it. Bound the attempts per
+// identifier so a recreate that keeps landing detached (e.g. a still-held host
+// port) can't loop remove->recreate forever - after the cap we leave it for
+// manual intervention. Reset once the container is seen properly attached.
+const MAX_NETWORK_HEAL_ATTEMPTS = 3;
+const networkHealAttempts = new Map();
+
 // The reconciler's canonical id is the bare component identifier
 // (`{component}_{app}`). Deciders disagree on the form they pass — masterSlave
 // uses the bare identifier, the syncthing flow passes the flux-prefixed docker
@@ -329,6 +337,24 @@ async function recreateMissing(identifier) {
   }
 }
 
+/**
+ * Whether a running container has come up attached to NO network - a start can
+ * succeed (the task runs) while libnetwork silently skips (re)attaching the
+ * container's endpoint, leaving it with no IP, no embedded DNS and no published
+ * ports. See dockerService.getContainerNetworkAttachment. An inspect blip must
+ * NOT be read as detached (that would trigger a needless recreate), so any error
+ * here is treated as "not detached" and the next reconcile re-checks.
+ */
+async function isDetachedFromOwnNetwork(identifier) {
+  try {
+    const attachment = await dockerService.getContainerNetworkAttachment(identifier);
+    return dockerService.isContainerDetachedFromNetwork(attachment);
+  } catch (err) {
+    log.warn(`appReconciler - could not read network attachment for ${identifier}: ${err.message}`);
+    return false;
+  }
+}
+
 // --- the reconcile -------------------------------------------------------
 
 async function reconcile(rawIdentifier) {
@@ -474,7 +500,43 @@ async function reconcile(rawIdentifier) {
     return;
   }
 
-  if (actual.running) return; // already where we want it
+  if (actual.running) {
+    // A running container is normally "already where we want it" - but a start
+    // can succeed while leaving the container attached to NO network when
+    // libnetwork holds a stale endpoint from an earlier failed "programming
+    // external connectivity" (e.g. a host-port bind conflict on a restart after
+    // an unclean reboot). It then runs with no IP, no embedded DNS (cannot
+    // resolve sibling components by name) and no published ports, and no future
+    // `docker start` repairs it - only a recreate clears the stale endpoint.
+    // Verify the attachment before trusting "running"; heal by recreating.
+    if (!(await isDetachedFromOwnNetwork(identifier))) {
+      networkHealAttempts.delete(identifier);
+      return; // running and properly attached - already where we want it
+    }
+    const attempts = (networkHealAttempts.get(identifier) || 0) + 1;
+    networkHealAttempts.set(identifier, attempts);
+    if (attempts > MAX_NETWORK_HEAL_ATTEMPTS) {
+      log.error(`appReconciler - ${identifier} still detached from its docker network after ${attempts - 1} recreate attempt(s); leaving as-is for manual intervention`);
+      fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkHealGaveUp' });
+      return;
+    }
+    log.warn(`appReconciler - ${identifier} is running but not attached to its docker network (attempt ${attempts}/${MAX_NETWORK_HEAL_ATTEMPTS}); recreating to clear the stale endpoint`);
+    await appTamperingDetectionService.recordEvent(mainAppName, 'network_detached', `Container ${identifier} running with no network endpoint on its own network`);
+    fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkDetached', attempt: attempts });
+    try {
+      // keep anonymous volumes (v=false); Flux data lives on bind mounts, so the
+      // recreate below reuses it via a soft install.
+      await dockerService.appDockerForceRemove(identifier, false);
+    } catch (err) {
+      log.error(`appReconciler - failed to remove detached ${identifier}: ${err.message}; retrying`);
+      scheduleRetry(identifier, MANAGED_RETRY_MS);
+      return;
+    }
+    // The container is gone now; recreate it through the tested vanished path,
+    // which allocates a fresh endpoint (and re-publishes ports) cleanly.
+    await recreateMissing(identifier);
+    return;
+  }
 
   if (!actual.exists) {
     await recreateMissing(identifier);

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -382,6 +382,11 @@ async function recreateForNetworkHeal(identifier) {
 async function attemptNetworkHeal(identifier, mainAppName) {
   await appTamperingDetectionService.recordEvent(mainAppName, 'network_detached', `Container ${identifier} running with no network endpoint on its own network`);
   fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkDetached' });
+  // Stop the per-minute stats monitor before removing the container (mirrors the
+  // uninstaller). Otherwise its interval runs against a gone container - and, if
+  // the recreate then fails/gives up, leaks and error-spams forever. The recreate
+  // re-establishes monitoring via startAppMonitoring on success.
+  appInspector.stopAppMonitoring(identifier, true, globalState.appsMonitored);
   try {
     // v=false: Flux data lives on bind mounts, so nothing is lost; the recreate
     // reuses it via a soft install.

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -21,7 +21,9 @@ const { AsyncGate } = require('../utils/asyncGate');
 // die event, stream reconnect, hourly tick, boot, post-install, and the
 // masterSlave/syncthing deciders) just enqueues a component identifier; one
 // reconcile per identifier drives the actual Docker state toward the desired
-// state. This is the ONLY place that calls appDockerStart/appDockerStop.
+// state. This is the ONLY place that calls appDockerStart/appDockerStop. It also
+// force-removes and recreates a container that came up detached from its own
+// docker network (a stale libnetwork endpoint), which a start alone cannot fix.
 //
 // Desired state inputs:
 //   operatorStopped (durable, appsRuntimeState) - user lock, wins over all.
@@ -107,13 +109,22 @@ const VOLUME_MOUNT_RETRY_MS = 30 * 1000;
 // event, so the paced retries don't re-record it every cycle
 const volumeMissingNoted = new Set();
 
-// A running container attached to NO network (stale libnetwork endpoint from an
-// earlier failed start) is healed by recreating it. Bound the attempts per
-// identifier so a recreate that keeps landing detached (e.g. a still-held host
-// port) can't loop remove->recreate forever - after the cap we leave it for
-// manual intervention. Reset once the container is seen properly attached.
+// A running container attached to NO network (a stale libnetwork endpoint left
+// by an earlier failed start) is healed by recreating it (force-remove + fresh
+// create; a plain start reuses the broken endpoint, and `network connect` does
+// not restore published host ports). This is destructive, so it is guarded:
+//   - DETACHED_CONFIRM_OBSERVATIONS: require the detached state on N consecutive
+//     reconciles before acting, so a transient inspect (e.g. dockerd mid-restart)
+//     never destroys a healthy container.
+//   - MAX_NETWORK_HEAL_ATTEMPTS: cap recreate attempts so a recreate that keeps
+//     landing detached (e.g. a still-held host port) can't loop forever.
+// Per-id state {obs, tries, gaveUp}; cleared once the container is seen attached.
+// Unlike the vanished path, a heal recreate failure NEVER uninstalls the app -
+// the component's spec/image are fine; only its host networking hit a transient
+// conflict, so we keep retrying (bounded) and otherwise leave it for a human.
+const DETACHED_CONFIRM_OBSERVATIONS = 2;
 const MAX_NETWORK_HEAL_ATTEMPTS = 3;
-const networkHealAttempts = new Map();
+const networkHealState = new Map();
 
 // The reconciler's canonical id is the bare component identifier
 // (`{component}_{app}`). Deciders disagree on the form they pass — masterSlave
@@ -243,6 +254,9 @@ async function dockerActual(identifier) {
       running: !!(info.State && info.State.Running),
       exitCode: everRan ? (info.State.ExitCode ?? null) : null,
       finishedAt,
+      // classified from THIS inspect so the running-branch network check needs no
+      // second docker call (and no TOCTOU between two inspects).
+      attachment: dockerService.parseContainerNetworkAttachment(info),
     };
   } catch (err) {
     let containers;
@@ -338,21 +352,46 @@ async function recreateMissing(identifier) {
 }
 
 /**
- * Whether a running container has come up attached to NO network - a start can
- * succeed (the task runs) while libnetwork silently skips (re)attaching the
- * container's endpoint, leaving it with no IP, no embedded DNS and no published
- * ports. See dockerService.getContainerNetworkAttachment. An inspect blip must
- * NOT be read as detached (that would trigger a needless recreate), so any error
- * here is treated as "not detached" and the next reconcile re-checks.
+ * Recreate a container that was removed to clear a detached network endpoint.
+ * Deliberately NOT recreateMissing: a failure here must not escalate to
+ * uninstalling the whole app (the trigger is a transient host-networking
+ * conflict, not tampering). On failure we just re-arm a paced retry; the caller's
+ * attempt cap bounds it. For a g: component recreateMissingContainers creates but
+ * does not start - the normal reconcile flow starts it on a later pass.
  */
-async function isDetachedFromOwnNetwork(identifier) {
+async function recreateForNetworkHeal(identifier) {
   try {
-    const attachment = await dockerService.getContainerNetworkAttachment(identifier);
-    return dockerService.isContainerDetachedFromNetwork(attachment);
+    await containerHealthMonitor.recreateMissingContainers(identifier);
+    appInspector.startAppMonitoring(identifier, globalState.appsMonitored);
+    log.info(`appReconciler - recreated ${identifier} to clear a detached network endpoint`);
+    fluxEventBus.publish('reconciler:actuated', { identifier, action: 'recreated', reason: 'networkDetached' });
+    notifyContainerStarted(identifier);
   } catch (err) {
-    log.warn(`appReconciler - could not read network attachment for ${identifier}: ${err.message}`);
-    return false;
+    log.error(`appReconciler - failed to recreate ${identifier} after network detach: ${err.message}; will retry (app NOT uninstalled)`);
+    fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkHealRecreateFailed', reason: err.message });
+    scheduleRetry(identifier, MANAGED_RETRY_MS);
   }
+}
+
+/**
+ * One heal cycle for a running-but-detached container: record the signal,
+ * force-remove the broken container (keeping bind-mounted data), then recreate
+ * it with a fresh endpoint. Force-remove is required because the recreate path
+ * (appDockerCreate) 409s on an existing container name.
+ */
+async function attemptNetworkHeal(identifier, mainAppName) {
+  await appTamperingDetectionService.recordEvent(mainAppName, 'network_detached', `Container ${identifier} running with no network endpoint on its own network`);
+  fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkDetached' });
+  try {
+    // v=false: Flux data lives on bind mounts, so nothing is lost; the recreate
+    // reuses it via a soft install.
+    await dockerService.appDockerForceRemove(identifier, false);
+  } catch (err) {
+    log.error(`appReconciler - failed to remove detached ${identifier}: ${err.message}; will retry`);
+    scheduleRetry(identifier, MANAGED_RETRY_MS);
+    return;
+  }
+  await recreateForNetworkHeal(identifier);
 }
 
 // --- the reconcile -------------------------------------------------------
@@ -374,7 +413,10 @@ async function reconcile(rawIdentifier) {
     scheduleRetry(identifier, MANAGED_RETRY_MS);
     return;
   }
-  if (!spec) return; // not installed here - nothing to enforce
+  if (!spec) { // not installed here - nothing to enforce
+    networkHealState.delete(identifier); // drop any heal bookkeeping for a gone app
+    return;
+  }
 
   // Invalid containerData (e.g. a sync flag on a non-primary mount, or an index-ref
   // primary): the spec can never be actuated — volume construction would throw — so
@@ -508,37 +550,61 @@ async function reconcile(rawIdentifier) {
     // an unclean reboot). It then runs with no IP, no embedded DNS (cannot
     // resolve sibling components by name) and no published ports, and no future
     // `docker start` repairs it - only a recreate clears the stale endpoint.
-    // Verify the attachment before trusting "running"; heal by recreating.
-    if (!(await isDetachedFromOwnNetwork(identifier))) {
-      networkHealAttempts.delete(identifier);
+    // Verify the attachment (from the inspect dockerActual already did) before
+    // trusting "running"; heal by recreating, debounced and bounded.
+    if (!dockerService.isContainerDetachedFromNetwork(actual.attachment)) {
+      networkHealState.delete(identifier);
       return; // running and properly attached - already where we want it
     }
-    const attempts = (networkHealAttempts.get(identifier) || 0) + 1;
-    networkHealAttempts.set(identifier, attempts);
-    if (attempts > MAX_NETWORK_HEAL_ATTEMPTS) {
-      log.error(`appReconciler - ${identifier} still detached from its docker network after ${attempts - 1} recreate attempt(s); leaving as-is for manual intervention`);
-      fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkHealGaveUp' });
-      return;
-    }
-    log.warn(`appReconciler - ${identifier} is running but not attached to its docker network (attempt ${attempts}/${MAX_NETWORK_HEAL_ATTEMPTS}); recreating to clear the stale endpoint`);
-    await appTamperingDetectionService.recordEvent(mainAppName, 'network_detached', `Container ${identifier} running with no network endpoint on its own network`);
-    fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkDetached', attempt: attempts });
-    try {
-      // keep anonymous volumes (v=false); Flux data lives on bind mounts, so the
-      // recreate below reuses it via a soft install.
-      await dockerService.appDockerForceRemove(identifier, false);
-    } catch (err) {
-      log.error(`appReconciler - failed to remove detached ${identifier}: ${err.message}; retrying`);
+    const st = networkHealState.get(identifier) || { obs: 0, tries: 0, gaveUp: false };
+    st.obs += 1;
+    if (st.obs < DETACHED_CONFIRM_OBSERVATIONS) {
+      // first sighting - confirm on the next pass before doing anything
+      // destructive, so a transient read never recreates a healthy container.
+      networkHealState.set(identifier, st);
+      log.warn(`appReconciler - ${identifier} appears detached from its docker network; confirming before acting`);
       scheduleRetry(identifier, MANAGED_RETRY_MS);
       return;
     }
-    // The container is gone now; recreate it through the tested vanished path,
-    // which allocates a fresh endpoint (and re-publishes ports) cleanly.
-    await recreateMissing(identifier);
+    if (st.tries >= MAX_NETWORK_HEAL_ATTEMPTS) {
+      if (!st.gaveUp) {
+        st.gaveUp = true;
+        networkHealState.set(identifier, st);
+        log.error(`appReconciler - ${identifier} still detached from its docker network after ${st.tries} recreate attempt(s); leaving it running for manual intervention (app NOT uninstalled)`);
+        fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkHealGaveUp' });
+      }
+      return;
+    }
+    st.tries += 1;
+    networkHealState.set(identifier, st);
+    log.warn(`appReconciler - ${identifier} running but not attached to its docker network (recreate ${st.tries}/${MAX_NETWORK_HEAL_ATTEMPTS}); clearing the stale endpoint`);
+    await attemptNetworkHeal(identifier, mainAppName);
     return;
   }
 
   if (!actual.exists) {
+    // If we removed this container for a network-detach heal (tries > 0) and the
+    // recreate has not yet brought it back, keep retrying the recreate WITHOUT the
+    // vanished path's uninstall-on-failure escalation - the trigger was transient
+    // host networking, not tampering, so a whole-app uninstall is wrong. Once the
+    // cap is hit we give up and, crucially, keep steering AWAY from recreateMissing
+    // so a heal never turns into an uninstall. Only a container that vanished by
+    // other means (no heal in flight) takes the tested vanished path.
+    const st = networkHealState.get(identifier);
+    if (st && st.tries > 0) {
+      if (st.gaveUp) return; // gave up earlier; leave removed, never uninstall
+      if (st.tries >= MAX_NETWORK_HEAL_ATTEMPTS) {
+        st.gaveUp = true;
+        networkHealState.set(identifier, st);
+        log.error(`appReconciler - ${identifier} still cannot be recreated after ${st.tries} network-heal attempt(s); leaving it removed for manual intervention (app NOT uninstalled)`);
+        fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkHealGaveUp' });
+        return;
+      }
+      st.tries += 1;
+      networkHealState.set(identifier, st);
+      await recreateForNetworkHeal(identifier);
+      return;
+    }
     await recreateMissing(identifier);
     return;
   }

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -112,19 +112,48 @@ const volumeMissingNoted = new Set();
 // A running container attached to NO network (a stale libnetwork endpoint left
 // by an earlier failed start) is healed by recreating it (force-remove + fresh
 // create; a plain start reuses the broken endpoint, and `network connect` does
-// not restore published host ports). This is destructive, so it is guarded:
-//   - DETACHED_CONFIRM_OBSERVATIONS: require the detached state on N consecutive
-//     reconciles before acting, so a transient inspect (e.g. dockerd mid-restart)
+// not restore published host ports). The remove is destructive, so it is guarded:
+//
+//   - Confirmed in-pass: on first sight of the detached state we settle, then
+//     re-inspect, and only act if it is still detached. Counting observations
+//     across reconciles would not do this - two reconciles can run back-to-back
+//     (a die event lands while the sweep's pass is in flight, and the workqueue
+//     re-runs the id immediately), so both "observations" can come from the same
+//     instant. A settle + re-read guarantees the time separation the confirmation
+//     is for: a transient inspect (dockerd mid-restart, the brief pre-IP window)
 //     never destroys a healthy container.
-//   - MAX_NETWORK_HEAL_ATTEMPTS: cap recreate attempts so a recreate that keeps
-//     landing detached (e.g. a still-held host port) can't loop forever.
-// Per-id state {obs, tries, gaveUp}; cleared once the container is seen attached.
-// Unlike the vanished path, a heal recreate failure NEVER uninstalls the app -
-// the component's spec/image are fine; only its host networking hit a transient
-// conflict, so we keep retrying (bounded) and otherwise leave it for a human.
-const DETACHED_CONFIRM_OBSERVATIONS = 2;
-const MAX_NETWORK_HEAL_ATTEMPTS = 3;
-const networkHealState = new Map();
+//   - Paced, not capped: heal attempts walk the SAME durable backoff ladder as
+//     crash restarts (appsRuntimeState), up to its 30m cap. A hard attempt cap
+//     would park the heal in a terminal state until the FluxOS process restarts,
+//     which is not level-based - a reconciler keeps trying at a bounded rate.
+//     Retrying forever is also convergent at the network level: while the
+//     container is broken or absent this node stops advertising it in apprunning,
+//     its location record expires on TTL and the app is re-placed elsewhere, all
+//     without destroying this node's bind-mounted data.
+//   - Never uninstalls: unlike the vanished path, a failed heal recreate does not
+//     escalate to removeAppLocally. The spec and image are fine; only the host
+//     networking hit a conflict.
+//
+// The one fact that must survive a FluxOS restart is "I removed this container on
+// purpose" (otherwise a restart between the remove and the recreate makes the next
+// reconcile read the absence as tampering and, on a failed recreate, uninstall the
+// app). That lives in appsRuntimeState.networkHealRemoval, not here.
+const NETWORK_DETACH_CONFIRM_MS = 3000;
+// a pruned network cannot be repaired by recreating the container - re-check on a
+// slow pace so a restored network is picked up without an hour's wait
+const NETWORK_PRUNED_RETRY_MS = 5 * 60 * 1000;
+// a container is normally verified attached only on the reconcile after its start,
+// i.e. the hourly sweep. But this pathology is BORN at start time, so re-check
+// shortly after every start/recreate we perform: detached-at-boot then heals in
+// under a minute, with the sweep as the backstop. (Docker network events cannot
+// cover this: a container born detached never emits a disconnect.)
+const POST_START_VERIFY_MS = 30 * 1000;
+
+// identifiers whose detach/prune was already recorded as a tampering event, so the
+// paced retries record it once per episode rather than once per attempt (the count
+// feeds a node-level signal). Cleared once the container is seen attached.
+const networkDetachedNoted = new Set();
+const networkPrunedNoted = new Set();
 
 // The reconciler's canonical id is the bare component identifier
 // (`{component}_{app}`). Deciders disagree on the form they pass — masterSlave
@@ -256,7 +285,7 @@ async function dockerActual(identifier) {
       finishedAt,
       // classified from THIS inspect so the running-branch network check needs no
       // second docker call (and no TOCTOU between two inspects).
-      attachment: dockerService.parseContainerNetworkAttachment(info),
+      attachment: dockerService.classifyContainerNetworkAttachment(info),
     };
   } catch (err) {
     let containers;
@@ -326,6 +355,7 @@ async function recreateMissing(identifier) {
     log.info(`appReconciler - recreated missing container ${identifier}`);
     fluxEventBus.publish('reconciler:actuated', { identifier, action: 'recreated' });
     notifyContainerStarted(identifier);
+    scheduleRetry(identifier, POST_START_VERIFY_MS); // verify it came up attached
   } catch (err) {
     // Removal must be justified by the state of the world NOW, not at
     // classification time: a whole recreate attempt (image pull - up to
@@ -355,9 +385,11 @@ async function recreateMissing(identifier) {
  * Recreate a container that was removed to clear a detached network endpoint.
  * Deliberately NOT recreateMissing: a failure here must not escalate to
  * uninstalling the whole app (the trigger is a transient host-networking
- * conflict, not tampering). On failure we just re-arm a paced retry; the caller's
- * attempt cap bounds it. For a g: component recreateMissingContainers creates but
- * does not start - the normal reconcile flow starts it on a later pass.
+ * conflict, not tampering). On failure we just re-arm a retry; the next pass
+ * paces it on the backoff ladder. For a g: component recreateMissingContainers
+ * creates but does not start - the normal reconcile flow starts it on a later
+ * pass. The durable heal-removal flag is NOT cleared here: only seeing the
+ * container running AND attached proves the heal worked.
  */
 async function recreateForNetworkHeal(identifier) {
   try {
@@ -366,6 +398,7 @@ async function recreateForNetworkHeal(identifier) {
     log.info(`appReconciler - recreated ${identifier} to clear a detached network endpoint`);
     fluxEventBus.publish('reconciler:actuated', { identifier, action: 'recreated', reason: 'networkDetached' });
     notifyContainerStarted(identifier);
+    scheduleRetry(identifier, POST_START_VERIFY_MS); // verify it came up attached
   } catch (err) {
     log.error(`appReconciler - failed to recreate ${identifier} after network detach: ${err.message}; will retry (app NOT uninstalled)`);
     fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkHealRecreateFailed', reason: err.message });
@@ -374,24 +407,108 @@ async function recreateForNetworkHeal(identifier) {
 }
 
 /**
- * One heal cycle for a running-but-detached container: force-remove the broken
- * container (keeping bind-mounted data), then recreate it with a fresh endpoint.
- * Force-remove is required because the recreate path (appDockerCreate) 409s on an
- * existing container name. The durable network_detached signal is recorded once
- * per episode by the caller, not here (this runs up to MAX times per episode).
+ * Drops all bookkeeping for a healed/healthy container: the record-once tampering
+ * markers and the durable "I removed this on purpose" flag. Called when a running
+ * container is seen properly attached - the only proof a heal actually worked.
  */
-async function attemptNetworkHeal(identifier) {
+async function clearNetworkHealState(identifier) {
+  networkDetachedNoted.delete(identifier);
+  networkPrunedNoted.delete(identifier);
+  await appsRuntimeState.clearNetworkHealRemoval(identifier);
+}
+
+/**
+ * Heals a container that looks running-but-detached from its own docker network:
+ * confirm it (settle + re-inspect), require its network to still exist, then
+ * force-remove (keeping bind-mounted data) and recreate with a fresh endpoint.
+ * Force-remove is required because the recreate path (appDockerCreate) 409s on an
+ * existing container name; `docker network connect` on a live container does not
+ * restore published host ports, so only a recreate fully heals it.
+ */
+async function healDetachedNetwork(identifier, mainAppName) {
+  // Confirm in-pass: a detached read can be transient (dockerd mid-restart, the
+  // brief window before an endpoint gets its IP). Settle, then look again, and
+  // only destroy on a state that survived the gap.
+  log.warn(`appReconciler - ${identifier} appears detached from its docker network; confirming before acting`);
+  await serviceHelper.delay(NETWORK_DETACH_CONFIRM_MS);
+  const confirmed = await dockerActual(identifier);
+  if (!confirmed.reachable || confirmed.indeterminate || !confirmed.exists || !confirmed.running) {
+    // docker went unhappy, or the container is no longer running: nothing here can
+    // be justified on this read. The next pass reconciles whatever it actually is.
+    scheduleRetry(identifier, MANAGED_RETRY_MS);
+    return;
+  }
+  if (!dockerService.isContainerDetachedFromNetwork(confirmed.attachment)) {
+    log.info(`appReconciler - ${identifier} is attached after all; no heal needed`);
+    await clearNetworkHealState(identifier);
+    return;
+  }
+  const { networkMode } = confirmed.attachment;
+
+  // Only a stale endpoint (network present, container not attached) is heal-able.
+  // If the network itself is gone the recreate would fail on a missing NetworkMode,
+  // so removing the container would only take it from partially-alive to removed-
+  // and-unrecreatable. And absence must be PROVEN: a failed network read is not
+  // evidence of a missing network, and acting on it destroys a container we then
+  // cannot bring back.
+  const networkState = await dockerService.dockerNetworkState(networkMode);
+  if (networkState === 'unknown') {
+    log.warn(`appReconciler - cannot determine whether ${networkMode} exists; deferring the heal of ${identifier}`);
+    scheduleRetry(identifier, MANAGED_RETRY_MS);
+    return;
+  }
+  if (networkState === 'absent') {
+    if (!networkPrunedNoted.has(identifier)) {
+      networkPrunedNoted.add(identifier);
+      log.error(`appReconciler - ${identifier} detached because its network ${networkMode} is missing; not recreating (needs network restore, app NOT touched)`);
+      await appTamperingDetectionService.recordEvent(mainAppName, 'network_pruned', `Network ${networkMode} missing while ${identifier} runs detached`);
+      fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkPruned' });
+    }
+    scheduleRetry(identifier, NETWORK_PRUNED_RETRY_MS); // keep watching for a restored network
+    return;
+  }
+  networkPrunedNoted.delete(identifier);
+
+  // Paced on the durable crash-backoff ladder (0, 30s, 5m, 15m, 30m cap), shared
+  // with restarts: a component that keeps needing intervention gets progressively
+  // slower attention, and the pacing survives a FluxOS restart. No attempt cap -
+  // the reconciler never parks in a terminal state.
+  const wait = await appsRuntimeState.restartWaitMs(identifier);
+  if (wait > 0) {
+    log.warn(`appReconciler - ${identifier} still detached, backing off ${Math.round(wait / 1000)}s before the next heal attempt`);
+    scheduleRetry(identifier, wait);
+    return;
+  }
+
+  if (!networkDetachedNoted.has(identifier)) {
+    networkDetachedNoted.add(identifier);
+    await appTamperingDetectionService.recordEvent(mainAppName, 'network_detached', `Container ${identifier} running with no network endpoint on its own network`);
+  }
+  log.warn(`appReconciler - ${identifier} running but not attached to its docker network; clearing the stale endpoint`);
   fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkDetached' });
+
+  await appsRuntimeState.recordRestart(identifier);
+  // Durable, and BEFORE the remove: if FluxOS restarts in the window between the
+  // remove and the recreate, this is the only thing that tells the next process the
+  // absence was ours - without it, the vanished path records a false tampering event
+  // and can uninstall the whole app on a failed recreate. A throw here aborts the
+  // remove, which is the safe direction (a detached container still half-serves).
+  await appsRuntimeState.setNetworkHealRemoval(identifier, true);
+
   // Stop the per-minute stats monitor before removing the container (mirrors the
-  // uninstaller). Otherwise its interval runs against a gone container - and, if
-  // the recreate then fails/gives up, leaks and error-spams forever. The recreate
-  // re-establishes monitoring via startAppMonitoring on success.
+  // uninstaller). Otherwise its interval runs against a gone container, leaking and
+  // error-spamming. The recreate re-establishes it via startAppMonitoring.
   appInspector.stopAppMonitoring(identifier, true, globalState.appsMonitored);
   try {
     // v=false: Flux data lives on bind mounts, so nothing is lost; the recreate
     // reuses it via a soft install.
     await dockerService.appDockerForceRemove(identifier, false);
   } catch (err) {
+    // The container is still there (or partially removed): put monitoring back so a
+    // container we did NOT manage to remove is not left unmonitored. The heal flag
+    // stays set on purpose - the remove may have partially succeeded, and a stale
+    // flag only keeps us on the recreate path (never the uninstall one).
+    appInspector.startAppMonitoring(identifier, globalState.appsMonitored);
     log.error(`appReconciler - failed to remove detached ${identifier}: ${err.message}; will retry`);
     scheduleRetry(identifier, MANAGED_RETRY_MS);
     return;
@@ -419,7 +536,10 @@ async function reconcile(rawIdentifier) {
     return;
   }
   if (!spec) { // not installed here - nothing to enforce
-    networkHealState.delete(identifier); // drop any heal bookkeeping for a gone app
+    // drop the in-memory heal markers for a gone app (its durable runtime-state doc
+    // is dropped by the uninstaller via appsRuntimeState.remove)
+    networkDetachedNoted.delete(identifier);
+    networkPrunedNoted.delete(identifier);
     return;
   }
 
@@ -556,78 +676,31 @@ async function reconcile(rawIdentifier) {
     // resolve sibling components by name) and no published ports, and no future
     // `docker start` repairs it - only a recreate clears the stale endpoint.
     // Verify the attachment (from the inspect dockerActual already did) before
-    // trusting "running"; heal by recreating, debounced and bounded.
+    // trusting "running"; heal by recreating, confirmed in-pass and paced.
     if (!dockerService.isContainerDetachedFromNetwork(actual.attachment)) {
-      networkHealState.delete(identifier);
-      return; // running and properly attached - already where we want it
-    }
-    const st = networkHealState.get(identifier) || { obs: 0, tries: 0, gaveUp: false };
-    st.obs += 1;
-    if (st.obs < DETACHED_CONFIRM_OBSERVATIONS) {
-      // first sighting - confirm on the next pass before doing anything
-      // destructive, so a transient read never recreates a healthy container.
-      networkHealState.set(identifier, st);
-      log.warn(`appReconciler - ${identifier} appears detached from its docker network; confirming before acting`);
-      scheduleRetry(identifier, MANAGED_RETRY_MS);
+      // running AND attached - already where we want it, and the only proof that
+      // any earlier heal actually worked.
+      await clearNetworkHealState(identifier);
       return;
     }
-    if (st.tries >= MAX_NETWORK_HEAL_ATTEMPTS) {
-      if (!st.gaveUp) {
-        st.gaveUp = true;
-        networkHealState.set(identifier, st);
-        log.error(`appReconciler - ${identifier} still detached from its docker network after ${st.tries} recreate attempt(s); leaving it running for manual intervention (app NOT uninstalled)`);
-        fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkHealGaveUp' });
-      }
-      return;
-    }
-    // Only heal a stale endpoint (network present, container not attached). If the
-    // network itself is gone, a recreate would fail on a missing NetworkMode, so
-    // removing the container would only take it from partially-alive to removed-
-    // and-unrecreatable. That is a different fault (network restore) - record it
-    // and leave the container in place rather than destroying it.
-    if (!(await dockerService.dockerNetworkExists(actual.attachment.networkMode))) {
-      if (!st.gaveUp) {
-        st.gaveUp = true;
-        networkHealState.set(identifier, st);
-        log.error(`appReconciler - ${identifier} detached because its network ${actual.attachment.networkMode} is missing; not recreating (needs network restore, app NOT touched)`);
-        await appTamperingDetectionService.recordEvent(mainAppName, 'network_pruned', `Network ${actual.attachment.networkMode} missing while ${identifier} runs detached`);
-        fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkPruned' });
-      }
-      return;
-    }
-    st.tries += 1;
-    networkHealState.set(identifier, st);
-    // Record the durable anomaly signal ONCE per episode (first attempt), not on
-    // every retry - it feeds a node-level tampering-event count, so a per-retry
-    // record would inflate it 3x for a single detachment.
-    if (st.tries === 1) {
-      await appTamperingDetectionService.recordEvent(mainAppName, 'network_detached', `Container ${identifier} running with no network endpoint on its own network`);
-    }
-    log.warn(`appReconciler - ${identifier} running but not attached to its docker network (recreate ${st.tries}/${MAX_NETWORK_HEAL_ATTEMPTS}); clearing the stale endpoint`);
-    await attemptNetworkHeal(identifier);
+    await healDetachedNetwork(identifier, mainAppName);
     return;
   }
 
   if (!actual.exists) {
-    // If we removed this container for a network-detach heal (tries > 0) and the
-    // recreate has not yet brought it back, keep retrying the recreate WITHOUT the
-    // vanished path's uninstall-on-failure escalation - the trigger was transient
-    // host networking, not tampering, so a whole-app uninstall is wrong. Once the
-    // cap is hit we give up and, crucially, keep steering AWAY from recreateMissing
-    // so a heal never turns into an uninstall. Only a container that vanished by
-    // other means (no heal in flight) takes the tested vanished path.
-    const st = networkHealState.get(identifier);
-    if (st && st.tries > 0) {
-      if (st.gaveUp) return; // gave up earlier; leave removed, never uninstall
-      if (st.tries >= MAX_NETWORK_HEAL_ATTEMPTS) {
-        st.gaveUp = true;
-        networkHealState.set(identifier, st);
-        log.error(`appReconciler - ${identifier} still cannot be recreated after ${st.tries} network-heal attempt(s); leaving it removed for manual intervention (app NOT uninstalled)`);
-        fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkHealGaveUp' });
+    // Durable, so it survives a FluxOS restart mid-heal: if WE removed this
+    // container to clear a stale endpoint, its absence is not tampering. Keep
+    // recreating it - paced on the backoff ladder, never escalating to the vanished
+    // path's uninstall-on-failure. Only a container that vanished by other means
+    // takes that path.
+    if (await appsRuntimeState.isNetworkHealRemoval(identifier)) {
+      const wait = await appsRuntimeState.restartWaitMs(identifier);
+      if (wait > 0) {
+        log.warn(`appReconciler - ${identifier} awaiting recreation after a network heal, backing off ${Math.round(wait / 1000)}s`);
+        scheduleRetry(identifier, wait);
         return;
       }
-      st.tries += 1;
-      networkHealState.set(identifier, st);
+      await appsRuntimeState.recordRestart(identifier);
       await recreateForNetworkHeal(identifier);
       return;
     }
@@ -678,6 +751,11 @@ async function reconcile(rawIdentifier) {
   log.info(`appReconciler - ${identifier} restarted`);
   fluxEventBus.publish('reconciler:actuated', { identifier, action: 'started', exitCode: actual.exitCode });
   notifyContainerStarted(identifier);
+  // A start is exactly when a container can come up attached to no network (a stale
+  // endpoint left by an earlier failed start). The attachment we hold was sampled
+  // BEFORE this start, so verify the new one shortly - otherwise a detached-at-boot
+  // container waits for the hourly sweep.
+  scheduleRetry(identifier, POST_START_VERIFY_MS);
 }
 
 // --- workqueue (per-key single-flight, boot-gated) -----------------------

--- a/ZelBack/src/services/appMonitoring/containerHealthMonitor.js
+++ b/ZelBack/src/services/appMonitoring/containerHealthMonitor.js
@@ -8,7 +8,23 @@ const { localAppsInformation } = require('../utils/appConstants');
 const { verifyAppVolumeMount } = require('../utils/volumeService');
 
 
-async function recreateMissingContainers(componentIdentifier) {
+/**
+ * Recreates the container(s) for an app/component from its local spec.
+ *
+ * softOnly: refuse the installApplicationHard fallback. A hard install runs
+ * createAppVolume, which fallocates and mke2fs's the app's volume file - i.e. it
+ * REFORMATS the app's data. That is acceptable when recreating a container whose
+ * volume could not be verified and which is gone anyway, but it is catastrophic
+ * for a caller that deliberately removed a live container whose data was intact
+ * (the network-detach heal): a transient verifyAppVolumeMount failure would wipe
+ * the user's data. Such callers pass softOnly and get a throw instead, so they
+ * can retry rather than reformat.
+ *
+ * @param {string} componentIdentifier
+ * @param {{softOnly?: boolean}} [options]
+ */
+async function recreateMissingContainers(componentIdentifier, options = {}) {
+  const { softOnly = false } = options;
   const mainAppName = componentIdentifier.split('_')[1] || componentIdentifier;
   const dbopen = dbHelper.databaseConnection();
   const appsDatabase = dbopen.db(config.database.appslocal.database);
@@ -53,6 +69,9 @@ async function recreateMissingContainers(componentIdentifier) {
     if (volumeMounted) {
       await appInstaller.installApplicationSoft(componentSpec, mainAppName, true, null, appSpec);
     } else {
+      if (softOnly) {
+        throw new Error(`Cannot recreate ${componentIdentifier} without reformatting its volume: the data volume for ${mainAppName} could not be verified as mounted`);
+      }
       await appInstaller.installApplicationHard(componentSpec, mainAppName, true, null, appSpec);
     }
   } else {
@@ -74,6 +93,9 @@ async function recreateMissingContainers(componentIdentifier) {
         // eslint-disable-next-line no-await-in-loop
         await appInstaller.installApplicationSoft(componentSpec, mainAppName, true, null, appSpec);
       } else {
+        if (softOnly) {
+          throw new Error(`Cannot recreate ${componentIdentifier} without reformatting its volume: the data volume for ${mainAppName} could not be verified as mounted`);
+        }
         // eslint-disable-next-line no-await-in-loop
         await appInstaller.installApplicationHard(componentSpec, mainAppName, true, null, appSpec);
       }

--- a/ZelBack/src/services/appTamperingDetectionService.js
+++ b/ZelBack/src/services/appTamperingDetectionService.js
@@ -34,7 +34,7 @@ function isNetworkMissingError(errorMessage) {
  * Documents expire automatically 30 days after detectedAt (TTL index).
  * @param {string} appName - Application name
  * @param {string} eventType - One of: container_vanished, network_pruned,
- *   mount_vanished, crontab_wiped, recreation_failed
+ *   mount_vanished, crontab_wiped, recreation_failed, network_detached
  * @param {string} details - Free-text context about the event
  */
 async function recordEvent(appName, eventType, details) {

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -1288,10 +1288,9 @@ async function appDockerImageRemove(idOrName) {
  * carries it (or carries it without an IP). Such a container runs with no IP, no
  * embedded DNS (it cannot resolve sibling components by name) and no published
  * ports, and a plain start never repairs it - only a recreate, which allocates a
- * fresh endpoint, clears the stale state. These helpers surface that condition so
- * callers (the reconciler) can detect and heal it. parseContainerNetworkAttachment
- * is the pure classifier over a Docker inspect object; getContainerNetworkAttachment
- * is the inspect-and-classify wrapper.
+ * fresh endpoint, clears the stale state. This pure classifier over a Docker
+ * inspect object surfaces that condition so callers (the reconciler, which
+ * already holds the inspect) can detect and heal it.
  *
  * @param {object} info - a Docker container inspect object
  * @returns {{managed: boolean, running: boolean, networkMode: (string|null), attached: boolean}}
@@ -1314,14 +1313,9 @@ function parseContainerNetworkAttachment(info) {
   };
 }
 
-async function getContainerNetworkAttachment(idOrName) {
-  const info = await dockerContainerInspect(idOrName);
-  return parseContainerNetworkAttachment(info);
-}
-
 /**
  * Whether a container is running but not attached to its own managed network -
- * the unrecoverable-by-restart state described in getContainerNetworkAttachment.
+ * the unrecoverable-by-restart state described in parseContainerNetworkAttachment.
  * A non-managed (host/none/bridge) container is never considered detached.
  *
  * @param {{managed: boolean, running: boolean, attached: boolean}} attachment
@@ -1882,7 +1876,6 @@ module.exports = {
   getAppContainerObjects,
   getAppNameByContainerIp,
   parseContainerNetworkAttachment,
-  getContainerNetworkAttachment,
   isContainerDetachedFromNetwork,
   dockerNetworkExists,
   waitForDocker,

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -1333,6 +1333,25 @@ function isContainerDetachedFromNetwork(attachment) {
 }
 
 /**
+ * Whether a docker network exists, by name. Used to distinguish a stale endpoint
+ * (network present, container not attached - recreatable) from a pruned network
+ * (network gone - a recreate would fail on a missing NetworkMode). Any inspect
+ * failure is treated as "does not exist".
+ *
+ * @param {string} networkName
+ * @returns {Promise<boolean>}
+ */
+async function dockerNetworkExists(networkName) {
+  if (!networkName) return false;
+  try {
+    await docker.getNetwork(networkName).inspect();
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
+
+/**
  * Pauses app's docker.
  *
  * @param {string} idOrName
@@ -1865,5 +1884,6 @@ module.exports = {
   parseContainerNetworkAttachment,
   getContainerNetworkAttachment,
   isContainerDetachedFromNetwork,
+  dockerNetworkExists,
   waitForDocker,
 };

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -1298,7 +1298,7 @@ async function appDockerImageRemove(idOrName) {
  *   running  - the container task is running
  *   attached - the NetworkMode network is present in Networks with an IP
  */
-function parseContainerNetworkAttachment(info) {
+function classifyContainerNetworkAttachment(info) {
   const networkMode = info && info.HostConfig ? info.HostConfig.NetworkMode || null : null;
   const running = !!(info && info.State && info.State.Running);
   const managed = typeof networkMode === 'string' && networkMode.startsWith('fluxDockerNetwork_');
@@ -1315,7 +1315,7 @@ function parseContainerNetworkAttachment(info) {
 
 /**
  * Whether a container is running but not attached to its own managed network -
- * the unrecoverable-by-restart state described in parseContainerNetworkAttachment.
+ * the unrecoverable-by-restart state described in classifyContainerNetworkAttachment.
  * A non-managed (host/none/bridge) container is never considered detached.
  *
  * @param {{managed: boolean, running: boolean, attached: boolean}} attachment
@@ -1327,21 +1327,35 @@ function isContainerDetachedFromNetwork(attachment) {
 }
 
 /**
- * Whether a docker network exists, by name. Used to distinguish a stale endpoint
- * (network present, container not attached - recreatable) from a pruned network
- * (network gone - a recreate would fail on a missing NetworkMode). Any inspect
- * failure is treated as "does not exist".
+ * Reads whether a docker network is present, by name. Used to distinguish a
+ * stale endpoint (network present, container not attached - recreatable) from a
+ * pruned network (network gone - a recreate would fail on a missing NetworkMode).
+ *
+ * A failed inspect is ambiguous - the network may be genuinely gone, or the one
+ * call may have failed while docker is fine - and the caller acts destructively
+ * on the answer, so absence is never inferred from an error. On an inspect
+ * failure we probe the daemon with a list call and use its ANSWER, not just its
+ * success (the same pattern the reconciler's dockerActual uses):
+ *   - list throws          -> 'unknown'  (docker is unhappy: the caller defers)
+ *   - the network IS listed -> 'exists'  (the inspect failure was transient)
+ *   - NOT listed            -> 'absent'  (docker itself confirms absence)
  *
  * @param {string} networkName
- * @returns {Promise<boolean>}
+ * @returns {Promise<'exists'|'absent'|'unknown'>}
  */
-async function dockerNetworkExists(networkName) {
-  if (!networkName) return false;
+async function dockerNetworkState(networkName) {
+  if (!networkName) return 'absent';
   try {
     await docker.getNetwork(networkName).inspect();
-    return true;
+    return 'exists';
   } catch (err) {
-    return false;
+    let networks;
+    try {
+      networks = await docker.listNetworks();
+    } catch (probeErr) {
+      return 'unknown';
+    }
+    return networks.some((n) => n.Name === networkName) ? 'exists' : 'absent';
   }
 }
 
@@ -1875,8 +1889,8 @@ module.exports = {
   getAppContainerNames,
   getAppContainerObjects,
   getAppNameByContainerIp,
-  parseContainerNetworkAttachment,
+  classifyContainerNetworkAttachment,
   isContainerDetachedFromNetwork,
-  dockerNetworkExists,
+  dockerNetworkState,
   waitForDocker,
 };

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -1276,6 +1276,63 @@ async function appDockerImageRemove(idOrName) {
 }
 
 /**
+ * Reads a container's network attachment against its own configured NetworkMode.
+ *
+ * A Flux app component container is created with NetworkMode =
+ * fluxDockerNetwork_<app> and a matching endpoint in NetworkSettings.Networks
+ * (see appDockerCreate). A start that fails "programming external connectivity"
+ * - e.g. a host-port bind conflict during a restart after an unclean reboot -
+ * can leave libnetwork holding a stale endpoint for that container: the next
+ * `docker start` then brings the task up attached to NO network at all.
+ * NetworkMode still names the network, but NetworkSettings.Networks no longer
+ * carries it (or carries it without an IP). Such a container runs with no IP, no
+ * embedded DNS (it cannot resolve sibling components by name) and no published
+ * ports, and a plain start never repairs it - only a recreate, which allocates a
+ * fresh endpoint, clears the stale state. These helpers surface that condition so
+ * callers (the reconciler) can detect and heal it. parseContainerNetworkAttachment
+ * is the pure classifier over a Docker inspect object; getContainerNetworkAttachment
+ * is the inspect-and-classify wrapper.
+ *
+ * @param {object} info - a Docker container inspect object
+ * @returns {{managed: boolean, running: boolean, networkMode: (string|null), attached: boolean}}
+ *   managed  - NetworkMode is a fluxDockerNetwork_* (we own its networking)
+ *   running  - the container task is running
+ *   attached - the NetworkMode network is present in Networks with an IP
+ */
+function parseContainerNetworkAttachment(info) {
+  const networkMode = info && info.HostConfig ? info.HostConfig.NetworkMode || null : null;
+  const running = !!(info && info.State && info.State.Running);
+  const managed = typeof networkMode === 'string' && networkMode.startsWith('fluxDockerNetwork_');
+  let attached = false;
+  if (managed) {
+    const networks = (info && info.NetworkSettings && info.NetworkSettings.Networks) || {};
+    const endpoint = networks[networkMode];
+    attached = !!(endpoint && endpoint.IPAddress);
+  }
+  return {
+    managed, running, networkMode, attached,
+  };
+}
+
+async function getContainerNetworkAttachment(idOrName) {
+  const info = await dockerContainerInspect(idOrName);
+  return parseContainerNetworkAttachment(info);
+}
+
+/**
+ * Whether a container is running but not attached to its own managed network -
+ * the unrecoverable-by-restart state described in getContainerNetworkAttachment.
+ * A non-managed (host/none/bridge) container is never considered detached.
+ *
+ * @param {{managed: boolean, running: boolean, attached: boolean}} attachment
+ * @returns {boolean}
+ */
+function isContainerDetachedFromNetwork(attachment) {
+  if (!attachment) return false;
+  return !!(attachment.managed && attachment.running && !attachment.attached);
+}
+
+/**
  * Pauses app's docker.
  *
  * @param {string} idOrName
@@ -1805,5 +1862,8 @@ module.exports = {
   getAppContainerNames,
   getAppContainerObjects,
   getAppNameByContainerIp,
+  parseContainerNetworkAttachment,
+  getContainerNetworkAttachment,
+  isContainerDetachedFromNetwork,
   waitForDocker,
 };

--- a/tests/unit/appReconciler.test.js
+++ b/tests/unit/appReconciler.test.js
@@ -52,16 +52,20 @@ describe('appReconciler tests', () => {
       volumeService: {
         ensureMountPathsExist: sinon.stub().resolves(),
         ensureAppVolumeMounted: sinon.stub().resolves({ mounted: true, alreadyMounted: true }),
+        // the heal will not destroy a container whose volume it cannot verify
+        verifyAppVolumeMount: sinon.stub().resolves(true),
       },
       appsRuntimeState: {
         isOperatorStopped: sinon.stub().resolves(false),
         restartWaitMs: sinon.stub().resolves(0),
         recordRestart: sinon.stub().resolves(),
         recordExit: sinon.stub().resolves(),
-        // durable "I removed this container for a network heal" flag
+        // durable "I removed this container for a network heal" flag + its own ladder
         isNetworkHealRemoval: sinon.stub().resolves(false),
         setNetworkHealRemoval: sinon.stub().resolves(),
-        clearNetworkHealRemoval: sinon.stub().resolves(),
+        recordNetworkHealAttempt: sinon.stub().resolves(),
+        networkHealWaitMs: sinon.stub().resolves(0),
+        clearNetworkHeal: sinon.stub().resolves(),
       },
       appQueryService: {
         decryptEnterpriseApps: sinon.stub().callsFake(async (arr) => arr),
@@ -1005,35 +1009,73 @@ describe('appReconciler tests', () => {
     // A running container reported as detached from its own docker network (stale
     // libnetwork endpoint). isContainerDetachedFromNetwork is stubbed directly so
     // these tests drive the reconciler's control flow, not the classifier (covered
-    // by dockerService tests). The heal confirms in-pass (settle + re-inspect), so
-    // one reconcile call is a complete heal cycle.
+    // by dockerService tests).
+    //
+    // A heal needs the detach to (a) survive an in-pass re-inspect and (b) persist
+    // for DETACHED_PERSIST_MS of wall-clock. Date is faked so tests can cross that
+    // window without waiting; setTimeout is NOT faked, so the reconciler's own
+    // scheduleRetry timers never fire and each pass is driven explicitly.
+    let clock;
+
     beforeEach(() => {
+      clock = sinon.useFakeTimers({ toFake: ['Date'] });
       stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: true, Status: 'running', ExitCode: 0 } });
       stubs.dockerService.classifyContainerNetworkAttachment.returns({
         managed: true, running: true, networkMode: 'fluxDockerNetwork_App', attached: false,
       });
+      stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
     });
+
+    // first pass opens the persistence window; the second, past it, may act
+    const healPasses = async (id = 'www_App') => {
+      await appReconciler.reconcile(id);
+      clock.tick(61 * 1000);
+      await appReconciler.reconcile(id);
+    };
 
     it('leaves a running, properly-attached container alone and clears any heal state', async () => {
       stubs.dockerService.isContainerDetachedFromNetwork.returns(false);
       await appReconciler.reconcile('www_App');
       expect(stubs.dockerService.appDockerForceRemove.called).to.be.false;
       expect(stubs.containerHealthMonitor.recreateMissingContainers.called).to.be.false;
-      expect(stubs.appsRuntimeState.clearNetworkHealRemoval.calledWith('www_App'), 'attached is the proof a heal worked: clear the durable flag').to.be.true;
+      expect(stubs.appsRuntimeState.clearNetworkHeal.calledWith('www_App'), 'a healthy container clears the durable heal state').to.be.true;
+    });
+
+    it('clears the durable heal state for a container that merely EXISTS, even stopped', async () => {
+      // the flag means "absent because I removed it" - once the container is back it
+      // is stale, whatever its run state. Leaking it would divert a later, genuine
+      // disappearance away from the vanished path forever.
+      stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: false, Status: 'exited', ExitCode: 0 } });
+      stubs.dockerService.isContainerDetachedFromNetwork.returns(false);
+      stubs.appsRuntimeState.restartWaitMs.resolves(60 * 1000); // stay in backoff, never start
+
+      await appReconciler.reconcile('www_App');
+
+      expect(stubs.appsRuntimeState.clearNetworkHeal.calledWith('www_App')).to.be.true;
     });
 
     it('confirms in-pass before acting: a detached read that clears on re-inspect destroys nothing', async () => {
-      // detached on the first read, attached on the confirming re-read
-      stubs.dockerService.isContainerDetachedFromNetwork.onFirstCall().returns(true).onSecondCall().returns(false);
+      // a pass reads the attachment three times: the stale-state clear, the running
+      // branch, then the heal's confirming re-inspect. Detached for the first two,
+      // attached on the re-inspect - i.e. the first read was transient.
+      stubs.dockerService.isContainerDetachedFromNetwork.onCall(2).returns(false);
       await appReconciler.reconcile('www_App');
       expect(stubs.serviceHelper.delay.called, 'settles before re-reading').to.be.true;
       expect(stubs.dockerService.dockerContainerInspect.callCount, 're-inspects to confirm').to.be.at.least(2);
       expect(stubs.dockerService.appDockerForceRemove.called, 'a transient detached read must never destroy a healthy container').to.be.false;
     });
 
-    it('heals a confirmed detach: durable flag set before the remove, monitoring stopped, recreate, never uninstall', async () => {
-      stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
+    it('waits for the detach to persist before destroying anything', async () => {
+      await appReconciler.reconcile('www_App'); // confirmed detached, but only just now
+      expect(stubs.dockerService.appDockerForceRemove.called, 'a detach seen for the first time is not yet actionable').to.be.false;
+
+      clock.tick(61 * 1000);
       await appReconciler.reconcile('www_App');
+      expect(stubs.dockerService.appDockerForceRemove.called, 'a detach that persisted is healed').to.be.true;
+    });
+
+    it('heals a persisted detach: durable flag before the remove, monitoring stopped, soft-only recreate, never uninstall', async () => {
+      await healPasses();
       expect(
         stubs.appsRuntimeState.setNetworkHealRemoval.calledWith('www_App', true),
         'records the deliberate removal durably',
@@ -1044,14 +1086,78 @@ describe('appReconciler tests', () => {
       ).to.be.true;
       expect(stubs.appInspector.stopAppMonitoring.calledWith('www_App', true), 'stops the stats monitor before removing').to.be.true;
       expect(stubs.dockerService.appDockerForceRemove.calledWith('www_App', false), 'force-removes keeping bind-mounted data').to.be.true;
-      expect(stubs.containerHealthMonitor.recreateMissingContainers.calledOnceWith('www_App'), 'recreates once').to.be.true;
+      expect(
+        stubs.containerHealthMonitor.recreateMissingContainers.calledOnceWith('www_App', { softOnly: true }),
+        'the recreate must never be allowed to fall back to a hard install: that reformats the data volume',
+      ).to.be.true;
       expect(stubs.appUninstaller.removeAppLocally.called, 'the heal must NEVER uninstall the app').to.be.false;
     });
 
-    it('does not destroy the container when docker confirms its network is gone (records network_pruned)', async () => {
-      stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
-      stubs.dockerService.dockerNetworkState.resolves('absent');
+    it('refuses to destroy a container it could never recreate (v1-3 app with no compose spec)', async () => {
+      // recreateMissingContainers throws unconditionally on a spec with no compose
+      // array, and the heal never escalates - so removing such a container would
+      // destroy it permanently.
+      localSpec = { name: 'App', version: 3, containerData: '/data' };
+
+      await healPasses('App');
+
+      expect(stubs.dockerService.appDockerForceRemove.called, 'must not remove what it cannot recreate').to.be.false;
+      expect(stubs.appUninstaller.removeAppLocally.called).to.be.false;
+      const blocked = stubs.log.error.getCalls().some((c) => /must NOT be recreated/.test(c.args[0]));
+      expect(blocked, 'says loudly why it refused').to.be.true;
+    });
+
+    it('refuses to destroy a container whose data volume cannot be verified', async () => {
+      // the recreate is soft-only, so an unverifiable volume means it would fail
+      // AFTER the container was destroyed
+      stubs.volumeService.verifyAppVolumeMount.resolves(false);
+
+      await healPasses();
+
+      expect(stubs.dockerService.appDockerForceRemove.called, 'a container whose volume cannot be verified must be left alone').to.be.false;
+      expect(stubs.containerHealthMonitor.recreateMissingContainers.called).to.be.false;
+    });
+
+    it('aborts the remove if another operation took the container over during the confirmation', async () => {
+      // isManagedElsewhere is sampled at reconcile entry, but the heal spends seconds
+      // confirming - a redeploy/backup starting in that window must not have its
+      // container force-removed underneath it.
+      await appReconciler.reconcile('www_App'); // opens the persistence window
+      clock.tick(61 * 1000);
+      stubs.serviceHelper.delay.callsFake(async () => {
+        stubs.globalState.isOperationInProgress = () => true; // a redeploy starts mid-settle
+      });
+
       await appReconciler.reconcile('www_App');
+
+      expect(stubs.dockerService.appDockerForceRemove.called, 'must not actuate on a container another subsystem owns').to.be.false;
+    });
+
+    it('does not rebuild the whole node when many containers look detached at once', async () => {
+      // a dockerd restart can serve inspects before libnetwork restores endpoint IPs,
+      // and the reconnect sweep enqueues everything at that moment
+      localSpec = {
+        name: 'App',
+        version: 4,
+        compose: [{ name: 'www', containerData: '/data' }, { name: 'api', containerData: '/data' }, { name: 'db', containerData: '/data' }],
+      };
+
+      await appReconciler.reconcile('www_App');
+      await appReconciler.reconcile('api_App');
+      await appReconciler.reconcile('db_App');
+      clock.tick(61 * 1000);
+      await appReconciler.reconcile('www_App');
+      await appReconciler.reconcile('api_App');
+      await appReconciler.reconcile('db_App');
+
+      expect(stubs.dockerService.appDockerForceRemove.called, 'a node-wide detach is a docker fault, not N stale endpoints').to.be.false;
+      const storm = stubs.log.error.getCalls().some((c) => /docker-level fault/.test(c.args[0]));
+      expect(storm, 'says loudly that it refused a node-wide rebuild').to.be.true;
+    });
+
+    it('does not destroy the container when docker confirms its network is gone (records network_pruned)', async () => {
+      stubs.dockerService.dockerNetworkState.resolves('absent');
+      await healPasses();
       expect(stubs.dockerService.appDockerForceRemove.called, 'must not remove a container it cannot recreate').to.be.false;
       expect(stubs.containerHealthMonitor.recreateMissingContainers.called).to.be.false;
       const pruned = stubs.appTamperingDetectionService.recordEvent.getCalls().some((c) => c.args[1] === 'network_pruned');
@@ -1059,26 +1165,39 @@ describe('appReconciler tests', () => {
     });
 
     it('defers (destroys nothing, records nothing) when docker cannot say whether the network exists', async () => {
-      stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
       stubs.dockerService.dockerNetworkState.resolves('unknown');
-      await appReconciler.reconcile('www_App');
+      await healPasses();
       expect(stubs.dockerService.appDockerForceRemove.called, 'an unreadable network is not a missing network').to.be.false;
       const pruned = stubs.appTamperingDetectionService.recordEvent.getCalls().some((c) => c.args[1] === 'network_pruned');
       expect(pruned, 'must not record a false network_pruned on a transient docker error').to.be.false;
     });
 
-    it('paces heal attempts on the durable backoff ladder instead of counting them', async () => {
-      stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
-      stubs.appsRuntimeState.restartWaitMs.resolves(30 * 1000); // ladder says: not yet
-      await appReconciler.reconcile('www_App');
+    it('paces heal attempts on its own durable ladder, not the crash-restart one', async () => {
+      stubs.appsRuntimeState.networkHealWaitMs.resolves(30 * 1000); // the heal ladder says: not yet
+      await healPasses();
       expect(stubs.dockerService.appDockerForceRemove.called, 'no destructive action while backing off').to.be.false;
       expect(stubs.appsRuntimeState.setNetworkHealRemoval.called).to.be.false;
+      expect(
+        stubs.appsRuntimeState.recordRestart.called,
+        'a heal must not write to the crash ladder: it would hold down the container it just fixed',
+      ).to.be.false;
+    });
+
+    it('does not remove the container if the heal cannot be recorded durably', async () => {
+      // the durable flag is what stops a restart mid-heal from uninstalling the app,
+      // and the ladder is what stops the retries hammering - without them, no remove
+      stubs.appsRuntimeState.setNetworkHealRemoval.rejects(new Error('db unavailable'));
+
+      await healPasses();
+
+      expect(stubs.dockerService.appDockerForceRemove.called, 'an unrecordable heal must not happen at all').to.be.false;
+      const noted = stubs.log.error.getCalls().some((c) => /cannot record the network heal/.test(c.args[0]));
+      expect(noted, 'logs and retries rather than throwing out of reconcile').to.be.true;
     });
 
     it('restores monitoring when the force-remove itself fails', async () => {
-      stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
       stubs.dockerService.appDockerForceRemove.rejects(new Error('device or resource busy'));
-      await appReconciler.reconcile('www_App');
+      await healPasses();
       expect(
         stubs.appInspector.startAppMonitoring.calledWith('www_App'),
         'the container is still there: it must not be left unmonitored',
@@ -1086,28 +1205,29 @@ describe('appReconciler tests', () => {
       expect(stubs.appUninstaller.removeAppLocally.called).to.be.false;
     });
 
-    it('a recreate failure retries but never uninstalls the app', async () => {
-      stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
+    it('a recreate failure retries, records the diagnostics, and never uninstalls the app', async () => {
       stubs.containerHealthMonitor.recreateMissingContainers.rejects(new Error('host port still in use'));
-      await appReconciler.reconcile('www_App');
+      await healPasses();
       expect(stubs.dockerService.appDockerForceRemove.called).to.be.true;
       expect(stubs.appUninstaller.removeAppLocally.called, 'a transient recreate failure must not uninstall').to.be.false;
+      const failed = stubs.appTamperingDetectionService.recordEvent.getCalls().some((c) => c.args[1] === 'recreation_failed');
+      expect(failed, 'a silently looping heal is an invisible outage: record the failure').to.be.true;
     });
 
     it('keeps retrying a broken heal at a bounded rate: no terminal give-up, no uninstall, one tamper event', async () => {
-      stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
       stubs.containerHealthMonitor.recreateMissingContainers.rejects(new Error('host port still in use'));
       // the container stays "running" (inspect stub), so each pass re-enters the
       // running-detached branch - as the hourly sweep would drive it
       for (let i = 0; i < 8; i += 1) {
         // eslint-disable-next-line no-await-in-loop
         await appReconciler.reconcile('www_App');
+        clock.tick(61 * 1000);
       }
       expect(stubs.appUninstaller.removeAppLocally.called, 'never uninstalls, however long it stays broken').to.be.false;
       expect(
         stubs.containerHealthMonitor.recreateMissingContainers.callCount,
-        'keeps trying (paced by the ladder) rather than parking in a terminal state',
-      ).to.equal(8);
+        'keeps trying (paced by its ladder) rather than parking in a terminal state',
+      ).to.be.at.least(6);
       // the durable tampering signal is recorded once per episode, not per attempt
       const detachedEvents = stubs.appTamperingDetectionService.recordEvent.getCalls().filter((c) => c.args[1] === 'network_detached').length;
       expect(detachedEvents, 'records network_detached once per episode, not per attempt').to.equal(1);
@@ -1127,6 +1247,21 @@ describe('appReconciler tests', () => {
       expect(vanished, 'our own removal must not be recorded as tampering').to.be.false;
       expect(stubs.containerHealthMonitor.recreateMissingContainers.called, 'recreates on the heal path').to.be.true;
       expect(stubs.appUninstaller.removeAppLocally.called, 'a failed recreate must not uninstall the app').to.be.false;
+    });
+
+    it('defers instead of guessing when the durable heal flag cannot be read', async () => {
+      // guessing "not a heal removal" is the destructive guess: it records a false
+      // tampering event and can uninstall the app on a failed recreate
+      stubs.appsRuntimeState.isNetworkHealRemoval.rejects(new Error('db unavailable'));
+      stubs.dockerService.dockerContainerInspect.rejects(new Error('no such container'));
+      stubs.dockerService.dockerListContainers.resolves([]);
+
+      await appReconciler.reconcile('www_App');
+
+      expect(stubs.containerHealthMonitor.recreateMissingContainers.called, 'no recreate on an unreadable state').to.be.false;
+      expect(stubs.appUninstaller.removeAppLocally.called, 'and above all, no uninstall').to.be.false;
+      const vanished = stubs.appTamperingDetectionService.recordEvent.getCalls().some((c) => c.args[1] === 'container_vanished');
+      expect(vanished, 'no false tampering event').to.be.false;
     });
 
     it('a container that vanished on its own (no heal flag) still takes the vanished path', async () => {

--- a/tests/unit/appReconciler.test.js
+++ b/tests/unit/appReconciler.test.js
@@ -33,11 +33,11 @@ describe('appReconciler tests', () => {
         // network-attachment helpers used by dockerActual + the running branch.
         // Default: a benign, attached container (not detached), so the heal path
         // stays dormant unless a test opts in.
-        parseContainerNetworkAttachment: sinon.stub().returns({
+        classifyContainerNetworkAttachment: sinon.stub().returns({
           managed: false, running: false, networkMode: null, attached: false,
         }),
         isContainerDetachedFromNetwork: sinon.stub().returns(false),
-        dockerNetworkExists: sinon.stub().resolves(true),
+        dockerNetworkState: sinon.stub().resolves('exists'),
       },
       globalState: {
         appsMonitored: {},
@@ -58,6 +58,10 @@ describe('appReconciler tests', () => {
         restartWaitMs: sinon.stub().resolves(0),
         recordRestart: sinon.stub().resolves(),
         recordExit: sinon.stub().resolves(),
+        // durable "I removed this container for a network heal" flag
+        isNetworkHealRemoval: sinon.stub().resolves(false),
+        setNetworkHealRemoval: sinon.stub().resolves(),
+        clearNetworkHealRemoval: sinon.stub().resolves(),
       },
       appQueryService: {
         decryptEnterpriseApps: sinon.stub().callsFake(async (arr) => arr),
@@ -522,13 +526,24 @@ describe('appReconciler tests', () => {
       clock.restore();
     });
 
-    it('does not schedule a retry after a successful start', async () => {
+    it('converges after a successful start: the verification pass re-checks but does not act again', async () => {
+      // a successful start schedules ONE verification pass (a container can come up
+      // detached from its network). That pass must find the container running and
+      // stop there - not start it again, and not keep re-arming itself.
       const clock = sinon.useFakeTimers({ toFake: ['setTimeout'] });
+      stubs.dockerService.appDockerStart.callsFake(async () => {
+        stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: true, Status: 'running', ExitCode: 0 } });
+      });
 
       await appReconciler.reconcile('www_App');
-
       expect(stubs.dockerService.appDockerStart.callCount).to.equal(1);
+
       clock.tick(60 * 1000);
+      await new Promise((resolve) => { setImmediate(() => { setImmediate(resolve); }); });
+      expect(stubs.dockerService.dockerContainerInspect.callCount, 'the verification pass ran').to.be.above(1);
+      expect(stubs.dockerService.appDockerStart.callCount, 'a running container is left alone').to.equal(1);
+
+      clock.tick(10 * 60 * 1000); // no further passes are armed once it is healthy
       await new Promise((resolve) => { setImmediate(() => { setImmediate(resolve); }); });
       expect(stubs.dockerService.appDockerStart.callCount).to.equal(1);
       clock.restore();
@@ -990,75 +1005,160 @@ describe('appReconciler tests', () => {
     // A running container reported as detached from its own docker network (stale
     // libnetwork endpoint). isContainerDetachedFromNetwork is stubbed directly so
     // these tests drive the reconciler's control flow, not the classifier (covered
-    // by dockerService tests).
+    // by dockerService tests). The heal confirms in-pass (settle + re-inspect), so
+    // one reconcile call is a complete heal cycle.
     beforeEach(() => {
       stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: true, Status: 'running', ExitCode: 0 } });
-      stubs.dockerService.parseContainerNetworkAttachment.returns({
+      stubs.dockerService.classifyContainerNetworkAttachment.returns({
         managed: true, running: true, networkMode: 'fluxDockerNetwork_App', attached: false,
       });
     });
 
-    it('leaves a running, properly-attached container alone', async () => {
+    it('leaves a running, properly-attached container alone and clears any heal state', async () => {
       stubs.dockerService.isContainerDetachedFromNetwork.returns(false);
       await appReconciler.reconcile('www_App');
       expect(stubs.dockerService.appDockerForceRemove.called).to.be.false;
       expect(stubs.containerHealthMonitor.recreateMissingContainers.called).to.be.false;
+      expect(stubs.appsRuntimeState.clearNetworkHealRemoval.calledWith('www_App'), 'attached is the proof a heal worked: clear the durable flag').to.be.true;
     });
 
-    it('debounces: does not act on the first detached observation', async () => {
+    it('confirms in-pass before acting: a detached read that clears on re-inspect destroys nothing', async () => {
+      // detached on the first read, attached on the confirming re-read
+      stubs.dockerService.isContainerDetachedFromNetwork.onFirstCall().returns(true).onSecondCall().returns(false);
+      await appReconciler.reconcile('www_App');
+      expect(stubs.serviceHelper.delay.called, 'settles before re-reading').to.be.true;
+      expect(stubs.dockerService.dockerContainerInspect.callCount, 're-inspects to confirm').to.be.at.least(2);
+      expect(stubs.dockerService.appDockerForceRemove.called, 'a transient detached read must never destroy a healthy container').to.be.false;
+    });
+
+    it('heals a confirmed detach: durable flag set before the remove, monitoring stopped, recreate, never uninstall', async () => {
       stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
       await appReconciler.reconcile('www_App');
-      expect(stubs.dockerService.appDockerForceRemove.called, 'no destructive action on first sighting').to.be.false;
-      expect(stubs.containerHealthMonitor.recreateMissingContainers.called).to.be.false;
-    });
-
-    it('recreates after two consecutive detached observations, stopping monitoring first and never uninstalling', async () => {
-      stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
-      await appReconciler.reconcile('www_App'); // obs 1 (debounce)
-      await appReconciler.reconcile('www_App'); // obs 2 (act)
+      expect(
+        stubs.appsRuntimeState.setNetworkHealRemoval.calledWith('www_App', true),
+        'records the deliberate removal durably',
+      ).to.be.true;
+      expect(
+        stubs.appsRuntimeState.setNetworkHealRemoval.calledBefore(stubs.dockerService.appDockerForceRemove),
+        'the flag must be durable BEFORE the container is removed, or a restart in the window reads the absence as tampering',
+      ).to.be.true;
       expect(stubs.appInspector.stopAppMonitoring.calledWith('www_App', true), 'stops the stats monitor before removing').to.be.true;
       expect(stubs.dockerService.appDockerForceRemove.calledWith('www_App', false), 'force-removes keeping bind-mounted data').to.be.true;
       expect(stubs.containerHealthMonitor.recreateMissingContainers.calledOnceWith('www_App'), 'recreates once').to.be.true;
       expect(stubs.appUninstaller.removeAppLocally.called, 'the heal must NEVER uninstall the app').to.be.false;
     });
 
-    it('does not destroy the container when its network is missing (records network_pruned)', async () => {
+    it('does not destroy the container when docker confirms its network is gone (records network_pruned)', async () => {
       stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
-      stubs.dockerService.dockerNetworkExists.resolves(false);
-      await appReconciler.reconcile('www_App'); // obs 1
-      await appReconciler.reconcile('www_App'); // obs 2 -> network gone -> skip destructive heal
+      stubs.dockerService.dockerNetworkState.resolves('absent');
+      await appReconciler.reconcile('www_App');
       expect(stubs.dockerService.appDockerForceRemove.called, 'must not remove a container it cannot recreate').to.be.false;
       expect(stubs.containerHealthMonitor.recreateMissingContainers.called).to.be.false;
       const pruned = stubs.appTamperingDetectionService.recordEvent.getCalls().some((c) => c.args[1] === 'network_pruned');
       expect(pruned, 'records a network_pruned event').to.be.true;
     });
 
+    it('defers (destroys nothing, records nothing) when docker cannot say whether the network exists', async () => {
+      stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
+      stubs.dockerService.dockerNetworkState.resolves('unknown');
+      await appReconciler.reconcile('www_App');
+      expect(stubs.dockerService.appDockerForceRemove.called, 'an unreadable network is not a missing network').to.be.false;
+      const pruned = stubs.appTamperingDetectionService.recordEvent.getCalls().some((c) => c.args[1] === 'network_pruned');
+      expect(pruned, 'must not record a false network_pruned on a transient docker error').to.be.false;
+    });
+
+    it('paces heal attempts on the durable backoff ladder instead of counting them', async () => {
+      stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
+      stubs.appsRuntimeState.restartWaitMs.resolves(30 * 1000); // ladder says: not yet
+      await appReconciler.reconcile('www_App');
+      expect(stubs.dockerService.appDockerForceRemove.called, 'no destructive action while backing off').to.be.false;
+      expect(stubs.appsRuntimeState.setNetworkHealRemoval.called).to.be.false;
+    });
+
+    it('restores monitoring when the force-remove itself fails', async () => {
+      stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
+      stubs.dockerService.appDockerForceRemove.rejects(new Error('device or resource busy'));
+      await appReconciler.reconcile('www_App');
+      expect(
+        stubs.appInspector.startAppMonitoring.calledWith('www_App'),
+        'the container is still there: it must not be left unmonitored',
+      ).to.be.true;
+      expect(stubs.appUninstaller.removeAppLocally.called).to.be.false;
+    });
+
     it('a recreate failure retries but never uninstalls the app', async () => {
       stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
       stubs.containerHealthMonitor.recreateMissingContainers.rejects(new Error('host port still in use'));
-      await appReconciler.reconcile('www_App'); // obs 1
-      await appReconciler.reconcile('www_App'); // obs 2 -> heal attempt -> recreate throws
+      await appReconciler.reconcile('www_App');
       expect(stubs.dockerService.appDockerForceRemove.called).to.be.true;
       expect(stubs.appUninstaller.removeAppLocally.called, 'a transient recreate failure must not uninstall').to.be.false;
     });
 
-    it('gives up after MAX attempts without ever uninstalling', async () => {
+    it('keeps retrying a broken heal at a bounded rate: no terminal give-up, no uninstall, one tamper event', async () => {
       stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
       stubs.containerHealthMonitor.recreateMissingContainers.rejects(new Error('host port still in use'));
-      // 1 debounce pass + several act passes; the container stays "running" (inspect
-      // stub), so each pass re-enters the running-detached branch.
+      // the container stays "running" (inspect stub), so each pass re-enters the
+      // running-detached branch - as the hourly sweep would drive it
       for (let i = 0; i < 8; i += 1) {
         // eslint-disable-next-line no-await-in-loop
         await appReconciler.reconcile('www_App');
       }
-      expect(stubs.appUninstaller.removeAppLocally.called, 'never uninstalls, even after giving up').to.be.false;
-      const gaveUp = stubs.log.error.getCalls().some((c) => /manual intervention/.test(c.args[0]));
-      expect(gaveUp, 'logs a give-up for manual intervention').to.be.true;
-      // bounded: at most MAX_NETWORK_HEAL_ATTEMPTS (3) recreate attempts, not one per pass
-      expect(stubs.containerHealthMonitor.recreateMissingContainers.callCount).to.be.at.most(3);
-      // the durable tampering signal is recorded once per episode, not per retry
+      expect(stubs.appUninstaller.removeAppLocally.called, 'never uninstalls, however long it stays broken').to.be.false;
+      expect(
+        stubs.containerHealthMonitor.recreateMissingContainers.callCount,
+        'keeps trying (paced by the ladder) rather than parking in a terminal state',
+      ).to.equal(8);
+      // the durable tampering signal is recorded once per episode, not per attempt
       const detachedEvents = stubs.appTamperingDetectionService.recordEvent.getCalls().filter((c) => c.args[1] === 'network_detached').length;
-      expect(detachedEvents, 'records network_detached once per episode, not per retry').to.equal(1);
+      expect(detachedEvents, 'records network_detached once per episode, not per attempt').to.equal(1);
+    });
+
+    it('a FluxOS restart mid-heal still recreates: the absence is ours, not tampering', async () => {
+      // fresh process: no in-memory heal state, container gone (removed just before
+      // the crash), but the durable flag survived
+      stubs.appsRuntimeState.isNetworkHealRemoval.resolves(true);
+      stubs.dockerService.dockerContainerInspect.rejects(new Error('no such container'));
+      stubs.dockerService.dockerListContainers.resolves([]); // docker up, container really absent
+      stubs.containerHealthMonitor.recreateMissingContainers.rejects(new Error('host port still in use'));
+
+      await appReconciler.reconcile('www_App');
+
+      const vanished = stubs.appTamperingDetectionService.recordEvent.getCalls().some((c) => c.args[1] === 'container_vanished');
+      expect(vanished, 'our own removal must not be recorded as tampering').to.be.false;
+      expect(stubs.containerHealthMonitor.recreateMissingContainers.called, 'recreates on the heal path').to.be.true;
+      expect(stubs.appUninstaller.removeAppLocally.called, 'a failed recreate must not uninstall the app').to.be.false;
+    });
+
+    it('a container that vanished on its own (no heal flag) still takes the vanished path', async () => {
+      stubs.appsRuntimeState.isNetworkHealRemoval.resolves(false);
+      stubs.dockerService.dockerContainerInspect.rejects(new Error('no such container'));
+      stubs.dockerService.dockerListContainers.resolves([]);
+
+      await appReconciler.reconcile('www_App');
+
+      const vanished = stubs.appTamperingDetectionService.recordEvent.getCalls().some((c) => c.args[1] === 'container_vanished');
+      expect(vanished, 'a genuine vanish is still a tampering signal').to.be.true;
+    });
+  });
+
+  describe('post-start attachment verification', () => {
+    it('re-checks a container shortly after starting it, instead of waiting for the hourly sweep', async () => {
+      const clock = sinon.useFakeTimers({ toFake: ['setTimeout'] });
+      try {
+        await appReconciler.reconcile('www_App'); // stopped -> start
+        expect(stubs.dockerService.appDockerStart.calledOnce).to.be.true;
+        const inspectsAfterStart = stubs.dockerService.dockerContainerInspect.callCount;
+
+        clock.tick(30 * 1000); // the post-start verification pass
+        await new Promise((resolve) => { setImmediate(resolve); });
+
+        expect(
+          stubs.dockerService.dockerContainerInspect.callCount,
+          'the start is when a container can come up detached, so it must be looked at again',
+        ).to.be.above(inspectsAfterStart);
+      } finally {
+        clock.restore();
+      }
     });
   });
 });

--- a/tests/unit/appReconciler.test.js
+++ b/tests/unit/appReconciler.test.js
@@ -1056,6 +1056,9 @@ describe('appReconciler tests', () => {
       expect(gaveUp, 'logs a give-up for manual intervention').to.be.true;
       // bounded: at most MAX_NETWORK_HEAL_ATTEMPTS (3) recreate attempts, not one per pass
       expect(stubs.containerHealthMonitor.recreateMissingContainers.callCount).to.be.at.most(3);
+      // the durable tampering signal is recorded once per episode, not per retry
+      const detachedEvents = stubs.appTamperingDetectionService.recordEvent.getCalls().filter((c) => c.args[1] === 'network_detached').length;
+      expect(detachedEvents, 'records network_detached once per episode, not per retry').to.equal(1);
     });
   });
 });

--- a/tests/unit/appReconciler.test.js
+++ b/tests/unit/appReconciler.test.js
@@ -26,9 +26,18 @@ describe('appReconciler tests', () => {
         getDockerContainerOnly: sinon.stub().resolves(undefined),
         appDockerStart: sinon.stub().resolves(),
         appDockerStop: sinon.stub().resolves(),
+        appDockerForceRemove: sinon.stub().resolves(),
         getAppIdentifier: (id) => `flux${id}`,
         getAppDockerNameIdentifier: (id) => `/flux${id}`,
         getBaseAppName: (id) => (id.startsWith('flux') ? id.slice(4) : id),
+        // network-attachment helpers used by dockerActual + the running branch.
+        // Default: a benign, attached container (not detached), so the heal path
+        // stays dormant unless a test opts in.
+        parseContainerNetworkAttachment: sinon.stub().returns({
+          managed: false, running: false, networkMode: null, attached: false,
+        }),
+        isContainerDetachedFromNetwork: sinon.stub().returns(false),
+        dockerNetworkExists: sinon.stub().resolves(true),
       },
       globalState: {
         appsMonitored: {},
@@ -39,7 +48,7 @@ describe('appReconciler tests', () => {
         bootContainerStateSettled: true,
         waitForBootContainerStateSettled: () => Promise.resolve(),
       },
-      appInspector: { startAppMonitoring: sinon.stub() },
+      appInspector: { startAppMonitoring: sinon.stub(), stopAppMonitoring: sinon.stub() },
       volumeService: {
         ensureMountPathsExist: sinon.stub().resolves(),
         ensureAppVolumeMounted: sinon.stub().resolves({ mounted: true, alreadyMounted: true }),
@@ -974,6 +983,79 @@ describe('appReconciler tests', () => {
       await reachedInspect[1].promise;
       expect(resolvers).to.have.lengthOf(2); // one re-run, not two
       resolvers[1]();
+    });
+  });
+
+  describe('network-detach heal', () => {
+    // A running container reported as detached from its own docker network (stale
+    // libnetwork endpoint). isContainerDetachedFromNetwork is stubbed directly so
+    // these tests drive the reconciler's control flow, not the classifier (covered
+    // by dockerService tests).
+    beforeEach(() => {
+      stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: true, Status: 'running', ExitCode: 0 } });
+      stubs.dockerService.parseContainerNetworkAttachment.returns({
+        managed: true, running: true, networkMode: 'fluxDockerNetwork_App', attached: false,
+      });
+    });
+
+    it('leaves a running, properly-attached container alone', async () => {
+      stubs.dockerService.isContainerDetachedFromNetwork.returns(false);
+      await appReconciler.reconcile('www_App');
+      expect(stubs.dockerService.appDockerForceRemove.called).to.be.false;
+      expect(stubs.containerHealthMonitor.recreateMissingContainers.called).to.be.false;
+    });
+
+    it('debounces: does not act on the first detached observation', async () => {
+      stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
+      await appReconciler.reconcile('www_App');
+      expect(stubs.dockerService.appDockerForceRemove.called, 'no destructive action on first sighting').to.be.false;
+      expect(stubs.containerHealthMonitor.recreateMissingContainers.called).to.be.false;
+    });
+
+    it('recreates after two consecutive detached observations, stopping monitoring first and never uninstalling', async () => {
+      stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
+      await appReconciler.reconcile('www_App'); // obs 1 (debounce)
+      await appReconciler.reconcile('www_App'); // obs 2 (act)
+      expect(stubs.appInspector.stopAppMonitoring.calledWith('www_App', true), 'stops the stats monitor before removing').to.be.true;
+      expect(stubs.dockerService.appDockerForceRemove.calledWith('www_App', false), 'force-removes keeping bind-mounted data').to.be.true;
+      expect(stubs.containerHealthMonitor.recreateMissingContainers.calledOnceWith('www_App'), 'recreates once').to.be.true;
+      expect(stubs.appUninstaller.removeAppLocally.called, 'the heal must NEVER uninstall the app').to.be.false;
+    });
+
+    it('does not destroy the container when its network is missing (records network_pruned)', async () => {
+      stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
+      stubs.dockerService.dockerNetworkExists.resolves(false);
+      await appReconciler.reconcile('www_App'); // obs 1
+      await appReconciler.reconcile('www_App'); // obs 2 -> network gone -> skip destructive heal
+      expect(stubs.dockerService.appDockerForceRemove.called, 'must not remove a container it cannot recreate').to.be.false;
+      expect(stubs.containerHealthMonitor.recreateMissingContainers.called).to.be.false;
+      const pruned = stubs.appTamperingDetectionService.recordEvent.getCalls().some((c) => c.args[1] === 'network_pruned');
+      expect(pruned, 'records a network_pruned event').to.be.true;
+    });
+
+    it('a recreate failure retries but never uninstalls the app', async () => {
+      stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
+      stubs.containerHealthMonitor.recreateMissingContainers.rejects(new Error('host port still in use'));
+      await appReconciler.reconcile('www_App'); // obs 1
+      await appReconciler.reconcile('www_App'); // obs 2 -> heal attempt -> recreate throws
+      expect(stubs.dockerService.appDockerForceRemove.called).to.be.true;
+      expect(stubs.appUninstaller.removeAppLocally.called, 'a transient recreate failure must not uninstall').to.be.false;
+    });
+
+    it('gives up after MAX attempts without ever uninstalling', async () => {
+      stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
+      stubs.containerHealthMonitor.recreateMissingContainers.rejects(new Error('host port still in use'));
+      // 1 debounce pass + several act passes; the container stays "running" (inspect
+      // stub), so each pass re-enters the running-detached branch.
+      for (let i = 0; i < 8; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await appReconciler.reconcile('www_App');
+      }
+      expect(stubs.appUninstaller.removeAppLocally.called, 'never uninstalls, even after giving up').to.be.false;
+      const gaveUp = stubs.log.error.getCalls().some((c) => /manual intervention/.test(c.args[0]));
+      expect(gaveUp, 'logs a give-up for manual intervention').to.be.true;
+      // bounded: at most MAX_NETWORK_HEAL_ATTEMPTS (3) recreate attempts, not one per pass
+      expect(stubs.containerHealthMonitor.recreateMissingContainers.callCount).to.be.at.most(3);
     });
   });
 });

--- a/tests/unit/appsRuntimeState.test.js
+++ b/tests/unit/appsRuntimeState.test.js
@@ -323,8 +323,28 @@ describe('appsRuntimeState tests', () => {
 
     it('clears the flag', async () => {
       await appsRuntimeState.setNetworkHealRemoval('www_App', true);
-      await appsRuntimeState.clearNetworkHealRemoval('www_App');
+      await appsRuntimeState.clearNetworkHeal('www_App');
       expect(await appsRuntimeState.isNetworkHealRemoval('www_App')).to.be.false;
+    });
+
+    it('a read failure throws rather than reporting "not a heal removal"', async () => {
+      // reading false on a DB blip is the DESTRUCTIVE guess: the reconciler would
+      // treat its own removal as a vanished container and can uninstall the app.
+      const failing = proxyquire('../../ZelBack/src/services/appManagement/appsRuntimeState', {
+        '../../lib/log': logStub,
+        '../dbHelper': {
+          databaseConnection: () => ({ db: () => ({}) }),
+          findOneInDatabase: async () => { throw new Error('db unavailable'); },
+          updateOneInDatabase: async () => {},
+          removeDocumentsFromCollection: async () => {},
+        },
+        '../dockerService': { getBaseAppName: (id) => id },
+      });
+
+      let thrown = null;
+      await failing.isNetworkHealRemoval('www_App').catch((e) => { thrown = e; });
+
+      expect(thrown, 'must not silently answer false').to.be.an('error');
     });
 
     it('is dropped with the rest of the component state on uninstall', async () => {
@@ -351,6 +371,36 @@ describe('appsRuntimeState tests', () => {
       });
 
       expect(await restarted.isNetworkHealRemoval('www_App')).to.be.true;
+    });
+  });
+
+  describe('network heal ladder (separate from the crash-restart ladder)', () => {
+    it('allows the first attempt immediately, then paces the next ones', async () => {
+      expect(await appsRuntimeState.networkHealWaitMs('www_App')).to.equal(0);
+
+      await appsRuntimeState.recordNetworkHealAttempt('www_App');
+      expect(await appsRuntimeState.networkHealWaitMs('www_App'), 'the second attempt waits').to.be.above(0);
+    });
+
+    it('does not touch the crash-restart backoff', async () => {
+      // sharing restartHistory would hold down the very container the heal just
+      // recreated (a g: component is created, not started, so the next pass reads the
+      // ladder the heal grew) - and would block a heal for a crash-looping container
+      await appsRuntimeState.recordNetworkHealAttempt('www_App');
+      await appsRuntimeState.recordNetworkHealAttempt('www_App');
+
+      expect(await appsRuntimeState.restartWaitMs('www_App'), 'the restart ladder is untouched').to.equal(0);
+      expect(store.get('www_App').restartHistory).to.equal(undefined);
+    });
+
+    it('is reset once the container is healthy, so a later episode starts from the bottom', async () => {
+      await appsRuntimeState.recordNetworkHealAttempt('www_App');
+      await appsRuntimeState.recordNetworkHealAttempt('www_App');
+      expect(await appsRuntimeState.networkHealWaitMs('www_App')).to.be.above(0);
+
+      await appsRuntimeState.clearNetworkHeal('www_App');
+
+      expect(await appsRuntimeState.networkHealWaitMs('www_App')).to.equal(0);
     });
   });
 

--- a/tests/unit/appsRuntimeState.test.js
+++ b/tests/unit/appsRuntimeState.test.js
@@ -311,6 +311,49 @@ describe('appsRuntimeState tests', () => {
     });
   });
 
+  describe('networkHealRemoval (durable "I removed this container on purpose")', () => {
+    it('persists the flag and reads it back', async () => {
+      await appsRuntimeState.setNetworkHealRemoval('www_App', true);
+      expect(await appsRuntimeState.isNetworkHealRemoval('www_App')).to.be.true;
+    });
+
+    it('defaults to false for an unknown component', async () => {
+      expect(await appsRuntimeState.isNetworkHealRemoval('nope_App')).to.be.false;
+    });
+
+    it('clears the flag', async () => {
+      await appsRuntimeState.setNetworkHealRemoval('www_App', true);
+      await appsRuntimeState.clearNetworkHealRemoval('www_App');
+      expect(await appsRuntimeState.isNetworkHealRemoval('www_App')).to.be.false;
+    });
+
+    it('is dropped with the rest of the component state on uninstall', async () => {
+      await appsRuntimeState.setNetworkHealRemoval('www_App', true);
+      await appsRuntimeState.remove('www_App');
+      expect(await appsRuntimeState.isNetworkHealRemoval('www_App')).to.be.false;
+    });
+
+    it('survives a process restart: a fresh module instance reads the persisted flag', async () => {
+      // this is the whole point of the flag - an in-memory map would lose the fact
+      // that the reconciler removed the container itself, and the next process would
+      // read the absence as tampering
+      await appsRuntimeState.setNetworkHealRemoval('www_App', true);
+
+      const restarted = proxyquire('../../ZelBack/src/services/appManagement/appsRuntimeState', {
+        '../../lib/log': logStub,
+        '../dbHelper': {
+          databaseConnection: () => ({ db: () => ({}) }),
+          findOneInDatabase: async (_db, _coll, query) => store.get(query.identifier) || null,
+          updateOneInDatabase: async () => {},
+          removeDocumentsFromCollection: async () => {},
+        },
+        '../dockerService': { getBaseAppName: (id) => id.replace(/^flux/, '').replace(/^zel/, '') },
+      });
+
+      expect(await restarted.isNetworkHealRemoval('www_App')).to.be.true;
+    });
+  });
+
   describe('prepareCollection (merge-dedupe + unique index)', () => {
     // Fleet nodes wrote into this collection before the unique index existed, so
     // same-identifier twins may exist - and because every later updateOne matched

--- a/tests/unit/containerHealthMonitor.test.js
+++ b/tests/unit/containerHealthMonitor.test.js
@@ -142,6 +142,51 @@ describe('containerHealthMonitor tests', () => {
       const recreated = appInstallerStub.installApplicationHard.getCalls().map((c) => c.args[0].name);
       expect(recreated).to.deep.equal(['web', 'db']);
     });
+
+    describe('softOnly (the network-detach heal)', () => {
+      // A hard install runs createAppVolume: fallocate + mke2fs on the app's volume
+      // file, i.e. it REFORMATS the app's data. The heal deliberately force-removes a
+      // LIVE container whose data is intact, so it must never be able to trigger that
+      // fallback - a transient verifyAppVolumeMount failure would wipe user data.
+      it('throws instead of hard-installing a component whose volume cannot be verified', async () => {
+        volumeServiceStub.verifyAppVolumeMount.resolves(false);
+        let err;
+        try {
+          await containerHealthMonitor.recreateMissingContainers('web_testapp', { softOnly: true });
+        } catch (e) { err = e; }
+
+        expect(err).to.be.an('error');
+        expect(err.message).to.include('without reformatting its volume');
+        expect(appInstallerStub.installApplicationHard.called, 'must never reformat the data volume of a container it was asked to rebuild softly').to.be.false;
+      });
+
+      it('throws instead of hard-installing on the whole-app path', async () => {
+        volumeServiceStub.verifyAppVolumeMount.resolves(false);
+        let err;
+        try {
+          await containerHealthMonitor.recreateMissingContainers('testapp', { softOnly: true });
+        } catch (e) { err = e; }
+
+        expect(err).to.be.an('error');
+        expect(appInstallerStub.installApplicationHard.called).to.be.false;
+      });
+
+      it('still soft-installs normally when the volume is verified', async () => {
+        volumeServiceStub.verifyAppVolumeMount.resolves(true);
+
+        await containerHealthMonitor.recreateMissingContainers('web_testapp', { softOnly: true });
+
+        expect(appInstallerStub.installApplicationSoft.calledOnce).to.be.true;
+      });
+
+      it('leaves the default (vanished-container) path free to hard-install', async () => {
+        volumeServiceStub.verifyAppVolumeMount.resolves(false);
+
+        await containerHealthMonitor.recreateMissingContainers('web_testapp');
+
+        expect(appInstallerStub.installApplicationHard.calledOnce, 'a container that is gone anyway may still be rebuilt from scratch').to.be.true;
+      });
+    });
   });
 
 });

--- a/tests/unit/dockerService.test.js
+++ b/tests/unit/dockerService.test.js
@@ -258,6 +258,77 @@ describe('dockerService tests', () => {
     });
   });
 
+  describe('parseContainerNetworkAttachment / isContainerDetachedFromNetwork tests', () => {
+    it('reports attached when the managed network carries an IP', () => {
+      const attachment = dockerService.parseContainerNetworkAttachment({
+        HostConfig: { NetworkMode: 'fluxDockerNetwork_appx' },
+        State: { Running: true },
+        NetworkSettings: { Networks: { fluxDockerNetwork_appx: { IPAddress: '172.23.0.5' } } },
+      });
+
+      expect(attachment).to.deep.equal({
+        managed: true, running: true, networkMode: 'fluxDockerNetwork_appx', attached: true,
+      });
+      expect(dockerService.isContainerDetachedFromNetwork(attachment)).to.equal(false);
+    });
+
+    it('flags a running managed container with an empty Networks as detached', () => {
+      const attachment = dockerService.parseContainerNetworkAttachment({
+        HostConfig: { NetworkMode: 'fluxDockerNetwork_appx' },
+        State: { Running: true },
+        NetworkSettings: { Networks: {} },
+      });
+
+      expect(attachment.managed).to.equal(true);
+      expect(attachment.attached).to.equal(false);
+      expect(dockerService.isContainerDetachedFromNetwork(attachment)).to.equal(true);
+    });
+
+    it('flags detached when the endpoint exists but has no IP (half-programmed)', () => {
+      const attachment = dockerService.parseContainerNetworkAttachment({
+        HostConfig: { NetworkMode: 'fluxDockerNetwork_appx' },
+        State: { Running: true },
+        NetworkSettings: { Networks: { fluxDockerNetwork_appx: { IPAddress: '' } } },
+      });
+
+      expect(dockerService.isContainerDetachedFromNetwork(attachment)).to.equal(true);
+    });
+
+    it('does not flag a stopped container as detached', () => {
+      const attachment = dockerService.parseContainerNetworkAttachment({
+        HostConfig: { NetworkMode: 'fluxDockerNetwork_appx' },
+        State: { Running: false },
+        NetworkSettings: { Networks: {} },
+      });
+
+      expect(attachment.running).to.equal(false);
+      expect(dockerService.isContainerDetachedFromNetwork(attachment)).to.equal(false);
+    });
+
+    it('never flags a non-managed (host-networked) container as detached', () => {
+      const attachment = dockerService.parseContainerNetworkAttachment({
+        HostConfig: { NetworkMode: 'host' },
+        State: { Running: true },
+        NetworkSettings: { Networks: {} },
+      });
+
+      expect(attachment.managed).to.equal(false);
+      expect(dockerService.isContainerDetachedFromNetwork(attachment)).to.equal(false);
+    });
+
+    it('tolerates a partial/empty inspect object', () => {
+      const attachment = dockerService.parseContainerNetworkAttachment({});
+      expect(attachment).to.deep.equal({
+        managed: false, running: false, networkMode: null, attached: false,
+      });
+    });
+
+    it('isContainerDetachedFromNetwork tolerates missing input', () => {
+      expect(dockerService.isContainerDetachedFromNetwork(undefined)).to.equal(false);
+      expect(dockerService.isContainerDetachedFromNetwork(null)).to.equal(false);
+    });
+  });
+
   describe('dockerContainerStats tests', () => {
     it('should return a valid stats object', async () => {
       const containerName = 'website';

--- a/tests/unit/dockerService.test.js
+++ b/tests/unit/dockerService.test.js
@@ -258,9 +258,9 @@ describe('dockerService tests', () => {
     });
   });
 
-  describe('parseContainerNetworkAttachment / isContainerDetachedFromNetwork tests', () => {
+  describe('classifyContainerNetworkAttachment / isContainerDetachedFromNetwork tests', () => {
     it('reports attached when the managed network carries an IP', () => {
-      const attachment = dockerService.parseContainerNetworkAttachment({
+      const attachment = dockerService.classifyContainerNetworkAttachment({
         HostConfig: { NetworkMode: 'fluxDockerNetwork_appx' },
         State: { Running: true },
         NetworkSettings: { Networks: { fluxDockerNetwork_appx: { IPAddress: '172.23.0.5' } } },
@@ -273,7 +273,7 @@ describe('dockerService tests', () => {
     });
 
     it('flags a running managed container with an empty Networks as detached', () => {
-      const attachment = dockerService.parseContainerNetworkAttachment({
+      const attachment = dockerService.classifyContainerNetworkAttachment({
         HostConfig: { NetworkMode: 'fluxDockerNetwork_appx' },
         State: { Running: true },
         NetworkSettings: { Networks: {} },
@@ -285,7 +285,7 @@ describe('dockerService tests', () => {
     });
 
     it('flags detached when the endpoint exists but has no IP (half-programmed)', () => {
-      const attachment = dockerService.parseContainerNetworkAttachment({
+      const attachment = dockerService.classifyContainerNetworkAttachment({
         HostConfig: { NetworkMode: 'fluxDockerNetwork_appx' },
         State: { Running: true },
         NetworkSettings: { Networks: { fluxDockerNetwork_appx: { IPAddress: '' } } },
@@ -295,7 +295,7 @@ describe('dockerService tests', () => {
     });
 
     it('does not flag a stopped container as detached', () => {
-      const attachment = dockerService.parseContainerNetworkAttachment({
+      const attachment = dockerService.classifyContainerNetworkAttachment({
         HostConfig: { NetworkMode: 'fluxDockerNetwork_appx' },
         State: { Running: false },
         NetworkSettings: { Networks: {} },
@@ -306,7 +306,7 @@ describe('dockerService tests', () => {
     });
 
     it('never flags a non-managed (host-networked) container as detached', () => {
-      const attachment = dockerService.parseContainerNetworkAttachment({
+      const attachment = dockerService.classifyContainerNetworkAttachment({
         HostConfig: { NetworkMode: 'host' },
         State: { Running: true },
         NetworkSettings: { Networks: {} },
@@ -317,7 +317,7 @@ describe('dockerService tests', () => {
     });
 
     it('tolerates a partial/empty inspect object', () => {
-      const attachment = dockerService.parseContainerNetworkAttachment({});
+      const attachment = dockerService.classifyContainerNetworkAttachment({});
       expect(attachment).to.deep.equal({
         managed: false, running: false, networkMode: null, attached: false,
       });
@@ -326,6 +326,41 @@ describe('dockerService tests', () => {
     it('isContainerDetachedFromNetwork tolerates missing input', () => {
       expect(dockerService.isContainerDetachedFromNetwork(undefined)).to.equal(false);
       expect(dockerService.isContainerDetachedFromNetwork(null)).to.equal(false);
+    });
+  });
+
+  describe('dockerNetworkState tests', () => {
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('reports exists when the network inspects cleanly', async () => {
+      sinon.stub(Dockerode.prototype, 'getNetwork').returns({ inspect: sinon.stub().resolves({ Name: 'fluxDockerNetwork_appx' }) });
+
+      await expect(dockerService.dockerNetworkState('fluxDockerNetwork_appx')).to.eventually.equal('exists');
+    });
+
+    it('reports absent only when docker itself confirms the network is not listed', async () => {
+      sinon.stub(Dockerode.prototype, 'getNetwork').returns({ inspect: sinon.stub().rejects(new Error('no such network')) });
+      sinon.stub(Dockerode.prototype, 'listNetworks').resolves([{ Name: 'bridge' }, { Name: 'fluxDockerNetwork_other' }]);
+
+      await expect(dockerService.dockerNetworkState('fluxDockerNetwork_appx')).to.eventually.equal('absent');
+    });
+
+    it('reports exists when the inspect failed transiently but the network IS listed', async () => {
+      sinon.stub(Dockerode.prototype, 'getNetwork').returns({ inspect: sinon.stub().rejects(new Error('EAI_AGAIN')) });
+      sinon.stub(Dockerode.prototype, 'listNetworks').resolves([{ Name: 'fluxDockerNetwork_appx' }]);
+
+      await expect(dockerService.dockerNetworkState('fluxDockerNetwork_appx')).to.eventually.equal('exists');
+    });
+
+    it('reports unknown (never absent) when docker cannot answer at all', async () => {
+      // the caller destroys a container on "absent", so an unreachable daemon must
+      // never be read as a missing network
+      sinon.stub(Dockerode.prototype, 'getNetwork').returns({ inspect: sinon.stub().rejects(new Error('connect ENOENT /var/run/docker.sock')) });
+      sinon.stub(Dockerode.prototype, 'listNetworks').rejects(new Error('connect ENOENT /var/run/docker.sock'));
+
+      await expect(dockerService.dockerNetworkState('fluxDockerNetwork_appx')).to.eventually.equal('unknown');
     });
   });
 


### PR DESCRIPTION
## Summary

Heals containers that are **running but attached to no docker network** — a state a plain `docker start` can never repair. The reconciler previously trusted any running container as "already where we want it", so such a container stayed broken indefinitely.

## The bug, from a real incident

A shared-db WordPress app whose **operator** component (`runonflux/shared-db`) could not reach its **mysql** component by name.

Reconstructed from the node's FluxOS logs (debug + error) and live `docker`/`journalctl`:

- **Healthy** until `2026-06-25T03:55:40`.
- At that instant a `docker start` of the operator failed:
  ```
  failed to set up container networking: driver failed programming external connectivity
  on endpoint fluxoperator_wordpress...: failed to bind host port 0.0.0.0:36622/tcp: address already in use
  ```
  (The `768e…` in that message is the **endpoint** id, not the container — container `a5c71e…` was created `2026-06-07` and never recreated.)
- From that minute the operator ran **detached** from `fluxDockerNetwork_<app>`: `State=running`, `NetworkMode=fluxDockerNetwork_<app>`, but `NetworkSettings.Networks = {}` and **no published ports**. No IP, no embedded DNS (so it couldn't resolve `mysql`), API port `36904` dead.
- `monitorSharedDBApps` logged `operatorStatus error: AggregateError` **every 5 min for ~11 days** (1 isolated error before, 2728+ continuous after). Live daemon logs confirmed the embedded resolver forwarding the operator's own name externally (absent from the network) and timing out.
- The node was rebooting **uncleanly every ~4h** (`cleanShutdown=false`), producing the transient host-port conflict at a restart; each later boot did a plain `docker start` → came up detached again, silently.

**Root cause of the persistence:** the reconciler's actuation had `if (actual.running) return; // already where we want it` — it never verified network attachment.

## Design

Invariant checked on **every reconcile of a running container** (post-start *and* the periodic sweep, so it fixes freshly-broken *and* long-broken containers):

> a **running** container whose `HostConfig.NetworkMode` is `fluxDockerNetwork_*` must appear in `NetworkSettings.Networks[NetworkMode]` with an `IPAddress`.

Repair is a **recreate**, not a reconnect: `docker network connect` on a live container does not restore published host ports (e.g. `36904`), so only recreating (fresh endpoint via the tested soft-install path) fully heals it.

The remove step is destructive, so it is guarded — see "Safety" below.

## Changes

- **`dockerService.js`**
  - `classifyContainerNetworkAttachment(info)` — pure classifier over a docker inspect object → `{ managed, running, networkMode, attached }`.
  - `isContainerDetachedFromNetwork(attachment)` — `managed && running && !attached`. Host/none/bridge are never "detached".
  - `dockerNetworkState(networkName)` → `'exists' | 'absent' | 'unknown'`. Distinguishes a stale endpoint from a pruned network. Absence is never inferred from an error: on a failed inspect it probes docker's network list and uses its ANSWER (the same pattern `dockerActual` uses); if docker can't answer at all, `'unknown'` and the caller defers.
- **`containerHealthMonitor.js`** — `recreateMissingContainers(id, { softOnly })`. Without it, the recreate silently falls back to `installApplicationHard` → `createAppVolume` → `fallocate` + `mke2fs`, i.e. it **reformats the app's data volume**, on any `verifyAppVolumeMount` failure. That is tolerable for a container that is gone anyway; it is catastrophic for the heal, which deliberately removes a *live* container whose data is intact. `softOnly` makes the recreate throw (and be retried) instead.
- **`appReconciler.js`**
  - `dockerActual` classifies attachment from the inspect it already does and carries it in `actual` (no second inspect / no TOCTOU).
  - Running branch: verify `actual.attachment`; if detached, confirm, check the preconditions, then recreate — paced, and **without** the uninstall escalation.
  - `!exists` branch: a container **we** removed for a heal is recreated on the no-uninstall path, gated on a **durable** flag rather than in-memory state.
  - Every successful start/recreate arms a short verification pass (a container born detached at boot would otherwise wait for the hourly sweep).
  - Stops the container's stats monitor before force-remove (matching the uninstaller) so its interval can't leak/error-spam against a gone container — and restores it if the remove fails.
- **`appsRuntimeState.js`** — the durable heal state: `networkHealRemoval` ("I removed this container on purpose") plus `networkHealHistory`, the heal's own backoff ladder. Both merged by `prepareCollection`.
- **`appTamperingDetectionService.js`** — document the new `network_detached` event type (audit row only — no scoring, no auto-uninstall).

## Safety

The heal removes a container *before* it recreates it, so every guard below exists to make sure that trade is never a bad one.

- **Never destroys what it cannot rebuild.** The remove is gated on the recreate's own preconditions, checked first: the app must have a `compose` spec (`recreateMissingContainers` throws unconditionally without one — a v1-3 app's container would have been destroyed permanently, since the heal by design never escalates to an uninstall that would re-place the app), and the data volume must verify as mounted (the recreate is `softOnly`, so an unverifiable volume means it would fail *after* the container was gone). If either fails, the container is left running and the reason is logged loudly.
- **Never reformats the app's data.** The recreate is `softOnly` (see Changes): a transient volume-check failure retries instead of running `mke2fs` over the user's volume.
- **Never uninstalls the app.** `recreateMissing`'s failure path runs `removeAppLocally` (the whole app); a transient recreate failure must not uninstall a degraded-but-serving app. The heal recreates directly and re-arms a paced retry; no path from the heal reaches an uninstall.
- **Survives a FluxOS restart mid-heal.** The container is legitimately absent between the force-remove and the recreate. That fact is persisted in `appsRuntimeState.networkHealRemoval` **before** the remove, and cleared as soon as the container exists again. Without it, a restart in that window would make the next process read the absence as tampering (a false `container_vanished`) and, on a failed recreate, uninstall the app. The read of that flag **fails closed**: a DB error throws and the reconciler defers, because guessing "not a heal removal" is the destructive guess.
- **Never actuates on a container it no longer owns.** `isManagedElsewhere` is sampled at reconcile entry, but the heal spends seconds confirming — so it is re-checked at actuation time, right before the force-remove. A redeploy or backup that starts during the confirmation must not have its container removed underneath it.
- **Confirmed, and persisted.** The detached state must survive an in-pass settle + re-inspect **and** have persisted for 60s of wall-clock since first sighting. (Wall-clock, not a count of reconcile passes: two passes can land in the same instant, since the workqueue re-runs a dirty id immediately.) A dockerd restart with live-restore can answer an inspect before libnetwork has restored endpoint IPs — and the reconnect sweep enqueues every component at exactly that moment — so a short confirm alone would rebuild the node's whole workload.
- **Refuses a node-wide rebuild.** If several containers look detached at once, that is a daemon-level fault, not N stale endpoints: the heal says so loudly and destroys nothing.
- **Paced, not capped.** Heal attempts walk their own durable ladder (same shape as the crash backoff, decaying to a 30m cap, but a *separate* history — sharing one would let a heal's attempts hold down the very container it just recreated, and would block the heal of a crash-looping container). A hard attempt cap would park the heal in a terminal state until the FluxOS process restarted — not level-based, and on an unattended node "leave it for manual intervention" means "leave it broken". Retrying forever is convergent at the network level: while the container is broken or absent this node stops advertising it in `apprunning`, its location record expires on TTL and the app is re-placed elsewhere — without destroying this node's bind-mounted data, while the paced retry keeps working the local problem.
- **Only heals a stale endpoint.** If the network itself was pruned, a recreate would fail on a missing `NetworkMode`, so the container is left in place and a `network_pruned` event is recorded. If docker cannot say whether the network exists, nothing is destroyed.
- **Fails loud, not silent.** The pre-remove writes (tamper event, ladder, flag) abort the remove and re-arm a retry if they throw, rather than escaping `reconcile` and leaving the container broken until the hourly sweep. A heal whose recreate keeps failing records `recreation_failed` / `network_pruned` — a looping heal must not be an invisible outage.
- **Bounded node-tampering-event footprint.** `network_detached` is recorded once per episode (not per attempt) into the tampering-events collection that `appTamperingBlocklistService` counts. That count only DOSes a node that is *also* on the manually-curated blocklist and over the threshold, so a normal node is never DOSed by it; recording once keeps the contribution minimal for what is an operational, not malicious, fault.
- Only `fluxDockerNetwork_*` containers are eligible; stopped / awaiting-controller containers are excluded; an inspect error is treated as "not detached".

## Testing

Run with `NODE_CONFIG_DIR=$PWD/tests/unit/globalconfig` (fully `proxyquire`-mocked — no DB/docker needed). **128 passing**, 0 failing:

- **`tests/unit/appReconciler.test.js`: 84** — the `network-detach heal` block covers: attached → no-op + heal state cleared; the state cleared for a container that merely *exists*, even stopped (the flag must not leak); a detached read that clears on re-inspect destroys nothing; a detach that has not persisted destroys nothing; a persisted detach sets the durable flag **before** the remove, stops monitoring, recreates with `{ softOnly: true }`, never uninstalls; **refuses to remove a v1-3 container it could never recreate**; **refuses to remove a container whose volume cannot be verified**; aborts when another operation takes the container over during the confirmation; **refuses a node-wide rebuild** when many containers look detached at once; network confirmed gone → no destroy + `network_pruned`; network *unreadable* → no destroy and no false `network_pruned`; paced on its own ladder (and provably not on the crash one); no remove if the heal cannot be recorded durably; a failed force-remove restores monitoring; a failed recreate retries, records `recreation_failed`, never uninstalls; a persistently broken heal keeps retrying (no terminal give-up) with one tamper event per episode; a **FluxOS restart mid-heal** still recreates while a genuine vanish still takes the vanished path; an **unreadable heal flag defers** rather than guessing. Plus post-start attachment verification.
- **`tests/unit/appsRuntimeState.test.js`: 32** — the durable flag (persists across a fresh module instance, dropped on uninstall, **throws rather than answering false** on a read failure) and the heal ladder (paces, does not touch `restartHistory`, resets once healthy).
- **`tests/unit/containerHealthMonitor.test.js`: 12** — `softOnly` throws instead of hard-installing (component and whole-app paths), still soft-installs normally, and leaves the default vanished-container path free to hard-install.
- **`tests/unit/dockerService.test.js`: 11** for the pure classifier + `dockerNetworkState` (notably: `unknown`, never `absent`, when docker can't answer).

## Scope / follow-up

Defense-in-depth (auto-heal). The environmental trigger — a node rebooting uncleanly every ~4h — is a separate operational issue, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
