### PR TITLE
feat(apps): honest, attributable app-tampering incident model

### DIFF
--- a/ZelBack/src/services/appTamperingBlocklistService.js
+++ b/ZelBack/src/services/appTamperingBlocklistService.js
@@ -6,30 +6,13 @@ const fluxNetworkHelper = require('./fluxNetworkHelper');
 const generalService = require('./generalService');
 const daemonServiceMiscRpcs = require('./daemonService/daemonServiceMiscRpcs');
 const benchmarkService = require('./benchmarkService');
+const appTamperingDetectionService = require('./appTamperingDetectionService');
 
 const BLOCKLIST_URL = `${config.github.rawBaseUrl}/helpers/tamperingblockednodes.json`;
 const CHECK_INTERVAL_MS = 12 * 60 * 60 * 1000; // 12 hours
 const SYNC_POLL_MS = 60 * 1000; // 60s while waiting for daemon sync
 const TAMPER_SCORE_THRESHOLD = 10;
 const DOS_MESSAGE_PREFIX = 'Node flagged via tampering blocklist';
-
-// Per-type weights for the tamper score. Not every event is tamper evidence:
-// recreation_failed is an operational fault (registry, image pull, disk) and
-// node_reboot is an observation feeding operator-level analysis — both weigh 0
-// via omission, because punishing them would penalize honest nodes for infra
-// noise. container_vanished weighs highest: containers persist as `exited`
-// across a clean reboot, so a positively-confirmed missing container is the
-// strongest local indicator of host-side interference this data has. The
-// mount/volume/network types are real signals but dominated by late-data-disk
-// and network-not-ready boot races, so they weigh low until the phase-1
-// schema can flag boot-storm context explicitly.
-const TAMPER_EVENT_WEIGHTS = {
-  container_vanished: 3,
-  network_pruned: 1,
-  network_detached: 1,
-  mount_vanished: 1,
-  volume_missing: 1,
-};
 
 const tamperingEventsCollection = config.database.local.collections.appTamperingEvents;
 
@@ -90,14 +73,14 @@ async function isArcaneOs() {
 }
 
 /**
- * Weighted tamper score over distinct incidents in the events collection
- * (30-day TTL bounds the window). Rows are collapsed to incident keys of
- * (eventType, appName, calendar day) before weighting: the collection is
- * row-per-observation, so a single flapping app — or rows inserted before
- * episode dedup existed — would otherwise count one incident many times.
- * A raw `countDocuments({})` here once meant a single late-disk reboot of a
- * multi-app node could cross the enforcement gate; distinct-incident scoring
- * makes the threshold mean "how many app-days showed tamper symptoms".
+ * Tamper score over incident documents (30-day TTL bounds the window).
+ * Each schemaVersion>=1 document already IS one deduplicated incident with a
+ * severity stamped at write time, so scoring is a plain sum: severity,
+ * discounted for incidents flagged duringBootStorm (any reboot with a late
+ * data disk produces per-app mount/volume noise — discounted, never dropped).
+ * Pre-schema rows are excluded on purpose: they are row-per-observation noise
+ * with no severity or boot context, exactly the data a raw countDocuments({})
+ * once let cross the enforcement gate on honest nodes; they age out via TTL.
  */
 async function computeTamperScore() {
   try {
@@ -105,18 +88,14 @@ async function computeTamperScore() {
     if (!db) return 0;
     const database = db.db(config.database.local.database);
     const pipeline = [
-      {
-        $group: {
-          _id: {
-            eventType: '$eventType',
-            appName: '$appName',
-            day: { $dateToString: { format: '%Y-%m-%d', date: '$detectedAt' } },
-          },
-        },
-      },
+      { $match: { schemaVersion: { $gte: 1 } } },
+      { $project: { _id: 0, severity: 1, duringBootStorm: 1 } },
     ];
     const incidents = await dbHelper.aggregateInDatabase(database, tamperingEventsCollection, pipeline);
-    return incidents.reduce((score, incident) => score + (TAMPER_EVENT_WEIGHTS[incident._id.eventType] ?? 0), 0);
+    return incidents.reduce((score, incident) => {
+      const discount = incident.duringBootStorm ? appTamperingDetectionService.BOOT_STORM_DISCOUNT : 1;
+      return score + (incident.severity ?? 0) * discount;
+    }, 0);
   } catch (error) {
     log.warn(`appTamperingBlocklist - failed to compute tamper score: ${error.message}`);
     return 0;
@@ -278,6 +257,5 @@ module.exports = {
   getMyTxhash,
   isDosActive,
   TAMPER_SCORE_THRESHOLD,
-  TAMPER_EVENT_WEIGHTS,
   DOS_MESSAGE_PREFIX,
 };

--- a/ZelBack/src/services/appTamperingBlocklistService.js
+++ b/ZelBack/src/services/appTamperingBlocklistService.js
@@ -89,12 +89,18 @@ async function computeTamperScore() {
     const database = db.db(config.database.local.database);
     const pipeline = [
       { $match: { schemaVersion: { $gte: 1 } } },
-      { $project: { _id: 0, severity: 1, duringBootStorm: 1 } },
+      { $project: {
+        _id: 0, severity: 1, duringBootStorm: 1, eventType: 1,
+      } },
     ];
     const incidents = await dbHelper.aggregateInDatabase(database, tamperingEventsCollection, pipeline);
     return incidents.reduce((score, incident) => {
-      const discount = incident.duringBootStorm ? appTamperingDetectionService.BOOT_STORM_DISCOUNT : 1;
-      return score + (incident.severity ?? 0) * discount;
+      // The storm discount applies only to the boot-race event family; a
+      // container_vanished right after boot scores full weight (see
+      // BOOT_STORM_DISCOUNT_TYPES for why).
+      const discounted = incident.duringBootStorm
+        && appTamperingDetectionService.BOOT_STORM_DISCOUNT_TYPES.includes(incident.eventType);
+      return score + (incident.severity ?? 0) * (discounted ? appTamperingDetectionService.BOOT_STORM_DISCOUNT : 1);
     }, 0);
   } catch (error) {
     log.warn(`appTamperingBlocklist - failed to compute tamper score: ${error.message}`);

--- a/ZelBack/src/services/appTamperingBlocklistService.js
+++ b/ZelBack/src/services/appTamperingBlocklistService.js
@@ -10,8 +10,26 @@ const benchmarkService = require('./benchmarkService');
 const BLOCKLIST_URL = `${config.github.rawBaseUrl}/helpers/tamperingblockednodes.json`;
 const CHECK_INTERVAL_MS = 12 * 60 * 60 * 1000; // 12 hours
 const SYNC_POLL_MS = 60 * 1000; // 60s while waiting for daemon sync
-const TAMPERING_EVENT_THRESHOLD = 10;
+const TAMPER_SCORE_THRESHOLD = 10;
 const DOS_MESSAGE_PREFIX = 'Node flagged via tampering blocklist';
+
+// Per-type weights for the tamper score. Not every event is tamper evidence:
+// recreation_failed is an operational fault (registry, image pull, disk) and
+// node_reboot is an observation feeding operator-level analysis — both weigh 0
+// via omission, because punishing them would penalize honest nodes for infra
+// noise. container_vanished weighs highest: containers persist as `exited`
+// across a clean reboot, so a positively-confirmed missing container is the
+// strongest local indicator of host-side interference this data has. The
+// mount/volume/network types are real signals but dominated by late-data-disk
+// and network-not-ready boot races, so they weigh low until the phase-1
+// schema can flag boot-storm context explicitly.
+const TAMPER_EVENT_WEIGHTS = {
+  container_vanished: 3,
+  network_pruned: 1,
+  network_detached: 1,
+  mount_vanished: 1,
+  volume_missing: 1,
+};
 
 const tamperingEventsCollection = config.database.local.collections.appTamperingEvents;
 
@@ -72,17 +90,35 @@ async function isArcaneOs() {
 }
 
 /**
- * Count documents in the tampering events collection (all types, all apps).
- * The 30-day TTL on detectedAt already scopes this.
+ * Weighted tamper score over distinct incidents in the events collection
+ * (30-day TTL bounds the window). Rows are collapsed to incident keys of
+ * (eventType, appName, calendar day) before weighting: the collection is
+ * row-per-observation, so a single flapping app — or rows inserted before
+ * episode dedup existed — would otherwise count one incident many times.
+ * A raw `countDocuments({})` here once meant a single late-disk reboot of a
+ * multi-app node could cross the enforcement gate; distinct-incident scoring
+ * makes the threshold mean "how many app-days showed tamper symptoms".
  */
-async function countTamperingEvents() {
+async function computeTamperScore() {
   try {
     const db = dbHelper.databaseConnection();
     if (!db) return 0;
     const database = db.db(config.database.local.database);
-    return await database.collection(tamperingEventsCollection).countDocuments({});
+    const pipeline = [
+      {
+        $group: {
+          _id: {
+            eventType: '$eventType',
+            appName: '$appName',
+            day: { $dateToString: { format: '%Y-%m-%d', date: '$detectedAt' } },
+          },
+        },
+      },
+    ];
+    const incidents = await dbHelper.aggregateInDatabase(database, tamperingEventsCollection, pipeline);
+    return incidents.reduce((score, incident) => score + (TAMPER_EVENT_WEIGHTS[incident._id.eventType] ?? 0), 0);
   } catch (error) {
-    log.warn(`appTamperingBlocklist - failed to count events: ${error.message}`);
+    log.warn(`appTamperingBlocklist - failed to compute tamper score: ${error.message}`);
     return 0;
   }
 }
@@ -121,8 +157,8 @@ async function waitForDaemonSynced() {
 }
 
 /**
- * Core check: if our txhash is in the blocklist AND we have more than
- * TAMPERING_EVENT_THRESHOLD events, DOS the node. Otherwise, if we previously
+ * Core check: if our txhash is in the blocklist AND the weighted tamper score
+ * exceeds TAMPER_SCORE_THRESHOLD, DOS the node. Otherwise, if we previously
  * DOSed it, clear the DOS. This service owns the DOS message it sets and only
  * clears it when its own condition is no longer true.
  */
@@ -143,10 +179,10 @@ async function enforceBlocklist() {
     return;
   }
 
-  const [myTxhash, blocklist, eventCount] = await Promise.all([
+  const [myTxhash, blocklist, tamperScore] = await Promise.all([
     getMyTxhash(),
     fetchBlocklist(),
-    countTamperingEvents(),
+    computeTamperScore(),
   ]);
 
   if (!myTxhash) {
@@ -155,13 +191,13 @@ async function enforceBlocklist() {
   }
 
   const listed = Array.isArray(blocklist) && blocklist.includes(myTxhash);
-  const exceedsThreshold = eventCount > TAMPERING_EVENT_THRESHOLD;
+  const exceedsThreshold = tamperScore > TAMPER_SCORE_THRESHOLD;
   const shouldDos = listed && exceedsThreshold;
 
-  log.info(`appTamperingBlocklist - txhash=${myTxhash} listed=${listed} events=${eventCount} shouldDos=${shouldDos}`);
+  log.info(`appTamperingBlocklist - txhash=${myTxhash} listed=${listed} score=${tamperScore} shouldDos=${shouldDos}`);
 
   if (shouldDos) {
-    const message = `${DOS_MESSAGE_PREFIX}: ${eventCount} events, txhash ${myTxhash}`;
+    const message = `${DOS_MESSAGE_PREFIX}: tamper score ${tamperScore}, txhash ${myTxhash}`;
     fluxNetworkHelper.setStickyDosMessage(message);
     fluxNetworkHelper.setStickyDosStateValue(100);
     ourDosActive = true;
@@ -170,7 +206,7 @@ async function enforceBlocklist() {
   }
 
   if (ourDosActive || isOurStickyDos()) {
-    log.info(`appTamperingBlocklist - clearing sticky DOS (listed=${listed}, events=${eventCount})`);
+    log.info(`appTamperingBlocklist - clearing sticky DOS (listed=${listed}, score=${tamperScore})`);
     fluxNetworkHelper.clearStickyDosMessage();
     ourDosActive = false;
   }
@@ -238,9 +274,10 @@ module.exports = {
   stop,
   enforceBlocklist,
   fetchBlocklist,
-  countTamperingEvents,
+  computeTamperScore,
   getMyTxhash,
   isDosActive,
-  TAMPERING_EVENT_THRESHOLD,
+  TAMPER_SCORE_THRESHOLD,
+  TAMPER_EVENT_WEIGHTS,
   DOS_MESSAGE_PREFIX,
 };

--- a/ZelBack/src/services/appTamperingBlocklistService.js
+++ b/ZelBack/src/services/appTamperingBlocklistService.js
@@ -6,7 +6,6 @@ const fluxNetworkHelper = require('./fluxNetworkHelper');
 const generalService = require('./generalService');
 const daemonServiceMiscRpcs = require('./daemonService/daemonServiceMiscRpcs');
 const benchmarkService = require('./benchmarkService');
-const appTamperingDetectionService = require('./appTamperingDetectionService');
 
 const BLOCKLIST_URL = `${config.github.rawBaseUrl}/helpers/tamperingblockednodes.json`;
 const CHECK_INTERVAL_MS = 12 * 60 * 60 * 1000; // 12 hours
@@ -75,9 +74,7 @@ async function isArcaneOs() {
 /**
  * Tamper score over incident documents (30-day TTL bounds the window).
  * Each schemaVersion>=1 document already IS one deduplicated incident with a
- * severity stamped at write time, so scoring is a plain sum: severity,
- * discounted for incidents flagged duringBootStorm (any reboot with a late
- * data disk produces per-app mount/volume noise — discounted, never dropped).
+ * severity stamped at write time, so scoring is a plain sum of severities.
  * Pre-schema rows are excluded on purpose: they are row-per-observation noise
  * with no severity or boot context, exactly the data a raw countDocuments({})
  * once let cross the enforcement gate on honest nodes; they age out via TTL.
@@ -89,19 +86,10 @@ async function computeTamperScore() {
     const database = db.db(config.database.local.database);
     const pipeline = [
       { $match: { schemaVersion: { $gte: 1 } } },
-      { $project: {
-        _id: 0, severity: 1, duringBootStorm: 1, eventType: 1,
-      } },
+      { $project: { _id: 0, severity: 1 } },
     ];
     const incidents = await dbHelper.aggregateInDatabase(database, tamperingEventsCollection, pipeline);
-    return incidents.reduce((score, incident) => {
-      // The storm discount applies only to the boot-race event family; a
-      // container_vanished right after boot scores full weight (see
-      // BOOT_STORM_DISCOUNT_TYPES for why).
-      const discounted = incident.duringBootStorm
-        && appTamperingDetectionService.BOOT_STORM_DISCOUNT_TYPES.includes(incident.eventType);
-      return score + (incident.severity ?? 0) * (discounted ? appTamperingDetectionService.BOOT_STORM_DISCOUNT : 1);
-    }, 0);
+    return incidents.reduce((score, incident) => score + (incident.severity ?? 0), 0);
   } catch (error) {
     log.warn(`appTamperingBlocklist - failed to compute tamper score: ${error.message}`);
     return 0;

--- a/ZelBack/src/services/appTamperingBlocklistService.js
+++ b/ZelBack/src/services/appTamperingBlocklistService.js
@@ -76,8 +76,9 @@ async function isArcaneOs() {
  * Each schemaVersion>=1 document already IS one deduplicated incident with a
  * severity stamped at write time, so scoring is a plain sum of severities.
  * Pre-schema rows are excluded on purpose: they are row-per-observation noise
- * with no severity or boot context, exactly the data a raw countDocuments({})
- * once let cross the enforcement gate on honest nodes; they age out via TTL.
+ * with no severity, exactly the data a raw countDocuments({}) once let cross
+ * the enforcement gate on honest nodes. The startup purge removes them; the
+ * filter here covers anything written before that purge has run.
  */
 async function computeTamperScore() {
   try {

--- a/ZelBack/src/services/appTamperingDetectionService.js
+++ b/ZelBack/src/services/appTamperingDetectionService.js
@@ -1,16 +1,21 @@
 const config = require('config');
+const os = require('os');
 const fs = require('fs').promises;
 const log = require('../lib/log');
 const dbHelper = require('./dbHelper');
 const messageHelper = require('./messageHelper');
+const generalService = require('./generalService');
+const daemonServiceFluxnodeRpcs = require('./daemonService/daemonServiceFluxnodeRpcs');
+const { localAppsInformation } = require('./utils/appConstants');
 
-// All tamper-feature behaviour (episode dedup, boot identity, event taxonomy)
+// All tamper-feature behaviour (incident rollup, boot identity, severities)
 // deliberately lives inside this service rather than at the emitting call
 // sites: the call sites (appReconciler, crontabAndMountsCleanup,
 // syncthingFolderStateMachine) sit in files under heavy parallel rework on the
 // v9 branch, while this file is identical across branches. Centralizing here
 // keeps the feature rebase-safe and guarantees every emitter gets the same
-// semantics without call-site edits.
+// semantics without call-site edits. Call sites still pass plain
+// (appName, eventType, details); everything else is derived here.
 
 const tamperingEventsCollection = config.database.local.collections.appTamperingEvents;
 const nodeStartupTrackerCollection = config.database.local.collections.nodeStartupTracker;
@@ -22,18 +27,62 @@ const BOOT_HISTORY_KEY = 'bootHistory';
 // cadence (~4h), comfortably beyond the collection's 30-day event TTL.
 const BOOT_HISTORY_MAX = 200;
 
-// One row per (appName, eventType) per hour. The reconciler re-attempts a
-// failed recreation on a seconds-scale backoff and re-sweeps hourly, so a
-// single persistent fault (unpullable image, missing volume) used to insert
-// hundreds of rows for one incident, drowning genuine signal and inflating
-// the enforcement count. Suppressed repeats are dropped, not counted, until
-// the phase-1 incident schema adds first/last-seen rollups.
-const EPISODE_WINDOW_MS = 60 * 60 * 1000;
-// `${appName}|${eventType}` -> epoch ms of the last inserted row. In-memory
-// on purpose: a process restart clears it, and per-boot events (mount races
-// on a late data disk) should record once per boot.
-const episodeMarkers = new Map();
-const EPISODE_MARKERS_MAX = 1000;
+// One incident document per (appName, eventType) per hour bucket. The
+// reconciler re-attempts a failed recreation on a seconds-scale backoff and
+// re-sweeps hourly, so a single persistent fault used to insert hundreds of
+// rows for one incident; the rollup collapses those into a count. The time
+// bucket is load-bearing: keyed on bootId alone, a node up for weeks would
+// fold every same-type event across that whole span into one document,
+// erasing distinct incidents.
+const INCIDENT_BUCKET_MS = 60 * 60 * 1000;
+
+// Events recorded within this window after a machine boot are flagged
+// duringBootStorm and down-weighted in scoring — never dropped. Any reboot
+// with a late data disk legitimately produces mount/volume events for every
+// app; outright suppression would instead hand tamperers a laundering trick
+// (tamper, then reboot, and the evidence goes out with the boot noise).
+const BOOT_STORM_WINDOW_MS = 30 * 60 * 1000;
+const BOOT_STORM_DISCOUNT = 0.25;
+
+// Per-type severity, stamped on each incident at write time so scoring reads
+// stored values rather than re-deriving them. recreation_failed is an
+// operational fault (registry, image pull, disk) and node_reboot is an
+// observation feeding operator-level analysis — both are recorded for
+// visibility but carry no tamper weight, because punishing them would
+// penalize honest nodes for infra noise. container_vanished weighs highest:
+// containers persist as `exited` across a clean reboot, so a
+// positively-confirmed missing container is the strongest local indicator of
+// host-side interference this data has. The mount/volume/network types are
+// real signals but dominated by boot races, hence low severity plus the
+// boot-storm discount.
+const EVENT_SEVERITY = {
+  container_vanished: 3,
+  network_pruned: 1,
+  network_detached: 1,
+  mount_vanished: 1,
+  volume_missing: 1,
+  recreation_failed: 0,
+  node_reboot: 0,
+};
+
+const EVENTS_DEFAULT_LIMIT = 500;
+const EVENTS_MAX_LIMIT = 1000;
+
+// Identity lookups are best-effort: an event must still record while the
+// daemon is down, just unattributed. Failures back off rather than hammering
+// a dead daemon on every event.
+const IDENTITY_RETRY_MS = 5 * 60 * 1000;
+const ATTRIBUTION_TTL_MS = 60 * 60 * 1000;
+
+// Boot context, set once by checkNodeReboot() during startup. Until it runs
+// (or on hosts without a readable boot_id) events fall back to an 'unknown'
+// boot in their incident key and are never flagged as boot storm.
+let currentBootId = null;
+let bootStormUntilMs = 0;
+
+let nodeIdentityCache = null;
+let identityRetryAfterMs = 0;
+const appAttributionCache = new Map(); // appName -> { ownerZelid, appHash, cachedAt }
 
 /**
  * Returns true when a Docker/daemon error message indicates a missing network
@@ -54,68 +103,189 @@ function isNetworkMissingError(errorMessage) {
 }
 
 /**
- * Drop episode markers whose window has already elapsed so the map cannot
- * grow unbounded on a node with many flapping apps.
- * @param {number} now - Current epoch ms
+ * Node identity (collateral outpoint, ip, operator pubkey/payout) from the
+ * daemon's own fluxnode status, cached for the process lifetime. Returns null
+ * while the daemon is unreachable — events record unattributed and the next
+ * event after the backoff retries.
+ * @returns {Promise<object|null>}
  */
-function pruneExpiredEpisodeMarkers(now) {
-  episodeMarkers.forEach((recordedAt, key) => {
-    if (now - recordedAt >= EPISODE_WINDOW_MS) episodeMarkers.delete(key);
-  });
+async function getNodeIdentity() {
+  if (nodeIdentityCache) return nodeIdentityCache;
+  if (Date.now() < identityRetryAfterMs) return null;
+  try {
+    const status = await daemonServiceFluxnodeRpcs.getFluxNodeStatus();
+    if (!status || status.status !== 'success' || !status.data) {
+      throw new Error('fluxnode status unavailable');
+    }
+    const node = status.data;
+    let nodeTxid = node.txhash ?? null;
+    let nodeOutidx = node.outidx ?? null;
+    if ((nodeTxid === null || nodeOutidx === null) && node.collateral) {
+      const collateralInfo = generalService.getCollateralInfo(node.collateral);
+      nodeTxid = collateralInfo.txhash;
+      nodeOutidx = collateralInfo.txindex;
+    }
+    nodeIdentityCache = {
+      nodeTxid,
+      nodeOutidx,
+      nodeIp: node.ip ?? null,
+      pubkey: node.pubkey ?? null,
+      paymentAddress: node.payment_address ?? null,
+    };
+    return nodeIdentityCache;
+  } catch (error) {
+    identityRetryAfterMs = Date.now() + IDENTITY_RETRY_MS;
+    log.debug(`appTamperingDetection - node identity unavailable: ${error.message}`);
+    return null;
+  }
 }
 
 /**
- * Record a tampering event. Inserts one row per (appName, eventType) episode:
- * repeat calls inside EPISODE_WINDOW_MS after a successful insert are dropped,
- * so retry storms collapse into a single row while distinct incidents in later
- * windows still record. Documents expire 30 days after detectedAt (TTL index).
+ * Reduce an emitted app name to the main app name used in the installed-apps
+ * database. Call sites pass either a spec name ('MyApp') or a docker
+ * identifier ('fluxcomponent_MyApp' / 'zelMyApp'); component and app names
+ * are alphanumeric, so everything after the first underscore is the app.
+ * @param {string} appName
+ * @returns {string}
+ */
+function deriveMainAppName(appName) {
+  let name = appName;
+  if (name.startsWith('zel')) name = name.slice(3);
+  else if (name.startsWith('flux')) name = name.slice(4);
+  const underscore = name.indexOf('_');
+  if (underscore !== -1) name = name.slice(underscore + 1);
+  return name;
+}
+
+/**
+ * Owner/spec-hash attribution for an app from the local installed-apps
+ * database, cached per emitted name. Tries the name as passed first (a real
+ * app name may itself start with 'flux'), then the derived main app name.
+ * Best-effort: returns null fields when the app cannot be found.
+ * @param {string} appName - Name exactly as passed by the emitter
+ * @returns {Promise<object|null>}
+ */
+async function getAppAttribution(appName) {
+  if (!appName || appName === SYSTEM_APP_NAME) return null;
+  const cached = appAttributionCache.get(appName);
+  if (cached && Date.now() - cached.cachedAt < ATTRIBUTION_TTL_MS) return cached;
+  try {
+    const db = dbHelper.databaseConnection();
+    if (!db) return null;
+    const appsDatabase = db.db(config.database.appslocal.database);
+    const projection = { projection: { _id: 0, owner: 1, hash: 1 } };
+    let app = await dbHelper.findOneInDatabase(
+      appsDatabase, localAppsInformation, { name: appName }, projection,
+    );
+    if (!app) {
+      const mainName = deriveMainAppName(appName);
+      if (mainName !== appName) {
+        app = await dbHelper.findOneInDatabase(
+          appsDatabase, localAppsInformation, { name: mainName }, projection,
+        );
+      }
+    }
+    const attribution = {
+      ownerZelid: app?.owner ?? null,
+      appHash: app?.hash ?? null,
+      cachedAt: Date.now(),
+    };
+    appAttributionCache.set(appName, attribution);
+    return attribution;
+  } catch (error) {
+    log.debug(`appTamperingDetection - attribution lookup failed for ${appName}: ${error.message}`);
+    return null;
+  }
+}
+
+/**
+ * Record a tampering event as an incident rollup (schemaVersion 1).
+ * One document per (appName, eventType, incidentKey) where incidentKey is
+ * the boot_id plus an hourly time bucket; repeat calls increment `count` and
+ * advance `lastSeen`, so retry storms collapse while the incident keeps its
+ * full observation tally. Each document carries node identity, operator
+ * identity, app attribution, severity and boot-storm context so fleet-level
+ * consumers can attribute and weigh it without joining local state.
+ * Documents expire 30 days after lastSeen (TTL index).
  * @param {string} appName - Application name (or SYSTEM_APP_NAME)
- * @param {string} eventType - One of: container_vanished, recreation_failed,
- *   network_pruned, network_detached, mount_vanished, volume_missing,
- *   node_reboot
- * @param {string} details - Free-text context about the event
+ * @param {string} eventType - One of the EVENT_SEVERITY keys
+ * @param {string} details - Free-text context (stored once per incident)
  */
 async function recordEvent(appName, eventType, details) {
   try {
-    const now = Date.now();
-    const episodeKey = `${appName}|${eventType}`;
-    const lastRecordedAt = episodeMarkers.get(episodeKey);
-    if (lastRecordedAt !== undefined && now - lastRecordedAt < EPISODE_WINDOW_MS) {
-      log.debug(`appTamperingDetection - ${eventType} for ${appName} already recorded this episode, skipping`);
-      return;
-    }
     const db = dbHelper.databaseConnection();
     if (!db) {
       log.warn('appTamperingDetection - DB not available, skipping event');
       return;
     }
     const database = db.db(config.database.local.database);
-    const doc = {
-      appName,
-      eventType,
-      details,
-      detectedAt: new Date(),
+    const now = new Date();
+    const incidentKey = `${currentBootId ?? 'unknown'}:${Math.floor(now.getTime() / INCIDENT_BUCKET_MS)}`;
+    const duringBootStorm = now.getTime() < bootStormUntilMs;
+    const [identity, attribution] = await Promise.all([
+      getNodeIdentity(),
+      getAppAttribution(appName),
+    ]);
+    const query = { appName, eventType, incidentKey };
+    const update = {
+      $setOnInsert: {
+        schemaVersion: 1,
+        appName,
+        eventType,
+        incidentKey,
+        severity: EVENT_SEVERITY[eventType] ?? 0,
+        duringBootStorm,
+        bootId: currentBootId,
+        uptimeSecAtEvent: Math.round(os.uptime()),
+        firstSeen: now,
+        detailsSample: details,
+        nodeTxid: identity?.nodeTxid ?? null,
+        nodeOutidx: identity?.nodeOutidx ?? null,
+        nodeIp: identity?.nodeIp ?? null,
+        pubkey: identity?.pubkey ?? null,
+        paymentAddress: identity?.paymentAddress ?? null,
+        ownerZelid: attribution?.ownerZelid ?? null,
+        appHash: attribution?.appHash ?? null,
+      },
+      $set: { lastSeen: now },
+      $inc: { count: 1 },
     };
-    await dbHelper.insertOneToDatabase(database, tamperingEventsCollection, doc);
-    // Marked only after a successful insert: a failed write must not consume
-    // the episode, otherwise the event would be silently lost for an hour.
-    episodeMarkers.set(episodeKey, now);
-    if (episodeMarkers.size > EPISODE_MARKERS_MAX) pruneExpiredEpisodeMarkers(now);
-    log.info(`appTamperingDetection - recorded ${eventType} for ${appName}`);
+    let result;
+    try {
+      result = await dbHelper.findOneAndUpdateInDatabase(
+        database, tamperingEventsCollection, query, update, { upsert: true },
+      );
+    } catch (error) {
+      // Two concurrent upserts racing on a brand-new incident key can trip
+      // the unique index; the loser retries once and lands as the increment.
+      if (error && error.code === 11000) {
+        result = await dbHelper.findOneAndUpdateInDatabase(
+          database, tamperingEventsCollection, query, update, { upsert: true },
+        );
+      } else {
+        throw error;
+      }
+    }
+    // Insert detection across driver result shapes: v6 returns the pre-image
+    // doc or null; older shapes return { value, lastErrorObject }.
+    const inserted = !result || result.value === null || result?.lastErrorObject?.updatedExisting === false;
+    if (inserted) {
+      log.info(`appTamperingDetection - recorded ${eventType} for ${appName}${duringBootStorm ? ' (boot storm)' : ''}`);
+    } else {
+      log.debug(`appTamperingDetection - ${eventType} for ${appName} repeated, incident count incremented`);
+    }
   } catch (error) {
     log.error(`appTamperingDetection - failed to record event: ${error.message}`);
   }
 }
 
-const EVENTS_DEFAULT_LIMIT = 500;
-const EVENTS_MAX_LIMIT = 1000;
-
 /**
- * GET API handler. Returns tampering events, optionally filtered by appname,
- * sorted by most recent first. Results are capped: the route is public, so an
- * uncapped no-arg query would dump the whole collection to anyone. A stable
- * paging key arrives with the phase-1 schema (_id is stripped today); until
- * then newest-first plus `limit` is the supported access pattern.
+ * GET API handler. Returns tampering incidents, optionally filtered by
+ * appname, most recent first. Results are capped: the route is public, so an
+ * uncapped no-arg query would dump the whole collection to anyone. Documents
+ * include _id as a stable paging/identity key. Pre-schema rows (detectedAt,
+ * no lastSeen) sort after current-schema incidents until they age out via
+ * their 30-day TTL.
  * Route: GET /apps/tamperingevents/:appname? (query: ?limit=1..1000)
  * @param {object} req - Express request
  * @param {object} res - Express response
@@ -131,11 +301,9 @@ async function getEvents(req, res) {
     const db = dbHelper.databaseConnection();
     const database = db.db(config.database.local.database);
     const query = appname ? { appName: appname } : {};
-    const projection = {
-      projection: { _id: 0 }, sort: { detectedAt: -1 }, limit,
-    };
+    const options = { sort: { lastSeen: -1, detectedAt: -1 }, limit };
     const results = await dbHelper.findInDatabase(
-      database, tamperingEventsCollection, query, projection,
+      database, tamperingEventsCollection, query, options,
     );
     const message = messageHelper.createDataMessage(results);
     res.json(message);
@@ -151,8 +319,10 @@ async function getEvents(req, res) {
  * restart using the kernel boot identity (/proc/sys/kernel/random/boot_id — a
  * UUID regenerated on every boot, stable across process restarts). On a
  * genuine reboot it records a single `node_reboot` observation under the
- * synthetic __system__ app and appends the boot to a rolling history, so
- * consumers can derive a reboot *rate/cadence* instead of a single interval.
+ * synthetic __system__ app, appends the boot to a rolling history so
+ * consumers can derive a reboot rate/cadence, and opens the boot-storm
+ * window that down-weights the mount/volume/network noise any boot with a
+ * late data disk produces.
  *
  * This replaces a wall-clock `frequent_restart` heuristic that measured
  * process-start gaps: a crash-loop or the serviceManager boot-retry looked
@@ -186,19 +356,20 @@ async function checkNodeReboot() {
       log.warn(`appTamperingDetection - legacy frequent_restart purge failed: ${error.message}`);
     }
 
-    let currentBootId = null;
+    let bootId = null;
     try {
       const bootIdPath = config.system?.bootIdPath ?? '/proc/sys/kernel/random/boot_id';
-      currentBootId = (await fs.readFile(bootIdPath, 'utf8')).trim();
+      bootId = (await fs.readFile(bootIdPath, 'utf8')).trim();
     } catch (error) {
-      currentBootId = null;
+      bootId = null;
     }
-    if (!currentBootId) {
+    if (!bootId) {
       // Without a boot identity, reboot vs restart is guesswork — recording
       // anything here would reintroduce the noise this check exists to remove.
       log.warn('appTamperingDetection - boot_id unreadable, skipping reboot check');
       return;
     }
+    currentBootId = bootId;
 
     const now = new Date();
     const previous = await dbHelper.findOneInDatabase(
@@ -206,25 +377,29 @@ async function checkNodeReboot() {
     );
     const previousBootId = previous && previous.bootId ? previous.bootId : null;
 
-    if (previousBootId && previousBootId !== currentBootId) {
-      const previousStart = previous.at ? new Date(previous.at).toISOString() : 'unknown';
-      await recordEvent(
-        SYSTEM_APP_NAME,
-        'node_reboot',
-        `Machine rebooted: boot_id ${previousBootId.slice(0, 8)} -> ${currentBootId.slice(0, 8)}, previous FluxOS start ${previousStart}`,
-      );
-    }
-
     if (previousBootId !== currentBootId) {
-      // First sighting of this boot_id (reboot, first run, or upgrade from the
-      // pre-boot_id marker). A same-boot_id process restart adds no entry, so
-      // the history reflects machine boots only.
+      // First sighting of this boot_id: genuine reboot, first run, or upgrade
+      // from the pre-boot_id marker. All three open the boot-storm window —
+      // when we cannot prove the machine did NOT just boot, erring toward the
+      // discount protects honest nodes and costs a tamperer nothing (the
+      // events still record). A same-boot_id process restart opens nothing:
+      // disks and Docker have been up throughout, so its events are real.
+      bootStormUntilMs = Date.now() + BOOT_STORM_WINDOW_MS;
       await dbHelper.findOneAndUpdateInDatabase(
         database,
         nodeStartupTrackerCollection,
         { _id: BOOT_HISTORY_KEY },
         { $push: { boots: { $each: [{ bootId: currentBootId, at: now }], $slice: -BOOT_HISTORY_MAX } } },
         { upsert: true },
+      );
+    }
+
+    if (previousBootId && previousBootId !== currentBootId) {
+      const previousStart = previous.at ? new Date(previous.at).toISOString() : 'unknown';
+      await recordEvent(
+        SYSTEM_APP_NAME,
+        'node_reboot',
+        `Machine rebooted: boot_id ${previousBootId.slice(0, 8)} -> ${currentBootId.slice(0, 8)}, previous FluxOS start ${previousStart}`,
       );
     }
 
@@ -245,7 +420,11 @@ module.exports = {
   getEvents,
   isNetworkMissingError,
   checkNodeReboot,
-  EPISODE_WINDOW_MS,
+  deriveMainAppName,
+  EVENT_SEVERITY,
+  BOOT_STORM_DISCOUNT,
+  BOOT_STORM_WINDOW_MS,
+  INCIDENT_BUCKET_MS,
   BOOT_HISTORY_MAX,
   SYSTEM_APP_NAME,
 };

--- a/ZelBack/src/services/appTamperingDetectionService.js
+++ b/ZelBack/src/services/appTamperingDetectionService.js
@@ -134,7 +134,9 @@ async function getNodeIdentity() {
     }
     nodeIdentityCache = {
       nodeTxid,
-      nodeOutidx,
+      // getzelnodestatus returns outidx as a string; keep the stored type
+      // numeric so fleet-level queries never juggle '0' vs 0
+      nodeOutidx: nodeOutidx === null ? null : Number(nodeOutidx),
       nodeIp: node.ip ?? null,
       pubkey: node.pubkey ?? null,
       paymentAddress: node.payment_address ?? null,

--- a/ZelBack/src/services/appTamperingDetectionService.js
+++ b/ZelBack/src/services/appTamperingDetectionService.js
@@ -174,6 +174,18 @@ async function checkNodeReboot() {
     }
     const database = db.db(config.database.local.database);
 
+    // The retired frequent_restart heuristic self-fired on the serviceManager
+    // boot retry, so live nodes carry noise rows under that type. Sweep them
+    // until every row written before the boot_id rework has aged past the
+    // 30-day TTL; after that this purge deletes nothing and can be removed.
+    try {
+      await dbHelper.removeDocumentsFromCollection(
+        database, tamperingEventsCollection, { eventType: 'frequent_restart' },
+      );
+    } catch (error) {
+      log.warn(`appTamperingDetection - legacy frequent_restart purge failed: ${error.message}`);
+    }
+
     let currentBootId = null;
     try {
       const bootIdPath = config.system?.bootIdPath ?? '/proc/sys/kernel/random/boot_id';

--- a/ZelBack/src/services/appTamperingDetectionService.js
+++ b/ZelBack/src/services/appTamperingDetectionService.js
@@ -322,9 +322,7 @@ async function recordEvent(appName, eventType, details) {
  * GET API handler. Returns tampering incidents, optionally filtered by
  * appname, most recent first. Results are capped: the route is public, so an
  * uncapped no-arg query would dump the whole collection to anyone. Documents
- * include _id as a stable paging/identity key. Pre-schema rows (detectedAt,
- * no lastSeen) sort after current-schema incidents until they age out via
- * their 30-day TTL.
+ * include _id as a stable paging/identity key.
  * Route: GET /apps/tamperingevents/:appname? (query: ?limit=1..1000)
  * @param {object} req - Express request
  * @param {object} res - Express response
@@ -380,16 +378,18 @@ async function checkNodeReboot() {
     }
     const database = db.db(config.database.local.database);
 
-    // The retired frequent_restart heuristic self-fired on the serviceManager
-    // boot retry, so live nodes carry noise rows under that type. Sweep them
-    // until every row written before the boot_id rework has aged past the
-    // 30-day TTL; after that this purge deletes nothing and can be removed.
+    // Pre-schema rows (no schemaVersion) are row-per-observation noise with
+    // no identity, severity or dedup — nothing consumes them, but the public
+    // API would keep serving them for up to 30 days of TTL. Sweeping them at
+    // startup gives an upgraded node an honest collection from its first
+    // boot. A no-op on every boot after that; removable once the fleet has
+    // upgraded past the incident schema.
     try {
       await dbHelper.removeDocumentsFromCollection(
-        database, tamperingEventsCollection, { eventType: 'frequent_restart' },
+        database, tamperingEventsCollection, { schemaVersion: { $exists: false } },
       );
     } catch (error) {
-      log.warn(`appTamperingDetection - legacy frequent_restart purge failed: ${error.message}`);
+      log.warn(`appTamperingDetection - pre-schema row purge failed: ${error.message}`);
     }
 
     // Started here (not lazily from recordEvent) so incidents written during

--- a/ZelBack/src/services/appTamperingDetectionService.js
+++ b/ZelBack/src/services/appTamperingDetectionService.js
@@ -73,6 +73,12 @@ const EVENTS_MAX_LIMIT = 1000;
 // a dead daemon on every event.
 const IDENTITY_RETRY_MS = 5 * 60 * 1000;
 const ATTRIBUTION_TTL_MS = 60 * 60 * 1000;
+// node_reboot always fires seconds after boot — before fluxd's RPC is up —
+// so without a later pass, reboot incidents would systematically carry null
+// identity (observed on the first live deploy). The backfill retries on this
+// interval until the daemon answers, stamps every unattributed incident, and
+// stops.
+const IDENTITY_BACKFILL_INTERVAL_MS = 5 * 60 * 1000;
 
 // Boot context, set once by checkNodeReboot() during startup. Until it runs
 // (or on hosts without a readable boot_id) events fall back to an 'unknown'
@@ -82,6 +88,7 @@ let bootStormUntilMs = 0;
 
 let nodeIdentityCache = null;
 let identityRetryAfterMs = 0;
+let identityBackfillTimer = null;
 const appAttributionCache = new Map(); // appName -> { ownerZelid, appHash, cachedAt }
 
 /**
@@ -138,6 +145,49 @@ async function getNodeIdentity() {
     log.debug(`appTamperingDetection - node identity unavailable: ${error.message}`);
     return null;
   }
+}
+
+/**
+ * Stamp node/operator identity onto incidents that recorded while the daemon
+ * was unreachable, retrying every IDENTITY_BACKFILL_INTERVAL_MS until it
+ * answers, then stopping for good. Keyed off nodeTxid: null — identity is
+ * constant for the life of the process, so one pass settles everything
+ * written before the daemon came up. Safe to call repeatedly (single timer).
+ */
+function startIdentityBackfill() {
+  if (identityBackfillTimer) return;
+  const attempt = async () => {
+    try {
+      const identity = await getNodeIdentity();
+      if (!identity || !identity.nodeTxid) return; // daemon not ready — next tick retries
+      const db = dbHelper.databaseConnection();
+      if (!db) return;
+      const database = db.db(config.database.local.database);
+      const result = await dbHelper.updateInDatabase(
+        database,
+        tamperingEventsCollection,
+        { schemaVersion: { $gte: 1 }, nodeTxid: null },
+        {
+          $set: {
+            nodeTxid: identity.nodeTxid,
+            nodeOutidx: identity.nodeOutidx,
+            nodeIp: identity.nodeIp,
+            pubkey: identity.pubkey,
+            paymentAddress: identity.paymentAddress,
+          },
+        },
+      );
+      const updated = result?.modifiedCount ?? 0;
+      if (updated > 0) log.info(`appTamperingDetection - backfilled identity onto ${updated} incident(s)`);
+      clearInterval(identityBackfillTimer);
+      identityBackfillTimer = null;
+    } catch (error) {
+      log.debug(`appTamperingDetection - identity backfill attempt failed: ${error.message}`);
+    }
+  };
+  identityBackfillTimer = setInterval(attempt, IDENTITY_BACKFILL_INTERVAL_MS);
+  if (identityBackfillTimer.unref) identityBackfillTimer.unref();
+  attempt();
 }
 
 /**
@@ -356,6 +406,11 @@ async function checkNodeReboot() {
       log.warn(`appTamperingDetection - legacy frequent_restart purge failed: ${error.message}`);
     }
 
+    // Started here (not lazily from recordEvent) so incidents written during
+    // boot — node_reboot above all — get their identity even on a node quiet
+    // enough that no later event ever triggers a lookup.
+    startIdentityBackfill();
+
     let bootId = null;
     try {
       const bootIdPath = config.system?.bootIdPath ?? '/proc/sys/kernel/random/boot_id';
@@ -420,11 +475,13 @@ module.exports = {
   getEvents,
   isNetworkMissingError,
   checkNodeReboot,
+  startIdentityBackfill,
   deriveMainAppName,
   EVENT_SEVERITY,
   BOOT_STORM_DISCOUNT,
   BOOT_STORM_WINDOW_MS,
   INCIDENT_BUCKET_MS,
+  IDENTITY_BACKFILL_INTERVAL_MS,
   BOOT_HISTORY_MAX,
   SYSTEM_APP_NAME,
 };

--- a/ZelBack/src/services/appTamperingDetectionService.js
+++ b/ZelBack/src/services/appTamperingDetectionService.js
@@ -70,9 +70,11 @@ const ATTRIBUTION_TTL_MS = 60 * 60 * 1000;
 // stamps every unattributed incident, and stops.
 const IDENTITY_BACKFILL_INTERVAL_MS = 5 * 60 * 1000;
 
-// Boot context, set once by checkNodeReboot() during startup. Until it runs
-// (or on hosts without a readable boot_id) events fall back to an 'unknown'
-// boot in their incident key.
+// Boot context, set by checkNodeReboot() during startup. serviceManager awaits
+// checkNodeReboot() before starting any tamper-event emitter (reconciler,
+// mount/crontab sweep, syncthing), so recordEvent sees a real bootId in normal
+// operation. The 'unknown' fallback only covers a host where boot_id itself is
+// unreadable.
 let currentBootId = null;
 
 let nodeIdentityCache = null;
@@ -132,6 +134,10 @@ async function getNodeIdentity() {
     };
     return nodeIdentityCache;
   } catch (error) {
+    // A concurrent caller (or the backfill) may have populated the cache while
+    // this RPC was in flight; prefer that over returning null and writing an
+    // unattributed row the one-shot backfill may already have stopped covering.
+    if (nodeIdentityCache) return nodeIdentityCache;
     identityRetryAfterMs = Date.now() + IDENTITY_RETRY_MS;
     log.debug(`appTamperingDetection - node identity unavailable: ${error.message}`);
     return null;
@@ -331,6 +337,9 @@ async function getEvents(req, res) {
   try {
     let { appname } = req.params;
     appname = appname || req.query.appname;
+    // The route is public: coerce to a string so a bracket-notation query
+    // (?appname[$gt]=) can't smuggle a Mongo operator object into the filter.
+    if (appname !== undefined && appname !== null) appname = String(appname);
     const requestedLimit = Number.parseInt(req.query.limit, 10);
     const limit = Number.isNaN(requestedLimit)
       ? EVENTS_DEFAULT_LIMIT

--- a/ZelBack/src/services/appTamperingDetectionService.js
+++ b/ZelBack/src/services/appTamperingDetectionService.js
@@ -43,6 +43,15 @@ const INCIDENT_BUCKET_MS = 60 * 60 * 1000;
 // (tamper, then reboot, and the evidence goes out with the boot noise).
 const BOOT_STORM_WINDOW_MS = 30 * 60 * 1000;
 const BOOT_STORM_DISCOUNT = 0.25;
+// Only the event types a boot race can actually produce are discounted inside
+// the storm window. container_vanished is deliberately absent: containers
+// persist as `exited` across a clean reboot, and a late-disk docker daemon
+// surfaces as docker-unreachable (deferred, never recorded) — so a missing
+// container is tamper signal even seconds after boot. Discounting it would
+// hand kill-style tampering a 4x discount for rebooting first, and unlike
+// persistent damage (a deleted volume re-records at full weight in the next
+// hourly bucket) a healed one-shot vanish never re-records.
+const BOOT_STORM_DISCOUNT_TYPES = ['mount_vanished', 'volume_missing', 'network_pruned', 'recreation_failed'];
 
 // Per-type severity, stamped on each incident at write time so scoring reads
 // stored values rather than re-deriving them. recreation_failed is an
@@ -481,6 +490,7 @@ module.exports = {
   deriveMainAppName,
   EVENT_SEVERITY,
   BOOT_STORM_DISCOUNT,
+  BOOT_STORM_DISCOUNT_TYPES,
   BOOT_STORM_WINDOW_MS,
   INCIDENT_BUCKET_MS,
   IDENTITY_BACKFILL_INTERVAL_MS,

--- a/ZelBack/src/services/appTamperingDetectionService.js
+++ b/ZelBack/src/services/appTamperingDetectionService.js
@@ -20,7 +20,6 @@ const { localAppsInformation } = require('./utils/appConstants');
 const tamperingEventsCollection = config.database.local.collections.appTamperingEvents;
 const nodeStartupTrackerCollection = config.database.local.collections.nodeStartupTracker;
 
-const SYSTEM_APP_NAME = '__system__';
 const STARTUP_MARKER_KEY = 'lastStartup';
 const BOOT_HISTORY_KEY = 'bootHistory';
 // ~200 boots covers >1 month even at the fastest observed abusive reboot
@@ -36,34 +35,18 @@ const BOOT_HISTORY_MAX = 200;
 // erasing distinct incidents.
 const INCIDENT_BUCKET_MS = 60 * 60 * 1000;
 
-// Events recorded within this window after a machine boot are flagged
-// duringBootStorm and down-weighted in scoring — never dropped. Any reboot
-// with a late data disk legitimately produces mount/volume events for every
-// app; outright suppression would instead hand tamperers a laundering trick
-// (tamper, then reboot, and the evidence goes out with the boot noise).
-const BOOT_STORM_WINDOW_MS = 30 * 60 * 1000;
-const BOOT_STORM_DISCOUNT = 0.25;
-// Only the event types a boot race can actually produce are discounted inside
-// the storm window. container_vanished is deliberately absent: containers
-// persist as `exited` across a clean reboot, and a late-disk docker daemon
-// surfaces as docker-unreachable (deferred, never recorded) — so a missing
-// container is tamper signal even seconds after boot. Discounting it would
-// hand kill-style tampering a 4x discount for rebooting first, and unlike
-// persistent damage (a deleted volume re-records at full weight in the next
-// hourly bucket) a healed one-shot vanish never re-records.
-const BOOT_STORM_DISCOUNT_TYPES = ['mount_vanished', 'volume_missing', 'network_pruned', 'recreation_failed'];
-
 // Per-type severity, stamped on each incident at write time so scoring reads
 // stored values rather than re-deriving them. recreation_failed is an
-// operational fault (registry, image pull, disk) and node_reboot is an
-// observation feeding operator-level analysis — both are recorded for
-// visibility but carry no tamper weight, because punishing them would
-// penalize honest nodes for infra noise. container_vanished weighs highest:
+// operational fault (registry, image pull, disk) — recorded for visibility
+// but zero-weighted, because punishing it would penalize honest nodes for
+// infra noise. container_vanished weighs highest:
 // containers persist as `exited` across a clean reboot, so a
 // positively-confirmed missing container is the strongest local indicator of
-// host-side interference this data has. The mount/volume/network types are
-// real signals but dominated by boot races, hence low severity plus the
-// boot-storm discount.
+// host-side interference this data has. The mount/volume/network types carry
+// low weight because they cannot distinguish interference from an unhealthy
+// host — fleet-wide they are dominated by persistent faults on broken nodes —
+// and a persistent fault re-records in every hourly bucket, so anything real
+// accumulates weight without needing a high per-incident severity.
 const EVENT_SEVERITY = {
   container_vanished: 3,
   network_pruned: 1,
@@ -71,7 +54,6 @@ const EVENT_SEVERITY = {
   mount_vanished: 1,
   volume_missing: 1,
   recreation_failed: 0,
-  node_reboot: 0,
 };
 
 const EVENTS_DEFAULT_LIMIT = 500;
@@ -82,18 +64,16 @@ const EVENTS_MAX_LIMIT = 1000;
 // a dead daemon on every event.
 const IDENTITY_RETRY_MS = 5 * 60 * 1000;
 const ATTRIBUTION_TTL_MS = 60 * 60 * 1000;
-// node_reboot always fires seconds after boot — before fluxd's RPC is up —
-// so without a later pass, reboot incidents would systematically carry null
-// identity (observed on the first live deploy). The backfill retries on this
-// interval until the daemon answers, stamps every unattributed incident, and
-// stops.
+// The boot-sweep harvest (mount/volume checks) fires before fluxd's RPC is
+// up, so without a later pass its incidents would systematically carry null
+// identity. The backfill retries on this interval until the daemon answers,
+// stamps every unattributed incident, and stops.
 const IDENTITY_BACKFILL_INTERVAL_MS = 5 * 60 * 1000;
 
 // Boot context, set once by checkNodeReboot() during startup. Until it runs
 // (or on hosts without a readable boot_id) events fall back to an 'unknown'
-// boot in their incident key and are never flagged as boot storm.
+// boot in their incident key.
 let currentBootId = null;
-let bootStormUntilMs = 0;
 
 let nodeIdentityCache = null;
 let identityRetryAfterMs = 0;
@@ -227,7 +207,7 @@ function deriveMainAppName(appName) {
  * @returns {Promise<object|null>}
  */
 async function getAppAttribution(appName) {
-  if (!appName || appName === SYSTEM_APP_NAME) return null;
+  if (!appName) return null;
   const cached = appAttributionCache.get(appName);
   if (cached && Date.now() - cached.cachedAt < ATTRIBUTION_TTL_MS) return cached;
   try {
@@ -265,10 +245,10 @@ async function getAppAttribution(appName) {
  * the boot_id plus an hourly time bucket; repeat calls increment `count` and
  * advance `lastSeen`, so retry storms collapse while the incident keeps its
  * full observation tally. Each document carries node identity, operator
- * identity, app attribution, severity and boot-storm context so fleet-level
- * consumers can attribute and weigh it without joining local state.
+ * identity, app attribution and severity so fleet-level consumers can
+ * attribute and weigh it without joining local state.
  * Documents expire 30 days after lastSeen (TTL index).
- * @param {string} appName - Application name (or SYSTEM_APP_NAME)
+ * @param {string} appName - Application name
  * @param {string} eventType - One of the EVENT_SEVERITY keys
  * @param {string} details - Free-text context (stored once per incident)
  */
@@ -282,7 +262,6 @@ async function recordEvent(appName, eventType, details) {
     const database = db.db(config.database.local.database);
     const now = new Date();
     const incidentKey = `${currentBootId ?? 'unknown'}:${Math.floor(now.getTime() / INCIDENT_BUCKET_MS)}`;
-    const duringBootStorm = now.getTime() < bootStormUntilMs;
     const [identity, attribution] = await Promise.all([
       getNodeIdentity(),
       getAppAttribution(appName),
@@ -295,7 +274,6 @@ async function recordEvent(appName, eventType, details) {
         eventType,
         incidentKey,
         severity: EVENT_SEVERITY[eventType] ?? 0,
-        duringBootStorm,
         bootId: currentBootId,
         uptimeSecAtEvent: Math.round(os.uptime()),
         firstSeen: now,
@@ -331,7 +309,7 @@ async function recordEvent(appName, eventType, details) {
     // doc or null; older shapes return { value, lastErrorObject }.
     const inserted = !result || result.value === null || result?.lastErrorObject?.updatedExisting === false;
     if (inserted) {
-      log.info(`appTamperingDetection - recorded ${eventType} for ${appName}${duringBootStorm ? ' (boot storm)' : ''}`);
+      log.info(`appTamperingDetection - recorded ${eventType} for ${appName}`);
     } else {
       log.debug(`appTamperingDetection - ${eventType} for ${appName} repeated, incident count incremented`);
     }
@@ -379,11 +357,8 @@ async function getEvents(req, res) {
  * Startup check: distinguishes a genuine machine reboot from a mere process
  * restart using the kernel boot identity (/proc/sys/kernel/random/boot_id — a
  * UUID regenerated on every boot, stable across process restarts). On a
- * genuine reboot it records a single `node_reboot` observation under the
- * synthetic __system__ app, appends the boot to a rolling history so
- * consumers can derive a reboot rate/cadence, and opens the boot-storm
- * window that down-weights the mount/volume/network noise any boot with a
- * late data disk produces.
+ * genuine reboot it appends the boot to a rolling history in
+ * nodestartuptracker so consumers can derive a reboot rate/cadence.
  *
  * This replaces a wall-clock `frequent_restart` heuristic that measured
  * process-start gaps: a crash-loop or the serviceManager boot-retry looked
@@ -418,8 +393,9 @@ async function checkNodeReboot() {
     }
 
     // Started here (not lazily from recordEvent) so incidents written during
-    // boot — node_reboot above all — get their identity even on a node quiet
-    // enough that no later event ever triggers a lookup.
+    // boot — the boot-sweep mount/volume harvest fires before fluxd's RPC is
+    // up — get their identity even on a node quiet enough that no later event
+    // ever triggers a lookup.
     startIdentityBackfill();
 
     let bootId = null;
@@ -445,28 +421,23 @@ async function checkNodeReboot() {
 
     if (previousBootId !== currentBootId) {
       // First sighting of this boot_id: genuine reboot, first run, or upgrade
-      // from the pre-boot_id marker. All three open the boot-storm window —
-      // when we cannot prove the machine did NOT just boot, erring toward the
-      // discount protects honest nodes and costs a tamperer nothing (the
-      // events still record). A same-boot_id process restart opens nothing:
-      // disks and Docker have been up throughout, so its events are real.
-      bootStormUntilMs = Date.now() + BOOT_STORM_WINDOW_MS;
+      // from the pre-boot_id marker. All three land in the boot history; a
+      // same-boot_id process restart does not, keeping the history a record
+      // of machine boots rather than FluxOS restarts. `bootedAt` is the
+      // machine's boot moment (uptime-derived) — cadence consumers want the
+      // boot period itself, free of FluxOS's variable start lag; `at` is when
+      // FluxOS first saw the boot.
+      const bootedAt = new Date(now.getTime() - Math.round(os.uptime() * 1000));
       await dbHelper.findOneAndUpdateInDatabase(
         database,
         nodeStartupTrackerCollection,
         { _id: BOOT_HISTORY_KEY },
-        { $push: { boots: { $each: [{ bootId: currentBootId, at: now }], $slice: -BOOT_HISTORY_MAX } } },
+        { $push: { boots: { $each: [{ bootId: currentBootId, bootedAt, at: now }], $slice: -BOOT_HISTORY_MAX } } },
         { upsert: true },
       );
-    }
-
-    if (previousBootId && previousBootId !== currentBootId) {
-      const previousStart = previous.at ? new Date(previous.at).toISOString() : 'unknown';
-      await recordEvent(
-        SYSTEM_APP_NAME,
-        'node_reboot',
-        `Machine rebooted: boot_id ${previousBootId.slice(0, 8)} -> ${currentBootId.slice(0, 8)}, previous FluxOS start ${previousStart}`,
-      );
+      if (previousBootId) {
+        log.info(`appTamperingDetection - machine reboot: boot_id ${previousBootId.slice(0, 8)} -> ${currentBootId.slice(0, 8)}`);
+      }
     }
 
     await dbHelper.findOneAndUpdateInDatabase(
@@ -489,11 +460,7 @@ module.exports = {
   startIdentityBackfill,
   deriveMainAppName,
   EVENT_SEVERITY,
-  BOOT_STORM_DISCOUNT,
-  BOOT_STORM_DISCOUNT_TYPES,
-  BOOT_STORM_WINDOW_MS,
   INCIDENT_BUCKET_MS,
   IDENTITY_BACKFILL_INTERVAL_MS,
   BOOT_HISTORY_MAX,
-  SYSTEM_APP_NAME,
 };

--- a/ZelBack/src/services/appTamperingDetectionService.js
+++ b/ZelBack/src/services/appTamperingDetectionService.js
@@ -1,14 +1,39 @@
 const config = require('config');
+const fs = require('fs').promises;
 const log = require('../lib/log');
 const dbHelper = require('./dbHelper');
 const messageHelper = require('./messageHelper');
 
+// All tamper-feature behaviour (episode dedup, boot identity, event taxonomy)
+// deliberately lives inside this service rather than at the emitting call
+// sites: the call sites (appReconciler, crontabAndMountsCleanup,
+// syncthingFolderStateMachine) sit in files under heavy parallel rework on the
+// v9 branch, while this file is identical across branches. Centralizing here
+// keeps the feature rebase-safe and guarantees every emitter gets the same
+// semantics without call-site edits.
+
 const tamperingEventsCollection = config.database.local.collections.appTamperingEvents;
 const nodeStartupTrackerCollection = config.database.local.collections.nodeStartupTracker;
 
-const FREQUENT_RESTART_THRESHOLD_MS = 60 * 60 * 1000; // 1 hour
-const STARTUP_MARKER_KEY = 'lastStartup';
 const SYSTEM_APP_NAME = '__system__';
+const STARTUP_MARKER_KEY = 'lastStartup';
+const BOOT_HISTORY_KEY = 'bootHistory';
+// ~200 boots covers >1 month even at the fastest observed abusive reboot
+// cadence (~4h), comfortably beyond the collection's 30-day event TTL.
+const BOOT_HISTORY_MAX = 200;
+
+// One row per (appName, eventType) per hour. The reconciler re-attempts a
+// failed recreation on a seconds-scale backoff and re-sweeps hourly, so a
+// single persistent fault (unpullable image, missing volume) used to insert
+// hundreds of rows for one incident, drowning genuine signal and inflating
+// the enforcement count. Suppressed repeats are dropped, not counted, until
+// the phase-1 incident schema adds first/last-seen rollups.
+const EPISODE_WINDOW_MS = 60 * 60 * 1000;
+// `${appName}|${eventType}` -> epoch ms of the last inserted row. In-memory
+// on purpose: a process restart clears it, and per-boot events (mount races
+// on a late data disk) should record once per boot.
+const episodeMarkers = new Map();
+const EPISODE_MARKERS_MAX = 1000;
 
 /**
  * Returns true when a Docker/daemon error message indicates a missing network
@@ -29,16 +54,36 @@ function isNetworkMissingError(errorMessage) {
 }
 
 /**
- * Record a tampering event as a new row in the events collection.
- * Each call inserts a new document so the full history per app is preserved.
- * Documents expire automatically 30 days after detectedAt (TTL index).
- * @param {string} appName - Application name
- * @param {string} eventType - One of: container_vanished, network_pruned,
- *   mount_vanished, crontab_wiped, recreation_failed, network_detached
+ * Drop episode markers whose window has already elapsed so the map cannot
+ * grow unbounded on a node with many flapping apps.
+ * @param {number} now - Current epoch ms
+ */
+function pruneExpiredEpisodeMarkers(now) {
+  episodeMarkers.forEach((recordedAt, key) => {
+    if (now - recordedAt >= EPISODE_WINDOW_MS) episodeMarkers.delete(key);
+  });
+}
+
+/**
+ * Record a tampering event. Inserts one row per (appName, eventType) episode:
+ * repeat calls inside EPISODE_WINDOW_MS after a successful insert are dropped,
+ * so retry storms collapse into a single row while distinct incidents in later
+ * windows still record. Documents expire 30 days after detectedAt (TTL index).
+ * @param {string} appName - Application name (or SYSTEM_APP_NAME)
+ * @param {string} eventType - One of: container_vanished, recreation_failed,
+ *   network_pruned, network_detached, mount_vanished, volume_missing,
+ *   node_reboot
  * @param {string} details - Free-text context about the event
  */
 async function recordEvent(appName, eventType, details) {
   try {
+    const now = Date.now();
+    const episodeKey = `${appName}|${eventType}`;
+    const lastRecordedAt = episodeMarkers.get(episodeKey);
+    if (lastRecordedAt !== undefined && now - lastRecordedAt < EPISODE_WINDOW_MS) {
+      log.debug(`appTamperingDetection - ${eventType} for ${appName} already recorded this episode, skipping`);
+      return;
+    }
     const db = dbHelper.databaseConnection();
     if (!db) {
       log.warn('appTamperingDetection - DB not available, skipping event');
@@ -52,16 +97,26 @@ async function recordEvent(appName, eventType, details) {
       detectedAt: new Date(),
     };
     await dbHelper.insertOneToDatabase(database, tamperingEventsCollection, doc);
+    // Marked only after a successful insert: a failed write must not consume
+    // the episode, otherwise the event would be silently lost for an hour.
+    episodeMarkers.set(episodeKey, now);
+    if (episodeMarkers.size > EPISODE_MARKERS_MAX) pruneExpiredEpisodeMarkers(now);
     log.info(`appTamperingDetection - recorded ${eventType} for ${appName}`);
   } catch (error) {
     log.error(`appTamperingDetection - failed to record event: ${error.message}`);
   }
 }
 
+const EVENTS_DEFAULT_LIMIT = 500;
+const EVENTS_MAX_LIMIT = 1000;
+
 /**
- * GET API handler. Returns all tampering events, optionally filtered by appname,
- * sorted by most recent first.
- * Route: GET /apps/tamperingevents/:appname?
+ * GET API handler. Returns tampering events, optionally filtered by appname,
+ * sorted by most recent first. Results are capped: the route is public, so an
+ * uncapped no-arg query would dump the whole collection to anyone. A stable
+ * paging key arrives with the phase-1 schema (_id is stripped today); until
+ * then newest-first plus `limit` is the supported access pattern.
+ * Route: GET /apps/tamperingevents/:appname? (query: ?limit=1..1000)
  * @param {object} req - Express request
  * @param {object} res - Express response
  */
@@ -69,10 +124,16 @@ async function getEvents(req, res) {
   try {
     let { appname } = req.params;
     appname = appname || req.query.appname;
+    const requestedLimit = Number.parseInt(req.query.limit, 10);
+    const limit = Number.isNaN(requestedLimit)
+      ? EVENTS_DEFAULT_LIMIT
+      : Math.min(Math.max(requestedLimit, 1), EVENTS_MAX_LIMIT);
     const db = dbHelper.databaseConnection();
     const database = db.db(config.database.local.database);
     const query = appname ? { appName: appname } : {};
-    const projection = { projection: { _id: 0 }, sort: { detectedAt: -1 } };
+    const projection = {
+      projection: { _id: 0 }, sort: { detectedAt: -1 }, limit,
+    };
     const results = await dbHelper.findInDatabase(
       database, tamperingEventsCollection, query, projection,
     );
@@ -86,43 +147,84 @@ async function getEvents(req, res) {
 }
 
 /**
- * Compares the current time to the previous recorded startup time. If the
- * gap is less than one hour, records a `frequent_restart` tampering event
- * under a synthetic system app name. Always updates the startup marker to
- * "now" before returning. Called once per FluxOS startup.
+ * Startup check: distinguishes a genuine machine reboot from a mere process
+ * restart using the kernel boot identity (/proc/sys/kernel/random/boot_id — a
+ * UUID regenerated on every boot, stable across process restarts). On a
+ * genuine reboot it records a single `node_reboot` observation under the
+ * synthetic __system__ app and appends the boot to a rolling history, so
+ * consumers can derive a reboot *rate/cadence* instead of a single interval.
+ *
+ * This replaces a wall-clock `frequent_restart` heuristic that measured
+ * process-start gaps: a crash-loop or the serviceManager boot-retry looked
+ * like a reboot (false positive), any reboot cycle slower than its 1h window
+ * was invisible (false negative), and clock skew across a hard reboot both
+ * evaded it and reset its baseline. boot_id comparison is immune to all three.
+ *
+ * The AppSyncOrchestrator heartbeat doc (same collection) also carries a
+ * machineBootId, but it is written only once that service starts — later in
+ * boot than this check runs — and is owned by it; reading it here would tie
+ * correctness to startup ordering. This service owns its own marker instead.
  */
-async function checkFrequentRestart() {
+async function checkNodeReboot() {
   try {
     const db = dbHelper.databaseConnection();
     if (!db) {
-      log.warn('appTamperingDetection - DB not available, skipping frequent-restart check');
+      log.warn('appTamperingDetection - DB not available, skipping reboot check');
       return;
     }
     const database = db.db(config.database.local.database);
+
+    let currentBootId = null;
+    try {
+      const bootIdPath = config.system?.bootIdPath ?? '/proc/sys/kernel/random/boot_id';
+      currentBootId = (await fs.readFile(bootIdPath, 'utf8')).trim();
+    } catch (error) {
+      currentBootId = null;
+    }
+    if (!currentBootId) {
+      // Without a boot identity, reboot vs restart is guesswork — recording
+      // anything here would reintroduce the noise this check exists to remove.
+      log.warn('appTamperingDetection - boot_id unreadable, skipping reboot check');
+      return;
+    }
+
     const now = new Date();
     const previous = await dbHelper.findOneInDatabase(
       database, nodeStartupTrackerCollection, { _id: STARTUP_MARKER_KEY },
     );
-    if (previous && previous.at) {
-      const delta = now.getTime() - new Date(previous.at).getTime();
-      if (delta >= 0 && delta < FREQUENT_RESTART_THRESHOLD_MS) {
-        const deltaSec = Math.floor(delta / 1000);
-        await recordEvent(
-          SYSTEM_APP_NAME,
-          'frequent_restart',
-          `FluxOS restarted ${deltaSec}s after previous start`,
-        );
-      }
+    const previousBootId = previous && previous.bootId ? previous.bootId : null;
+
+    if (previousBootId && previousBootId !== currentBootId) {
+      const previousStart = previous.at ? new Date(previous.at).toISOString() : 'unknown';
+      await recordEvent(
+        SYSTEM_APP_NAME,
+        'node_reboot',
+        `Machine rebooted: boot_id ${previousBootId.slice(0, 8)} -> ${currentBootId.slice(0, 8)}, previous FluxOS start ${previousStart}`,
+      );
     }
+
+    if (previousBootId !== currentBootId) {
+      // First sighting of this boot_id (reboot, first run, or upgrade from the
+      // pre-boot_id marker). A same-boot_id process restart adds no entry, so
+      // the history reflects machine boots only.
+      await dbHelper.findOneAndUpdateInDatabase(
+        database,
+        nodeStartupTrackerCollection,
+        { _id: BOOT_HISTORY_KEY },
+        { $push: { boots: { $each: [{ bootId: currentBootId, at: now }], $slice: -BOOT_HISTORY_MAX } } },
+        { upsert: true },
+      );
+    }
+
     await dbHelper.findOneAndUpdateInDatabase(
       database,
       nodeStartupTrackerCollection,
       { _id: STARTUP_MARKER_KEY },
-      { $set: { at: now } },
+      { $set: { at: now, bootId: currentBootId } },
       { upsert: true },
     );
   } catch (error) {
-    log.error(`appTamperingDetection - checkFrequentRestart failed: ${error.message}`);
+    log.error(`appTamperingDetection - checkNodeReboot failed: ${error.message}`);
   }
 }
 
@@ -130,7 +232,8 @@ module.exports = {
   recordEvent,
   getEvents,
   isNetworkMissingError,
-  checkFrequentRestart,
-  FREQUENT_RESTART_THRESHOLD_MS,
+  checkNodeReboot,
+  EPISODE_WINDOW_MS,
+  BOOT_HISTORY_MAX,
   SYSTEM_APP_NAME,
 };

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -186,8 +186,9 @@ async function startFluxFunctions() {
     await ensureIndex(database.collection(config.database.local.collections.completedPayments), { paymentId: 1 });
     await ensureIndex(database.collection(config.database.local.collections.completedPayments), { createdAt: 1 }, { expireAfterSeconds: 7 * 24 * 60 * 60 });
     // legacy pre-incident-schema rows expire via detectedAt; current incident
-    // documents expire via lastSeen. Drop the detectedAt pair once every
-    // pre-schema row has aged past the 30-day TTL.
+    // documents expire via lastSeen. The tamper service purges pre-schema
+    // rows at startup, so the detectedAt pair only matters where old code
+    // still writes; drop it once the fleet is past the incident schema.
     await ensureIndex(
       database.collection(config.database.local.collections.appTamperingEvents),
       { detectedAt: 1 },

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -185,6 +185,9 @@ async function startFluxFunctions() {
     await ensureIndex(database.collection(config.database.local.collections.activePaymentRequests), { createdAt: 1 }, { expireAfterSeconds: 3600 });
     await ensureIndex(database.collection(config.database.local.collections.completedPayments), { paymentId: 1 });
     await ensureIndex(database.collection(config.database.local.collections.completedPayments), { createdAt: 1 }, { expireAfterSeconds: 7 * 24 * 60 * 60 });
+    // legacy pre-incident-schema rows expire via detectedAt; current incident
+    // documents expire via lastSeen. Drop the detectedAt pair once every
+    // pre-schema row has aged past the 30-day TTL.
     await ensureIndex(
       database.collection(config.database.local.collections.appTamperingEvents),
       { detectedAt: 1 },
@@ -194,6 +197,24 @@ async function startFluxFunctions() {
       database.collection(config.database.local.collections.appTamperingEvents),
       { appName: 1, detectedAt: -1 },
       { name: 'appName_detectedAt' },
+    );
+    await ensureIndex(
+      database.collection(config.database.local.collections.appTamperingEvents),
+      { lastSeen: 1 },
+      { expireAfterSeconds: 30 * 24 * 60 * 60, name: 'lastSeen_ttl' }, // 30 days
+    );
+    // upsert key of the incident rollup; unique so concurrent recorders
+    // cannot double-insert an incident. Partial: legacy rows lack incidentKey
+    // and would otherwise collide on null.
+    await ensureIndex(
+      database.collection(config.database.local.collections.appTamperingEvents),
+      { appName: 1, eventType: 1, incidentKey: 1 },
+      { unique: true, partialFilterExpression: { incidentKey: { $exists: true } }, name: 'incident_upsert' },
+    );
+    await ensureIndex(
+      database.collection(config.database.local.collections.appTamperingEvents),
+      { appName: 1, eventType: 1, lastSeen: -1 },
+      { name: 'appName_eventType_lastSeen' },
     );
     await appTamperingDetectionService.checkNodeReboot();
     // appsRuntimeState (localzelapps): merge any pre-unique-index duplicate docs,

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -195,7 +195,7 @@ async function startFluxFunctions() {
       { appName: 1, detectedAt: -1 },
       { name: 'appName_detectedAt' },
     );
-    await appTamperingDetectionService.checkFrequentRestart();
+    await appTamperingDetectionService.checkNodeReboot();
     // appsRuntimeState (localzelapps): merge any pre-unique-index duplicate docs,
     // then enforce one doc per component identifier
     await appsRuntimeState.prepareCollection();

--- a/tests/unit/appTamperingBlocklistService.test.js
+++ b/tests/unit/appTamperingBlocklistService.test.js
@@ -35,7 +35,10 @@ describe('appTamperingBlocklistService tests', () => {
       './generalService': generalServiceStub,
       './daemonService/daemonServiceMiscRpcs': daemonMiscStub,
       './benchmarkService': benchmarkServiceStub,
-      './appTamperingDetectionService': { BOOT_STORM_DISCOUNT: 0.25 },
+      './appTamperingDetectionService': {
+        BOOT_STORM_DISCOUNT: 0.25,
+        BOOT_STORM_DISCOUNT_TYPES: ['mount_vanished', 'volume_missing', 'network_pruned', 'recreation_failed'],
+      },
     });
   }
 
@@ -82,7 +85,7 @@ describe('appTamperingBlocklistService tests', () => {
   // outside any boot storm, i.e. a tamper score of exactly n.
   function setTamperScore(n) {
     const incidents = Array.from({ length: n }, () => ({
-      severity: 1, duringBootStorm: false,
+      eventType: 'mount_vanished', severity: 1, duringBootStorm: false,
     }));
     dbHelperStub.aggregateInDatabase = sinon.stub().resolves(incidents);
   }
@@ -126,10 +129,10 @@ describe('appTamperingBlocklistService tests', () => {
 
     it('sums stored severities across incidents', async () => {
       dbHelperStub.aggregateInDatabase = sinon.stub().resolves([
-        { severity: 3, duringBootStorm: false },
-        { severity: 1, duringBootStorm: false },
-        { severity: 1, duringBootStorm: false },
-        { severity: 0, duringBootStorm: false }, // operational/observational
+        { eventType: 'container_vanished', severity: 3, duringBootStorm: false },
+        { eventType: 'network_pruned', severity: 1, duringBootStorm: false },
+        { eventType: 'network_detached', severity: 1, duringBootStorm: false },
+        { eventType: 'recreation_failed', severity: 0, duringBootStorm: false }, // operational
       ]);
 
       const result = await service.computeTamperScore();
@@ -137,11 +140,11 @@ describe('appTamperingBlocklistService tests', () => {
       expect(result).to.equal(5);
     });
 
-    it('discounts incidents flagged duringBootStorm', async () => {
+    it('discounts boot-race incidents flagged duringBootStorm', async () => {
       dbHelperStub.aggregateInDatabase = sinon.stub().resolves([
-        { severity: 1, duringBootStorm: true },
-        { severity: 1, duringBootStorm: true },
-        { severity: 3, duringBootStorm: false },
+        { eventType: 'mount_vanished', severity: 1, duringBootStorm: true },
+        { eventType: 'volume_missing', severity: 1, duringBootStorm: true },
+        { eventType: 'container_vanished', severity: 3, duringBootStorm: false },
       ]);
 
       const result = await service.computeTamperScore();
@@ -149,9 +152,22 @@ describe('appTamperingBlocklistService tests', () => {
       expect(result).to.equal(3.5); // 2 × (1 × 0.25) + 3
     });
 
+    it('never discounts container_vanished, even inside the boot-storm window', async () => {
+      // Containers persist as exited across a clean reboot, so a vanished
+      // container is tamper signal regardless of the window — a reboot must
+      // not buy kill-style tampering a discount.
+      dbHelperStub.aggregateInDatabase = sinon.stub().resolves([
+        { eventType: 'container_vanished', severity: 3, duringBootStorm: true },
+      ]);
+
+      const result = await service.computeTamperScore();
+
+      expect(result).to.equal(3);
+    });
+
     it('treats a missing severity as zero', async () => {
       dbHelperStub.aggregateInDatabase = sinon.stub().resolves([
-        { duringBootStorm: false },
+        { eventType: 'mount_vanished', duringBootStorm: false },
       ]);
 
       const result = await service.computeTamperScore();

--- a/tests/unit/appTamperingBlocklistService.test.js
+++ b/tests/unit/appTamperingBlocklistService.test.js
@@ -45,12 +45,9 @@ describe('appTamperingBlocklistService tests', () => {
 
     dbHelperStub = {
       databaseConnection: sinon.stub().returns({
-        db: sinon.stub().returns({
-          collection: sinon.stub().returns({
-            countDocuments: sinon.stub().resolves(0),
-          }),
-        }),
+        db: sinon.stub().returns({ name: 'mockdb' }),
       }),
+      aggregateInDatabase: sinon.stub().resolves([]),
     };
 
     fluxNetworkHelperStub = {
@@ -80,15 +77,13 @@ describe('appTamperingBlocklistService tests', () => {
     sinon.restore();
   });
 
-  // Helper: set documents returned by the mongo countDocuments stub
-  function setEventCount(n) {
-    dbHelperStub.databaseConnection = sinon.stub().returns({
-      db: sinon.stub().returns({
-        collection: sinon.stub().returns({
-          countDocuments: sinon.stub().resolves(n),
-        }),
-      }),
-    });
+  // Helper: make the incident aggregation return n distinct weight-1
+  // (mount_vanished) incidents, i.e. a tamper score of exactly n.
+  function setTamperScore(n) {
+    const incidents = Array.from({ length: n }, (_, i) => ({
+      _id: { eventType: 'mount_vanished', appName: `app${i}`, day: '2026-07-16' },
+    }));
+    dbHelperStub.aggregateInDatabase = sinon.stub().resolves(incidents);
   }
 
   describe('fetchBlocklist', () => {
@@ -118,33 +113,55 @@ describe('appTamperingBlocklistService tests', () => {
     });
   });
 
-  describe('countTamperingEvents', () => {
-    it('returns the count from mongo', async () => {
-      setEventCount(42);
+  describe('computeTamperScore', () => {
+    it('groups rows into distinct (eventType, appName, day) incidents', async () => {
+      setTamperScore(1);
 
-      const result = await service.countTamperingEvents();
+      await service.computeTamperScore();
 
-      expect(result).to.equal(42);
+      const pipeline = dbHelperStub.aggregateInDatabase.firstCall.args[2];
+      const groupId = pipeline[0].$group._id;
+      expect(groupId).to.have.keys(['eventType', 'appName', 'day']);
+    });
+
+    it('sums per-type weights across incidents', async () => {
+      dbHelperStub.aggregateInDatabase = sinon.stub().resolves([
+        { _id: { eventType: 'container_vanished', appName: 'a', day: '2026-07-16' } }, // 3
+        { _id: { eventType: 'network_pruned', appName: 'a', day: '2026-07-16' } }, // 1
+        { _id: { eventType: 'network_detached', appName: 'b', day: '2026-07-16' } }, // 1
+        { _id: { eventType: 'mount_vanished', appName: 'b', day: '2026-07-16' } }, // 1
+        { _id: { eventType: 'volume_missing', appName: 'c', day: '2026-07-16' } }, // 1
+      ]);
+
+      const result = await service.computeTamperScore();
+
+      expect(result).to.equal(7);
+    });
+
+    it('gives operational and observational event types zero weight', async () => {
+      dbHelperStub.aggregateInDatabase = sinon.stub().resolves([
+        { _id: { eventType: 'recreation_failed', appName: 'a', day: '2026-07-16' } },
+        { _id: { eventType: 'node_reboot', appName: '__system__', day: '2026-07-16' } },
+        { _id: { eventType: 'frequent_restart', appName: '__system__', day: '2026-07-16' } },
+      ]);
+
+      const result = await service.computeTamperScore();
+
+      expect(result).to.equal(0);
     });
 
     it('returns 0 when DB is unavailable', async () => {
       dbHelperStub.databaseConnection = sinon.stub().returns(null);
 
-      const result = await service.countTamperingEvents();
+      const result = await service.computeTamperScore();
 
       expect(result).to.equal(0);
     });
 
     it('returns 0 on mongo errors', async () => {
-      dbHelperStub.databaseConnection = sinon.stub().returns({
-        db: sinon.stub().returns({
-          collection: sinon.stub().returns({
-            countDocuments: sinon.stub().rejects(new Error('mongo boom')),
-          }),
-        }),
-      });
+      dbHelperStub.aggregateInDatabase = sinon.stub().rejects(new Error('mongo boom'));
 
-      const result = await service.countTamperingEvents();
+      const result = await service.computeTamperScore();
 
       expect(result).to.equal(0);
     });
@@ -195,25 +212,25 @@ describe('appTamperingBlocklistService tests', () => {
 
     it('does nothing when txhash is not on the blocklist', async () => {
       serviceHelperStub.axiosGet.resolves({ data: ['otherhash'] });
-      setEventCount(100);
+      setTamperScore(100);
 
       await service.enforceBlocklist();
 
       expect(fluxNetworkHelperStub.setStickyDosMessage.called).to.be.false;
     });
 
-    it('does nothing when listed but events <= threshold', async () => {
+    it('does nothing when listed but score <= threshold', async () => {
       serviceHelperStub.axiosGet.resolves({ data: [MOCK_TXHASH] });
-      setEventCount(10); // threshold is >10, so exactly 10 should NOT trigger
+      setTamperScore(10); // threshold is >10, so exactly 10 should NOT trigger
 
       await service.enforceBlocklist();
 
       expect(fluxNetworkHelperStub.setStickyDosMessage.called).to.be.false;
     });
 
-    it('sets sticky DOS when listed AND events > threshold', async () => {
+    it('sets sticky DOS when listed AND score > threshold', async () => {
       serviceHelperStub.axiosGet.resolves({ data: [MOCK_TXHASH] });
-      setEventCount(11);
+      setTamperScore(11);
 
       await service.enforceBlocklist();
 
@@ -229,7 +246,7 @@ describe('appTamperingBlocklistService tests', () => {
     it('clears sticky DOS on next tick when condition no longer holds', async () => {
       // First tick: set DOS
       serviceHelperStub.axiosGet.resolves({ data: [MOCK_TXHASH] });
-      setEventCount(15);
+      setTamperScore(15);
       await service.enforceBlocklist();
       expect(service.isDosActive()).to.be.true;
 
@@ -241,13 +258,13 @@ describe('appTamperingBlocklistService tests', () => {
       expect(service.isDosActive()).to.be.false;
     });
 
-    it('clears sticky DOS when events drop to <= threshold', async () => {
+    it('clears sticky DOS when the score drops to <= threshold', async () => {
       serviceHelperStub.axiosGet.resolves({ data: [MOCK_TXHASH] });
-      setEventCount(15);
+      setTamperScore(15);
       await service.enforceBlocklist();
       expect(service.isDosActive()).to.be.true;
 
-      setEventCount(5);
+      setTamperScore(5);
       await service.enforceBlocklist();
 
       sinon.assert.called(fluxNetworkHelperStub.clearStickyDosMessage);
@@ -256,10 +273,10 @@ describe('appTamperingBlocklistService tests', () => {
 
     it('clears an orphaned sticky DOS message owned by this service', async () => {
       // ourDosActive is false, but sticky owned by us (prefix match) from prior run
-      const ours = `${service.DOS_MESSAGE_PREFIX}: 42 events, txhash xyz`;
+      const ours = `${service.DOS_MESSAGE_PREFIX}: tamper score 42, txhash xyz`;
       fluxNetworkHelperStub.getStickyDosMessage = sinon.stub().returns(ours);
       serviceHelperStub.axiosGet.resolves({ data: [] });
-      setEventCount(0);
+      setTamperScore(0);
 
       await service.enforceBlocklist();
 
@@ -270,7 +287,7 @@ describe('appTamperingBlocklistService tests', () => {
       // Some other module set sticky for an unrelated reason
       fluxNetworkHelperStub.getStickyDosMessage = sinon.stub().returns('some other module sticky reason');
       serviceHelperStub.axiosGet.resolves({ data: [] });
-      setEventCount(0);
+      setTamperScore(0);
 
       await service.enforceBlocklist();
 
@@ -324,7 +341,7 @@ describe('appTamperingBlocklistService tests', () => {
     it('enforceBlocklist is a no-op when bench reports systemsecure=true', async () => {
       const arcaneService = makeArcaneService();
       serviceHelperStub.axiosGet.resolves({ data: [MOCK_TXHASH] });
-      setEventCount(100);
+      setTamperScore(100);
 
       await arcaneService.enforceBlocklist();
 
@@ -357,7 +374,7 @@ describe('appTamperingBlocklistService tests', () => {
       benchmarkServiceStub.getBenchmarks = sinon.stub().rejects(new Error('bench down'));
       const svc = loadService();
       serviceHelperStub.axiosGet.resolves({ data: [MOCK_TXHASH] });
-      setEventCount(100);
+      setTamperScore(100);
 
       await svc.enforceBlocklist();
 
@@ -369,7 +386,7 @@ describe('appTamperingBlocklistService tests', () => {
       benchmarkServiceStub.getBenchmarks = sinon.stub().resolves({ status: 'error' });
       const svc = loadService();
       serviceHelperStub.axiosGet.resolves({ data: [MOCK_TXHASH] });
-      setEventCount(100);
+      setTamperScore(100);
 
       await svc.enforceBlocklist();
 
@@ -384,7 +401,7 @@ describe('appTamperingBlocklistService tests', () => {
       });
       const svc = loadService();
       serviceHelperStub.axiosGet.resolves({ data: [MOCK_TXHASH] });
-      setEventCount(100);
+      setTamperScore(100);
 
       await svc.enforceBlocklist();
 
@@ -398,7 +415,7 @@ describe('appTamperingBlocklistService tests', () => {
       process.env.FLUXOS_PATH = '/fake/arcane/path';
       try {
         serviceHelperStub.axiosGet.resolves({ data: [MOCK_TXHASH] });
-        setEventCount(100);
+        setTamperScore(100);
         const svc = loadService();
 
         await svc.enforceBlocklist();

--- a/tests/unit/appTamperingBlocklistService.test.js
+++ b/tests/unit/appTamperingBlocklistService.test.js
@@ -35,6 +35,7 @@ describe('appTamperingBlocklistService tests', () => {
       './generalService': generalServiceStub,
       './daemonService/daemonServiceMiscRpcs': daemonMiscStub,
       './benchmarkService': benchmarkServiceStub,
+      './appTamperingDetectionService': { BOOT_STORM_DISCOUNT: 0.25 },
     });
   }
 
@@ -77,11 +78,11 @@ describe('appTamperingBlocklistService tests', () => {
     sinon.restore();
   });
 
-  // Helper: make the incident aggregation return n distinct weight-1
-  // (mount_vanished) incidents, i.e. a tamper score of exactly n.
+  // Helper: make the incident aggregation return n severity-1 incidents
+  // outside any boot storm, i.e. a tamper score of exactly n.
   function setTamperScore(n) {
-    const incidents = Array.from({ length: n }, (_, i) => ({
-      _id: { eventType: 'mount_vanished', appName: `app${i}`, day: '2026-07-16' },
+    const incidents = Array.from({ length: n }, () => ({
+      severity: 1, duringBootStorm: false,
     }));
     dbHelperStub.aggregateInDatabase = sinon.stub().resolves(incidents);
   }
@@ -114,35 +115,43 @@ describe('appTamperingBlocklistService tests', () => {
   });
 
   describe('computeTamperScore', () => {
-    it('groups rows into distinct (eventType, appName, day) incidents', async () => {
+    it('scores only current-schema incident documents', async () => {
       setTamperScore(1);
 
       await service.computeTamperScore();
 
       const pipeline = dbHelperStub.aggregateInDatabase.firstCall.args[2];
-      const groupId = pipeline[0].$group._id;
-      expect(groupId).to.have.keys(['eventType', 'appName', 'day']);
+      expect(pipeline[0]).to.deep.equal({ $match: { schemaVersion: { $gte: 1 } } });
     });
 
-    it('sums per-type weights across incidents', async () => {
+    it('sums stored severities across incidents', async () => {
       dbHelperStub.aggregateInDatabase = sinon.stub().resolves([
-        { _id: { eventType: 'container_vanished', appName: 'a', day: '2026-07-16' } }, // 3
-        { _id: { eventType: 'network_pruned', appName: 'a', day: '2026-07-16' } }, // 1
-        { _id: { eventType: 'network_detached', appName: 'b', day: '2026-07-16' } }, // 1
-        { _id: { eventType: 'mount_vanished', appName: 'b', day: '2026-07-16' } }, // 1
-        { _id: { eventType: 'volume_missing', appName: 'c', day: '2026-07-16' } }, // 1
+        { severity: 3, duringBootStorm: false },
+        { severity: 1, duringBootStorm: false },
+        { severity: 1, duringBootStorm: false },
+        { severity: 0, duringBootStorm: false }, // operational/observational
       ]);
 
       const result = await service.computeTamperScore();
 
-      expect(result).to.equal(7);
+      expect(result).to.equal(5);
     });
 
-    it('gives operational and observational event types zero weight', async () => {
+    it('discounts incidents flagged duringBootStorm', async () => {
       dbHelperStub.aggregateInDatabase = sinon.stub().resolves([
-        { _id: { eventType: 'recreation_failed', appName: 'a', day: '2026-07-16' } },
-        { _id: { eventType: 'node_reboot', appName: '__system__', day: '2026-07-16' } },
-        { _id: { eventType: 'frequent_restart', appName: '__system__', day: '2026-07-16' } },
+        { severity: 1, duringBootStorm: true },
+        { severity: 1, duringBootStorm: true },
+        { severity: 3, duringBootStorm: false },
+      ]);
+
+      const result = await service.computeTamperScore();
+
+      expect(result).to.equal(3.5); // 2 × (1 × 0.25) + 3
+    });
+
+    it('treats a missing severity as zero', async () => {
+      dbHelperStub.aggregateInDatabase = sinon.stub().resolves([
+        { duringBootStorm: false },
       ]);
 
       const result = await service.computeTamperScore();

--- a/tests/unit/appTamperingBlocklistService.test.js
+++ b/tests/unit/appTamperingBlocklistService.test.js
@@ -35,10 +35,6 @@ describe('appTamperingBlocklistService tests', () => {
       './generalService': generalServiceStub,
       './daemonService/daemonServiceMiscRpcs': daemonMiscStub,
       './benchmarkService': benchmarkServiceStub,
-      './appTamperingDetectionService': {
-        BOOT_STORM_DISCOUNT: 0.25,
-        BOOT_STORM_DISCOUNT_TYPES: ['mount_vanished', 'volume_missing', 'network_pruned', 'recreation_failed'],
-      },
     });
   }
 
@@ -81,11 +77,11 @@ describe('appTamperingBlocklistService tests', () => {
     sinon.restore();
   });
 
-  // Helper: make the incident aggregation return n severity-1 incidents
-  // outside any boot storm, i.e. a tamper score of exactly n.
+  // Helper: make the incident aggregation return n severity-1 incidents,
+  // i.e. a tamper score of exactly n.
   function setTamperScore(n) {
     const incidents = Array.from({ length: n }, () => ({
-      eventType: 'mount_vanished', severity: 1, duringBootStorm: false,
+      eventType: 'mount_vanished', severity: 1,
     }));
     dbHelperStub.aggregateInDatabase = sinon.stub().resolves(incidents);
   }
@@ -129,10 +125,10 @@ describe('appTamperingBlocklistService tests', () => {
 
     it('sums stored severities across incidents', async () => {
       dbHelperStub.aggregateInDatabase = sinon.stub().resolves([
-        { eventType: 'container_vanished', severity: 3, duringBootStorm: false },
-        { eventType: 'network_pruned', severity: 1, duringBootStorm: false },
-        { eventType: 'network_detached', severity: 1, duringBootStorm: false },
-        { eventType: 'recreation_failed', severity: 0, duringBootStorm: false }, // operational
+        { eventType: 'container_vanished', severity: 3 },
+        { eventType: 'network_pruned', severity: 1 },
+        { eventType: 'network_detached', severity: 1 },
+        { eventType: 'recreation_failed', severity: 0 }, // operational
       ]);
 
       const result = await service.computeTamperScore();
@@ -140,34 +136,22 @@ describe('appTamperingBlocklistService tests', () => {
       expect(result).to.equal(5);
     });
 
-    it('discounts boot-race incidents flagged duringBootStorm', async () => {
+    it('scores full weight regardless of stored duringBootStorm flags', async () => {
+      // Stored incidents may carry a duringBootStorm flag; it is inert —
+      // severities always sum in full.
       dbHelperStub.aggregateInDatabase = sinon.stub().resolves([
         { eventType: 'mount_vanished', severity: 1, duringBootStorm: true },
-        { eventType: 'volume_missing', severity: 1, duringBootStorm: true },
-        { eventType: 'container_vanished', severity: 3, duringBootStorm: false },
-      ]);
-
-      const result = await service.computeTamperScore();
-
-      expect(result).to.equal(3.5); // 2 × (1 × 0.25) + 3
-    });
-
-    it('never discounts container_vanished, even inside the boot-storm window', async () => {
-      // Containers persist as exited across a clean reboot, so a vanished
-      // container is tamper signal regardless of the window — a reboot must
-      // not buy kill-style tampering a discount.
-      dbHelperStub.aggregateInDatabase = sinon.stub().resolves([
         { eventType: 'container_vanished', severity: 3, duringBootStorm: true },
       ]);
 
       const result = await service.computeTamperScore();
 
-      expect(result).to.equal(3);
+      expect(result).to.equal(4);
     });
 
     it('treats a missing severity as zero', async () => {
       dbHelperStub.aggregateInDatabase = sinon.stub().resolves([
-        { eventType: 'mount_vanished', duringBootStorm: false },
+        { eventType: 'mount_vanished' },
       ]);
 
       const result = await service.computeTamperScore();

--- a/tests/unit/appTamperingDetectionService.test.js
+++ b/tests/unit/appTamperingDetectionService.test.js
@@ -195,7 +195,6 @@ describe('appTamperingDetectionService tests', () => {
       const ins = update.$setOnInsert;
       expect(ins.schemaVersion).to.equal(1);
       expect(ins.severity).to.equal(service.EVENT_SEVERITY.container_vanished);
-      expect(ins.duringBootStorm).to.be.false;
       expect(ins.firstSeen).to.be.instanceOf(Date);
       expect(ins.detailsSample).to.equal('details here');
       expect(ins.uptimeSecAtEvent).to.equal(3600);
@@ -266,12 +265,10 @@ describe('appTamperingDetectionService tests', () => {
       expect(ins.appHash).to.equal('spechash1');
     });
 
-    it('records null attribution for unknown apps and for __system__', async () => {
+    it('records null attribution for unknown apps', async () => {
       await service.recordEvent('ghostapp', 'container_vanished', 'x');
-      await service.recordEvent(service.SYSTEM_APP_NAME, 'node_reboot', 'x');
 
       expect(eventUpserts()[0].update.$setOnInsert.ownerZelid).to.be.null;
-      expect(eventUpserts()[1].update.$setOnInsert.ownerZelid).to.be.null;
     });
 
     it('uses the same incidentKey for repeats within the hour bucket', async () => {
@@ -339,45 +336,11 @@ describe('appTamperingDetectionService tests', () => {
     });
   });
 
-  describe('boot storm flagging', () => {
-    async function rebootNow() {
+  describe('boot context keying', () => {
+    it('keys incidents by the current boot_id once checkNodeReboot has run', async () => {
       dbHelperStub.findOneInDatabase = sinon.stub().callsFake(async (db, coll, query) => {
         if (coll === 'nodestartuptracker' && query._id === 'lastStartup') {
           return { _id: 'lastStartup', at: new Date(), bootId: PREVIOUS_BOOT_ID };
-        }
-        return null;
-      });
-      await service.checkNodeReboot();
-    }
-
-    it('flags events inside the window after a boot_id change', async () => {
-      sinon.useFakeTimers(new Date('2026-07-16T10:00:00Z'));
-      await rebootNow();
-
-      await service.recordEvent('myapp', 'mount_vanished', 'late disk');
-
-      const incident = eventUpserts().find((c) => c.query.eventType === 'mount_vanished');
-      expect(incident.update.$setOnInsert.duringBootStorm).to.be.true;
-      expect(incident.update.$setOnInsert.bootId).to.equal(CURRENT_BOOT_ID);
-      expect(incident.query.incidentKey).to.include(CURRENT_BOOT_ID);
-    });
-
-    it('stops flagging once the window has elapsed', async () => {
-      const clock = sinon.useFakeTimers(new Date('2026-07-16T10:00:00Z'));
-      await rebootNow();
-
-      clock.tick(service.BOOT_STORM_WINDOW_MS);
-      await service.recordEvent('myapp', 'mount_vanished', 'vanished while up');
-
-      const incident = eventUpserts().find((c) => c.query.eventType === 'mount_vanished');
-      expect(incident.update.$setOnInsert.duringBootStorm).to.be.false;
-    });
-
-    it('does NOT open the window on a same-boot_id process restart', async () => {
-      sinon.useFakeTimers(new Date('2026-07-16T10:00:00Z'));
-      dbHelperStub.findOneInDatabase = sinon.stub().callsFake(async (db, coll, query) => {
-        if (coll === 'nodestartuptracker' && query._id === 'lastStartup') {
-          return { _id: 'lastStartup', at: new Date(), bootId: CURRENT_BOOT_ID };
         }
         return null;
       });
@@ -386,7 +349,8 @@ describe('appTamperingDetectionService tests', () => {
       await service.recordEvent('myapp', 'mount_vanished', 'x');
 
       const incident = eventUpserts().find((c) => c.query.eventType === 'mount_vanished');
-      expect(incident.update.$setOnInsert.duringBootStorm).to.be.false;
+      expect(incident.update.$setOnInsert.bootId).to.equal(CURRENT_BOOT_ID);
+      expect(incident.query.incidentKey).to.include(CURRENT_BOOT_ID);
     });
   });
 
@@ -544,20 +508,14 @@ describe('appTamperingDetectionService tests', () => {
       });
     }
 
-    it('records a node_reboot incident when the boot_id changed', async () => {
-      const previousAt = new Date('2026-07-15T10:00:00Z');
-      setMarker({ _id: 'lastStartup', at: previousAt, bootId: PREVIOUS_BOOT_ID });
+    it('records a reboot only in the boot history, never as an incident', async () => {
+      setMarker({ _id: 'lastStartup', at: new Date('2026-07-15T10:00:00Z'), bootId: PREVIOUS_BOOT_ID });
 
       await service.checkNodeReboot();
 
-      const reboots = eventUpserts().filter((c) => c.query.eventType === 'node_reboot');
-      expect(reboots).to.have.lengthOf(1);
-      expect(reboots[0].query.appName).to.equal(service.SYSTEM_APP_NAME);
-      const ins = reboots[0].update.$setOnInsert;
-      expect(ins.severity).to.equal(0);
-      expect(ins.detailsSample).to.include(PREVIOUS_BOOT_ID.slice(0, 8));
-      expect(ins.detailsSample).to.include(CURRENT_BOOT_ID.slice(0, 8));
-      expect(ins.detailsSample).to.include(previousAt.toISOString());
+      expect(eventUpserts()).to.have.lengthOf(0);
+      expect(historyUpdates()).to.have.lengthOf(1);
+      expect(markerUpdates()).to.have.lengthOf(1);
     });
 
     it('does NOT record an incident on a same-boot_id process restart', async () => {
@@ -605,6 +563,9 @@ describe('appTamperingDetectionService tests', () => {
       const push = history[0].update.$push.boots;
       expect(push.$each[0].bootId).to.equal(CURRENT_BOOT_ID);
       expect(push.$each[0].at).to.be.instanceOf(Date);
+      // bootedAt = FluxOS start minus the stubbed 3600s of machine uptime
+      expect(push.$each[0].bootedAt).to.be.instanceOf(Date);
+      expect(push.$each[0].at.getTime() - push.$each[0].bootedAt.getTime()).to.equal(3600 * 1000);
       expect(push.$slice).to.equal(-service.BOOT_HISTORY_MAX);
       expect(history[0].options).to.deep.equal({ upsert: true });
     });

--- a/tests/unit/appTamperingDetectionService.test.js
+++ b/tests/unit/appTamperingDetectionService.test.js
@@ -38,6 +38,7 @@ describe('appTamperingDetectionService tests', () => {
       }),
       findOneInDatabase: sinon.stub().resolves(null),
       findOneAndUpdateInDatabase: sinon.stub().resolves({ value: null }),
+      removeDocumentsFromCollection: sinon.stub().resolves({ deletedCount: 0 }),
     };
 
     logStub = {
@@ -410,6 +411,24 @@ describe('appTamperingDetectionService tests', () => {
       expect(dbHelperStub.findOneAndUpdateInDatabase.called).to.be.false;
     });
 
+    it('purges legacy frequent_restart rows', async () => {
+      await service.checkNodeReboot();
+
+      sinon.assert.calledOnce(dbHelperStub.removeDocumentsFromCollection);
+      const { args } = dbHelperStub.removeDocumentsFromCollection.firstCall;
+      expect(args[1]).to.equal('apptamperingevents');
+      expect(args[2]).to.deep.equal({ eventType: 'frequent_restart' });
+    });
+
+    it('still tracks the boot when the legacy purge fails', async () => {
+      dbHelperStub.removeDocumentsFromCollection = sinon.stub().rejects(new Error('no permission'));
+
+      await service.checkNodeReboot();
+
+      expect(markerUpdates()).to.have.lengthOf(1);
+      sinon.assert.called(logStub.warn);
+    });
+
     it('no-ops when DB is unavailable', async () => {
       dbHelperStub.databaseConnection = sinon.stub().returns(null);
 
@@ -417,6 +436,7 @@ describe('appTamperingDetectionService tests', () => {
 
       expect(dbHelperStub.findOneInDatabase.called).to.be.false;
       expect(dbHelperStub.findOneAndUpdateInDatabase.called).to.be.false;
+      expect(dbHelperStub.removeDocumentsFromCollection.called).to.be.false;
     });
 
     it('swallows errors without throwing and logs them', async () => {

--- a/tests/unit/appTamperingDetectionService.test.js
+++ b/tests/unit/appTamperingDetectionService.test.js
@@ -7,28 +7,54 @@ describe('appTamperingDetectionService tests', () => {
   let dbHelperStub;
   let logStub;
   let fsReadFileStub;
-  let insertedDocs;
+  let fluxnodeRpcsStub;
+  let generalServiceStub;
+  let upsertCalls;
   let findResults;
   let lastFindArgs;
-  let databaseConnectionReturn;
+  let installedApps;
 
   const CURRENT_BOOT_ID = 'aaaaaaaa-1111-2222-3333-444444444444';
   const PREVIOUS_BOOT_ID = 'bbbbbbbb-5555-6666-7777-888888888888';
+  const NODE_STATUS = {
+    status: 'success',
+    data: {
+      txhash: 'deadbeefcafe',
+      outidx: 0,
+      ip: '65.108.1.2:16127',
+      pubkey: '04aabbcc',
+      payment_address: 't1payout',
+      collateral: 'COutPoint(deadbeefcafe, 0)',
+    },
+  };
+
+  function eventUpserts() {
+    return upsertCalls.filter((c) => c.coll === 'apptamperingevents');
+  }
+
+  function markerUpdates() {
+    return upsertCalls.filter((c) => c.coll === 'nodestartuptracker' && c.query._id === 'lastStartup');
+  }
+
+  function historyUpdates() {
+    return upsertCalls.filter((c) => c.coll === 'nodestartuptracker' && c.query._id === 'bootHistory');
+  }
 
   beforeEach(() => {
-    insertedDocs = [];
+    upsertCalls = [];
     findResults = [];
     lastFindArgs = null;
-
-    databaseConnectionReturn = {
-      db: sinon.stub().returns({ name: 'mockdb' }),
-    };
+    installedApps = {}; // name -> { owner, hash }
 
     dbHelperStub = {
-      databaseConnection: sinon.stub().callsFake(() => databaseConnectionReturn),
-      insertOneToDatabase: sinon.stub().callsFake(async (db, coll, doc) => {
-        insertedDocs.push({ db, coll, doc });
-        return { insertedId: 'mock-id' };
+      databaseConnection: sinon.stub().returns({
+        db: sinon.stub().callsFake((name) => ({ name })),
+      }),
+      findOneAndUpdateInDatabase: sinon.stub().callsFake(async (db, coll, query, update, options) => {
+        upsertCalls.push({
+          db, coll, query, update, options,
+        });
+        return null; // driver v6 upsert shape: null means a fresh insert
       }),
       findInDatabase: sinon.stub().callsFake(async (db, coll, query, options) => {
         lastFindArgs = {
@@ -36,8 +62,10 @@ describe('appTamperingDetectionService tests', () => {
         };
         return findResults;
       }),
-      findOneInDatabase: sinon.stub().resolves(null),
-      findOneAndUpdateInDatabase: sinon.stub().resolves({ value: null }),
+      findOneInDatabase: sinon.stub().callsFake(async (db, coll, query) => {
+        if (coll === 'zelappsinformation') return installedApps[query.name] || null;
+        return null; // startup marker by default absent
+      }),
       removeDocumentsFromCollection: sinon.stub().resolves({ deletedCount: 0 }),
     };
 
@@ -46,6 +74,8 @@ describe('appTamperingDetectionService tests', () => {
     };
 
     fsReadFileStub = sinon.stub().resolves(`${CURRENT_BOOT_ID}\n`);
+    fluxnodeRpcsStub = { getFluxNodeStatus: sinon.stub().resolves(NODE_STATUS) };
+    generalServiceStub = { getCollateralInfo: sinon.stub().returns({ txhash: 'colTx', txindex: 7 }) };
 
     service = proxyquire('../../ZelBack/src/services/appTamperingDetectionService', {
       config: {
@@ -57,6 +87,10 @@ describe('appTamperingDetectionService tests', () => {
               nodeStartupTracker: 'nodestartuptracker',
             },
           },
+          appslocal: {
+            database: 'localzelappsinformation',
+            collections: { appsInformation: 'zelappsinformation' },
+          },
         },
         system: {
           bootIdPath: '/proc/sys/kernel/random/boot_id',
@@ -65,8 +99,12 @@ describe('appTamperingDetectionService tests', () => {
       fs: {
         promises: { readFile: fsReadFileStub },
       },
+      os: { uptime: () => 3600 },
       './dbHelper': dbHelperStub,
       '../lib/log': logStub,
+      './generalService': generalServiceStub,
+      './daemonService/daemonServiceFluxnodeRpcs': fluxnodeRpcsStub,
+      './utils/appConstants': { localAppsInformation: 'zelappsinformation' },
       './messageHelper': {
         createDataMessage: (d) => ({ status: 'success', data: d }),
         createErrorMessage: (m) => ({ status: 'error', data: { message: m } }),
@@ -123,92 +161,231 @@ describe('appTamperingDetectionService tests', () => {
     });
   });
 
+  describe('deriveMainAppName', () => {
+    it('passes a plain app name through', () => {
+      expect(service.deriveMainAppName('MyApp')).to.equal('MyApp');
+    });
+
+    it('strips the flux docker prefix', () => {
+      expect(service.deriveMainAppName('fluxMyApp')).to.equal('MyApp');
+    });
+
+    it('strips the zel docker prefix', () => {
+      expect(service.deriveMainAppName('zelMyApp')).to.equal('MyApp');
+    });
+
+    it('reduces a component identifier to the main app name', () => {
+      expect(service.deriveMainAppName('fluxweb_MyApp')).to.equal('MyApp');
+      expect(service.deriveMainAppName('web_MyApp')).to.equal('MyApp');
+    });
+  });
+
   describe('recordEvent', () => {
-    it('inserts a new document with expected shape', async () => {
+    it('upserts an incident with the full schema on first sight', async () => {
       await service.recordEvent('myapp', 'container_vanished', 'details here');
 
-      expect(insertedDocs).to.have.lengthOf(1);
-      const { coll, doc } = insertedDocs[0];
-      expect(coll).to.equal('apptamperingevents');
-      expect(doc.appName).to.equal('myapp');
-      expect(doc.eventType).to.equal('container_vanished');
-      expect(doc.details).to.equal('details here');
-      expect(doc.detectedAt).to.be.instanceOf(Date);
+      expect(eventUpserts()).to.have.lengthOf(1);
+      const { query, update, options } = eventUpserts()[0];
+      expect(query.appName).to.equal('myapp');
+      expect(query.eventType).to.equal('container_vanished');
+      expect(query.incidentKey).to.be.a('string');
+      expect(options).to.deep.equal({ upsert: true });
+
+      const ins = update.$setOnInsert;
+      expect(ins.schemaVersion).to.equal(1);
+      expect(ins.severity).to.equal(service.EVENT_SEVERITY.container_vanished);
+      expect(ins.duringBootStorm).to.be.false;
+      expect(ins.firstSeen).to.be.instanceOf(Date);
+      expect(ins.detailsSample).to.equal('details here');
+      expect(ins.uptimeSecAtEvent).to.equal(3600);
+      expect(update.$set.lastSeen).to.be.instanceOf(Date);
+      expect(update.$inc).to.deep.equal({ count: 1 });
     });
 
-    it('suppresses repeat (appName, eventType) calls within the episode window', async () => {
+    it('stamps node and operator identity from the daemon status', async () => {
+      await service.recordEvent('myapp', 'container_vanished', 'x');
+
+      const ins = eventUpserts()[0].update.$setOnInsert;
+      expect(ins.nodeTxid).to.equal('deadbeefcafe');
+      expect(ins.nodeOutidx).to.equal(0);
+      expect(ins.nodeIp).to.equal('65.108.1.2:16127');
+      expect(ins.pubkey).to.equal('04aabbcc');
+      expect(ins.paymentAddress).to.equal('t1payout');
+    });
+
+    it('caches node identity across events (one RPC)', async () => {
+      await service.recordEvent('a', 'container_vanished', 'x');
+      await service.recordEvent('b', 'container_vanished', 'x');
+
+      sinon.assert.calledOnce(fluxnodeRpcsStub.getFluxNodeStatus);
+    });
+
+    it('falls back to collateral parsing when status lacks txhash/outidx', async () => {
+      fluxnodeRpcsStub.getFluxNodeStatus.resolves({
+        status: 'success',
+        data: { collateral: 'COutPoint(colTx, 7)', ip: '1.2.3.4' },
+      });
+
+      await service.recordEvent('myapp', 'container_vanished', 'x');
+
+      const ins = eventUpserts()[0].update.$setOnInsert;
+      expect(ins.nodeTxid).to.equal('colTx');
+      expect(ins.nodeOutidx).to.equal(7);
+    });
+
+    it('records unattributed when the daemon is unreachable, and backs off', async () => {
+      fluxnodeRpcsStub.getFluxNodeStatus.rejects(new Error('daemon down'));
+
+      await service.recordEvent('a', 'container_vanished', 'x');
+      await service.recordEvent('b', 'container_vanished', 'x');
+
+      expect(eventUpserts()).to.have.lengthOf(2);
+      expect(eventUpserts()[0].update.$setOnInsert.nodeTxid).to.be.null;
+      expect(eventUpserts()[0].update.$setOnInsert.pubkey).to.be.null;
+      sinon.assert.calledOnce(fluxnodeRpcsStub.getFluxNodeStatus); // backoff, no hammering
+    });
+
+    it('attributes the app owner and spec hash by exact name', async () => {
+      installedApps.myapp = { owner: '1ownerZelid', hash: 'spechash1' };
+
+      await service.recordEvent('myapp', 'container_vanished', 'x');
+
+      const ins = eventUpserts()[0].update.$setOnInsert;
+      expect(ins.ownerZelid).to.equal('1ownerZelid');
+      expect(ins.appHash).to.equal('spechash1');
+    });
+
+    it('attributes a component identifier via the derived main app name', async () => {
+      installedApps.MyApp = { owner: '1ownerZelid', hash: 'spechash1' };
+
+      await service.recordEvent('fluxweb_MyApp', 'mount_vanished', 'x');
+
+      const ins = eventUpserts()[0].update.$setOnInsert;
+      expect(ins.ownerZelid).to.equal('1ownerZelid');
+      expect(ins.appHash).to.equal('spechash1');
+    });
+
+    it('records null attribution for unknown apps and for __system__', async () => {
+      await service.recordEvent('ghostapp', 'container_vanished', 'x');
+      await service.recordEvent(service.SYSTEM_APP_NAME, 'node_reboot', 'x');
+
+      expect(eventUpserts()[0].update.$setOnInsert.ownerZelid).to.be.null;
+      expect(eventUpserts()[1].update.$setOnInsert.ownerZelid).to.be.null;
+    });
+
+    it('uses the same incidentKey for repeats within the hour bucket', async () => {
+      const clock = sinon.useFakeTimers(new Date('2026-07-16T10:00:00Z'));
+
       await service.recordEvent('myapp', 'mount_vanished', 'a');
+      clock.tick(10 * 60 * 1000);
       await service.recordEvent('myapp', 'mount_vanished', 'b');
-      await service.recordEvent('myapp', 'mount_vanished', 'c');
 
-      expect(insertedDocs).to.have.lengthOf(1);
-      expect(insertedDocs[0].doc.details).to.equal('a');
+      expect(eventUpserts()).to.have.lengthOf(2); // both reach the DB: count rolls up
+      expect(eventUpserts()[0].query.incidentKey).to.equal(eventUpserts()[1].query.incidentKey);
     });
 
-    it('records different event types for the same app independently', async () => {
-      await service.recordEvent('myapp', 'container_vanished', 'a');
-      await service.recordEvent('myapp', 'recreation_failed', 'b');
+    it('opens a new incident in the next hour bucket', async () => {
+      const clock = sinon.useFakeTimers(new Date('2026-07-16T10:00:00Z'));
 
-      expect(insertedDocs).to.have.lengthOf(2);
+      await service.recordEvent('myapp', 'mount_vanished', 'a');
+      clock.tick(service.INCIDENT_BUCKET_MS);
+      await service.recordEvent('myapp', 'mount_vanished', 'b');
+
+      expect(eventUpserts()[0].query.incidentKey).to.not.equal(eventUpserts()[1].query.incidentKey);
     });
 
-    it('records the same event type for different apps independently', async () => {
-      await service.recordEvent('app1', 'mount_vanished', 'a');
-      await service.recordEvent('app2', 'mount_vanished', 'b');
+    it('stamps severity 0 for operational and unknown event types', async () => {
+      await service.recordEvent('myapp', 'recreation_failed', 'x');
+      await service.recordEvent('myapp', 'some_future_type', 'x');
 
-      expect(insertedDocs).to.have.lengthOf(2);
+      expect(eventUpserts()[0].update.$setOnInsert.severity).to.equal(0);
+      expect(eventUpserts()[1].update.$setOnInsert.severity).to.equal(0);
     });
 
-    it('records again once the episode window has elapsed', async () => {
-      const clock = sinon.useFakeTimers(new Date('2026-07-16T00:00:00Z'));
+    it('retries once when concurrent upserts race on the unique index', async () => {
+      const dupErr = new Error('E11000 duplicate key');
+      dupErr.code = 11000;
+      dbHelperStub.findOneAndUpdateInDatabase = sinon.stub()
+        .onFirstCall().rejects(dupErr)
+        .callsFake(async (db, coll, query, update, options) => {
+          upsertCalls.push({
+            db, coll, query, update, options,
+          });
+          return { count: 1 };
+        });
 
-      await service.recordEvent('myapp', 'mount_vanished', 'first episode');
-      clock.tick(service.EPISODE_WINDOW_MS);
-      await service.recordEvent('myapp', 'mount_vanished', 'second episode');
+      await service.recordEvent('myapp', 'container_vanished', 'x');
 
-      expect(insertedDocs).to.have.lengthOf(2);
-    });
-
-    it('still suppresses just before the episode window elapses', async () => {
-      const clock = sinon.useFakeTimers(new Date('2026-07-16T00:00:00Z'));
-
-      await service.recordEvent('myapp', 'mount_vanished', 'first');
-      clock.tick(service.EPISODE_WINDOW_MS - 1);
-      await service.recordEvent('myapp', 'mount_vanished', 'still same episode');
-
-      expect(insertedDocs).to.have.lengthOf(1);
+      expect(eventUpserts()).to.have.lengthOf(1);
+      expect(logStub.error.called).to.be.false;
     });
 
     it('no-ops when DB is not available', async () => {
-      databaseConnectionReturn = null;
       dbHelperStub.databaseConnection = sinon.stub().returns(null);
 
       await service.recordEvent('myapp', 'container_vanished', 'x');
 
-      expect(dbHelperStub.insertOneToDatabase.called).to.be.false;
+      expect(dbHelperStub.findOneAndUpdateInDatabase.called).to.be.false;
     });
 
-    it('swallows insert errors without throwing and logs them', async () => {
-      dbHelperStub.insertOneToDatabase = sinon.stub().rejects(new Error('boom'));
+    it('swallows write errors without throwing and logs them', async () => {
+      dbHelperStub.findOneAndUpdateInDatabase = sinon.stub().rejects(new Error('boom'));
 
       await service.recordEvent('myapp', 'container_vanished', 'x');
 
       sinon.assert.calledOnce(logStub.error);
       expect(logStub.error.firstCall.args[0]).to.include('boom');
     });
+  });
 
-    it('does not consume the episode when the insert fails', async () => {
-      dbHelperStub.insertOneToDatabase = sinon.stub().rejects(new Error('boom'));
-      await service.recordEvent('myapp', 'container_vanished', 'lost');
-
-      dbHelperStub.insertOneToDatabase = sinon.stub().callsFake(async (db, coll, doc) => {
-        insertedDocs.push({ db, coll, doc });
-        return { insertedId: 'mock-id' };
+  describe('boot storm flagging', () => {
+    async function rebootNow() {
+      dbHelperStub.findOneInDatabase = sinon.stub().callsFake(async (db, coll, query) => {
+        if (coll === 'nodestartuptracker' && query._id === 'lastStartup') {
+          return { _id: 'lastStartup', at: new Date(), bootId: PREVIOUS_BOOT_ID };
+        }
+        return null;
       });
-      await service.recordEvent('myapp', 'container_vanished', 'retried');
+      await service.checkNodeReboot();
+    }
 
-      expect(insertedDocs).to.have.lengthOf(1);
-      expect(insertedDocs[0].doc.details).to.equal('retried');
+    it('flags events inside the window after a boot_id change', async () => {
+      sinon.useFakeTimers(new Date('2026-07-16T10:00:00Z'));
+      await rebootNow();
+
+      await service.recordEvent('myapp', 'mount_vanished', 'late disk');
+
+      const incident = eventUpserts().find((c) => c.query.eventType === 'mount_vanished');
+      expect(incident.update.$setOnInsert.duringBootStorm).to.be.true;
+      expect(incident.update.$setOnInsert.bootId).to.equal(CURRENT_BOOT_ID);
+      expect(incident.query.incidentKey).to.include(CURRENT_BOOT_ID);
+    });
+
+    it('stops flagging once the window has elapsed', async () => {
+      const clock = sinon.useFakeTimers(new Date('2026-07-16T10:00:00Z'));
+      await rebootNow();
+
+      clock.tick(service.BOOT_STORM_WINDOW_MS);
+      await service.recordEvent('myapp', 'mount_vanished', 'vanished while up');
+
+      const incident = eventUpserts().find((c) => c.query.eventType === 'mount_vanished');
+      expect(incident.update.$setOnInsert.duringBootStorm).to.be.false;
+    });
+
+    it('does NOT open the window on a same-boot_id process restart', async () => {
+      sinon.useFakeTimers(new Date('2026-07-16T10:00:00Z'));
+      dbHelperStub.findOneInDatabase = sinon.stub().callsFake(async (db, coll, query) => {
+        if (coll === 'nodestartuptracker' && query._id === 'lastStartup') {
+          return { _id: 'lastStartup', at: new Date(), bootId: CURRENT_BOOT_ID };
+        }
+        return null;
+      });
+      await service.checkNodeReboot();
+
+      await service.recordEvent('myapp', 'mount_vanished', 'x');
+
+      const incident = eventUpserts().find((c) => c.query.eventType === 'mount_vanished');
+      expect(incident.update.$setOnInsert.duringBootStorm).to.be.false;
     });
   });
 
@@ -219,9 +396,9 @@ describe('appTamperingDetectionService tests', () => {
       return res;
     }
 
-    it('returns all events when no appname filter, sorted by detectedAt desc', async () => {
+    it('returns events newest first, keeping _id as the stable paging key', async () => {
       findResults = [
-        { appName: 'a', eventType: 'x', detectedAt: new Date() },
+        { _id: 'x', appName: 'a', eventType: 'y' },
       ];
       const req = { params: {}, query: {} };
       const res = makeRes();
@@ -230,8 +407,8 @@ describe('appTamperingDetectionService tests', () => {
 
       expect(lastFindArgs.coll).to.equal('apptamperingevents');
       expect(lastFindArgs.query).to.deep.equal({});
-      expect(lastFindArgs.options.sort).to.deep.equal({ detectedAt: -1 });
-      expect(lastFindArgs.options.projection).to.deep.equal({ _id: 0 });
+      expect(lastFindArgs.options.sort).to.deep.equal({ lastSeen: -1, detectedAt: -1 });
+      expect(lastFindArgs.options.projection).to.equal(undefined);
       sinon.assert.calledWith(res.json, sinon.match({ status: 'success' }));
     });
 
@@ -310,105 +487,76 @@ describe('appTamperingDetectionService tests', () => {
   });
 
   describe('checkNodeReboot', () => {
-    function markerUpdates() {
-      return dbHelperStub.findOneAndUpdateInDatabase.getCalls()
-        .filter((c) => c.args[2] && c.args[2]._id === 'lastStartup');
-    }
-
-    function historyUpdates() {
-      return dbHelperStub.findOneAndUpdateInDatabase.getCalls()
-        .filter((c) => c.args[2] && c.args[2]._id === 'bootHistory');
-    }
-
-    it('records a node_reboot event when the boot_id changed', async () => {
-      const previousAt = new Date('2026-07-15T10:00:00Z');
-      dbHelperStub.findOneInDatabase = sinon.stub().resolves({
-        _id: 'lastStartup', at: previousAt, bootId: PREVIOUS_BOOT_ID,
+    function setMarker(marker) {
+      dbHelperStub.findOneInDatabase = sinon.stub().callsFake(async (db, coll, query) => {
+        if (coll === 'nodestartuptracker' && query._id === 'lastStartup') return marker;
+        return null;
       });
+    }
+
+    it('records a node_reboot incident when the boot_id changed', async () => {
+      const previousAt = new Date('2026-07-15T10:00:00Z');
+      setMarker({ _id: 'lastStartup', at: previousAt, bootId: PREVIOUS_BOOT_ID });
 
       await service.checkNodeReboot();
 
-      expect(insertedDocs).to.have.lengthOf(1);
-      const { doc } = insertedDocs[0];
-      expect(doc.appName).to.equal(service.SYSTEM_APP_NAME);
-      expect(doc.eventType).to.equal('node_reboot');
-      expect(doc.details).to.include(PREVIOUS_BOOT_ID.slice(0, 8));
-      expect(doc.details).to.include(CURRENT_BOOT_ID.slice(0, 8));
-      expect(doc.details).to.include(previousAt.toISOString());
+      const reboots = eventUpserts().filter((c) => c.query.eventType === 'node_reboot');
+      expect(reboots).to.have.lengthOf(1);
+      expect(reboots[0].query.appName).to.equal(service.SYSTEM_APP_NAME);
+      const ins = reboots[0].update.$setOnInsert;
+      expect(ins.severity).to.equal(0);
+      expect(ins.detailsSample).to.include(PREVIOUS_BOOT_ID.slice(0, 8));
+      expect(ins.detailsSample).to.include(CURRENT_BOOT_ID.slice(0, 8));
+      expect(ins.detailsSample).to.include(previousAt.toISOString());
     });
 
-    it('does NOT record an event on a same-boot_id process restart', async () => {
-      dbHelperStub.findOneInDatabase = sinon.stub().resolves({
-        _id: 'lastStartup', at: new Date(), bootId: CURRENT_BOOT_ID,
-      });
+    it('does NOT record an incident on a same-boot_id process restart', async () => {
+      setMarker({ _id: 'lastStartup', at: new Date(), bootId: CURRENT_BOOT_ID });
 
       await service.checkNodeReboot();
 
-      expect(insertedDocs).to.have.lengthOf(0);
+      expect(eventUpserts()).to.have.lengthOf(0);
       expect(historyUpdates()).to.have.lengthOf(0);
       expect(markerUpdates()).to.have.lengthOf(1);
     });
 
-    it('does NOT record an event on first-ever startup, but seeds marker and history', async () => {
-      dbHelperStub.findOneInDatabase = sinon.stub().resolves(null);
+    it('does NOT record an incident on first-ever startup, but seeds marker and history', async () => {
+      setMarker(null);
 
       await service.checkNodeReboot();
 
-      expect(insertedDocs).to.have.lengthOf(0);
+      expect(eventUpserts()).to.have.lengthOf(0);
       expect(historyUpdates()).to.have.lengthOf(1);
       const marker = markerUpdates();
       expect(marker).to.have.lengthOf(1);
-      expect(marker[0].args[3].$set.bootId).to.equal(CURRENT_BOOT_ID);
-      expect(marker[0].args[3].$set.at).to.be.instanceOf(Date);
-      expect(marker[0].args[4]).to.deep.equal({ upsert: true });
+      expect(marker[0].update.$set.bootId).to.equal(CURRENT_BOOT_ID);
+      expect(marker[0].update.$set.at).to.be.instanceOf(Date);
+      expect(marker[0].options).to.deep.equal({ upsert: true });
     });
 
-    it('does NOT record an event when upgrading from a marker without bootId', async () => {
+    it('does NOT record an incident when upgrading from a marker without bootId', async () => {
       // Pre-boot_id marker only carried `at`; reboot vs restart is unknowable.
-      dbHelperStub.findOneInDatabase = sinon.stub().resolves({
-        _id: 'lastStartup', at: new Date(Date.now() - 1000),
-      });
+      setMarker({ _id: 'lastStartup', at: new Date(Date.now() - 1000) });
 
       await service.checkNodeReboot();
 
-      expect(insertedDocs).to.have.lengthOf(0);
+      expect(eventUpserts()).to.have.lengthOf(0);
       expect(historyUpdates()).to.have.lengthOf(1);
       expect(markerUpdates()).to.have.lengthOf(1);
     });
 
     it('appends the new boot to the rolling history on reboot', async () => {
-      dbHelperStub.findOneInDatabase = sinon.stub().resolves({
-        _id: 'lastStartup', at: new Date(), bootId: PREVIOUS_BOOT_ID,
-      });
+      setMarker({ _id: 'lastStartup', at: new Date(), bootId: PREVIOUS_BOOT_ID });
 
       await service.checkNodeReboot();
 
       const history = historyUpdates();
       expect(history).to.have.lengthOf(1);
-      const push = history[0].args[3].$push.boots;
+      const push = history[0].update.$push.boots;
       expect(push.$each[0].bootId).to.equal(CURRENT_BOOT_ID);
       expect(push.$each[0].at).to.be.instanceOf(Date);
       expect(push.$slice).to.equal(-service.BOOT_HISTORY_MAX);
-      expect(history[0].args[4]).to.deep.equal({ upsert: true });
-    });
-
-    it('skips entirely when boot_id cannot be read', async () => {
-      fsReadFileStub.rejects(new Error('ENOENT'));
-
-      await service.checkNodeReboot();
-
-      expect(insertedDocs).to.have.lengthOf(0);
-      expect(dbHelperStub.findOneAndUpdateInDatabase.called).to.be.false;
-      sinon.assert.called(logStub.warn);
-    });
-
-    it('skips entirely when boot_id reads empty', async () => {
-      fsReadFileStub.resolves('  \n');
-
-      await service.checkNodeReboot();
-
-      expect(insertedDocs).to.have.lengthOf(0);
-      expect(dbHelperStub.findOneAndUpdateInDatabase.called).to.be.false;
+      expect(history[0].options).to.deep.equal({ upsert: true });
     });
 
     it('purges legacy frequent_restart rows', async () => {
@@ -427,6 +575,23 @@ describe('appTamperingDetectionService tests', () => {
 
       expect(markerUpdates()).to.have.lengthOf(1);
       sinon.assert.called(logStub.warn);
+    });
+
+    it('skips entirely when boot_id cannot be read', async () => {
+      fsReadFileStub.rejects(new Error('ENOENT'));
+
+      await service.checkNodeReboot();
+
+      expect(upsertCalls).to.have.lengthOf(0);
+      sinon.assert.called(logStub.warn);
+    });
+
+    it('skips entirely when boot_id reads empty', async () => {
+      fsReadFileStub.resolves('  \n');
+
+      await service.checkNodeReboot();
+
+      expect(upsertCalls).to.have.lengthOf(0);
     });
 
     it('no-ops when DB is unavailable', async () => {

--- a/tests/unit/appTamperingDetectionService.test.js
+++ b/tests/unit/appTamperingDetectionService.test.js
@@ -5,10 +5,15 @@ const proxyquire = require('proxyquire').noCallThru();
 describe('appTamperingDetectionService tests', () => {
   let service;
   let dbHelperStub;
+  let logStub;
+  let fsReadFileStub;
   let insertedDocs;
   let findResults;
   let lastFindArgs;
   let databaseConnectionReturn;
+
+  const CURRENT_BOOT_ID = 'aaaaaaaa-1111-2222-3333-444444444444';
+  const PREVIOUS_BOOT_ID = 'bbbbbbbb-5555-6666-7777-888888888888';
 
   beforeEach(() => {
     insertedDocs = [];
@@ -26,12 +31,20 @@ describe('appTamperingDetectionService tests', () => {
         return { insertedId: 'mock-id' };
       }),
       findInDatabase: sinon.stub().callsFake(async (db, coll, query, options) => {
-        lastFindArgs = { db, coll, query, options };
+        lastFindArgs = {
+          db, coll, query, options,
+        };
         return findResults;
       }),
       findOneInDatabase: sinon.stub().resolves(null),
       findOneAndUpdateInDatabase: sinon.stub().resolves({ value: null }),
     };
+
+    logStub = {
+      info: sinon.stub(), warn: sinon.stub(), error: sinon.stub(), debug: sinon.stub(),
+    };
+
+    fsReadFileStub = sinon.stub().resolves(`${CURRENT_BOOT_ID}\n`);
 
     service = proxyquire('../../ZelBack/src/services/appTamperingDetectionService', {
       config: {
@@ -44,11 +57,15 @@ describe('appTamperingDetectionService tests', () => {
             },
           },
         },
+        system: {
+          bootIdPath: '/proc/sys/kernel/random/boot_id',
+        },
+      },
+      fs: {
+        promises: { readFile: fsReadFileStub },
       },
       './dbHelper': dbHelperStub,
-      '../lib/log': {
-        info: sinon.stub(), warn: sinon.stub(), error: sinon.stub(),
-      },
+      '../lib/log': logStub,
       './messageHelper': {
         createDataMessage: (d) => ({ status: 'success', data: d }),
         createErrorMessage: (m) => ({ status: 'error', data: { message: m } }),
@@ -118,13 +135,47 @@ describe('appTamperingDetectionService tests', () => {
       expect(doc.detectedAt).to.be.instanceOf(Date);
     });
 
-    it('inserts a NEW row on every call (does not upsert)', async () => {
+    it('suppresses repeat (appName, eventType) calls within the episode window', async () => {
       await service.recordEvent('myapp', 'mount_vanished', 'a');
       await service.recordEvent('myapp', 'mount_vanished', 'b');
       await service.recordEvent('myapp', 'mount_vanished', 'c');
 
-      expect(insertedDocs).to.have.lengthOf(3);
-      expect(insertedDocs.map((x) => x.doc.details)).to.deep.equal(['a', 'b', 'c']);
+      expect(insertedDocs).to.have.lengthOf(1);
+      expect(insertedDocs[0].doc.details).to.equal('a');
+    });
+
+    it('records different event types for the same app independently', async () => {
+      await service.recordEvent('myapp', 'container_vanished', 'a');
+      await service.recordEvent('myapp', 'recreation_failed', 'b');
+
+      expect(insertedDocs).to.have.lengthOf(2);
+    });
+
+    it('records the same event type for different apps independently', async () => {
+      await service.recordEvent('app1', 'mount_vanished', 'a');
+      await service.recordEvent('app2', 'mount_vanished', 'b');
+
+      expect(insertedDocs).to.have.lengthOf(2);
+    });
+
+    it('records again once the episode window has elapsed', async () => {
+      const clock = sinon.useFakeTimers(new Date('2026-07-16T00:00:00Z'));
+
+      await service.recordEvent('myapp', 'mount_vanished', 'first episode');
+      clock.tick(service.EPISODE_WINDOW_MS);
+      await service.recordEvent('myapp', 'mount_vanished', 'second episode');
+
+      expect(insertedDocs).to.have.lengthOf(2);
+    });
+
+    it('still suppresses just before the episode window elapses', async () => {
+      const clock = sinon.useFakeTimers(new Date('2026-07-16T00:00:00Z'));
+
+      await service.recordEvent('myapp', 'mount_vanished', 'first');
+      clock.tick(service.EPISODE_WINDOW_MS - 1);
+      await service.recordEvent('myapp', 'mount_vanished', 'still same episode');
+
+      expect(insertedDocs).to.have.lengthOf(1);
     });
 
     it('no-ops when DB is not available', async () => {
@@ -136,11 +187,27 @@ describe('appTamperingDetectionService tests', () => {
       expect(dbHelperStub.insertOneToDatabase.called).to.be.false;
     });
 
-    it('swallows insert errors without throwing', async () => {
+    it('swallows insert errors without throwing and logs them', async () => {
       dbHelperStub.insertOneToDatabase = sinon.stub().rejects(new Error('boom'));
 
       await service.recordEvent('myapp', 'container_vanished', 'x');
-      // no assertion needed — test passes if no error thrown
+
+      sinon.assert.calledOnce(logStub.error);
+      expect(logStub.error.firstCall.args[0]).to.include('boom');
+    });
+
+    it('does not consume the episode when the insert fails', async () => {
+      dbHelperStub.insertOneToDatabase = sinon.stub().rejects(new Error('boom'));
+      await service.recordEvent('myapp', 'container_vanished', 'lost');
+
+      dbHelperStub.insertOneToDatabase = sinon.stub().callsFake(async (db, coll, doc) => {
+        insertedDocs.push({ db, coll, doc });
+        return { insertedId: 'mock-id' };
+      });
+      await service.recordEvent('myapp', 'container_vanished', 'retried');
+
+      expect(insertedDocs).to.have.lengthOf(1);
+      expect(insertedDocs[0].doc.details).to.equal('retried');
     });
   });
 
@@ -165,6 +232,51 @@ describe('appTamperingDetectionService tests', () => {
       expect(lastFindArgs.options.sort).to.deep.equal({ detectedAt: -1 });
       expect(lastFindArgs.options.projection).to.deep.equal({ _id: 0 });
       sinon.assert.calledWith(res.json, sinon.match({ status: 'success' }));
+    });
+
+    it('caps results at the default limit when none is requested', async () => {
+      const req = { params: {}, query: {} };
+      const res = makeRes();
+
+      await service.getEvents(req, res);
+
+      expect(lastFindArgs.options.limit).to.equal(500);
+    });
+
+    it('honours an explicit limit', async () => {
+      const req = { params: {}, query: { limit: '50' } };
+      const res = makeRes();
+
+      await service.getEvents(req, res);
+
+      expect(lastFindArgs.options.limit).to.equal(50);
+    });
+
+    it('clamps the limit to the maximum', async () => {
+      const req = { params: {}, query: { limit: '999999' } };
+      const res = makeRes();
+
+      await service.getEvents(req, res);
+
+      expect(lastFindArgs.options.limit).to.equal(1000);
+    });
+
+    it('clamps a non-positive limit up to 1', async () => {
+      const req = { params: {}, query: { limit: '-5' } };
+      const res = makeRes();
+
+      await service.getEvents(req, res);
+
+      expect(lastFindArgs.options.limit).to.equal(1);
+    });
+
+    it('falls back to the default limit on a non-numeric limit', async () => {
+      const req = { params: {}, query: { limit: 'lots' } };
+      const res = makeRes();
+
+      await service.getEvents(req, res);
+
+      expect(lastFindArgs.options.limit).to.equal(500);
     });
 
     it('filters by appname from params', async () => {
@@ -196,82 +308,124 @@ describe('appTamperingDetectionService tests', () => {
     });
   });
 
-  describe('checkFrequentRestart', () => {
-    it('records a frequent_restart event when previous start was under one hour ago', async () => {
-      const previousAt = new Date(Date.now() - (30 * 60 * 1000)); // 30 min ago
-      dbHelperStub.findOneInDatabase = sinon.stub().resolves({ _id: 'lastStartup', at: previousAt });
+  describe('checkNodeReboot', () => {
+    function markerUpdates() {
+      return dbHelperStub.findOneAndUpdateInDatabase.getCalls()
+        .filter((c) => c.args[2] && c.args[2]._id === 'lastStartup');
+    }
 
-      await service.checkFrequentRestart();
+    function historyUpdates() {
+      return dbHelperStub.findOneAndUpdateInDatabase.getCalls()
+        .filter((c) => c.args[2] && c.args[2]._id === 'bootHistory');
+    }
+
+    it('records a node_reboot event when the boot_id changed', async () => {
+      const previousAt = new Date('2026-07-15T10:00:00Z');
+      dbHelperStub.findOneInDatabase = sinon.stub().resolves({
+        _id: 'lastStartup', at: previousAt, bootId: PREVIOUS_BOOT_ID,
+      });
+
+      await service.checkNodeReboot();
 
       expect(insertedDocs).to.have.lengthOf(1);
       const { doc } = insertedDocs[0];
       expect(doc.appName).to.equal(service.SYSTEM_APP_NAME);
-      expect(doc.eventType).to.equal('frequent_restart');
-      expect(doc.details).to.match(/FluxOS restarted \d+s after previous start/);
+      expect(doc.eventType).to.equal('node_reboot');
+      expect(doc.details).to.include(PREVIOUS_BOOT_ID.slice(0, 8));
+      expect(doc.details).to.include(CURRENT_BOOT_ID.slice(0, 8));
+      expect(doc.details).to.include(previousAt.toISOString());
     });
 
-    it('does NOT record an event when previous start was over one hour ago', async () => {
-      const previousAt = new Date(Date.now() - (2 * 60 * 60 * 1000)); // 2 hours ago
-      dbHelperStub.findOneInDatabase = sinon.stub().resolves({ _id: 'lastStartup', at: previousAt });
+    it('does NOT record an event on a same-boot_id process restart', async () => {
+      dbHelperStub.findOneInDatabase = sinon.stub().resolves({
+        _id: 'lastStartup', at: new Date(), bootId: CURRENT_BOOT_ID,
+      });
 
-      await service.checkFrequentRestart();
+      await service.checkNodeReboot();
 
       expect(insertedDocs).to.have.lengthOf(0);
+      expect(historyUpdates()).to.have.lengthOf(0);
+      expect(markerUpdates()).to.have.lengthOf(1);
     });
 
-    it('does NOT record an event when previous start is exactly at threshold', async () => {
-      const previousAt = new Date(Date.now() - service.FREQUENT_RESTART_THRESHOLD_MS);
-      dbHelperStub.findOneInDatabase = sinon.stub().resolves({ _id: 'lastStartup', at: previousAt });
-
-      await service.checkFrequentRestart();
-
-      expect(insertedDocs).to.have.lengthOf(0);
-    });
-
-    it('does NOT record an event on first-ever startup (no previous marker)', async () => {
+    it('does NOT record an event on first-ever startup, but seeds marker and history', async () => {
       dbHelperStub.findOneInDatabase = sinon.stub().resolves(null);
 
-      await service.checkFrequentRestart();
+      await service.checkNodeReboot();
 
       expect(insertedDocs).to.have.lengthOf(0);
+      expect(historyUpdates()).to.have.lengthOf(1);
+      const marker = markerUpdates();
+      expect(marker).to.have.lengthOf(1);
+      expect(marker[0].args[3].$set.bootId).to.equal(CURRENT_BOOT_ID);
+      expect(marker[0].args[3].$set.at).to.be.instanceOf(Date);
+      expect(marker[0].args[4]).to.deep.equal({ upsert: true });
     });
 
-    it('ignores a negative delta (clock skew: previous marker in the future)', async () => {
-      const previousAt = new Date(Date.now() + (5 * 60 * 1000)); // 5 min in future
-      dbHelperStub.findOneInDatabase = sinon.stub().resolves({ _id: 'lastStartup', at: previousAt });
+    it('does NOT record an event when upgrading from a marker without bootId', async () => {
+      // Pre-boot_id marker only carried `at`; reboot vs restart is unknowable.
+      dbHelperStub.findOneInDatabase = sinon.stub().resolves({
+        _id: 'lastStartup', at: new Date(Date.now() - 1000),
+      });
 
-      await service.checkFrequentRestart();
+      await service.checkNodeReboot();
 
       expect(insertedDocs).to.have.lengthOf(0);
+      expect(historyUpdates()).to.have.lengthOf(1);
+      expect(markerUpdates()).to.have.lengthOf(1);
     });
 
-    it('always upserts the startup marker to now', async () => {
-      dbHelperStub.findOneInDatabase = sinon.stub().resolves(null);
+    it('appends the new boot to the rolling history on reboot', async () => {
+      dbHelperStub.findOneInDatabase = sinon.stub().resolves({
+        _id: 'lastStartup', at: new Date(), bootId: PREVIOUS_BOOT_ID,
+      });
 
-      await service.checkFrequentRestart();
+      await service.checkNodeReboot();
 
-      sinon.assert.calledOnce(dbHelperStub.findOneAndUpdateInDatabase);
-      const args = dbHelperStub.findOneAndUpdateInDatabase.firstCall.args;
-      expect(args[1]).to.equal('nodestartuptracker'); // collection
-      expect(args[2]).to.deep.equal({ _id: 'lastStartup' });
-      expect(args[3].$set.at).to.be.instanceOf(Date);
-      expect(args[4]).to.deep.equal({ upsert: true });
+      const history = historyUpdates();
+      expect(history).to.have.lengthOf(1);
+      const push = history[0].args[3].$push.boots;
+      expect(push.$each[0].bootId).to.equal(CURRENT_BOOT_ID);
+      expect(push.$each[0].at).to.be.instanceOf(Date);
+      expect(push.$slice).to.equal(-service.BOOT_HISTORY_MAX);
+      expect(history[0].args[4]).to.deep.equal({ upsert: true });
+    });
+
+    it('skips entirely when boot_id cannot be read', async () => {
+      fsReadFileStub.rejects(new Error('ENOENT'));
+
+      await service.checkNodeReboot();
+
+      expect(insertedDocs).to.have.lengthOf(0);
+      expect(dbHelperStub.findOneAndUpdateInDatabase.called).to.be.false;
+      sinon.assert.called(logStub.warn);
+    });
+
+    it('skips entirely when boot_id reads empty', async () => {
+      fsReadFileStub.resolves('  \n');
+
+      await service.checkNodeReboot();
+
+      expect(insertedDocs).to.have.lengthOf(0);
+      expect(dbHelperStub.findOneAndUpdateInDatabase.called).to.be.false;
     });
 
     it('no-ops when DB is unavailable', async () => {
       dbHelperStub.databaseConnection = sinon.stub().returns(null);
 
-      await service.checkFrequentRestart();
+      await service.checkNodeReboot();
 
       expect(dbHelperStub.findOneInDatabase.called).to.be.false;
       expect(dbHelperStub.findOneAndUpdateInDatabase.called).to.be.false;
     });
 
-    it('swallows errors without throwing', async () => {
+    it('swallows errors without throwing and logs them', async () => {
       dbHelperStub.findOneInDatabase = sinon.stub().rejects(new Error('mongo down'));
 
-      await service.checkFrequentRestart();
-      // test passes if no exception propagates
+      await service.checkNodeReboot();
+
+      sinon.assert.calledOnce(logStub.error);
+      expect(logStub.error.firstCall.args[0]).to.include('mongo down');
     });
   });
 });

--- a/tests/unit/appTamperingDetectionService.test.js
+++ b/tests/unit/appTamperingDetectionService.test.js
@@ -67,6 +67,7 @@ describe('appTamperingDetectionService tests', () => {
         return null; // startup marker by default absent
       }),
       removeDocumentsFromCollection: sinon.stub().resolves({ deletedCount: 0 }),
+      updateInDatabase: sinon.stub().resolves({ modifiedCount: 0 }),
     };
 
     logStub = {
@@ -386,6 +387,55 @@ describe('appTamperingDetectionService tests', () => {
 
       const incident = eventUpserts().find((c) => c.query.eventType === 'mount_vanished');
       expect(incident.update.$setOnInsert.duringBootStorm).to.be.false;
+    });
+  });
+
+  describe('identity backfill', () => {
+    it('stamps identity onto unattributed incidents once the daemon answers, then stops', async () => {
+      const clock = sinon.useFakeTimers(new Date('2026-07-16T10:00:00Z'));
+      fluxnodeRpcsStub.getFluxNodeStatus.rejects(new Error('daemon starting'));
+
+      await service.checkNodeReboot(); // starts the backfill; immediate attempt fails
+      await clock.tickAsync(0);
+      expect(dbHelperStub.updateInDatabase.called).to.be.false;
+
+      fluxnodeRpcsStub.getFluxNodeStatus.resolves(NODE_STATUS);
+      await clock.tickAsync(service.IDENTITY_BACKFILL_INTERVAL_MS);
+
+      sinon.assert.calledOnce(dbHelperStub.updateInDatabase);
+      const call = dbHelperStub.updateInDatabase.firstCall;
+      expect(call.args[1]).to.equal('apptamperingevents');
+      expect(call.args[2]).to.deep.equal({ schemaVersion: { $gte: 1 }, nodeTxid: null });
+      expect(call.args[3].$set.nodeTxid).to.equal('deadbeefcafe');
+      expect(call.args[3].$set.pubkey).to.equal('04aabbcc');
+      expect(call.args[3].$set.paymentAddress).to.equal('t1payout');
+
+      // stopped for good: further intervals do not fire another update
+      await clock.tickAsync(2 * service.IDENTITY_BACKFILL_INTERVAL_MS);
+      sinon.assert.calledOnce(dbHelperStub.updateInDatabase);
+    });
+
+    it('keeps retrying while the daemon stays unreachable', async () => {
+      const clock = sinon.useFakeTimers(new Date('2026-07-16T10:00:00Z'));
+      fluxnodeRpcsStub.getFluxNodeStatus.rejects(new Error('daemon down'));
+
+      await service.checkNodeReboot();
+      await clock.tickAsync(2 * service.IDENTITY_BACKFILL_INTERVAL_MS);
+
+      expect(dbHelperStub.updateInDatabase.called).to.be.false;
+      expect(fluxnodeRpcsStub.getFluxNodeStatus.callCount).to.be.greaterThan(1);
+    });
+
+    it('does not start a second timer when called repeatedly', async () => {
+      const clock = sinon.useFakeTimers(new Date('2026-07-16T10:00:00Z'));
+      fluxnodeRpcsStub.getFluxNodeStatus.rejects(new Error('daemon down'));
+
+      service.startIdentityBackfill();
+      service.startIdentityBackfill();
+      await clock.tickAsync(service.IDENTITY_BACKFILL_INTERVAL_MS);
+
+      // one immediate attempt + one interval tick — not doubled
+      expect(fluxnodeRpcsStub.getFluxNodeStatus.callCount).to.equal(2);
     });
   });
 

--- a/tests/unit/appTamperingDetectionService.test.js
+++ b/tests/unit/appTamperingDetectionService.test.js
@@ -570,13 +570,13 @@ describe('appTamperingDetectionService tests', () => {
       expect(history[0].options).to.deep.equal({ upsert: true });
     });
 
-    it('purges legacy frequent_restart rows', async () => {
+    it('purges all pre-schema rows at startup', async () => {
       await service.checkNodeReboot();
 
       sinon.assert.calledOnce(dbHelperStub.removeDocumentsFromCollection);
       const { args } = dbHelperStub.removeDocumentsFromCollection.firstCall;
       expect(args[1]).to.equal('apptamperingevents');
-      expect(args[2]).to.deep.equal({ eventType: 'frequent_restart' });
+      expect(args[2]).to.deep.equal({ schemaVersion: { $exists: false } });
     });
 
     it('still tracks the boot when the legacy purge fails', async () => {

--- a/tests/unit/appTamperingDetectionService.test.js
+++ b/tests/unit/appTamperingDetectionService.test.js
@@ -20,7 +20,7 @@ describe('appTamperingDetectionService tests', () => {
     status: 'success',
     data: {
       txhash: 'deadbeefcafe',
-      outidx: 0,
+      outidx: '0', // the daemon RPC returns outidx as a string
       ip: '65.108.1.2:16127',
       pubkey: '04aabbcc',
       payment_address: 't1payout',

--- a/tests/unit/appTamperingDetectionService.test.js
+++ b/tests/unit/appTamperingDetectionService.test.js
@@ -245,6 +245,28 @@ describe('appTamperingDetectionService tests', () => {
       sinon.assert.calledOnce(fluxnodeRpcsStub.getFluxNodeStatus); // backoff, no hammering
     });
 
+    it('uses a concurrently-populated identity cache when its own RPC fails (daemon flap)', async () => {
+      // Race: this event enters getNodeIdentity with the cache empty, a
+      // concurrent call populates it, then this event's own RPC rejects. The
+      // catch must prefer the now-populated cache over writing a null-identity
+      // row that the one-shot backfill may already have stopped covering.
+      let rejectSecond;
+      const secondRpc = new Promise((_, reject) => { rejectSecond = reject; });
+      fluxnodeRpcsStub.getFluxNodeStatus = sinon.stub()
+        .onFirstCall().resolves(NODE_STATUS)
+        .onSecondCall().returns(secondRpc);
+
+      const first = service.recordEvent('a', 'container_vanished', 'x'); // populates cache
+      const second = service.recordEvent('b', 'container_vanished', 'x'); // RPC left pending
+      await first;
+      rejectSecond(new Error('daemon flap'));
+      await second;
+
+      const bUpsert = eventUpserts().find((c) => c.query.appName === 'b');
+      expect(bUpsert.update.$setOnInsert.nodeTxid).to.equal('deadbeefcafe');
+      expect(bUpsert.update.$setOnInsert.pubkey).to.equal('04aabbcc');
+    });
+
     it('attributes the app owner and spec hash by exact name', async () => {
       installedApps.myapp = { owner: '1ownerZelid', hash: 'spechash1' };
 
@@ -292,6 +314,18 @@ describe('appTamperingDetectionService tests', () => {
       expect(eventUpserts()[0].query.incidentKey).to.not.equal(eventUpserts()[1].query.incidentKey);
     });
 
+    it('keys under "unknown" and stamps bootId:null before checkNodeReboot has run', async () => {
+      // This block never calls checkNodeReboot(), so currentBootId is still
+      // null — the same fallback state as a host with an unreadable boot_id.
+      // In production serviceManager awaits checkNodeReboot() before any
+      // emitter, so this path is a safety net; it must still key deterministically.
+      await service.recordEvent('myapp', 'mount_vanished', 'x');
+
+      const { query, update } = eventUpserts()[0];
+      expect(query.incidentKey).to.match(/^unknown:\d+$/);
+      expect(update.$setOnInsert.bootId).to.be.null;
+    });
+
     it('stamps severity 0 for operational and unknown event types', async () => {
       await service.recordEvent('myapp', 'recreation_failed', 'x');
       await service.recordEvent('myapp', 'some_future_type', 'x');
@@ -316,6 +350,46 @@ describe('appTamperingDetectionService tests', () => {
 
       expect(eventUpserts()).to.have.lengthOf(1);
       expect(logStub.error.called).to.be.false;
+    });
+
+    it('rolls up a repeat (v6 non-null pre-image) as inserted=false, no fresh-insert log', async () => {
+      // The real mongodb v6 driver returns the matched pre-image document (not
+      // null) when the upsert hits an existing incident; the default mock
+      // returns null (insert). Model the repeat and pin the count-rollup branch.
+      dbHelperStub.findOneAndUpdateInDatabase = sinon.stub().callsFake(async (db, coll, query, update, options) => {
+        upsertCalls.push({
+          db, coll, query, update, options,
+        });
+        return { _id: 'existing', count: 1 }; // v6 pre-image of the matched doc
+      });
+
+      await service.recordEvent('myapp', 'container_vanished', 'x');
+
+      expect(eventUpserts()[0].update.$inc).to.deep.equal({ count: 1 });
+      expect(logStub.debug.calledWithMatch(/repeated, incident count incremented/)).to.be.true;
+      expect(logStub.info.calledWithMatch(/recorded container_vanished/)).to.be.false;
+    });
+
+    it('reads insert vs repeat from the legacy { value, lastErrorObject } driver shape', async () => {
+      dbHelperStub.findOneAndUpdateInDatabase = sinon.stub()
+        .onFirstCall().callsFake(async (db, coll, query, update, options) => {
+          upsertCalls.push({
+            db, coll, query, update, options,
+          });
+          return { value: null, lastErrorObject: { updatedExisting: false } }; // insert
+        })
+        .onSecondCall().callsFake(async (db, coll, query, update, options) => {
+          upsertCalls.push({
+            db, coll, query, update, options,
+          });
+          return { value: { _id: 'e', count: 1 }, lastErrorObject: { updatedExisting: true } }; // repeat
+        });
+
+      await service.recordEvent('myapp', 'container_vanished', 'insert');
+      await service.recordEvent('myapp', 'container_vanished', 'repeat');
+
+      expect(logStub.info.calledWithMatch(/recorded container_vanished/)).to.be.true;
+      expect(logStub.debug.calledWithMatch(/repeated, incident count incremented/)).to.be.true;
     });
 
     it('no-ops when DB is not available', async () => {
@@ -487,6 +561,18 @@ describe('appTamperingDetectionService tests', () => {
       await service.getEvents(req, res);
 
       expect(lastFindArgs.query).to.deep.equal({ appName: 'otherapp' });
+    });
+
+    it('coerces an object appname query param to a string (NoSQL operator guard)', async () => {
+      // Express extended parser turns ?appname[$gt]= into an object; it must
+      // not reach the mongo filter as a field-level operator.
+      const req = { params: {}, query: { appname: { $gt: '' } } };
+      const res = makeRes();
+
+      await service.getEvents(req, res);
+
+      expect(lastFindArgs.query.appName).to.be.a('string');
+      expect(lastFindArgs.query.appName).to.equal('[object Object]');
     });
 
     it('returns an error message when the query throws', async () => {


### PR DESCRIPTION
## What this does

Rebuilds app-tampering detection into an **honest, attributable, deduplicated incident model**, and makes its tamper score safe to reason about. All behaviour is centralized in `appTamperingDetectionService.js`; call sites still pass plain `(appName, eventType, details)`.

- **Reboot detection by kernel `boot_id`.** `/proc/sys/kernel/random/boot_id` (a per-boot UUID, stable across process restarts) is compared to a stored marker. A genuine reboot appends to a rolling `bootHistory` (capped at 200) in `nodestartuptracker`, recording both the uptime-derived machine boot moment (`bootedAt`) and when FluxOS first saw it (`at`). A same-`boot_id` process restart records nothing.
- **Incident model, not an event log.** One document per `(appName, eventType, incidentKey)` where `incidentKey = boot_id + hourly bucket`. Repeats `$inc` a `count` and advance `lastSeen` instead of inserting a new row, so a retry storm collapses to a single deduplicated incident while distinct incidents in later hours stay separate.
- **Attribution stamped at write time.** Every incident carries node identity (`nodeTxid`/`nodeOutidx`/`nodeIp`), operator identity (`pubkey`/`paymentAddress`), and app attribution (`ownerZelid`/`appHash`). Identity is best-effort with daemon backoff; a one-shot backfill enriches anything written before `fluxd`'s RPC was up.
- **Weighted score over distinct incidents.** `computeTamperScore` sums a per-incident `severity` (stamped at write time) over `schemaVersion >= 1` documents: `container_vanished` = 3 (a container positively confirmed missing is the strongest local interference signal — containers persist as `exited` across a clean reboot); mount/volume/network types = 1; `recreation_failed` = 0 (operational: registry/image/disk).
- **Startup purge of pre-schema rows.** On boot the service removes any document without a `schemaVersion`, so an upgraded node presents an honest collection from its first boot rather than serving a month of un-attributed, un-deduplicated rows until they TTL.
- **Capped public API.** `GET /apps/tamperingevents/:appname?` returns incidents most-recent first, default 500 / max 1000 (`?limit=`), with `_id` as a stable paging key. The `appname` filter is string-coerced so a bracket-notation query can't inject a Mongo operator.

## Why

The existing feature collects data too noisy and too unattributable to act on, which is why its enforcement path is dormant behind a manually-curated, currently-empty blocklist. Two problems dominate:

1. **The score can't tell tampering from operational churn.** Scoring on `countDocuments({})` counts every row of every type, undifferentiated and un-deduplicated, so a single flapping app or one routine reboot can dominate the count.
2. **Reboot detection measures the wrong thing.** A wall-clock "restart gap" heuristic is blind to a slow reboot cadence, false-positives on crash loops, and is evadable by clock skew.

This branch fixes both: `boot_id` gives a reboot signal that can't be faked by clock skew or confused by process restarts, and the dedup + severity + identity schema turns the raw log into per-incident, per-operator data a fleet-level system can trust.

## Fleet evidence

The scoring design was validated against two full-network scans (tooling and raw results in `dev/tampering/`).

**Noise is concentrated, not fleet-wide (full-network scan, 7,538 nodes).** 96% of all `mount_vanished` events came from just 30 nodes running structural FoldingAtHome churn; a single node emitted **21,724** events in 46 hours (the sweep re-recording every ~30s for the same missing directory). This is exactly the row-per-observation noise the old `countDocuments` score could not distinguish from tampering — the incident rollup collapses each such fault to **one document plus a count**.

**Benign boot-clustered noise is negligible (full-network scan, 6,561 nodes).** Correlating every event timestamp against each node's boot time (scan time − `/flux/systemuptime`), of **2,901 nodes rebooted within the 30-day retention window** (2,599 ArcaneOS / 302 legacy), only **6 (0.21%)** showed a genuine benign mount/volume event in the first 30 minutes after boot — each affecting **1–2 apps**, one event apiece, all self-healing, none recurring. Fleet-wide, `container_vanished` had **1** in-window event out of 14,906. This is why boot proximity needs no special handling in scoring: a benign post-boot blip costs an honest node at most ~2 points for 30 days (dedup), while persistent damage keeps re-recording at full weight in every hourly bucket — the score naturally separates the two.

## Safety

Nothing in this PR can DOS a node. Enforcement (`appTamperingBlocklistService`) is **double-gated**: a node self-limits only if its txhash is on the manually-curated blocklist (currently `[]`) **AND** its score exceeds the threshold, and enforcement is skipped entirely on ArcaneOS. The scoring/schema changes here do not touch that gate; they only make the underlying data trustworthy enough to eventually drive it.

## Scope

Data-quality and attribution only — an honest local event log and an incident schema a fleet-level system can consume. The network-wide per-operator aggregate and any enforcement redesign are **not** in this PR, and enforcement stays double-gated behind the empty blocklist.

## Follow-up

A small number of emitter-side refinements are intentionally out of scope here: their call sites are in the reconciler, which is under active restructuring on the v9 branch. They'll land in a follow-up PR once that work settles, to avoid conflicting with it.

## Testing

- Unit suites for both services green (86 tests), lint clean.
- Adjacent call-site suites (appReconciler, crontab/mounts cleanup, syncthing state machine) green.
- Deployed and exercised on live nodes: real tampering (container/network/mount/volume removal) recorded and healed; cold-migration from the current release verified (pre-schema purge, marker upgrade, index build, `bootHistory` seeding); reboot path recording confirmed.
- Enforcement-safety paths (empty blocklist, benchmark unavailable, daemon not synced, txhash undetermined, ArcaneOS) covered by the blocklist suite.
