### PR TITLE
fix(apps): recreate a pruned per-app docker network in the reconciler heal path

### DIFF
--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -41,9 +41,6 @@ const appNetworkLinker = require('./appNetworkLinker');
 
 const isArcane = Boolean(process.env.FLUXOS_PATH);
 
-// Legacy apps that use old gateway IP assignment method
-const appsThatMightBeUsingOldGatewayIpAssignment = ['HNSDoH', 'dane', 'fdm', 'Jetpack2', 'fdmdedicated', 'isokosse', 'ChainBraryDApp', 'health', 'ethercalc'];
-
 // Master/slave app tracking
 const mastersRunningGSyncthingApps = new Map();
 const timeTostartNewMasterApp = new Map();
@@ -921,47 +918,14 @@ async function softRegisterAppLocally(appSpecs, componentSpecs, res) {
     await appNetworkLinker.checkAppNetworkRequirements(appSpecifications);
 
     if (!isComponent) {
-      let dockerNetworkAddrValue = Math.floor(Math.random() * 256);
-      if (appsThatMightBeUsingOldGatewayIpAssignment.includes(appName)) {
-        dockerNetworkAddrValue = appName.charCodeAt(appName.length - 1);
-      }
-      const fluxNetworkStatus = {
-        status: `Checking Flux App network of ${appName}...`,
-      };
-      log.info(fluxNetworkStatus);
-      if (res) {
-        res.write(serviceHelper.ensureString(fluxNetworkStatus));
-        if (res.flush) res.flush();
-      }
-      let fluxNet = null;
-      for (let i = 0; i <= 20; i += 1) {
-        // eslint-disable-next-line no-await-in-loop
-        fluxNet = await dockerService.createFluxAppDockerNetwork(appName, dockerNetworkAddrValue).catch((error) => log.error(error));
-        if (fluxNet || appsThatMightBeUsingOldGatewayIpAssignment.includes(appName)) {
-          break;
-        }
-        dockerNetworkAddrValue = Math.floor(Math.random() * 256);
-      }
-      if (!fluxNet) {
-        throw new Error(`Flux App network of ${appName} failed to initiate. Not possible to create docker application network.`);
-      }
-      log.info(serviceHelper.ensureString(fluxNet));
-      const fluxNetworkInterfaces = await dockerService.getFluxDockerNetworkPhysicalInterfaceNames();
-      const accessRemoved = await fluxNetworkHelper.removeDockerContainerAccessToNonRoutable(fluxNetworkInterfaces);
-      const accessRemovedRes = {
-        status: accessRemoved ? `Private network access removed for ${appName}` : `Error removing private network access for ${appName}`,
-      };
-      if (res) {
-        res.write(serviceHelper.ensureString(accessRemovedRes));
-        if (res.flush) res.flush();
-      }
-      const fluxNetResponse = {
-        status: `Docker network of ${appName} initiated.`,
-      };
-      if (res) {
-        res.write(serviceHelper.ensureString(fluxNetResponse));
-        if (res.flush) res.flush();
-      }
+      // One creator for install and heal: idempotent, collision-safe, and
+      // exhaustion-bounded. Replaces the old random-octet + fixed-21-retry loop
+      // that could pick octet 0 (colliding with the base network) and throw while
+      // subnets were still free, escalating a soft-register to an uninstall.
+      // Dynamic require because appInstaller <-> advancedWorkflows is a circular
+      // dependency (dynamically required throughout this file); to be untangled in v9.
+      const appInstaller = require('./appInstaller');
+      await appInstaller.ensureAppDockerNetwork(appName, res);
     }
 
     const appInstallation = {

--- a/ZelBack/src/services/appLifecycle/appInstaller.js
+++ b/ZelBack/src/services/appLifecycle/appInstaller.js
@@ -44,6 +44,11 @@ const volumeService = require('../utils/volumeService');
 // Legacy apps that use old gateway IP assignment method
 const appsThatMightBeUsingOldGatewayIpAssignment = ['HNSDoH', 'dane', 'fdm', 'Jetpack2', 'fdmdedicated', 'isokosse', 'ChainBraryDApp', 'health', 'ethercalc'];
 
+// The octets those legacy apps pin by name (charCodeAt of the last character).
+// Reserve them in the free-octet scan so a non-legacy app can't take one before
+// the legacy app heals onto its fixed octet.
+const legacyPinnedOctets = appsThatMightBeUsingOldGatewayIpAssignment.map((name) => name.charCodeAt(name.length - 1));
+
 // Helper functions and constants for installApplicationHard
 const util = require('util');
 
@@ -340,6 +345,14 @@ async function ensureAppDockerNetwork(appName, res) {
   }
 
   if (await dockerService.dockerNetworkState(`fluxDockerNetwork_${appName}`) === 'exists') {
+    const existsStatus = {
+      status: `Flux App network of ${appName} already exists.`,
+    };
+    log.info(existsStatus);
+    if (res) {
+      res.write(serviceHelper.ensureString(existsStatus));
+      if (res.flush) res.flush();
+    }
     return `Flux App Network of ${appName} already exists.`;
   }
 
@@ -351,9 +364,11 @@ async function ensureAppDockerNetwork(appName, res) {
   } else {
     // Take the lowest free 172.23.x.0/24, advancing past any octet a create loses
     // (a concurrent heal of another app, or a non-flux network holding the subnet).
-    // Give up only when the octet space is genuinely exhausted, never on a fixed
-    // count - see the JSDoc for why a premature throw is dangerous here.
-    const tried = new Set();
+    // Seed the exclude set with the legacy-pinned octets so a non-legacy app can't
+    // squat an octet a legacy app must heal onto. Give up only when the octet space
+    // is genuinely exhausted, never on a fixed count - see the JSDoc for why a
+    // premature throw is dangerous here.
+    const tried = new Set(legacyPinnedOctets);
     while (!fluxNet) {
       // eslint-disable-next-line no-await-in-loop
       const octet = await dockerService.getFreeFluxAppNetworkOctet(tried);

--- a/ZelBack/src/services/appLifecycle/appInstaller.js
+++ b/ZelBack/src/services/appLifecycle/appInstaller.js
@@ -305,6 +305,90 @@ async function verifyAndPullImage(appSpecifications, appName, isComponent, res, 
 }
 
 /**
+ * Ensures the per-app docker network (fluxDockerNetwork_<appName>) exists,
+ * creating it with a free /24 (172.23.<octet>.0/24) if absent. Safe to call on
+ * every install and from the reconciler's heal path, where a pruned network
+ * (docker prune, daemon restart) must be re-created before any container can be
+ * re-created onto it.
+ *
+ * When the network already exists this returns EARLY - no allocation and, crucially,
+ * no firewall work: its interface is already in the node-wide DOCKER-USER rules, so
+ * re-running removeDockerContainerAccessToNonRoutable here would flush and rebuild
+ * the whole chain on every heal recreate for no gain (briefly dropping RFC1918
+ * protection for every flux container on the node).
+ *
+ * Allocation is deterministic (lowest free octet) but collision-safe: many heals can
+ * run concurrently after a mass prune, so a create that loses its octet to another
+ * app - or to a non-flux network whose subnet docker rejects - is retried against the
+ * NEXT free octet, giving up only on true exhaustion. A premature give-up would throw,
+ * and on the vanished-container path that throw escalates to an app uninstall, so the
+ * loop must never fail while octets are free. The subnet is not persisted; nothing
+ * outside the container depends on it (ports are host-mapped, gelf targets resolve
+ * from the collector's live container IP at create time).
+ * @param {string} appName bare app name (the network is per-app, not per-component)
+ * @param {object} [res] optional express response for install-status streaming
+ * @returns {Promise<object|string>} the created-or-existing network response
+ */
+async function ensureAppDockerNetwork(appName, res) {
+  const fluxNetworkStatus = {
+    status: `Checking Flux App network of ${appName}...`,
+  };
+  log.info(fluxNetworkStatus);
+  if (res) {
+    res.write(serviceHelper.ensureString(fluxNetworkStatus));
+    if (res.flush) res.flush();
+  }
+
+  if (await dockerService.dockerNetworkState(`fluxDockerNetwork_${appName}`) === 'exists') {
+    return `Flux App Network of ${appName} already exists.`;
+  }
+
+  let fluxNet = null;
+  if (appsThatMightBeUsingOldGatewayIpAssignment.includes(appName)) {
+    // legacy apps pinned their gateway octet by name (it was baked into their
+    // config); they must keep it rather than take the next free one.
+    fluxNet = await dockerService.createFluxAppDockerNetwork(appName, appName.charCodeAt(appName.length - 1)).catch((error) => log.error(error));
+  } else {
+    // Take the lowest free 172.23.x.0/24, advancing past any octet a create loses
+    // (a concurrent heal of another app, or a non-flux network holding the subnet).
+    // Give up only when the octet space is genuinely exhausted, never on a fixed
+    // count - see the JSDoc for why a premature throw is dangerous here.
+    const tried = new Set();
+    while (!fluxNet) {
+      // eslint-disable-next-line no-await-in-loop
+      const octet = await dockerService.getFreeFluxAppNetworkOctet(tried);
+      if (octet === null) {
+        throw new Error(`Flux App network of ${appName} failed to initiate. No free 172.23.x.0/24 subnet available on this node.`);
+      }
+      // eslint-disable-next-line no-await-in-loop
+      fluxNet = await dockerService.createFluxAppDockerNetwork(appName, octet).catch((error) => log.error(error));
+      if (!fluxNet) tried.add(octet);
+    }
+  }
+  if (!fluxNet) {
+    throw new Error(`Flux App network of ${appName} failed to initiate. Not possible to create docker application network.`);
+  }
+  log.info(serviceHelper.ensureString(fluxNet));
+  const fluxNetworkInterfaces = await dockerService.getFluxDockerNetworkPhysicalInterfaceNames();
+  const accessRemoved = await fluxNetworkHelper.removeDockerContainerAccessToNonRoutable(fluxNetworkInterfaces);
+  const accessRemovedRes = {
+    status: accessRemoved ? `Private network access removed for ${appName}` : `Error removing private network access for ${appName}`,
+  };
+  if (res) {
+    res.write(serviceHelper.ensureString(accessRemovedRes));
+    if (res.flush) res.flush();
+  }
+  const fluxNetResponse = {
+    status: `Docker network of ${appName} initiated.`,
+  };
+  if (res) {
+    res.write(serviceHelper.ensureString(fluxNetResponse));
+    if (res.flush) res.flush();
+  }
+  return fluxNet;
+}
+
+/**
  * To register an app locally. Performs pre-installation checks - database in place, Flux Docker network in place and if app already installed. Then registers app in database and performs hard install. If registration fails, the app is removed locally.
  * @param {object} appSpecs App specifications.
  * @param {object} componentSpecs Component specifications.
@@ -451,47 +535,7 @@ async function registerAppLocally(appSpecs, componentSpecs, res, test = false, s
     await appNetworkLinker.checkAppNetworkRequirements(appSpecifications);
 
     if (!isComponent) {
-      let dockerNetworkAddrValue = Math.floor(Math.random() * 256);
-      if (appsThatMightBeUsingOldGatewayIpAssignment.includes(appName)) {
-        dockerNetworkAddrValue = appName.charCodeAt(appName.length - 1);
-      }
-      const fluxNetworkStatus = {
-        status: `Checking Flux App network of ${appName}...`,
-      };
-      log.info(fluxNetworkStatus);
-      if (res) {
-        res.write(serviceHelper.ensureString(fluxNetworkStatus));
-        if (res.flush) res.flush();
-      }
-      let fluxNet = null;
-      for (let i = 0; i <= 20; i += 1) {
-        // eslint-disable-next-line no-await-in-loop
-        fluxNet = await dockerService.createFluxAppDockerNetwork(appName, dockerNetworkAddrValue).catch((error) => log.error(error));
-        if (fluxNet || appsThatMightBeUsingOldGatewayIpAssignment.includes(appName)) {
-          break;
-        }
-        dockerNetworkAddrValue = Math.floor(Math.random() * 256);
-      }
-      if (!fluxNet) {
-        throw new Error(`Flux App network of ${appName} failed to initiate. Not possible to create docker application network.`);
-      }
-      log.info(serviceHelper.ensureString(fluxNet));
-      const fluxNetworkInterfaces = await dockerService.getFluxDockerNetworkPhysicalInterfaceNames();
-      const accessRemoved = await fluxNetworkHelper.removeDockerContainerAccessToNonRoutable(fluxNetworkInterfaces);
-      const accessRemovedRes = {
-        status: accessRemoved ? `Private network access removed for ${appName}` : `Error removing private network access for ${appName}`,
-      };
-      if (res) {
-        res.write(serviceHelper.ensureString(accessRemovedRes));
-        if (res.flush) res.flush();
-      }
-      const fluxNetResponse = {
-        status: `Docker network of ${appName} initiated.`,
-      };
-      if (res) {
-        res.write(serviceHelper.ensureString(fluxNetResponse));
-        if (res.flush) res.flush();
-      }
+      await ensureAppDockerNetwork(appName, res);
     }
 
     const appInstallation = {
@@ -1234,6 +1278,7 @@ async function testAppInstall(req, res) {
 
 module.exports = {
   registerAppLocally,
+  ensureAppDockerNetwork,
   installApplicationHard,
   installApplicationSoft,
   installAppLocally,

--- a/ZelBack/src/services/appMonitoring/containerHealthMonitor.js
+++ b/ZelBack/src/services/appMonitoring/containerHealthMonitor.js
@@ -45,6 +45,14 @@ async function recreateMissingContainers(componentIdentifier, options = {}) {
     throw new Error(`App ${mainAppName} has no components to install`);
   }
 
+  // A container can only be (re)created onto an existing docker network, but the
+  // per-app network (fluxDockerNetwork_<app>) is otherwise created only at install
+  // time (registerAppLocally). If it was pruned - docker prune, daemon restart -
+  // every recreate below would loop forever on "network not found". Recreate it
+  // first; ensureAppDockerNetwork returns early (no create, no firewall work) when
+  // the network already exists, so the common intact-network recreate stays cheap.
+  await appInstaller.ensureAppDockerNetwork(mainAppName);
+
   const tier = await generalService.nodeTier();
   const isComponent = componentIdentifier.includes('_');
 

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -1473,6 +1473,34 @@ async function getFluxDockerNetworkSubnets() {
 }
 
 /**
+ * Returns the lowest free third octet for a new flux app network
+ * (172.23.<octet>.0/24). It scans EVERY docker network's subnet (not just flux
+ * ones) because docker enforces subnet uniqueness across all networks - a non-flux
+ * network sitting on a 172.23.x block must be treated as used or the create would
+ * fail. The optional excludeOctets lets a caller skip octets it has already lost a
+ * create race on this attempt, so a bounded collision retry keeps advancing to a
+ * genuinely free octet rather than re-picking the same one. Deterministic and
+ * reports exhaustion definitively (null) rather than guessing.
+ * @param {Set<number>} [excludeOctets] octets to treat as used (already tried/lost)
+ * @returns {Promise<number|null>} lowest free octet in 1..255, or null if none free
+ */
+async function getFreeFluxAppNetworkOctet(excludeOctets = new Set()) {
+  const networks = await docker.listNetworks();
+  const used = new Set(excludeOctets);
+  networks.forEach((network) => {
+    const configs = (network.IPAM && network.IPAM.Config) || [];
+    configs.forEach((cfg) => {
+      const match = /^172\.23\.(\d{1,3})\.0\/24$/.exec((cfg && cfg.Subnet) || '');
+      if (match) used.add(Number(match[1]));
+    });
+  });
+  for (let octet = 1; octet <= 255; octet += 1) {
+    if (!used.has(octet)) return octet;
+  }
+  return null;
+}
+
+/**
  * Creates flux application docker network if doesn't exist
  *
  * @returns {object} response
@@ -1878,6 +1906,7 @@ module.exports = {
   getDockerContainerOnly,
   getFluxDockerNetworkPhysicalInterfaceNames,
   getFluxDockerNetworkSubnets,
+  getFreeFluxAppNetworkOctet,
   migrateContainerRestartPolicies,
   pruneContainers,
   pruneImages,

--- a/tests/unit/appInstaller.test.js
+++ b/tests/unit/appInstaller.test.js
@@ -2,6 +2,27 @@ const { expect } = require('chai');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
 
+// The full-install dockerService stub, shared by every proxyquire setup that
+// drives registerAppLocally. Pass overrides for the few tests that need a
+// specific return (e.g. a distinct getAppIdentifier or a shared pruneContainers
+// spy). Fresh sinon stubs per call, so each proxyquired module gets its own.
+const makeDockerServiceStub = (overrides = {}) => ({
+  dockerListContainers: sinon.stub().resolves([]),
+  pruneContainers: sinon.stub().resolves(),
+  pruneNetworks: sinon.stub().resolves(),
+  pruneVolumes: sinon.stub().resolves(),
+  pruneImages: sinon.stub().resolves(),
+  dockerNetworkState: sinon.stub().resolves('absent'),
+  getFreeFluxAppNetworkOctet: sinon.stub().resolves(1),
+  createFluxAppDockerNetwork: sinon.stub().resolves('network-created'),
+  getFluxDockerNetworkPhysicalInterfaceNames: sinon.stub().resolves([]),
+  appDockerCreate: sinon.stub().resolves(),
+  appDockerStart: sinon.stub().resolves('container-started'),
+  getAppIdentifier: sinon.stub().returns('testapp'),
+  dockerPullStream: sinon.stub().resolves('pulled'),
+  ...overrides,
+});
+
 describe('appInstaller tests', () => {
   let appInstaller;
   let verificationHelperStub;
@@ -141,19 +162,7 @@ describe('appInstaller tests', () => {
       '../geolocationService': {
         isStaticIP: sinon.stub().returns(true),
       },
-      '../dockerService': {
-        dockerListContainers: sinon.stub().resolves([]),
-        pruneContainers: sinon.stub().resolves(),
-        pruneNetworks: sinon.stub().resolves(),
-        pruneVolumes: sinon.stub().resolves(),
-        pruneImages: sinon.stub().resolves(),
-        createFluxAppDockerNetwork: sinon.stub().resolves('network-created'),
-        getFluxDockerNetworkPhysicalInterfaceNames: sinon.stub().resolves([]),
-        appDockerCreate: sinon.stub().resolves(),
-        appDockerStart: sinon.stub().resolves('container-started'),
-        getAppIdentifier: sinon.stub().returns('testapp'),
-        dockerPullStream: sinon.stub().yields(null, 'pulled'),
-      },
+      '../dockerService': makeDockerServiceStub({ dockerPullStream: sinon.stub().yields(null, 'pulled') }),
       './appUninstaller': {
         removeAppLocally: sinon.stub().resolves(),
       },
@@ -609,8 +618,6 @@ describe('appInstaller tests', () => {
         systemArchitecture: sinon.stub().resolves('amd64'), // Node is AMD64
       };
 
-      const registerAppLocallyStub = sinon.stub().resolves();
-
       const appInstallerForArchTest = proxyquire('../../ZelBack/src/services/appLifecycle/appInstaller', {
         config: configStub,
         '../verificationHelper': verificationHelperStub,
@@ -646,19 +653,7 @@ describe('appInstaller tests', () => {
         '../geolocationService': {
           isStaticIP: sinon.stub().returns(true),
         },
-        '../dockerService': {
-          dockerListContainers: sinon.stub().resolves([]),
-          pruneContainers: sinon.stub().resolves(),
-          pruneNetworks: sinon.stub().resolves(),
-          pruneVolumes: sinon.stub().resolves(),
-          pruneImages: sinon.stub().resolves(),
-          createFluxAppDockerNetwork: sinon.stub().resolves('network-created'),
-          getFluxDockerNetworkPhysicalInterfaceNames: sinon.stub().resolves([]),
-          appDockerCreate: sinon.stub().resolves(),
-          appDockerStart: sinon.stub().resolves('container-started'),
-          getAppIdentifier: sinon.stub().returns('multiarchapp'),
-          dockerPullStream: sinon.stub().resolves('pulled'),
-        },
+        '../dockerService': makeDockerServiceStub({ getAppIdentifier: sinon.stub().returns('multiarchapp') }),
         './appUninstaller': {
           removeAppLocally: sinon.stub().resolves(),
         },
@@ -842,19 +837,7 @@ describe('appInstaller tests', () => {
         '../geolocationService': {
           isStaticIP: sinon.stub().returns(true),
         },
-        '../dockerService': {
-          dockerListContainers: sinon.stub().resolves([]),
-          pruneContainers: sinon.stub().resolves(),
-          pruneNetworks: sinon.stub().resolves(),
-          pruneVolumes: sinon.stub().resolves(),
-          pruneImages: sinon.stub().resolves(),
-          createFluxAppDockerNetwork: sinon.stub().resolves('network-created'),
-          getFluxDockerNetworkPhysicalInterfaceNames: sinon.stub().resolves([]),
-          appDockerCreate: sinon.stub().resolves(),
-          appDockerStart: sinon.stub().resolves('container-started'),
-          getAppIdentifier: sinon.stub().returns('testapp'),
-          dockerPullStream: sinon.stub().resolves('pulled'),
-        },
+        '../dockerService': makeDockerServiceStub(),
         './appUninstaller': {
           removeAppLocally: sinon.stub().resolves(),
         },
@@ -966,19 +949,7 @@ describe('appInstaller tests', () => {
         '../geolocationService': {
           isStaticIP: sinon.stub().returns(true),
         },
-        '../dockerService': {
-          dockerListContainers: sinon.stub().resolves([]),
-          pruneContainers: sinon.stub().resolves(),
-          pruneNetworks: sinon.stub().resolves(),
-          pruneVolumes: sinon.stub().resolves(),
-          pruneImages: sinon.stub().resolves(),
-          createFluxAppDockerNetwork: sinon.stub().resolves('network-created'),
-          getFluxDockerNetworkPhysicalInterfaceNames: sinon.stub().resolves([]),
-          appDockerCreate: sinon.stub().resolves(),
-          appDockerStart: sinon.stub().resolves('container-started'),
-          getAppIdentifier: sinon.stub().returns('testapp'),
-          dockerPullStream: sinon.stub().resolves('pulled'),
-        },
+        '../dockerService': makeDockerServiceStub(),
         './appUninstaller': {
           removeAppLocally: sinon.stub().resolves(),
         },
@@ -1106,19 +1077,7 @@ describe('appInstaller tests', () => {
           getLocalSocketAddress: sinon.stub().resolves('1.2.3.4:16127'),
         },
         '../geolocationService': { isStaticIP: sinon.stub().returns(true) },
-        '../dockerService': {
-          dockerListContainers: sinon.stub().resolves([]),
-          pruneContainers: sinon.stub().resolves(),
-          pruneNetworks: sinon.stub().resolves(),
-          pruneVolumes: sinon.stub().resolves(),
-          pruneImages: sinon.stub().resolves(),
-          createFluxAppDockerNetwork: sinon.stub().resolves('network-created'),
-          getFluxDockerNetworkPhysicalInterfaceNames: sinon.stub().resolves([]),
-          appDockerCreate: sinon.stub().resolves(),
-          appDockerStart: sinon.stub().resolves('container-started'),
-          getAppIdentifier: sinon.stub().returns('testapp'),
-          dockerPullStream: sinon.stub().resolves('pulled'),
-        },
+        '../dockerService': makeDockerServiceStub(),
         './appUninstaller': { removeAppLocally: sinon.stub().resolves() },
         './advancedWorkflows': { createAppVolume: sinon.stub().resolves() },
         './appNetworkLinker': {
@@ -1214,21 +1173,19 @@ describe('appInstaller tests', () => {
         '../serviceHelper': { ensureString: sinon.stub().returnsArg(0), ensureNumber: sinon.stub().returnsArg(0), delay: sinon.stub().resolves() },
         '../generalService': { nodeTier: sinon.stub().resolves('cumulus'), checkSynced: sinon.stub().resolves(true) },
         '../daemonService/daemonServiceMiscRpcs': { isDaemonSynced: sinon.stub().returns({ status: 'success', data: { synced: true, height: 2094961 } }) },
-        '../fluxNetworkHelper': { getLocalSocketAddress: sinon.stub().resolves('192.168.1.1:16127'), getNumberOfPeers: sinon.stub().returns(15), isFirewallActive: sinon.stub().resolves(false), allowPort: sinon.stub().resolves({ status: true }), removeDockerContainerAccessToNonRoutable: sinon.stub().resolves(true) },
-        '../geolocationService': { isStaticIP: sinon.stub().returns(true) },
-        '../dockerService': {
-          dockerListContainers: sinon.stub().resolves([]),
-          pruneContainers: pruneContainersStub,
-          pruneNetworks: sinon.stub().resolves(),
-          pruneVolumes: sinon.stub().resolves(),
-          pruneImages: sinon.stub().resolves(),
-          createFluxAppDockerNetwork: sinon.stub().resolves('net'),
-          getFluxDockerNetworkPhysicalInterfaceNames: sinon.stub().resolves([]),
-          appDockerCreate: sinon.stub().resolves(),
-          appDockerStart: sinon.stub().resolves('ok'),
-          getAppIdentifier: sinon.stub().returns('testapp'),
-          dockerPullStream: sinon.stub().resolves('pulled'),
+        '../fluxNetworkHelper': {
+          getLocalSocketAddress: sinon.stub().resolves('192.168.1.1:16127'),
+          getNumberOfPeers: sinon.stub().returns(15),
+          isFirewallActive: sinon.stub().resolves(false),
+          allowPort: sinon.stub().resolves({ status: true }),
+          removeDockerContainerAccessToNonRoutable: sinon.stub().resolves(true),
         },
+        '../geolocationService': { isStaticIP: sinon.stub().returns(true) },
+        '../dockerService': makeDockerServiceStub({
+          pruneContainers: pruneContainersStub,
+          createFluxAppDockerNetwork: sinon.stub().resolves('net'),
+          appDockerStart: sinon.stub().resolves('ok'),
+        }),
         './appUninstaller': { removeAppLocally: sinon.stub().resolves() },
         './advancedWorkflows': { createAppVolume: sinon.stub().resolves() },
         '../fluxCommunicationMessagesSender': { broadcastMessageToOutgoing: sinon.stub().resolves(), broadcastMessageToIncoming: sinon.stub().resolves() },
@@ -1269,6 +1226,134 @@ describe('appInstaller tests', () => {
       // Decrypted enterprise app has a stopped component (MyComponent_enterpriseapp123 not running)
       // so pruneContainers should NOT be called
       expect(pruneContainersStub.called).to.be.false;
+    });
+  });
+
+  describe('ensureAppDockerNetwork tests', () => {
+    let appInstallerNet;
+    let dockerServiceStub;
+    let removeAccessStub;
+
+    beforeEach(() => {
+      process.env.NODE_CONFIG_DIR = `${process.cwd()}/tests/unit/globalconfig`;
+      dockerServiceStub = makeDockerServiceStub({ getFreeFluxAppNetworkOctet: sinon.stub().resolves(7) });
+      removeAccessStub = sinon.stub().resolves(true);
+      appInstallerNet = proxyquire('../../ZelBack/src/services/appLifecycle/appInstaller', {
+        '../serviceHelper': { ensureString: sinon.stub().returnsArg(0) },
+        '../dockerService': dockerServiceStub,
+        '../fluxNetworkHelper': { removeDockerContainerAccessToNonRoutable: removeAccessStub },
+        '../../lib/log': { info: sinon.stub(), warn: sinon.stub(), error: sinon.stub() },
+      });
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('returns early (no create, no firewall rebuild) when the network already exists', async () => {
+      dockerServiceStub.dockerNetworkState.resolves('exists');
+
+      const result = await appInstallerNet.ensureAppDockerNetwork('myapp');
+
+      expect(dockerServiceStub.getFreeFluxAppNetworkOctet.called).to.be.false;
+      expect(dockerServiceStub.createFluxAppDockerNetwork.called).to.be.false;
+      // intact network: its interface is already in DOCKER-USER, so no iptables churn
+      expect(dockerServiceStub.getFluxDockerNetworkPhysicalInterfaceNames.called).to.be.false;
+      expect(removeAccessStub.called).to.be.false;
+      expect(result).to.include('already exists');
+    });
+
+    it('creates the network on the lowest free octet when absent', async () => {
+      dockerServiceStub.getFreeFluxAppNetworkOctet.resolves(7);
+
+      await appInstallerNet.ensureAppDockerNetwork('myapp');
+
+      expect(dockerServiceStub.createFluxAppDockerNetwork.calledOnceWithExactly('myapp', 7)).to.be.true;
+      expect(removeAccessStub.calledOnce).to.be.true;
+    });
+
+    it('re-scans for the next free octet when a create collides', async () => {
+      dockerServiceStub.getFreeFluxAppNetworkOctet.onFirstCall().resolves(7);
+      dockerServiceStub.getFreeFluxAppNetworkOctet.onSecondCall().resolves(8);
+      dockerServiceStub.createFluxAppDockerNetwork.onFirstCall().resolves(undefined); // collision
+      dockerServiceStub.createFluxAppDockerNetwork.onSecondCall().resolves('network-created');
+
+      await appInstallerNet.ensureAppDockerNetwork('myapp');
+
+      expect(dockerServiceStub.createFluxAppDockerNetwork.getCall(0).args).to.deep.equal(['myapp', 7]);
+      expect(dockerServiceStub.createFluxAppDockerNetwork.getCall(1).args).to.deep.equal(['myapp', 8]);
+      // the lost octet is excluded from the next allocation so it never re-picks it
+      expect([...dockerServiceStub.getFreeFluxAppNetworkOctet.secondCall.args[0]]).to.include(7);
+    });
+
+    it('throws a clear error when no free subnet is available', async () => {
+      dockerServiceStub.getFreeFluxAppNetworkOctet.resolves(null);
+      let err;
+      try {
+        await appInstallerNet.ensureAppDockerNetwork('myapp');
+      } catch (e) { err = e; }
+
+      expect(err).to.be.an('error');
+      expect(err.message).to.include('No free 172.23.x.0/24 subnet available');
+      expect(dockerServiceStub.createFluxAppDockerNetwork.called).to.be.false;
+    });
+
+    it('pins the octet by name for legacy gateway-assignment apps', async () => {
+      // 'fdm' is in appsThatMightBeUsingOldGatewayIpAssignment; octet = 'm'.charCodeAt = 109
+      await appInstallerNet.ensureAppDockerNetwork('fdm');
+
+      expect(dockerServiceStub.getFreeFluxAppNetworkOctet.called).to.be.false;
+      expect(dockerServiceStub.createFluxAppDockerNetwork.calledOnceWithExactly('fdm', 'm'.charCodeAt(0))).to.be.true;
+    });
+
+    it('advances through EVERY free octet and gives up only on exhaustion, not a fixed count', async () => {
+      // Simulate a nearly-full node: octets 1..FREE are free, every create loses. Drive
+      // the allocator off the real exclude set so it must try all FREE octets before the
+      // space is exhausted. FREE is deliberately larger than any plausible fixed retry cap:
+      // a reintroduced cap (the finding-1 regression) would throw early and fail callCount.
+      const FREE = 20;
+      dockerServiceStub.getFreeFluxAppNetworkOctet = sinon.stub().callsFake(async (excluded = new Set()) => {
+        for (let octet = 1; octet <= FREE; octet += 1) {
+          if (!excluded.has(octet)) return octet;
+        }
+        return null;
+      });
+      dockerServiceStub.createFluxAppDockerNetwork.resolves(undefined); // every create loses
+      let err;
+      try {
+        await appInstallerNet.ensureAppDockerNetwork('myapp');
+      } catch (e) { err = e; }
+
+      // it attempted all FREE octets (never re-picking one) and only threw at true exhaustion
+      expect(dockerServiceStub.createFluxAppDockerNetwork.callCount).to.equal(FREE);
+      const attemptedOctets = dockerServiceStub.createFluxAppDockerNetwork.getCalls().map((c) => c.args[1]);
+      expect(attemptedOctets).to.deep.equal(Array.from({ length: FREE }, (_, i) => i + 1));
+      expect(err).to.be.an('error');
+      expect(err.message).to.include('No free 172.23.x.0/24 subnet available');
+    });
+
+    it('treats an unknown network state as not-present and attempts a create', async () => {
+      // dockerNetworkState returns 'unknown' on a transient docker glitch; the guard
+      // is `=== exists`, so unknown must fall through to an (idempotent) create rather
+      // than be mistaken for an existing network (which would skip the heal recreate).
+      dockerServiceStub.dockerNetworkState.resolves('unknown');
+      dockerServiceStub.getFreeFluxAppNetworkOctet.resolves(7);
+
+      await appInstallerNet.ensureAppDockerNetwork('myapp');
+
+      expect(dockerServiceStub.createFluxAppDockerNetwork.calledOnceWithExactly('myapp', 7)).to.be.true;
+    });
+
+    it('legacy app throws if its pinned octet cannot be created', async () => {
+      dockerServiceStub.createFluxAppDockerNetwork.resolves(undefined);
+      let err;
+      try {
+        await appInstallerNet.ensureAppDockerNetwork('fdm');
+      } catch (e) { err = e; }
+
+      expect(dockerServiceStub.getFreeFluxAppNetworkOctet.called).to.be.false;
+      expect(err).to.be.an('error');
+      expect(err.message).to.include('Not possible to create docker application network');
     });
   });
 });

--- a/tests/unit/appInstaller.test.js
+++ b/tests/unit/appInstaller.test.js
@@ -1355,5 +1355,29 @@ describe('appInstaller tests', () => {
       expect(err).to.be.an('error');
       expect(err.message).to.include('Not possible to create docker application network');
     });
+
+    it('reserves the legacy-pinned octets so a non-legacy app cannot squat one', async () => {
+      dockerServiceStub.getFreeFluxAppNetworkOctet.resolves(7);
+
+      await appInstallerNet.ensureAppDockerNetwork('myapp');
+
+      // the legacy octets are seeded into the exclude set on the very first allocation
+      // so the free-octet scan never hands one out: 'fdm'->'m'(109), 'health'->'h'(104),
+      // 'Jetpack2'->'2'(50).
+      const excluded = [...dockerServiceStub.getFreeFluxAppNetworkOctet.firstCall.args[0]];
+      expect(excluded).to.include('m'.charCodeAt(0));
+      expect(excluded).to.include('h'.charCodeAt(0));
+      expect(excluded).to.include('2'.charCodeAt(0));
+    });
+
+    it('streams an already-exists status on the early-return path', async () => {
+      dockerServiceStub.dockerNetworkState.resolves('exists');
+      const writes = [];
+      const res = { write: (chunk) => writes.push(chunk) };
+
+      await appInstallerNet.ensureAppDockerNetwork('myapp', res);
+
+      expect(writes.some((w) => w && w.status && w.status.includes('already exists'))).to.be.true;
+    });
   });
 });

--- a/tests/unit/containerHealthMonitor.test.js
+++ b/tests/unit/containerHealthMonitor.test.js
@@ -45,6 +45,7 @@ describe('containerHealthMonitor tests', () => {
     appInstallerStub = {
       installApplicationHard: sinon.stub().resolves(),
       installApplicationSoft: sinon.stub().resolves(),
+      ensureAppDockerNetwork: sinon.stub().resolves('network-ready'),
     };
 
     appUninstallerStub = {
@@ -119,6 +120,15 @@ describe('containerHealthMonitor tests', () => {
       const [componentSpec, mainAppName] = appInstallerStub.installApplicationSoft.firstCall.args;
       expect(componentSpec.name).to.equal('web');
       expect(mainAppName).to.equal('testapp');
+    });
+
+    it('ensures the app docker network before recreating any container', async () => {
+      // A pruned per-app network (docker prune / daemon restart) is created only
+      // at install time; without this the recreate loops on "network not found".
+      volumeServiceStub.verifyAppVolumeMount.resolves(true);
+      await containerHealthMonitor.recreateMissingContainers('web_testapp');
+      expect(appInstallerStub.ensureAppDockerNetwork.calledOnceWith('testapp')).to.be.true;
+      expect(appInstallerStub.ensureAppDockerNetwork.calledBefore(appInstallerStub.installApplicationSoft)).to.be.true;
     });
 
     it('hard-installs a single component when its volume is gone', async () => {

--- a/tests/unit/dockerService.test.js
+++ b/tests/unit/dockerService.test.js
@@ -364,6 +364,71 @@ describe('dockerService tests', () => {
     });
   });
 
+  describe('getFreeFluxAppNetworkOctet tests', () => {
+    const net = (subnet) => ({ Name: 'fluxDockerNetwork_x', IPAM: { Config: [{ Subnet: subnet }] } });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('returns the lowest free octet (1) when only the base network exists', async () => {
+      sinon.stub(Dockerode.prototype, 'listNetworks').resolves([net('172.23.0.0/24')]);
+
+      await expect(dockerService.getFreeFluxAppNetworkOctet()).to.eventually.equal(1);
+    });
+
+    it('returns the first gap when low octets are already taken', async () => {
+      sinon.stub(Dockerode.prototype, 'listNetworks').resolves(
+        ['172.23.0.0/24', '172.23.1.0/24', '172.23.2.0/24', '172.23.4.0/24'].map(net),
+      );
+
+      await expect(dockerService.getFreeFluxAppNetworkOctet()).to.eventually.equal(3);
+    });
+
+    it('ignores subnets outside the 172.23.x.0/24 app range', async () => {
+      sinon.stub(Dockerode.prototype, 'listNetworks').resolves(
+        ['172.23.1.0/24', '10.0.0.0/24', null].map(net),
+      );
+
+      // only octet 1 is a used app subnet, so 2 is the lowest free
+      await expect(dockerService.getFreeFluxAppNetworkOctet()).to.eventually.equal(2);
+    });
+
+    it('returns null when every 172.23.x.0/24 block is taken', async () => {
+      const all = [];
+      for (let octet = 0; octet <= 255; octet += 1) all.push(net(`172.23.${octet}.0/24`));
+      sinon.stub(Dockerode.prototype, 'listNetworks').resolves(all);
+
+      await expect(dockerService.getFreeFluxAppNetworkOctet()).to.eventually.be.null;
+    });
+
+    it('counts NON-flux networks too (docker enforces global subnet uniqueness)', async () => {
+      sinon.stub(Dockerode.prototype, 'listNetworks').resolves([
+        { Name: 'bridge', IPAM: { Config: [{ Subnet: '172.23.1.0/24' }] } },
+        net('172.23.2.0/24'),
+      ]);
+
+      // octet 1 (a non-flux network) and 2 (flux) are both used -> 3 is lowest free
+      await expect(dockerService.getFreeFluxAppNetworkOctet()).to.eventually.equal(3);
+    });
+
+    it('treats excluded octets as used (collision-retry advancement)', async () => {
+      sinon.stub(Dockerode.prototype, 'listNetworks').resolves([net('172.23.0.0/24')]);
+
+      await expect(dockerService.getFreeFluxAppNetworkOctet(new Set([1, 2, 3]))).to.eventually.equal(4);
+    });
+
+    it('tolerates networks with no IPAM config', async () => {
+      sinon.stub(Dockerode.prototype, 'listNetworks').resolves([
+        { Name: 'host' },
+        { Name: 'none', IPAM: {} },
+        net('172.23.1.0/24'),
+      ]);
+
+      await expect(dockerService.getFreeFluxAppNetworkOctet()).to.eventually.equal(2);
+    });
+  });
+
   describe('dockerContainerStats tests', () => {
     it('should return a valid stats object', async () => {
       const containerName = 'website';


### PR DESCRIPTION
## Summary

App containers can get stuck in docker `created` state, looping indefinitely on `failed to set up container networking: network fluxDockerNetwork_<app> not found`, when the app's per-app docker network goes missing (e.g. `docker network prune`, a docker daemon restart). The per-app network was only ever created at install time (`registerAppLocally`); nothing in the reconciler/heal loop recreated it, so `recreateMissingContainers` and every container start failed and retried forever. On the vanished-container path the repeated failure eventually escalates to `removeAppLocally`.

## Fix

- **`containerHealthMonitor.recreateMissingContainers` now ensures the app network exists before recreating any container.** This is the core fix — both the vanished-container path and the network-detach heal path funnel through `recreateMissingContainers`, so a pruned network is recreated before `appDockerCreate` instead of looping on "network not found".
- **`ensureAppDockerNetwork` extracted from `registerAppLocally`** — the single creator for install and heal:
  - *Idempotent* — returns early when the network exists, doing no allocation and no `DOCKER-USER` iptables rebuild (an intact interface is already in the chain), so a heal recreate on an existing network is cheap.
  - *Deterministic but collision-safe allocation* — lowest-free `172.23.x.0/24`, scanning **all** docker networks (docker enforces subnet uniqueness globally), and advancing past any octet a create loses to a concurrent allocation. It gives up only on genuine octet exhaustion — never a fixed retry count, because a premature throw on the vanished path would escalate to an app uninstall while subnets were still free.
  - *Reserves the legacy-pinned octets* in the free-octet scan so a non-legacy app cannot squat an octet a legacy gateway-pinned app must heal onto.
- **`dockerService.getFreeFluxAppNetworkOctet(excludeOctets)`** — lowest-free octet across all networks, with a caller exclude set for the collision retry.
- **`softRegisterAppLocally` (soft-install / soft-redeploy) now delegates to `ensureAppDockerNetwork`** instead of a near-duplicate allocator. The duplicate still used `Math.random()*256` (which could pick octet `0`, colliding with the base network) and a fixed 21-try cap that could throw while subnets were still free and escalate a soft-register to an uninstall — the exact fragility this PR argues against. One creator now serves install, soft-install, and heal; the install stream messages are unchanged.
- Legacy gateway-pinned apps (`appsThatMightBeUsingOldGatewayIpAssignment`) keep their name-derived octet, unchanged. `appReconciler.js` is unchanged.

## Testing

- **Verified end-to-end on a live node.** With the fix deployed, a running app's container was removed and its per-app docker network pruned, then FluxOS was restarted. The reconciler detected the vanished container, recreated the missing network via `ensureAppDockerNetwork`, and restarted the container within ~5s — the app returned to `running`. The healed (non-legacy) app was re-assigned a fresh lowest-free octet, confirming the deterministic-allocator path; this is octet-independent for correctness (host port mappings and the `172.23.0.0/16` firewall coverage do not depend on the octet).
- Unit coverage across `appInstaller`, `containerHealthMonitor`, `dockerService`: network-ensured-before-recreate; deterministic lowest-free allocation; non-flux networks counted; exclude-set advancement; exhaustion → clear error; idempotent exists path does no create and no firewall rebuild; `unknown` docker-network state falls through to an idempotent create; **legacy-octet reservation; exists-path status stream**. The exhaustion test is **mutation-verified** — reintroducing a fixed retry cap makes it fail.
- All affected unit suites green with no regression: appInstaller (incl. 2 new cases), containerHealthMonitor, dockerService, appReconciler, advancedWorkflows (51 — confirms the soft-register consolidation is a behaviour-preserving delegation), appSpawner, peerNotification.
- Hardened under two adversarial review passes plus maintainer review; the allocator's concurrency behaviour (no false failure / no spurious uninstall during a mass-prune recovery), the all-networks scan, and the no-firewall-on-exists path were added in response.

## Deferred follow-ups (not in this PR)

- The per-app subnet allocator is a hand-rolled reimplementation of docker's native IPAM, kept only for legacy gateway pinning and the `172.23.0.0/16` firewall coupling. Replacing it with docker `default-address-pools` allocation is a separate cross-repo change (node daemon.json + careful rollout ordering).
- The `DOCKER-USER` rebuild runs once per created network during a mass-prune recovery (N healing apps → N rebuilds, each a brief protection drop). Inherent to the per-app network design and not worsened here; a batching opportunity that folds naturally into the IPAM migration above.

Written against commits `5f24a94` + `4db9b3f`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
