### PR TITLE
Release 8.17.0: tampering incident model + reconciler network heal

### DIFF
--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -41,9 +41,6 @@ const appNetworkLinker = require('./appNetworkLinker');
 
 const isArcane = Boolean(process.env.FLUXOS_PATH);
 
-// Legacy apps that use old gateway IP assignment method
-const appsThatMightBeUsingOldGatewayIpAssignment = ['HNSDoH', 'dane', 'fdm', 'Jetpack2', 'fdmdedicated', 'isokosse', 'ChainBraryDApp', 'health', 'ethercalc'];
-
 // Master/slave app tracking
 const mastersRunningGSyncthingApps = new Map();
 const timeTostartNewMasterApp = new Map();
@@ -921,47 +918,14 @@ async function softRegisterAppLocally(appSpecs, componentSpecs, res) {
     await appNetworkLinker.checkAppNetworkRequirements(appSpecifications);
 
     if (!isComponent) {
-      let dockerNetworkAddrValue = Math.floor(Math.random() * 256);
-      if (appsThatMightBeUsingOldGatewayIpAssignment.includes(appName)) {
-        dockerNetworkAddrValue = appName.charCodeAt(appName.length - 1);
-      }
-      const fluxNetworkStatus = {
-        status: `Checking Flux App network of ${appName}...`,
-      };
-      log.info(fluxNetworkStatus);
-      if (res) {
-        res.write(serviceHelper.ensureString(fluxNetworkStatus));
-        if (res.flush) res.flush();
-      }
-      let fluxNet = null;
-      for (let i = 0; i <= 20; i += 1) {
-        // eslint-disable-next-line no-await-in-loop
-        fluxNet = await dockerService.createFluxAppDockerNetwork(appName, dockerNetworkAddrValue).catch((error) => log.error(error));
-        if (fluxNet || appsThatMightBeUsingOldGatewayIpAssignment.includes(appName)) {
-          break;
-        }
-        dockerNetworkAddrValue = Math.floor(Math.random() * 256);
-      }
-      if (!fluxNet) {
-        throw new Error(`Flux App network of ${appName} failed to initiate. Not possible to create docker application network.`);
-      }
-      log.info(serviceHelper.ensureString(fluxNet));
-      const fluxNetworkInterfaces = await dockerService.getFluxDockerNetworkPhysicalInterfaceNames();
-      const accessRemoved = await fluxNetworkHelper.removeDockerContainerAccessToNonRoutable(fluxNetworkInterfaces);
-      const accessRemovedRes = {
-        status: accessRemoved ? `Private network access removed for ${appName}` : `Error removing private network access for ${appName}`,
-      };
-      if (res) {
-        res.write(serviceHelper.ensureString(accessRemovedRes));
-        if (res.flush) res.flush();
-      }
-      const fluxNetResponse = {
-        status: `Docker network of ${appName} initiated.`,
-      };
-      if (res) {
-        res.write(serviceHelper.ensureString(fluxNetResponse));
-        if (res.flush) res.flush();
-      }
+      // One creator for install and heal: idempotent, collision-safe, and
+      // exhaustion-bounded. Replaces the old random-octet + fixed-21-retry loop
+      // that could pick octet 0 (colliding with the base network) and throw while
+      // subnets were still free, escalating a soft-register to an uninstall.
+      // Dynamic require because appInstaller <-> advancedWorkflows is a circular
+      // dependency (dynamically required throughout this file); to be untangled in v9.
+      const appInstaller = require('./appInstaller');
+      await appInstaller.ensureAppDockerNetwork(appName, res);
     }
 
     const appInstallation = {

--- a/ZelBack/src/services/appLifecycle/appInstaller.js
+++ b/ZelBack/src/services/appLifecycle/appInstaller.js
@@ -44,6 +44,11 @@ const volumeService = require('../utils/volumeService');
 // Legacy apps that use old gateway IP assignment method
 const appsThatMightBeUsingOldGatewayIpAssignment = ['HNSDoH', 'dane', 'fdm', 'Jetpack2', 'fdmdedicated', 'isokosse', 'ChainBraryDApp', 'health', 'ethercalc'];
 
+// The octets those legacy apps pin by name (charCodeAt of the last character).
+// Reserve them in the free-octet scan so a non-legacy app can't take one before
+// the legacy app heals onto its fixed octet.
+const legacyPinnedOctets = appsThatMightBeUsingOldGatewayIpAssignment.map((name) => name.charCodeAt(name.length - 1));
+
 // Helper functions and constants for installApplicationHard
 const util = require('util');
 
@@ -340,6 +345,14 @@ async function ensureAppDockerNetwork(appName, res) {
   }
 
   if (await dockerService.dockerNetworkState(`fluxDockerNetwork_${appName}`) === 'exists') {
+    const existsStatus = {
+      status: `Flux App network of ${appName} already exists.`,
+    };
+    log.info(existsStatus);
+    if (res) {
+      res.write(serviceHelper.ensureString(existsStatus));
+      if (res.flush) res.flush();
+    }
     return `Flux App Network of ${appName} already exists.`;
   }
 
@@ -351,9 +364,11 @@ async function ensureAppDockerNetwork(appName, res) {
   } else {
     // Take the lowest free 172.23.x.0/24, advancing past any octet a create loses
     // (a concurrent heal of another app, or a non-flux network holding the subnet).
-    // Give up only when the octet space is genuinely exhausted, never on a fixed
-    // count - see the JSDoc for why a premature throw is dangerous here.
-    const tried = new Set();
+    // Seed the exclude set with the legacy-pinned octets so a non-legacy app can't
+    // squat an octet a legacy app must heal onto. Give up only when the octet space
+    // is genuinely exhausted, never on a fixed count - see the JSDoc for why a
+    // premature throw is dangerous here.
+    const tried = new Set(legacyPinnedOctets);
     while (!fluxNet) {
       // eslint-disable-next-line no-await-in-loop
       const octet = await dockerService.getFreeFluxAppNetworkOctet(tried);

--- a/ZelBack/src/services/appLifecycle/appInstaller.js
+++ b/ZelBack/src/services/appLifecycle/appInstaller.js
@@ -305,6 +305,90 @@ async function verifyAndPullImage(appSpecifications, appName, isComponent, res, 
 }
 
 /**
+ * Ensures the per-app docker network (fluxDockerNetwork_<appName>) exists,
+ * creating it with a free /24 (172.23.<octet>.0/24) if absent. Safe to call on
+ * every install and from the reconciler's heal path, where a pruned network
+ * (docker prune, daemon restart) must be re-created before any container can be
+ * re-created onto it.
+ *
+ * When the network already exists this returns EARLY - no allocation and, crucially,
+ * no firewall work: its interface is already in the node-wide DOCKER-USER rules, so
+ * re-running removeDockerContainerAccessToNonRoutable here would flush and rebuild
+ * the whole chain on every heal recreate for no gain (briefly dropping RFC1918
+ * protection for every flux container on the node).
+ *
+ * Allocation is deterministic (lowest free octet) but collision-safe: many heals can
+ * run concurrently after a mass prune, so a create that loses its octet to another
+ * app - or to a non-flux network whose subnet docker rejects - is retried against the
+ * NEXT free octet, giving up only on true exhaustion. A premature give-up would throw,
+ * and on the vanished-container path that throw escalates to an app uninstall, so the
+ * loop must never fail while octets are free. The subnet is not persisted; nothing
+ * outside the container depends on it (ports are host-mapped, gelf targets resolve
+ * from the collector's live container IP at create time).
+ * @param {string} appName bare app name (the network is per-app, not per-component)
+ * @param {object} [res] optional express response for install-status streaming
+ * @returns {Promise<object|string>} the created-or-existing network response
+ */
+async function ensureAppDockerNetwork(appName, res) {
+  const fluxNetworkStatus = {
+    status: `Checking Flux App network of ${appName}...`,
+  };
+  log.info(fluxNetworkStatus);
+  if (res) {
+    res.write(serviceHelper.ensureString(fluxNetworkStatus));
+    if (res.flush) res.flush();
+  }
+
+  if (await dockerService.dockerNetworkState(`fluxDockerNetwork_${appName}`) === 'exists') {
+    return `Flux App Network of ${appName} already exists.`;
+  }
+
+  let fluxNet = null;
+  if (appsThatMightBeUsingOldGatewayIpAssignment.includes(appName)) {
+    // legacy apps pinned their gateway octet by name (it was baked into their
+    // config); they must keep it rather than take the next free one.
+    fluxNet = await dockerService.createFluxAppDockerNetwork(appName, appName.charCodeAt(appName.length - 1)).catch((error) => log.error(error));
+  } else {
+    // Take the lowest free 172.23.x.0/24, advancing past any octet a create loses
+    // (a concurrent heal of another app, or a non-flux network holding the subnet).
+    // Give up only when the octet space is genuinely exhausted, never on a fixed
+    // count - see the JSDoc for why a premature throw is dangerous here.
+    const tried = new Set();
+    while (!fluxNet) {
+      // eslint-disable-next-line no-await-in-loop
+      const octet = await dockerService.getFreeFluxAppNetworkOctet(tried);
+      if (octet === null) {
+        throw new Error(`Flux App network of ${appName} failed to initiate. No free 172.23.x.0/24 subnet available on this node.`);
+      }
+      // eslint-disable-next-line no-await-in-loop
+      fluxNet = await dockerService.createFluxAppDockerNetwork(appName, octet).catch((error) => log.error(error));
+      if (!fluxNet) tried.add(octet);
+    }
+  }
+  if (!fluxNet) {
+    throw new Error(`Flux App network of ${appName} failed to initiate. Not possible to create docker application network.`);
+  }
+  log.info(serviceHelper.ensureString(fluxNet));
+  const fluxNetworkInterfaces = await dockerService.getFluxDockerNetworkPhysicalInterfaceNames();
+  const accessRemoved = await fluxNetworkHelper.removeDockerContainerAccessToNonRoutable(fluxNetworkInterfaces);
+  const accessRemovedRes = {
+    status: accessRemoved ? `Private network access removed for ${appName}` : `Error removing private network access for ${appName}`,
+  };
+  if (res) {
+    res.write(serviceHelper.ensureString(accessRemovedRes));
+    if (res.flush) res.flush();
+  }
+  const fluxNetResponse = {
+    status: `Docker network of ${appName} initiated.`,
+  };
+  if (res) {
+    res.write(serviceHelper.ensureString(fluxNetResponse));
+    if (res.flush) res.flush();
+  }
+  return fluxNet;
+}
+
+/**
  * To register an app locally. Performs pre-installation checks - database in place, Flux Docker network in place and if app already installed. Then registers app in database and performs hard install. If registration fails, the app is removed locally.
  * @param {object} appSpecs App specifications.
  * @param {object} componentSpecs Component specifications.
@@ -451,47 +535,7 @@ async function registerAppLocally(appSpecs, componentSpecs, res, test = false, s
     await appNetworkLinker.checkAppNetworkRequirements(appSpecifications);
 
     if (!isComponent) {
-      let dockerNetworkAddrValue = Math.floor(Math.random() * 256);
-      if (appsThatMightBeUsingOldGatewayIpAssignment.includes(appName)) {
-        dockerNetworkAddrValue = appName.charCodeAt(appName.length - 1);
-      }
-      const fluxNetworkStatus = {
-        status: `Checking Flux App network of ${appName}...`,
-      };
-      log.info(fluxNetworkStatus);
-      if (res) {
-        res.write(serviceHelper.ensureString(fluxNetworkStatus));
-        if (res.flush) res.flush();
-      }
-      let fluxNet = null;
-      for (let i = 0; i <= 20; i += 1) {
-        // eslint-disable-next-line no-await-in-loop
-        fluxNet = await dockerService.createFluxAppDockerNetwork(appName, dockerNetworkAddrValue).catch((error) => log.error(error));
-        if (fluxNet || appsThatMightBeUsingOldGatewayIpAssignment.includes(appName)) {
-          break;
-        }
-        dockerNetworkAddrValue = Math.floor(Math.random() * 256);
-      }
-      if (!fluxNet) {
-        throw new Error(`Flux App network of ${appName} failed to initiate. Not possible to create docker application network.`);
-      }
-      log.info(serviceHelper.ensureString(fluxNet));
-      const fluxNetworkInterfaces = await dockerService.getFluxDockerNetworkPhysicalInterfaceNames();
-      const accessRemoved = await fluxNetworkHelper.removeDockerContainerAccessToNonRoutable(fluxNetworkInterfaces);
-      const accessRemovedRes = {
-        status: accessRemoved ? `Private network access removed for ${appName}` : `Error removing private network access for ${appName}`,
-      };
-      if (res) {
-        res.write(serviceHelper.ensureString(accessRemovedRes));
-        if (res.flush) res.flush();
-      }
-      const fluxNetResponse = {
-        status: `Docker network of ${appName} initiated.`,
-      };
-      if (res) {
-        res.write(serviceHelper.ensureString(fluxNetResponse));
-        if (res.flush) res.flush();
-      }
+      await ensureAppDockerNetwork(appName, res);
     }
 
     const appInstallation = {
@@ -1234,6 +1278,7 @@ async function testAppInstall(req, res) {
 
 module.exports = {
   registerAppLocally,
+  ensureAppDockerNetwork,
   installApplicationHard,
   installApplicationSoft,
   installAppLocally,

--- a/ZelBack/src/services/appManagement/appsRuntimeState.js
+++ b/ZelBack/src/services/appManagement/appsRuntimeState.js
@@ -191,29 +191,80 @@ async function setNetworkHealRemoval(identifier, removed) {
 /**
  * Whether the reconciler removed this container itself for a network heal.
  *
+ * Deliberately does NOT reuse getState: getState swallows a read failure and
+ * returns null, which here would read as "not a heal removal" - the DESTRUCTIVE
+ * direction (the caller would treat its own removal as a vanished container,
+ * record a false tampering event and, on a failed recreate, uninstall the app).
+ * A read failure must be a failure, so the caller can defer instead of guess.
+ *
  * @param {string} identifier
- * @returns {Promise<boolean>}
+ * @returns {Promise<boolean>} - throws if the state cannot be read
  */
-async function isNetworkHealRemoval(identifier) {
-  const state = await getState(identifier);
+async function isNetworkHealRemoval(rawIdentifier) {
+  const identifier = canonical(rawIdentifier);
+  const database = collection();
+  const state = await dbHelper.findOneInDatabase(database, appsRuntimeState, { identifier }, { projection: { _id: 0 } });
   return state?.networkHealRemoval === true;
 }
 
 /**
- * Clears the heal-removal flag. Reads first so the healthy steady state (every
- * reconcile of every attached container) costs a lookup, not a write.
+ * Appends a network-heal attempt to its OWN durable ladder. Kept separate from
+ * restartHistory: sharing it would cross-contaminate in both directions - a heal
+ * that recreates a g: component (created, not started) would then have the very
+ * container it just fixed held down by the crash ladder its own attempts grew,
+ * and a crash-looping container could not be healed for up to the 30m cap.
  *
  * @param {string} identifier
  */
-async function clearNetworkHealRemoval(identifier) {
+async function recordNetworkHealAttempt(identifier) {
+  // No catch: pacing that silently fails to persist means the next pass sees an
+  // empty ladder, waits 0, and hammers the destructive heal. The caller defers.
+  const state = await getState(identifier);
+  const history = (state && state.networkHealHistory) || [];
+  history.push(Date.now());
+  if (history.length > MAX_HISTORY) {
+    history.splice(0, history.length - MAX_HISTORY);
+  }
+  await setFields(identifier, { networkHealHistory: history });
+}
+
+/**
+ * How long (ms) before the next network-heal attempt is allowed - 0 means now.
+ * Same ladder shape as the crash backoff (immediate, 30s, 5m, 15m, 30m cap), so
+ * a container that keeps coming back detached is retried forever but at a
+ * decaying rate. The ladder is reset by clearNetworkHeal once the container is
+ * seen healthy, so a later, unrelated episode starts from the bottom again.
+ *
+ * @param {string} identifier
+ * @returns {Promise<number>}
+ */
+async function networkHealWaitMs(identifier) {
+  const state = await getState(identifier);
+  const history = (state && state.networkHealHistory) || [];
+  if (history.length === 0) return 0;
+  const last = history[history.length - 1];
+  const index = Math.min(history.length, BACKOFF_DELAYS_MS.length - 1);
+  return Math.max(0, BACKOFF_DELAYS_MS[index] - (Date.now() - last));
+}
+
+/**
+ * Drops all network-heal state (the removal flag and the heal ladder) once the
+ * container is healthy again. Reads first so the healthy steady state - every
+ * reconcile of every attached container - costs a lookup, not a write.
+ *
+ * @param {string} identifier
+ */
+async function clearNetworkHeal(identifier) {
   try {
-    if (!(await isNetworkHealRemoval(identifier))) return;
-    await setFields(identifier, { networkHealRemoval: false });
+    const state = await getState(identifier);
+    if (!state) return;
+    if (state.networkHealRemoval !== true && !(state.networkHealHistory || []).length) return;
+    await setFields(identifier, { networkHealRemoval: false, networkHealHistory: [] });
   } catch (err) {
-    // A stale `true` only ever makes the reconciler MORE conservative (it keeps
+    // A stale flag only ever makes the reconciler MORE conservative (it keeps
     // recreating instead of escalating to an uninstall), so a failed clear is safe
     // to log and move on from - unlike a failed set, which must abort the remove.
-    log.error(`appsRuntimeState - failed to clear network heal removal for ${identifier}: ${err.message}`);
+    log.error(`appsRuntimeState - failed to clear network heal state for ${identifier}: ${err.message}`);
   }
 }
 
@@ -278,6 +329,7 @@ async function prepareCollection() {
           // likewise, a heal-removal anywhere means a heal may be mid-flight: keep
           // the reconciler on the recreate path rather than the uninstall path
           networkHealRemoval: twins.some((t) => t.networkHealRemoval === true),
+          networkHealHistory: [...new Set(twins.flatMap((t) => t.networkHealHistory || []))].sort((a, b) => a - b).slice(-MAX_HISTORY),
           restartHistory: [...new Set(twins.flatMap((t) => t.restartHistory || []))].sort((a, b) => a - b).slice(-MAX_HISTORY),
           updatedAt: Math.max(...twins.map((t) => t.updatedAt || 0)),
         };
@@ -308,7 +360,9 @@ module.exports = {
   restartWaitMs,
   setNetworkHealRemoval,
   isNetworkHealRemoval,
-  clearNetworkHealRemoval,
+  recordNetworkHealAttempt,
+  networkHealWaitMs,
+  clearNetworkHeal,
   recordExit,
   remove,
   BACKOFF_DELAYS_MS,

--- a/ZelBack/src/services/appManagement/appsRuntimeState.js
+++ b/ZelBack/src/services/appManagement/appsRuntimeState.js
@@ -170,6 +170,54 @@ async function restartWaitMs(identifier, lastFinishedAtMs = null) {
 }
 
 /**
+ * The network-detach heal force-removes a container in order to recreate it with
+ * a fresh endpoint. Between those two steps the container is legitimately absent,
+ * and that fact MUST be durable: if FluxOS restarts in that window, the next
+ * reconcile would otherwise see a missing container with no heal in flight, call
+ * it vanished (a false tampering signal) and, on a failed recreate, uninstall the
+ * whole app. This flag is the reconciler's memory of "I removed this on purpose";
+ * it is set before the remove and cleared once the container is seen running AND
+ * attached again (see appReconciler).
+ *
+ * @param {string} identifier
+ * @param {boolean} removed
+ */
+async function setNetworkHealRemoval(identifier, removed) {
+  // No catch: the flag is what keeps a failed heal from escalating to an app
+  // uninstall. If it cannot be persisted, the caller must not remove the container.
+  await setFields(identifier, { networkHealRemoval: removed });
+}
+
+/**
+ * Whether the reconciler removed this container itself for a network heal.
+ *
+ * @param {string} identifier
+ * @returns {Promise<boolean>}
+ */
+async function isNetworkHealRemoval(identifier) {
+  const state = await getState(identifier);
+  return state?.networkHealRemoval === true;
+}
+
+/**
+ * Clears the heal-removal flag. Reads first so the healthy steady state (every
+ * reconcile of every attached container) costs a lookup, not a write.
+ *
+ * @param {string} identifier
+ */
+async function clearNetworkHealRemoval(identifier) {
+  try {
+    if (!(await isNetworkHealRemoval(identifier))) return;
+    await setFields(identifier, { networkHealRemoval: false });
+  } catch (err) {
+    // A stale `true` only ever makes the reconciler MORE conservative (it keeps
+    // recreating instead of escalating to an uninstall), so a failed clear is safe
+    // to log and move on from - unlike a failed set, which must abort the remove.
+    log.error(`appsRuntimeState - failed to clear network heal removal for ${identifier}: ${err.message}`);
+  }
+}
+
+/**
  * Records the last observed exit for diagnostics / tampering signals.
  *
  * @param {string} identifier
@@ -227,6 +275,9 @@ async function prepareCollection() {
           identifier,
           // a lock anywhere is a lock: never auto-start a deliberately stopped app
           operatorStopped: twins.some((t) => t.operatorStopped === true),
+          // likewise, a heal-removal anywhere means a heal may be mid-flight: keep
+          // the reconciler on the recreate path rather than the uninstall path
+          networkHealRemoval: twins.some((t) => t.networkHealRemoval === true),
           restartHistory: [...new Set(twins.flatMap((t) => t.restartHistory || []))].sort((a, b) => a - b).slice(-MAX_HISTORY),
           updatedAt: Math.max(...twins.map((t) => t.updatedAt || 0)),
         };
@@ -255,6 +306,9 @@ module.exports = {
   isOperatorStopped,
   recordRestart,
   restartWaitMs,
+  setNetworkHealRemoval,
+  isNetworkHealRemoval,
+  clearNetworkHealRemoval,
   recordExit,
   remove,
   BACKOFF_DELAYS_MS,

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -374,13 +374,13 @@ async function recreateForNetworkHeal(identifier) {
 }
 
 /**
- * One heal cycle for a running-but-detached container: record the signal,
- * force-remove the broken container (keeping bind-mounted data), then recreate
- * it with a fresh endpoint. Force-remove is required because the recreate path
- * (appDockerCreate) 409s on an existing container name.
+ * One heal cycle for a running-but-detached container: force-remove the broken
+ * container (keeping bind-mounted data), then recreate it with a fresh endpoint.
+ * Force-remove is required because the recreate path (appDockerCreate) 409s on an
+ * existing container name. The durable network_detached signal is recorded once
+ * per episode by the caller, not here (this runs up to MAX times per episode).
  */
-async function attemptNetworkHeal(identifier, mainAppName) {
-  await appTamperingDetectionService.recordEvent(mainAppName, 'network_detached', `Container ${identifier} running with no network endpoint on its own network`);
+async function attemptNetworkHeal(identifier) {
   fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkDetached' });
   // Stop the per-minute stats monitor before removing the container (mirrors the
   // uninstaller). Otherwise its interval runs against a gone container - and, if
@@ -597,8 +597,14 @@ async function reconcile(rawIdentifier) {
     }
     st.tries += 1;
     networkHealState.set(identifier, st);
+    // Record the durable anomaly signal ONCE per episode (first attempt), not on
+    // every retry - it feeds a node-level tampering-event count, so a per-retry
+    // record would inflate it 3x for a single detachment.
+    if (st.tries === 1) {
+      await appTamperingDetectionService.recordEvent(mainAppName, 'network_detached', `Container ${identifier} running with no network endpoint on its own network`);
+    }
     log.warn(`appReconciler - ${identifier} running but not attached to its docker network (recreate ${st.tries}/${MAX_NETWORK_HEAL_ATTEMPTS}); clearing the stale endpoint`);
-    await attemptNetworkHeal(identifier, mainAppName);
+    await attemptNetworkHeal(identifier);
     return;
   }
 

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -122,10 +122,13 @@ const volumeMissingNoted = new Set();
 //     instant. A settle + re-read guarantees the time separation the confirmation
 //     is for: a transient inspect (dockerd mid-restart, the brief pre-IP window)
 //     never destroys a healthy container.
-//   - Paced, not capped: heal attempts walk the SAME durable backoff ladder as
-//     crash restarts (appsRuntimeState), up to its 30m cap. A hard attempt cap
-//     would park the heal in a terminal state until the FluxOS process restarts,
-//     which is not level-based - a reconciler keeps trying at a bounded rate.
+//   - Paced, not capped: heal attempts walk their own durable ladder in
+//     appsRuntimeState (same shape as the crash backoff, up to a 30m cap, but a
+//     SEPARATE history - sharing one would let a heal's attempts hold down the
+//     very container it just recreated, and would block the heal of a container
+//     that happens to be crash-looping). A hard attempt cap would park the heal in
+//     a terminal state until the FluxOS process restarts, which is not level-based
+//     - a reconciler keeps trying at a bounded rate.
 //     Retrying forever is also convergent at the network level: while the
 //     container is broken or absent this node stops advertising it in apprunning,
 //     its location record expires on TTL and the app is re-placed elsewhere, all
@@ -139,6 +142,19 @@ const volumeMissingNoted = new Set();
 // reconcile read the absence as tampering and, on a failed recreate, uninstall the
 // app). That lives in appsRuntimeState.networkHealRemoval, not here.
 const NETWORK_DETACH_CONFIRM_MS = 3000;
+// ...and the detach must ALSO have persisted for this long since we first saw it.
+// A dockerd restart with live-restore can answer an inspect before libnetwork has
+// re-populated endpoint IPs on running containers - and the event-stream reconnect
+// sweep enqueues every component at exactly that moment, so a short confirm alone
+// would rebuild every container on the node. This is wall-clock since the first
+// sighting, NOT a count of reconcile passes (two passes can land in the same
+// instant), so it is a real settle window whatever the trigger cadence.
+const DETACHED_PERSIST_MS = 60 * 1000;
+// id -> ms epoch of the first detached sighting of the current episode
+const detachedSince = new Map();
+// One container detached is a stale endpoint. Several at once is the daemon, not
+// the containers - refuse to force-remove the whole node's workload on that read.
+const DETACH_STORM_THRESHOLD = 3;
 // a pruned network cannot be repaired by recreating the container - re-check on a
 // slow pace so a restored network is picked up without an hour's wait
 const NETWORK_PRUNED_RETRY_MS = 5 * 60 * 1000;
@@ -386,35 +402,82 @@ async function recreateMissing(identifier) {
  * Deliberately NOT recreateMissing: a failure here must not escalate to
  * uninstalling the whole app (the trigger is a transient host-networking
  * conflict, not tampering). On failure we just re-arm a retry; the next pass
- * paces it on the backoff ladder. For a g: component recreateMissingContainers
+ * paces it on the heal ladder. For a g: component recreateMissingContainers
  * creates but does not start - the normal reconcile flow starts it on a later
  * pass. The durable heal-removal flag is NOT cleared here: only seeing the
- * container running AND attached proves the heal worked.
+ * container back proves the heal worked.
  */
 async function recreateForNetworkHeal(identifier) {
+  const mainAppName = identifier.split('_')[1] || identifier;
   try {
-    await containerHealthMonitor.recreateMissingContainers(identifier);
+    // softOnly: a hard install would REFORMAT the app's data volume (createAppVolume
+    // fallocates + mke2fs). We removed a live container whose data was intact, so a
+    // recreate that cannot verify the volume must fail and be retried - never wipe it.
+    await containerHealthMonitor.recreateMissingContainers(identifier, { softOnly: true });
     appInspector.startAppMonitoring(identifier, globalState.appsMonitored);
     log.info(`appReconciler - recreated ${identifier} to clear a detached network endpoint`);
     fluxEventBus.publish('reconciler:actuated', { identifier, action: 'recreated', reason: 'networkDetached' });
     notifyContainerStarted(identifier);
     scheduleRetry(identifier, POST_START_VERIFY_MS); // verify it came up attached
   } catch (err) {
+    // Same diagnostics the vanished path emits - minus the uninstall escalation.
+    // Without these a heal-removed container whose recreate keeps failing (e.g. its
+    // network was pruned in the meantime) would loop with no operator-visible signal.
     log.error(`appReconciler - failed to recreate ${identifier} after network detach: ${err.message}; will retry (app NOT uninstalled)`);
     fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkHealRecreateFailed', reason: err.message });
+    await appTamperingDetectionService.recordEvent(mainAppName, 'recreation_failed', `Container recreation failure after network detach: ${err.message}`).catch(() => {});
+    if (appTamperingDetectionService.isNetworkMissingError(err.message) && !networkPrunedNoted.has(identifier)) {
+      networkPrunedNoted.add(identifier);
+      await appTamperingDetectionService.recordEvent(mainAppName, 'network_pruned', `Docker network missing while recreating ${identifier}: ${err.message}`).catch(() => {});
+    }
     scheduleRetry(identifier, MANAGED_RETRY_MS);
   }
 }
 
 /**
- * Drops all bookkeeping for a healed/healthy container: the record-once tampering
- * markers and the durable "I removed this on purpose" flag. Called when a running
- * container is seen properly attached - the only proof a heal actually worked.
+ * Drops all bookkeeping for a healthy container: the in-memory episode markers and
+ * the durable heal state (the "I removed this on purpose" flag and the heal ladder).
+ * Called whenever the container is seen to EXIST and not be detached - existing is
+ * what makes the removal flag stale, so this must not be gated on `running`, or the
+ * flag would leak on every path that leaves the container stopped (a g: component
+ * awaiting its controller, an operator stop) and would then divert a later, genuine
+ * disappearance away from the vanished path forever.
  */
 async function clearNetworkHealState(identifier) {
   networkDetachedNoted.delete(identifier);
   networkPrunedNoted.delete(identifier);
-  await appsRuntimeState.clearNetworkHealRemoval(identifier);
+  detachedSince.delete(identifier);
+  await appsRuntimeState.clearNetworkHeal(identifier);
+}
+
+/**
+ * Whether a detached container can actually be recreated after we destroy it.
+ * The heal removes FIRST and recreates second, so every precondition of the
+ * recreate must hold BEFORE the remove - otherwise we turn a partially-alive
+ * container into a permanently gone one. Returns null when it is safe to proceed,
+ * or a reason string.
+ */
+async function networkHealBlocker(identifier, spec) {
+  // recreateMissingContainers throws unconditionally on a spec with no compose
+  // array (v1-3 apps, which getLocalComponentSpec explicitly supports). Removing
+  // such a container destroys it forever: the recreate can never succeed, and the
+  // heal - by design - never escalates to an uninstall that would re-place the app.
+  if (!(spec.appSpec.version >= 4 && Array.isArray(spec.appSpec.compose) && spec.appSpec.compose.length)) {
+    return 'the app has no compose spec, so its container cannot be recreated';
+  }
+  // The recreate refuses to reformat (softOnly), so an unverifiable volume means it
+  // would fail AFTER we destroyed the container. Check the same thing the recreate
+  // checks, before committing.
+  const mainAppName = identifier.split('_')[1] || identifier;
+  const componentName = identifier.split('_')[0];
+  const isComponent = identifier.includes('_');
+  const volumeMounted = await volumeService
+    .verifyAppVolumeMount(mainAppName, true, isComponent ? componentName : spec.comp.name)
+    .catch(() => false);
+  if (!volumeMounted) {
+    return 'its data volume cannot be verified as mounted, so the recreate would fail';
+  }
+  return null;
 }
 
 /**
@@ -425,7 +488,7 @@ async function clearNetworkHealState(identifier) {
  * existing container name; `docker network connect` on a live container does not
  * restore published host ports, so only a recreate fully heals it.
  */
-async function healDetachedNetwork(identifier, mainAppName) {
+async function healDetachedNetwork(identifier, mainAppName, spec) {
   // Confirm in-pass: a detached read can be transient (dockerd mid-restart, the
   // brief window before an endpoint gets its IP). Settle, then look again, and
   // only destroy on a state that survived the gap.
@@ -444,6 +507,32 @@ async function healDetachedNetwork(identifier, mainAppName) {
     return;
   }
   const { networkMode } = confirmed.attachment;
+
+  // The detach must also have PERSISTED. A dockerd restart (live-restore) can serve
+  // a successful inspect before libnetwork has re-populated endpoint IPs, and the
+  // reconnect sweep enqueues everything at that moment - without a real settle
+  // window we would rebuild every container on the node.
+  if (!detachedSince.has(identifier)) {
+    detachedSince.set(identifier, Date.now());
+    log.warn(`appReconciler - ${identifier} detached; waiting for it to persist before healing`);
+    scheduleRetry(identifier, DETACHED_PERSIST_MS);
+    return;
+  }
+  const detachedFor = Date.now() - detachedSince.get(identifier);
+  if (detachedFor < DETACHED_PERSIST_MS) {
+    scheduleRetry(identifier, DETACHED_PERSIST_MS - detachedFor);
+    return;
+  }
+
+  // Several containers detached at once is a daemon-level fault, not N stale
+  // endpoints. Force-removing the node's whole workload on that read is never the
+  // right answer - say so loudly and wait for the daemon to settle instead.
+  if (detachedSince.size >= DETACH_STORM_THRESHOLD) {
+    log.error(`appReconciler - ${detachedSince.size} containers look detached at once; treating this as a docker-level fault and NOT recreating any of them (including ${identifier})`);
+    fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkDetachStorm', count: detachedSince.size });
+    scheduleRetry(identifier, NETWORK_PRUNED_RETRY_MS);
+    return;
+  }
 
   // Only a stale endpoint (network present, container not attached) is heal-able.
   // If the network itself is gone the recreate would fail on a missing NetworkMode,
@@ -469,39 +558,70 @@ async function healDetachedNetwork(identifier, mainAppName) {
   }
   networkPrunedNoted.delete(identifier);
 
-  // Paced on the durable crash-backoff ladder (0, 30s, 5m, 15m, 30m cap), shared
-  // with restarts: a component that keeps needing intervention gets progressively
-  // slower attention, and the pacing survives a FluxOS restart. No attempt cap -
-  // the reconciler never parks in a terminal state.
-  const wait = await appsRuntimeState.restartWaitMs(identifier);
+  // Never destroy what we cannot rebuild: every precondition of the recreate must
+  // hold BEFORE the remove, or the heal turns a half-alive container into a gone one.
+  const blocker = await networkHealBlocker(identifier, spec);
+  if (blocker) {
+    log.error(`appReconciler - ${identifier} runs detached but must NOT be recreated: ${blocker}; leaving the container in place (app NOT touched)`);
+    fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkHealBlocked', reason: blocker });
+    scheduleRetry(identifier, NETWORK_PRUNED_RETRY_MS);
+    return;
+  }
+
+  // Paced on its OWN durable ladder (0, 30s, 5m, 15m, 30m cap), not the crash one:
+  // a container that keeps coming back detached is retried forever but at a decaying
+  // rate, without holding down (or being held down by) the restart backoff.
+  const wait = await appsRuntimeState.networkHealWaitMs(identifier);
   if (wait > 0) {
     log.warn(`appReconciler - ${identifier} still detached, backing off ${Math.round(wait / 1000)}s before the next heal attempt`);
     scheduleRetry(identifier, wait);
     return;
   }
 
-  if (!networkDetachedNoted.has(identifier)) {
-    networkDetachedNoted.add(identifier);
-    await appTamperingDetectionService.recordEvent(mainAppName, 'network_detached', `Container ${identifier} running with no network endpoint on its own network`);
+  // The ONLY ownership sample was at reconcile entry, and everything above this
+  // point - the settle, two inspects, the network probe, the volume check - has
+  // taken seconds. A redeploy/backup/uninstall may have taken the container over in
+  // the meantime, and force-removing it from under them is exactly what
+  // isManagedElsewhere exists to prevent. Re-check at actuation time (the same
+  // re-read-before-acting discipline the controller verdict and recreateMissing use).
+  if (isManagedElsewhere(identifier)) {
+    log.info(`appReconciler - ${identifier} was taken over by another operation during the heal confirmation; aborting the recreate`);
+    scheduleRetry(identifier, MANAGED_RETRY_MS);
+    return;
   }
+
   log.warn(`appReconciler - ${identifier} running but not attached to its docker network; clearing the stale endpoint`);
   fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkDetached' });
 
-  await appsRuntimeState.recordRestart(identifier);
-  // Durable, and BEFORE the remove: if FluxOS restarts in the window between the
-  // remove and the recreate, this is the only thing that tells the next process the
-  // absence was ours - without it, the vanished path records a false tampering event
-  // and can uninstall the whole app on a failed recreate. A throw here aborts the
-  // remove, which is the safe direction (a detached container still half-serves).
-  await appsRuntimeState.setNetworkHealRemoval(identifier, true);
+  try {
+    // Record the anomaly (once per episode) and the durable "I removed this on
+    // purpose" flag BEFORE the remove: if FluxOS restarts in the window between the
+    // remove and the recreate, the flag is the only thing that tells the next process
+    // the absence was ours - without it, the vanished path records a false tampering
+    // event and can uninstall the whole app on a failed recreate. The marker is only
+    // set AFTER a successful record, so a failed write does not suppress the event.
+    if (!networkDetachedNoted.has(identifier)) {
+      await appTamperingDetectionService.recordEvent(mainAppName, 'network_detached', `Container ${identifier} running with no network endpoint on its own network`);
+      networkDetachedNoted.add(identifier);
+    }
+    await appsRuntimeState.recordNetworkHealAttempt(identifier);
+    await appsRuntimeState.setNetworkHealRemoval(identifier, true);
+  } catch (err) {
+    // These writes are what make the remove safe and paced, so a failure must abort
+    // it - and must re-arm a retry, or the container stays broken until the hourly
+    // sweep (every other failure path here paces its own retry).
+    log.error(`appReconciler - cannot record the network heal of ${identifier} (${err.message}); not removing the container, will retry`);
+    scheduleRetry(identifier, MANAGED_RETRY_MS);
+    return;
+  }
 
   // Stop the per-minute stats monitor before removing the container (mirrors the
   // uninstaller). Otherwise its interval runs against a gone container, leaking and
   // error-spamming. The recreate re-establishes it via startAppMonitoring.
   appInspector.stopAppMonitoring(identifier, true, globalState.appsMonitored);
   try {
-    // v=false: Flux data lives on bind mounts, so nothing is lost; the recreate
-    // reuses it via a soft install.
+    // v=false: Flux data lives on bind mounts; the recreate reuses them via a soft
+    // install (enforced: recreateForNetworkHeal passes softOnly).
     await dockerService.appDockerForceRemove(identifier, false);
   } catch (err) {
     // The container is still there (or partially removed): put monitoring back so a
@@ -540,6 +660,7 @@ async function reconcile(rawIdentifier) {
     // is dropped by the uninstaller via appsRuntimeState.remove)
     networkDetachedNoted.delete(identifier);
     networkPrunedNoted.delete(identifier);
+    detachedSince.delete(identifier);
     return;
   }
 
@@ -616,6 +737,16 @@ async function reconcile(rawIdentifier) {
     return;
   }
 
+  // The heal state says "this container is absent because I removed it". The moment
+  // the container exists and is not detached, that is stale - whatever its run state,
+  // and whatever the desired state below turns out to be. Clearing here (rather than
+  // only on the running+attached path) is what stops the flag leaking on every branch
+  // that leaves a container stopped (awaiting-controller g:, operator stop), which
+  // would otherwise divert a later, genuine disappearance away from the vanished path.
+  if (actual.exists && !dockerService.isContainerDetachedFromNetwork(actual.attachment)) {
+    await clearNetworkHealState(identifier);
+  }
+
   // Pending data wipe: the sync layer flagged this component's local appdata as
   // stale/to-be-reset and to be cleared before it runs again. This is the highest-
   // priority data action and is resolved here, inside the per-key single-flight and
@@ -678,29 +809,44 @@ async function reconcile(rawIdentifier) {
     // Verify the attachment (from the inspect dockerActual already did) before
     // trusting "running"; heal by recreating, confirmed in-pass and paced.
     if (!dockerService.isContainerDetachedFromNetwork(actual.attachment)) {
-      // running AND attached - already where we want it, and the only proof that
-      // any earlier heal actually worked.
-      await clearNetworkHealState(identifier);
-      return;
+      return; // running and properly attached (heal state was cleared above)
     }
-    await healDetachedNetwork(identifier, mainAppName);
+    await healDetachedNetwork(identifier, mainAppName, spec);
     return;
   }
 
   if (!actual.exists) {
     // Durable, so it survives a FluxOS restart mid-heal: if WE removed this
     // container to clear a stale endpoint, its absence is not tampering. Keep
-    // recreating it - paced on the backoff ladder, never escalating to the vanished
+    // recreating it - paced on the heal ladder, never escalating to the vanished
     // path's uninstall-on-failure. Only a container that vanished by other means
     // takes that path.
-    if (await appsRuntimeState.isNetworkHealRemoval(identifier)) {
-      const wait = await appsRuntimeState.restartWaitMs(identifier);
+    let healRemoved;
+    try {
+      healRemoved = await appsRuntimeState.isNetworkHealRemoval(identifier);
+    } catch (err) {
+      // We cannot tell whether we removed this container ourselves. Guessing "no" is
+      // the destructive guess: it records a false tampering event and can uninstall
+      // the whole app on a failed recreate. Defer until the state is readable.
+      log.warn(`appReconciler - cannot read the heal state of the missing ${identifier} (${err.message}); deferring rather than treating it as vanished`);
+      scheduleRetry(identifier, MANAGED_RETRY_MS);
+      return;
+    }
+    if (healRemoved) {
+      const wait = await appsRuntimeState.networkHealWaitMs(identifier);
       if (wait > 0) {
         log.warn(`appReconciler - ${identifier} awaiting recreation after a network heal, backing off ${Math.round(wait / 1000)}s`);
         scheduleRetry(identifier, wait);
         return;
       }
-      await appsRuntimeState.recordRestart(identifier);
+      try {
+        await appsRuntimeState.recordNetworkHealAttempt(identifier);
+      } catch (err) {
+        // unpaced retries would hammer the recreate; defer instead
+        log.error(`appReconciler - cannot pace the heal recreate of ${identifier} (${err.message}); will retry`);
+        scheduleRetry(identifier, MANAGED_RETRY_MS);
+        return;
+      }
       await recreateForNetworkHeal(identifier);
       return;
     }

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -575,6 +575,21 @@ async function reconcile(rawIdentifier) {
       }
       return;
     }
+    // Only heal a stale endpoint (network present, container not attached). If the
+    // network itself is gone, a recreate would fail on a missing NetworkMode, so
+    // removing the container would only take it from partially-alive to removed-
+    // and-unrecreatable. That is a different fault (network restore) - record it
+    // and leave the container in place rather than destroying it.
+    if (!(await dockerService.dockerNetworkExists(actual.attachment.networkMode))) {
+      if (!st.gaveUp) {
+        st.gaveUp = true;
+        networkHealState.set(identifier, st);
+        log.error(`appReconciler - ${identifier} detached because its network ${actual.attachment.networkMode} is missing; not recreating (needs network restore, app NOT touched)`);
+        await appTamperingDetectionService.recordEvent(mainAppName, 'network_pruned', `Network ${actual.attachment.networkMode} missing while ${identifier} runs detached`);
+        fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkPruned' });
+      }
+      return;
+    }
     st.tries += 1;
     networkHealState.set(identifier, st);
     log.warn(`appReconciler - ${identifier} running but not attached to its docker network (recreate ${st.tries}/${MAX_NETWORK_HEAL_ATTEMPTS}); clearing the stale endpoint`);

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -107,6 +107,14 @@ const VOLUME_MOUNT_RETRY_MS = 30 * 1000;
 // event, so the paced retries don't re-record it every cycle
 const volumeMissingNoted = new Set();
 
+// A running container attached to NO network (stale libnetwork endpoint from an
+// earlier failed start) is healed by recreating it. Bound the attempts per
+// identifier so a recreate that keeps landing detached (e.g. a still-held host
+// port) can't loop remove->recreate forever - after the cap we leave it for
+// manual intervention. Reset once the container is seen properly attached.
+const MAX_NETWORK_HEAL_ATTEMPTS = 3;
+const networkHealAttempts = new Map();
+
 // The reconciler's canonical id is the bare component identifier
 // (`{component}_{app}`). Deciders disagree on the form they pass — masterSlave
 // uses the bare identifier, the syncthing flow passes the flux-prefixed docker
@@ -329,6 +337,24 @@ async function recreateMissing(identifier) {
   }
 }
 
+/**
+ * Whether a running container has come up attached to NO network - a start can
+ * succeed (the task runs) while libnetwork silently skips (re)attaching the
+ * container's endpoint, leaving it with no IP, no embedded DNS and no published
+ * ports. See dockerService.getContainerNetworkAttachment. An inspect blip must
+ * NOT be read as detached (that would trigger a needless recreate), so any error
+ * here is treated as "not detached" and the next reconcile re-checks.
+ */
+async function isDetachedFromOwnNetwork(identifier) {
+  try {
+    const attachment = await dockerService.getContainerNetworkAttachment(identifier);
+    return dockerService.isContainerDetachedFromNetwork(attachment);
+  } catch (err) {
+    log.warn(`appReconciler - could not read network attachment for ${identifier}: ${err.message}`);
+    return false;
+  }
+}
+
 // --- the reconcile -------------------------------------------------------
 
 async function reconcile(rawIdentifier) {
@@ -474,7 +500,43 @@ async function reconcile(rawIdentifier) {
     return;
   }
 
-  if (actual.running) return; // already where we want it
+  if (actual.running) {
+    // A running container is normally "already where we want it" - but a start
+    // can succeed while leaving the container attached to NO network when
+    // libnetwork holds a stale endpoint from an earlier failed "programming
+    // external connectivity" (e.g. a host-port bind conflict on a restart after
+    // an unclean reboot). It then runs with no IP, no embedded DNS (cannot
+    // resolve sibling components by name) and no published ports, and no future
+    // `docker start` repairs it - only a recreate clears the stale endpoint.
+    // Verify the attachment before trusting "running"; heal by recreating.
+    if (!(await isDetachedFromOwnNetwork(identifier))) {
+      networkHealAttempts.delete(identifier);
+      return; // running and properly attached - already where we want it
+    }
+    const attempts = (networkHealAttempts.get(identifier) || 0) + 1;
+    networkHealAttempts.set(identifier, attempts);
+    if (attempts > MAX_NETWORK_HEAL_ATTEMPTS) {
+      log.error(`appReconciler - ${identifier} still detached from its docker network after ${attempts - 1} recreate attempt(s); leaving as-is for manual intervention`);
+      fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkHealGaveUp' });
+      return;
+    }
+    log.warn(`appReconciler - ${identifier} is running but not attached to its docker network (attempt ${attempts}/${MAX_NETWORK_HEAL_ATTEMPTS}); recreating to clear the stale endpoint`);
+    await appTamperingDetectionService.recordEvent(mainAppName, 'network_detached', `Container ${identifier} running with no network endpoint on its own network`);
+    fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkDetached', attempt: attempts });
+    try {
+      // keep anonymous volumes (v=false); Flux data lives on bind mounts, so the
+      // recreate below reuses it via a soft install.
+      await dockerService.appDockerForceRemove(identifier, false);
+    } catch (err) {
+      log.error(`appReconciler - failed to remove detached ${identifier}: ${err.message}; retrying`);
+      scheduleRetry(identifier, MANAGED_RETRY_MS);
+      return;
+    }
+    // The container is gone now; recreate it through the tested vanished path,
+    // which allocates a fresh endpoint (and re-publishes ports) cleanly.
+    await recreateMissing(identifier);
+    return;
+  }
 
   if (!actual.exists) {
     await recreateMissing(identifier);

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -382,6 +382,11 @@ async function recreateForNetworkHeal(identifier) {
 async function attemptNetworkHeal(identifier, mainAppName) {
   await appTamperingDetectionService.recordEvent(mainAppName, 'network_detached', `Container ${identifier} running with no network endpoint on its own network`);
   fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkDetached' });
+  // Stop the per-minute stats monitor before removing the container (mirrors the
+  // uninstaller). Otherwise its interval runs against a gone container - and, if
+  // the recreate then fails/gives up, leaks and error-spams forever. The recreate
+  // re-establishes monitoring via startAppMonitoring on success.
+  appInspector.stopAppMonitoring(identifier, true, globalState.appsMonitored);
   try {
     // v=false: Flux data lives on bind mounts, so nothing is lost; the recreate
     // reuses it via a soft install.

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -21,7 +21,9 @@ const { AsyncGate } = require('../utils/asyncGate');
 // die event, stream reconnect, hourly tick, boot, post-install, and the
 // masterSlave/syncthing deciders) just enqueues a component identifier; one
 // reconcile per identifier drives the actual Docker state toward the desired
-// state. This is the ONLY place that calls appDockerStart/appDockerStop.
+// state. This is the ONLY place that calls appDockerStart/appDockerStop. It also
+// force-removes and recreates a container that came up detached from its own
+// docker network (a stale libnetwork endpoint), which a start alone cannot fix.
 //
 // Desired state inputs:
 //   operatorStopped (durable, appsRuntimeState) - user lock, wins over all.
@@ -107,13 +109,22 @@ const VOLUME_MOUNT_RETRY_MS = 30 * 1000;
 // event, so the paced retries don't re-record it every cycle
 const volumeMissingNoted = new Set();
 
-// A running container attached to NO network (stale libnetwork endpoint from an
-// earlier failed start) is healed by recreating it. Bound the attempts per
-// identifier so a recreate that keeps landing detached (e.g. a still-held host
-// port) can't loop remove->recreate forever - after the cap we leave it for
-// manual intervention. Reset once the container is seen properly attached.
+// A running container attached to NO network (a stale libnetwork endpoint left
+// by an earlier failed start) is healed by recreating it (force-remove + fresh
+// create; a plain start reuses the broken endpoint, and `network connect` does
+// not restore published host ports). This is destructive, so it is guarded:
+//   - DETACHED_CONFIRM_OBSERVATIONS: require the detached state on N consecutive
+//     reconciles before acting, so a transient inspect (e.g. dockerd mid-restart)
+//     never destroys a healthy container.
+//   - MAX_NETWORK_HEAL_ATTEMPTS: cap recreate attempts so a recreate that keeps
+//     landing detached (e.g. a still-held host port) can't loop forever.
+// Per-id state {obs, tries, gaveUp}; cleared once the container is seen attached.
+// Unlike the vanished path, a heal recreate failure NEVER uninstalls the app -
+// the component's spec/image are fine; only its host networking hit a transient
+// conflict, so we keep retrying (bounded) and otherwise leave it for a human.
+const DETACHED_CONFIRM_OBSERVATIONS = 2;
 const MAX_NETWORK_HEAL_ATTEMPTS = 3;
-const networkHealAttempts = new Map();
+const networkHealState = new Map();
 
 // The reconciler's canonical id is the bare component identifier
 // (`{component}_{app}`). Deciders disagree on the form they pass — masterSlave
@@ -243,6 +254,9 @@ async function dockerActual(identifier) {
       running: !!(info.State && info.State.Running),
       exitCode: everRan ? (info.State.ExitCode ?? null) : null,
       finishedAt,
+      // classified from THIS inspect so the running-branch network check needs no
+      // second docker call (and no TOCTOU between two inspects).
+      attachment: dockerService.parseContainerNetworkAttachment(info),
     };
   } catch (err) {
     let containers;
@@ -338,21 +352,46 @@ async function recreateMissing(identifier) {
 }
 
 /**
- * Whether a running container has come up attached to NO network - a start can
- * succeed (the task runs) while libnetwork silently skips (re)attaching the
- * container's endpoint, leaving it with no IP, no embedded DNS and no published
- * ports. See dockerService.getContainerNetworkAttachment. An inspect blip must
- * NOT be read as detached (that would trigger a needless recreate), so any error
- * here is treated as "not detached" and the next reconcile re-checks.
+ * Recreate a container that was removed to clear a detached network endpoint.
+ * Deliberately NOT recreateMissing: a failure here must not escalate to
+ * uninstalling the whole app (the trigger is a transient host-networking
+ * conflict, not tampering). On failure we just re-arm a paced retry; the caller's
+ * attempt cap bounds it. For a g: component recreateMissingContainers creates but
+ * does not start - the normal reconcile flow starts it on a later pass.
  */
-async function isDetachedFromOwnNetwork(identifier) {
+async function recreateForNetworkHeal(identifier) {
   try {
-    const attachment = await dockerService.getContainerNetworkAttachment(identifier);
-    return dockerService.isContainerDetachedFromNetwork(attachment);
+    await containerHealthMonitor.recreateMissingContainers(identifier);
+    appInspector.startAppMonitoring(identifier, globalState.appsMonitored);
+    log.info(`appReconciler - recreated ${identifier} to clear a detached network endpoint`);
+    fluxEventBus.publish('reconciler:actuated', { identifier, action: 'recreated', reason: 'networkDetached' });
+    notifyContainerStarted(identifier);
   } catch (err) {
-    log.warn(`appReconciler - could not read network attachment for ${identifier}: ${err.message}`);
-    return false;
+    log.error(`appReconciler - failed to recreate ${identifier} after network detach: ${err.message}; will retry (app NOT uninstalled)`);
+    fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkHealRecreateFailed', reason: err.message });
+    scheduleRetry(identifier, MANAGED_RETRY_MS);
   }
+}
+
+/**
+ * One heal cycle for a running-but-detached container: record the signal,
+ * force-remove the broken container (keeping bind-mounted data), then recreate
+ * it with a fresh endpoint. Force-remove is required because the recreate path
+ * (appDockerCreate) 409s on an existing container name.
+ */
+async function attemptNetworkHeal(identifier, mainAppName) {
+  await appTamperingDetectionService.recordEvent(mainAppName, 'network_detached', `Container ${identifier} running with no network endpoint on its own network`);
+  fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkDetached' });
+  try {
+    // v=false: Flux data lives on bind mounts, so nothing is lost; the recreate
+    // reuses it via a soft install.
+    await dockerService.appDockerForceRemove(identifier, false);
+  } catch (err) {
+    log.error(`appReconciler - failed to remove detached ${identifier}: ${err.message}; will retry`);
+    scheduleRetry(identifier, MANAGED_RETRY_MS);
+    return;
+  }
+  await recreateForNetworkHeal(identifier);
 }
 
 // --- the reconcile -------------------------------------------------------
@@ -374,7 +413,10 @@ async function reconcile(rawIdentifier) {
     scheduleRetry(identifier, MANAGED_RETRY_MS);
     return;
   }
-  if (!spec) return; // not installed here - nothing to enforce
+  if (!spec) { // not installed here - nothing to enforce
+    networkHealState.delete(identifier); // drop any heal bookkeeping for a gone app
+    return;
+  }
 
   // Invalid containerData (e.g. a sync flag on a non-primary mount, or an index-ref
   // primary): the spec can never be actuated — volume construction would throw — so
@@ -508,37 +550,61 @@ async function reconcile(rawIdentifier) {
     // an unclean reboot). It then runs with no IP, no embedded DNS (cannot
     // resolve sibling components by name) and no published ports, and no future
     // `docker start` repairs it - only a recreate clears the stale endpoint.
-    // Verify the attachment before trusting "running"; heal by recreating.
-    if (!(await isDetachedFromOwnNetwork(identifier))) {
-      networkHealAttempts.delete(identifier);
+    // Verify the attachment (from the inspect dockerActual already did) before
+    // trusting "running"; heal by recreating, debounced and bounded.
+    if (!dockerService.isContainerDetachedFromNetwork(actual.attachment)) {
+      networkHealState.delete(identifier);
       return; // running and properly attached - already where we want it
     }
-    const attempts = (networkHealAttempts.get(identifier) || 0) + 1;
-    networkHealAttempts.set(identifier, attempts);
-    if (attempts > MAX_NETWORK_HEAL_ATTEMPTS) {
-      log.error(`appReconciler - ${identifier} still detached from its docker network after ${attempts - 1} recreate attempt(s); leaving as-is for manual intervention`);
-      fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkHealGaveUp' });
-      return;
-    }
-    log.warn(`appReconciler - ${identifier} is running but not attached to its docker network (attempt ${attempts}/${MAX_NETWORK_HEAL_ATTEMPTS}); recreating to clear the stale endpoint`);
-    await appTamperingDetectionService.recordEvent(mainAppName, 'network_detached', `Container ${identifier} running with no network endpoint on its own network`);
-    fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkDetached', attempt: attempts });
-    try {
-      // keep anonymous volumes (v=false); Flux data lives on bind mounts, so the
-      // recreate below reuses it via a soft install.
-      await dockerService.appDockerForceRemove(identifier, false);
-    } catch (err) {
-      log.error(`appReconciler - failed to remove detached ${identifier}: ${err.message}; retrying`);
+    const st = networkHealState.get(identifier) || { obs: 0, tries: 0, gaveUp: false };
+    st.obs += 1;
+    if (st.obs < DETACHED_CONFIRM_OBSERVATIONS) {
+      // first sighting - confirm on the next pass before doing anything
+      // destructive, so a transient read never recreates a healthy container.
+      networkHealState.set(identifier, st);
+      log.warn(`appReconciler - ${identifier} appears detached from its docker network; confirming before acting`);
       scheduleRetry(identifier, MANAGED_RETRY_MS);
       return;
     }
-    // The container is gone now; recreate it through the tested vanished path,
-    // which allocates a fresh endpoint (and re-publishes ports) cleanly.
-    await recreateMissing(identifier);
+    if (st.tries >= MAX_NETWORK_HEAL_ATTEMPTS) {
+      if (!st.gaveUp) {
+        st.gaveUp = true;
+        networkHealState.set(identifier, st);
+        log.error(`appReconciler - ${identifier} still detached from its docker network after ${st.tries} recreate attempt(s); leaving it running for manual intervention (app NOT uninstalled)`);
+        fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkHealGaveUp' });
+      }
+      return;
+    }
+    st.tries += 1;
+    networkHealState.set(identifier, st);
+    log.warn(`appReconciler - ${identifier} running but not attached to its docker network (recreate ${st.tries}/${MAX_NETWORK_HEAL_ATTEMPTS}); clearing the stale endpoint`);
+    await attemptNetworkHeal(identifier, mainAppName);
     return;
   }
 
   if (!actual.exists) {
+    // If we removed this container for a network-detach heal (tries > 0) and the
+    // recreate has not yet brought it back, keep retrying the recreate WITHOUT the
+    // vanished path's uninstall-on-failure escalation - the trigger was transient
+    // host networking, not tampering, so a whole-app uninstall is wrong. Once the
+    // cap is hit we give up and, crucially, keep steering AWAY from recreateMissing
+    // so a heal never turns into an uninstall. Only a container that vanished by
+    // other means (no heal in flight) takes the tested vanished path.
+    const st = networkHealState.get(identifier);
+    if (st && st.tries > 0) {
+      if (st.gaveUp) return; // gave up earlier; leave removed, never uninstall
+      if (st.tries >= MAX_NETWORK_HEAL_ATTEMPTS) {
+        st.gaveUp = true;
+        networkHealState.set(identifier, st);
+        log.error(`appReconciler - ${identifier} still cannot be recreated after ${st.tries} network-heal attempt(s); leaving it removed for manual intervention (app NOT uninstalled)`);
+        fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkHealGaveUp' });
+        return;
+      }
+      st.tries += 1;
+      networkHealState.set(identifier, st);
+      await recreateForNetworkHeal(identifier);
+      return;
+    }
     await recreateMissing(identifier);
     return;
   }

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -112,19 +112,48 @@ const volumeMissingNoted = new Set();
 // A running container attached to NO network (a stale libnetwork endpoint left
 // by an earlier failed start) is healed by recreating it (force-remove + fresh
 // create; a plain start reuses the broken endpoint, and `network connect` does
-// not restore published host ports). This is destructive, so it is guarded:
-//   - DETACHED_CONFIRM_OBSERVATIONS: require the detached state on N consecutive
-//     reconciles before acting, so a transient inspect (e.g. dockerd mid-restart)
+// not restore published host ports). The remove is destructive, so it is guarded:
+//
+//   - Confirmed in-pass: on first sight of the detached state we settle, then
+//     re-inspect, and only act if it is still detached. Counting observations
+//     across reconciles would not do this - two reconciles can run back-to-back
+//     (a die event lands while the sweep's pass is in flight, and the workqueue
+//     re-runs the id immediately), so both "observations" can come from the same
+//     instant. A settle + re-read guarantees the time separation the confirmation
+//     is for: a transient inspect (dockerd mid-restart, the brief pre-IP window)
 //     never destroys a healthy container.
-//   - MAX_NETWORK_HEAL_ATTEMPTS: cap recreate attempts so a recreate that keeps
-//     landing detached (e.g. a still-held host port) can't loop forever.
-// Per-id state {obs, tries, gaveUp}; cleared once the container is seen attached.
-// Unlike the vanished path, a heal recreate failure NEVER uninstalls the app -
-// the component's spec/image are fine; only its host networking hit a transient
-// conflict, so we keep retrying (bounded) and otherwise leave it for a human.
-const DETACHED_CONFIRM_OBSERVATIONS = 2;
-const MAX_NETWORK_HEAL_ATTEMPTS = 3;
-const networkHealState = new Map();
+//   - Paced, not capped: heal attempts walk the SAME durable backoff ladder as
+//     crash restarts (appsRuntimeState), up to its 30m cap. A hard attempt cap
+//     would park the heal in a terminal state until the FluxOS process restarts,
+//     which is not level-based - a reconciler keeps trying at a bounded rate.
+//     Retrying forever is also convergent at the network level: while the
+//     container is broken or absent this node stops advertising it in apprunning,
+//     its location record expires on TTL and the app is re-placed elsewhere, all
+//     without destroying this node's bind-mounted data.
+//   - Never uninstalls: unlike the vanished path, a failed heal recreate does not
+//     escalate to removeAppLocally. The spec and image are fine; only the host
+//     networking hit a conflict.
+//
+// The one fact that must survive a FluxOS restart is "I removed this container on
+// purpose" (otherwise a restart between the remove and the recreate makes the next
+// reconcile read the absence as tampering and, on a failed recreate, uninstall the
+// app). That lives in appsRuntimeState.networkHealRemoval, not here.
+const NETWORK_DETACH_CONFIRM_MS = 3000;
+// a pruned network cannot be repaired by recreating the container - re-check on a
+// slow pace so a restored network is picked up without an hour's wait
+const NETWORK_PRUNED_RETRY_MS = 5 * 60 * 1000;
+// a container is normally verified attached only on the reconcile after its start,
+// i.e. the hourly sweep. But this pathology is BORN at start time, so re-check
+// shortly after every start/recreate we perform: detached-at-boot then heals in
+// under a minute, with the sweep as the backstop. (Docker network events cannot
+// cover this: a container born detached never emits a disconnect.)
+const POST_START_VERIFY_MS = 30 * 1000;
+
+// identifiers whose detach/prune was already recorded as a tampering event, so the
+// paced retries record it once per episode rather than once per attempt (the count
+// feeds a node-level signal). Cleared once the container is seen attached.
+const networkDetachedNoted = new Set();
+const networkPrunedNoted = new Set();
 
 // The reconciler's canonical id is the bare component identifier
 // (`{component}_{app}`). Deciders disagree on the form they pass — masterSlave
@@ -256,7 +285,7 @@ async function dockerActual(identifier) {
       finishedAt,
       // classified from THIS inspect so the running-branch network check needs no
       // second docker call (and no TOCTOU between two inspects).
-      attachment: dockerService.parseContainerNetworkAttachment(info),
+      attachment: dockerService.classifyContainerNetworkAttachment(info),
     };
   } catch (err) {
     let containers;
@@ -326,6 +355,7 @@ async function recreateMissing(identifier) {
     log.info(`appReconciler - recreated missing container ${identifier}`);
     fluxEventBus.publish('reconciler:actuated', { identifier, action: 'recreated' });
     notifyContainerStarted(identifier);
+    scheduleRetry(identifier, POST_START_VERIFY_MS); // verify it came up attached
   } catch (err) {
     // Removal must be justified by the state of the world NOW, not at
     // classification time: a whole recreate attempt (image pull - up to
@@ -355,9 +385,11 @@ async function recreateMissing(identifier) {
  * Recreate a container that was removed to clear a detached network endpoint.
  * Deliberately NOT recreateMissing: a failure here must not escalate to
  * uninstalling the whole app (the trigger is a transient host-networking
- * conflict, not tampering). On failure we just re-arm a paced retry; the caller's
- * attempt cap bounds it. For a g: component recreateMissingContainers creates but
- * does not start - the normal reconcile flow starts it on a later pass.
+ * conflict, not tampering). On failure we just re-arm a retry; the next pass
+ * paces it on the backoff ladder. For a g: component recreateMissingContainers
+ * creates but does not start - the normal reconcile flow starts it on a later
+ * pass. The durable heal-removal flag is NOT cleared here: only seeing the
+ * container running AND attached proves the heal worked.
  */
 async function recreateForNetworkHeal(identifier) {
   try {
@@ -366,6 +398,7 @@ async function recreateForNetworkHeal(identifier) {
     log.info(`appReconciler - recreated ${identifier} to clear a detached network endpoint`);
     fluxEventBus.publish('reconciler:actuated', { identifier, action: 'recreated', reason: 'networkDetached' });
     notifyContainerStarted(identifier);
+    scheduleRetry(identifier, POST_START_VERIFY_MS); // verify it came up attached
   } catch (err) {
     log.error(`appReconciler - failed to recreate ${identifier} after network detach: ${err.message}; will retry (app NOT uninstalled)`);
     fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkHealRecreateFailed', reason: err.message });
@@ -374,24 +407,108 @@ async function recreateForNetworkHeal(identifier) {
 }
 
 /**
- * One heal cycle for a running-but-detached container: force-remove the broken
- * container (keeping bind-mounted data), then recreate it with a fresh endpoint.
- * Force-remove is required because the recreate path (appDockerCreate) 409s on an
- * existing container name. The durable network_detached signal is recorded once
- * per episode by the caller, not here (this runs up to MAX times per episode).
+ * Drops all bookkeeping for a healed/healthy container: the record-once tampering
+ * markers and the durable "I removed this on purpose" flag. Called when a running
+ * container is seen properly attached - the only proof a heal actually worked.
  */
-async function attemptNetworkHeal(identifier) {
+async function clearNetworkHealState(identifier) {
+  networkDetachedNoted.delete(identifier);
+  networkPrunedNoted.delete(identifier);
+  await appsRuntimeState.clearNetworkHealRemoval(identifier);
+}
+
+/**
+ * Heals a container that looks running-but-detached from its own docker network:
+ * confirm it (settle + re-inspect), require its network to still exist, then
+ * force-remove (keeping bind-mounted data) and recreate with a fresh endpoint.
+ * Force-remove is required because the recreate path (appDockerCreate) 409s on an
+ * existing container name; `docker network connect` on a live container does not
+ * restore published host ports, so only a recreate fully heals it.
+ */
+async function healDetachedNetwork(identifier, mainAppName) {
+  // Confirm in-pass: a detached read can be transient (dockerd mid-restart, the
+  // brief window before an endpoint gets its IP). Settle, then look again, and
+  // only destroy on a state that survived the gap.
+  log.warn(`appReconciler - ${identifier} appears detached from its docker network; confirming before acting`);
+  await serviceHelper.delay(NETWORK_DETACH_CONFIRM_MS);
+  const confirmed = await dockerActual(identifier);
+  if (!confirmed.reachable || confirmed.indeterminate || !confirmed.exists || !confirmed.running) {
+    // docker went unhappy, or the container is no longer running: nothing here can
+    // be justified on this read. The next pass reconciles whatever it actually is.
+    scheduleRetry(identifier, MANAGED_RETRY_MS);
+    return;
+  }
+  if (!dockerService.isContainerDetachedFromNetwork(confirmed.attachment)) {
+    log.info(`appReconciler - ${identifier} is attached after all; no heal needed`);
+    await clearNetworkHealState(identifier);
+    return;
+  }
+  const { networkMode } = confirmed.attachment;
+
+  // Only a stale endpoint (network present, container not attached) is heal-able.
+  // If the network itself is gone the recreate would fail on a missing NetworkMode,
+  // so removing the container would only take it from partially-alive to removed-
+  // and-unrecreatable. And absence must be PROVEN: a failed network read is not
+  // evidence of a missing network, and acting on it destroys a container we then
+  // cannot bring back.
+  const networkState = await dockerService.dockerNetworkState(networkMode);
+  if (networkState === 'unknown') {
+    log.warn(`appReconciler - cannot determine whether ${networkMode} exists; deferring the heal of ${identifier}`);
+    scheduleRetry(identifier, MANAGED_RETRY_MS);
+    return;
+  }
+  if (networkState === 'absent') {
+    if (!networkPrunedNoted.has(identifier)) {
+      networkPrunedNoted.add(identifier);
+      log.error(`appReconciler - ${identifier} detached because its network ${networkMode} is missing; not recreating (needs network restore, app NOT touched)`);
+      await appTamperingDetectionService.recordEvent(mainAppName, 'network_pruned', `Network ${networkMode} missing while ${identifier} runs detached`);
+      fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkPruned' });
+    }
+    scheduleRetry(identifier, NETWORK_PRUNED_RETRY_MS); // keep watching for a restored network
+    return;
+  }
+  networkPrunedNoted.delete(identifier);
+
+  // Paced on the durable crash-backoff ladder (0, 30s, 5m, 15m, 30m cap), shared
+  // with restarts: a component that keeps needing intervention gets progressively
+  // slower attention, and the pacing survives a FluxOS restart. No attempt cap -
+  // the reconciler never parks in a terminal state.
+  const wait = await appsRuntimeState.restartWaitMs(identifier);
+  if (wait > 0) {
+    log.warn(`appReconciler - ${identifier} still detached, backing off ${Math.round(wait / 1000)}s before the next heal attempt`);
+    scheduleRetry(identifier, wait);
+    return;
+  }
+
+  if (!networkDetachedNoted.has(identifier)) {
+    networkDetachedNoted.add(identifier);
+    await appTamperingDetectionService.recordEvent(mainAppName, 'network_detached', `Container ${identifier} running with no network endpoint on its own network`);
+  }
+  log.warn(`appReconciler - ${identifier} running but not attached to its docker network; clearing the stale endpoint`);
   fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkDetached' });
+
+  await appsRuntimeState.recordRestart(identifier);
+  // Durable, and BEFORE the remove: if FluxOS restarts in the window between the
+  // remove and the recreate, this is the only thing that tells the next process the
+  // absence was ours - without it, the vanished path records a false tampering event
+  // and can uninstall the whole app on a failed recreate. A throw here aborts the
+  // remove, which is the safe direction (a detached container still half-serves).
+  await appsRuntimeState.setNetworkHealRemoval(identifier, true);
+
   // Stop the per-minute stats monitor before removing the container (mirrors the
-  // uninstaller). Otherwise its interval runs against a gone container - and, if
-  // the recreate then fails/gives up, leaks and error-spams forever. The recreate
-  // re-establishes monitoring via startAppMonitoring on success.
+  // uninstaller). Otherwise its interval runs against a gone container, leaking and
+  // error-spamming. The recreate re-establishes it via startAppMonitoring.
   appInspector.stopAppMonitoring(identifier, true, globalState.appsMonitored);
   try {
     // v=false: Flux data lives on bind mounts, so nothing is lost; the recreate
     // reuses it via a soft install.
     await dockerService.appDockerForceRemove(identifier, false);
   } catch (err) {
+    // The container is still there (or partially removed): put monitoring back so a
+    // container we did NOT manage to remove is not left unmonitored. The heal flag
+    // stays set on purpose - the remove may have partially succeeded, and a stale
+    // flag only keeps us on the recreate path (never the uninstall one).
+    appInspector.startAppMonitoring(identifier, globalState.appsMonitored);
     log.error(`appReconciler - failed to remove detached ${identifier}: ${err.message}; will retry`);
     scheduleRetry(identifier, MANAGED_RETRY_MS);
     return;
@@ -419,7 +536,10 @@ async function reconcile(rawIdentifier) {
     return;
   }
   if (!spec) { // not installed here - nothing to enforce
-    networkHealState.delete(identifier); // drop any heal bookkeeping for a gone app
+    // drop the in-memory heal markers for a gone app (its durable runtime-state doc
+    // is dropped by the uninstaller via appsRuntimeState.remove)
+    networkDetachedNoted.delete(identifier);
+    networkPrunedNoted.delete(identifier);
     return;
   }
 
@@ -556,78 +676,31 @@ async function reconcile(rawIdentifier) {
     // resolve sibling components by name) and no published ports, and no future
     // `docker start` repairs it - only a recreate clears the stale endpoint.
     // Verify the attachment (from the inspect dockerActual already did) before
-    // trusting "running"; heal by recreating, debounced and bounded.
+    // trusting "running"; heal by recreating, confirmed in-pass and paced.
     if (!dockerService.isContainerDetachedFromNetwork(actual.attachment)) {
-      networkHealState.delete(identifier);
-      return; // running and properly attached - already where we want it
-    }
-    const st = networkHealState.get(identifier) || { obs: 0, tries: 0, gaveUp: false };
-    st.obs += 1;
-    if (st.obs < DETACHED_CONFIRM_OBSERVATIONS) {
-      // first sighting - confirm on the next pass before doing anything
-      // destructive, so a transient read never recreates a healthy container.
-      networkHealState.set(identifier, st);
-      log.warn(`appReconciler - ${identifier} appears detached from its docker network; confirming before acting`);
-      scheduleRetry(identifier, MANAGED_RETRY_MS);
+      // running AND attached - already where we want it, and the only proof that
+      // any earlier heal actually worked.
+      await clearNetworkHealState(identifier);
       return;
     }
-    if (st.tries >= MAX_NETWORK_HEAL_ATTEMPTS) {
-      if (!st.gaveUp) {
-        st.gaveUp = true;
-        networkHealState.set(identifier, st);
-        log.error(`appReconciler - ${identifier} still detached from its docker network after ${st.tries} recreate attempt(s); leaving it running for manual intervention (app NOT uninstalled)`);
-        fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkHealGaveUp' });
-      }
-      return;
-    }
-    // Only heal a stale endpoint (network present, container not attached). If the
-    // network itself is gone, a recreate would fail on a missing NetworkMode, so
-    // removing the container would only take it from partially-alive to removed-
-    // and-unrecreatable. That is a different fault (network restore) - record it
-    // and leave the container in place rather than destroying it.
-    if (!(await dockerService.dockerNetworkExists(actual.attachment.networkMode))) {
-      if (!st.gaveUp) {
-        st.gaveUp = true;
-        networkHealState.set(identifier, st);
-        log.error(`appReconciler - ${identifier} detached because its network ${actual.attachment.networkMode} is missing; not recreating (needs network restore, app NOT touched)`);
-        await appTamperingDetectionService.recordEvent(mainAppName, 'network_pruned', `Network ${actual.attachment.networkMode} missing while ${identifier} runs detached`);
-        fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkPruned' });
-      }
-      return;
-    }
-    st.tries += 1;
-    networkHealState.set(identifier, st);
-    // Record the durable anomaly signal ONCE per episode (first attempt), not on
-    // every retry - it feeds a node-level tampering-event count, so a per-retry
-    // record would inflate it 3x for a single detachment.
-    if (st.tries === 1) {
-      await appTamperingDetectionService.recordEvent(mainAppName, 'network_detached', `Container ${identifier} running with no network endpoint on its own network`);
-    }
-    log.warn(`appReconciler - ${identifier} running but not attached to its docker network (recreate ${st.tries}/${MAX_NETWORK_HEAL_ATTEMPTS}); clearing the stale endpoint`);
-    await attemptNetworkHeal(identifier);
+    await healDetachedNetwork(identifier, mainAppName);
     return;
   }
 
   if (!actual.exists) {
-    // If we removed this container for a network-detach heal (tries > 0) and the
-    // recreate has not yet brought it back, keep retrying the recreate WITHOUT the
-    // vanished path's uninstall-on-failure escalation - the trigger was transient
-    // host networking, not tampering, so a whole-app uninstall is wrong. Once the
-    // cap is hit we give up and, crucially, keep steering AWAY from recreateMissing
-    // so a heal never turns into an uninstall. Only a container that vanished by
-    // other means (no heal in flight) takes the tested vanished path.
-    const st = networkHealState.get(identifier);
-    if (st && st.tries > 0) {
-      if (st.gaveUp) return; // gave up earlier; leave removed, never uninstall
-      if (st.tries >= MAX_NETWORK_HEAL_ATTEMPTS) {
-        st.gaveUp = true;
-        networkHealState.set(identifier, st);
-        log.error(`appReconciler - ${identifier} still cannot be recreated after ${st.tries} network-heal attempt(s); leaving it removed for manual intervention (app NOT uninstalled)`);
-        fluxEventBus.publish('reconciler:actuated', { identifier, action: 'networkHealGaveUp' });
+    // Durable, so it survives a FluxOS restart mid-heal: if WE removed this
+    // container to clear a stale endpoint, its absence is not tampering. Keep
+    // recreating it - paced on the backoff ladder, never escalating to the vanished
+    // path's uninstall-on-failure. Only a container that vanished by other means
+    // takes that path.
+    if (await appsRuntimeState.isNetworkHealRemoval(identifier)) {
+      const wait = await appsRuntimeState.restartWaitMs(identifier);
+      if (wait > 0) {
+        log.warn(`appReconciler - ${identifier} awaiting recreation after a network heal, backing off ${Math.round(wait / 1000)}s`);
+        scheduleRetry(identifier, wait);
         return;
       }
-      st.tries += 1;
-      networkHealState.set(identifier, st);
+      await appsRuntimeState.recordRestart(identifier);
       await recreateForNetworkHeal(identifier);
       return;
     }
@@ -678,6 +751,11 @@ async function reconcile(rawIdentifier) {
   log.info(`appReconciler - ${identifier} restarted`);
   fluxEventBus.publish('reconciler:actuated', { identifier, action: 'started', exitCode: actual.exitCode });
   notifyContainerStarted(identifier);
+  // A start is exactly when a container can come up attached to no network (a stale
+  // endpoint left by an earlier failed start). The attachment we hold was sampled
+  // BEFORE this start, so verify the new one shortly - otherwise a detached-at-boot
+  // container waits for the hourly sweep.
+  scheduleRetry(identifier, POST_START_VERIFY_MS);
 }
 
 // --- workqueue (per-key single-flight, boot-gated) -----------------------

--- a/ZelBack/src/services/appMonitoring/containerHealthMonitor.js
+++ b/ZelBack/src/services/appMonitoring/containerHealthMonitor.js
@@ -8,7 +8,23 @@ const { localAppsInformation } = require('../utils/appConstants');
 const { verifyAppVolumeMount } = require('../utils/volumeService');
 
 
-async function recreateMissingContainers(componentIdentifier) {
+/**
+ * Recreates the container(s) for an app/component from its local spec.
+ *
+ * softOnly: refuse the installApplicationHard fallback. A hard install runs
+ * createAppVolume, which fallocates and mke2fs's the app's volume file - i.e. it
+ * REFORMATS the app's data. That is acceptable when recreating a container whose
+ * volume could not be verified and which is gone anyway, but it is catastrophic
+ * for a caller that deliberately removed a live container whose data was intact
+ * (the network-detach heal): a transient verifyAppVolumeMount failure would wipe
+ * the user's data. Such callers pass softOnly and get a throw instead, so they
+ * can retry rather than reformat.
+ *
+ * @param {string} componentIdentifier
+ * @param {{softOnly?: boolean}} [options]
+ */
+async function recreateMissingContainers(componentIdentifier, options = {}) {
+  const { softOnly = false } = options;
   const mainAppName = componentIdentifier.split('_')[1] || componentIdentifier;
   const dbopen = dbHelper.databaseConnection();
   const appsDatabase = dbopen.db(config.database.appslocal.database);
@@ -53,6 +69,9 @@ async function recreateMissingContainers(componentIdentifier) {
     if (volumeMounted) {
       await appInstaller.installApplicationSoft(componentSpec, mainAppName, true, null, appSpec);
     } else {
+      if (softOnly) {
+        throw new Error(`Cannot recreate ${componentIdentifier} without reformatting its volume: the data volume for ${mainAppName} could not be verified as mounted`);
+      }
       await appInstaller.installApplicationHard(componentSpec, mainAppName, true, null, appSpec);
     }
   } else {
@@ -74,6 +93,9 @@ async function recreateMissingContainers(componentIdentifier) {
         // eslint-disable-next-line no-await-in-loop
         await appInstaller.installApplicationSoft(componentSpec, mainAppName, true, null, appSpec);
       } else {
+        if (softOnly) {
+          throw new Error(`Cannot recreate ${componentIdentifier} without reformatting its volume: the data volume for ${mainAppName} could not be verified as mounted`);
+        }
         // eslint-disable-next-line no-await-in-loop
         await appInstaller.installApplicationHard(componentSpec, mainAppName, true, null, appSpec);
       }

--- a/ZelBack/src/services/appMonitoring/containerHealthMonitor.js
+++ b/ZelBack/src/services/appMonitoring/containerHealthMonitor.js
@@ -45,6 +45,14 @@ async function recreateMissingContainers(componentIdentifier, options = {}) {
     throw new Error(`App ${mainAppName} has no components to install`);
   }
 
+  // A container can only be (re)created onto an existing docker network, but the
+  // per-app network (fluxDockerNetwork_<app>) is otherwise created only at install
+  // time (registerAppLocally). If it was pruned - docker prune, daemon restart -
+  // every recreate below would loop forever on "network not found". Recreate it
+  // first; ensureAppDockerNetwork returns early (no create, no firewall work) when
+  // the network already exists, so the common intact-network recreate stays cheap.
+  await appInstaller.ensureAppDockerNetwork(mainAppName);
+
   const tier = await generalService.nodeTier();
   const isComponent = componentIdentifier.includes('_');
 

--- a/ZelBack/src/services/appTamperingBlocklistService.js
+++ b/ZelBack/src/services/appTamperingBlocklistService.js
@@ -6,30 +6,13 @@ const fluxNetworkHelper = require('./fluxNetworkHelper');
 const generalService = require('./generalService');
 const daemonServiceMiscRpcs = require('./daemonService/daemonServiceMiscRpcs');
 const benchmarkService = require('./benchmarkService');
+const appTamperingDetectionService = require('./appTamperingDetectionService');
 
 const BLOCKLIST_URL = `${config.github.rawBaseUrl}/helpers/tamperingblockednodes.json`;
 const CHECK_INTERVAL_MS = 12 * 60 * 60 * 1000; // 12 hours
 const SYNC_POLL_MS = 60 * 1000; // 60s while waiting for daemon sync
 const TAMPER_SCORE_THRESHOLD = 10;
 const DOS_MESSAGE_PREFIX = 'Node flagged via tampering blocklist';
-
-// Per-type weights for the tamper score. Not every event is tamper evidence:
-// recreation_failed is an operational fault (registry, image pull, disk) and
-// node_reboot is an observation feeding operator-level analysis — both weigh 0
-// via omission, because punishing them would penalize honest nodes for infra
-// noise. container_vanished weighs highest: containers persist as `exited`
-// across a clean reboot, so a positively-confirmed missing container is the
-// strongest local indicator of host-side interference this data has. The
-// mount/volume/network types are real signals but dominated by late-data-disk
-// and network-not-ready boot races, so they weigh low until the phase-1
-// schema can flag boot-storm context explicitly.
-const TAMPER_EVENT_WEIGHTS = {
-  container_vanished: 3,
-  network_pruned: 1,
-  network_detached: 1,
-  mount_vanished: 1,
-  volume_missing: 1,
-};
 
 const tamperingEventsCollection = config.database.local.collections.appTamperingEvents;
 
@@ -90,14 +73,14 @@ async function isArcaneOs() {
 }
 
 /**
- * Weighted tamper score over distinct incidents in the events collection
- * (30-day TTL bounds the window). Rows are collapsed to incident keys of
- * (eventType, appName, calendar day) before weighting: the collection is
- * row-per-observation, so a single flapping app — or rows inserted before
- * episode dedup existed — would otherwise count one incident many times.
- * A raw `countDocuments({})` here once meant a single late-disk reboot of a
- * multi-app node could cross the enforcement gate; distinct-incident scoring
- * makes the threshold mean "how many app-days showed tamper symptoms".
+ * Tamper score over incident documents (30-day TTL bounds the window).
+ * Each schemaVersion>=1 document already IS one deduplicated incident with a
+ * severity stamped at write time, so scoring is a plain sum: severity,
+ * discounted for incidents flagged duringBootStorm (any reboot with a late
+ * data disk produces per-app mount/volume noise — discounted, never dropped).
+ * Pre-schema rows are excluded on purpose: they are row-per-observation noise
+ * with no severity or boot context, exactly the data a raw countDocuments({})
+ * once let cross the enforcement gate on honest nodes; they age out via TTL.
  */
 async function computeTamperScore() {
   try {
@@ -105,18 +88,14 @@ async function computeTamperScore() {
     if (!db) return 0;
     const database = db.db(config.database.local.database);
     const pipeline = [
-      {
-        $group: {
-          _id: {
-            eventType: '$eventType',
-            appName: '$appName',
-            day: { $dateToString: { format: '%Y-%m-%d', date: '$detectedAt' } },
-          },
-        },
-      },
+      { $match: { schemaVersion: { $gte: 1 } } },
+      { $project: { _id: 0, severity: 1, duringBootStorm: 1 } },
     ];
     const incidents = await dbHelper.aggregateInDatabase(database, tamperingEventsCollection, pipeline);
-    return incidents.reduce((score, incident) => score + (TAMPER_EVENT_WEIGHTS[incident._id.eventType] ?? 0), 0);
+    return incidents.reduce((score, incident) => {
+      const discount = incident.duringBootStorm ? appTamperingDetectionService.BOOT_STORM_DISCOUNT : 1;
+      return score + (incident.severity ?? 0) * discount;
+    }, 0);
   } catch (error) {
     log.warn(`appTamperingBlocklist - failed to compute tamper score: ${error.message}`);
     return 0;
@@ -278,6 +257,5 @@ module.exports = {
   getMyTxhash,
   isDosActive,
   TAMPER_SCORE_THRESHOLD,
-  TAMPER_EVENT_WEIGHTS,
   DOS_MESSAGE_PREFIX,
 };

--- a/ZelBack/src/services/appTamperingBlocklistService.js
+++ b/ZelBack/src/services/appTamperingBlocklistService.js
@@ -89,12 +89,18 @@ async function computeTamperScore() {
     const database = db.db(config.database.local.database);
     const pipeline = [
       { $match: { schemaVersion: { $gte: 1 } } },
-      { $project: { _id: 0, severity: 1, duringBootStorm: 1 } },
+      { $project: {
+        _id: 0, severity: 1, duringBootStorm: 1, eventType: 1,
+      } },
     ];
     const incidents = await dbHelper.aggregateInDatabase(database, tamperingEventsCollection, pipeline);
     return incidents.reduce((score, incident) => {
-      const discount = incident.duringBootStorm ? appTamperingDetectionService.BOOT_STORM_DISCOUNT : 1;
-      return score + (incident.severity ?? 0) * discount;
+      // The storm discount applies only to the boot-race event family; a
+      // container_vanished right after boot scores full weight (see
+      // BOOT_STORM_DISCOUNT_TYPES for why).
+      const discounted = incident.duringBootStorm
+        && appTamperingDetectionService.BOOT_STORM_DISCOUNT_TYPES.includes(incident.eventType);
+      return score + (incident.severity ?? 0) * (discounted ? appTamperingDetectionService.BOOT_STORM_DISCOUNT : 1);
     }, 0);
   } catch (error) {
     log.warn(`appTamperingBlocklist - failed to compute tamper score: ${error.message}`);

--- a/ZelBack/src/services/appTamperingBlocklistService.js
+++ b/ZelBack/src/services/appTamperingBlocklistService.js
@@ -10,8 +10,26 @@ const benchmarkService = require('./benchmarkService');
 const BLOCKLIST_URL = `${config.github.rawBaseUrl}/helpers/tamperingblockednodes.json`;
 const CHECK_INTERVAL_MS = 12 * 60 * 60 * 1000; // 12 hours
 const SYNC_POLL_MS = 60 * 1000; // 60s while waiting for daemon sync
-const TAMPERING_EVENT_THRESHOLD = 10;
+const TAMPER_SCORE_THRESHOLD = 10;
 const DOS_MESSAGE_PREFIX = 'Node flagged via tampering blocklist';
+
+// Per-type weights for the tamper score. Not every event is tamper evidence:
+// recreation_failed is an operational fault (registry, image pull, disk) and
+// node_reboot is an observation feeding operator-level analysis — both weigh 0
+// via omission, because punishing them would penalize honest nodes for infra
+// noise. container_vanished weighs highest: containers persist as `exited`
+// across a clean reboot, so a positively-confirmed missing container is the
+// strongest local indicator of host-side interference this data has. The
+// mount/volume/network types are real signals but dominated by late-data-disk
+// and network-not-ready boot races, so they weigh low until the phase-1
+// schema can flag boot-storm context explicitly.
+const TAMPER_EVENT_WEIGHTS = {
+  container_vanished: 3,
+  network_pruned: 1,
+  network_detached: 1,
+  mount_vanished: 1,
+  volume_missing: 1,
+};
 
 const tamperingEventsCollection = config.database.local.collections.appTamperingEvents;
 
@@ -72,17 +90,35 @@ async function isArcaneOs() {
 }
 
 /**
- * Count documents in the tampering events collection (all types, all apps).
- * The 30-day TTL on detectedAt already scopes this.
+ * Weighted tamper score over distinct incidents in the events collection
+ * (30-day TTL bounds the window). Rows are collapsed to incident keys of
+ * (eventType, appName, calendar day) before weighting: the collection is
+ * row-per-observation, so a single flapping app — or rows inserted before
+ * episode dedup existed — would otherwise count one incident many times.
+ * A raw `countDocuments({})` here once meant a single late-disk reboot of a
+ * multi-app node could cross the enforcement gate; distinct-incident scoring
+ * makes the threshold mean "how many app-days showed tamper symptoms".
  */
-async function countTamperingEvents() {
+async function computeTamperScore() {
   try {
     const db = dbHelper.databaseConnection();
     if (!db) return 0;
     const database = db.db(config.database.local.database);
-    return await database.collection(tamperingEventsCollection).countDocuments({});
+    const pipeline = [
+      {
+        $group: {
+          _id: {
+            eventType: '$eventType',
+            appName: '$appName',
+            day: { $dateToString: { format: '%Y-%m-%d', date: '$detectedAt' } },
+          },
+        },
+      },
+    ];
+    const incidents = await dbHelper.aggregateInDatabase(database, tamperingEventsCollection, pipeline);
+    return incidents.reduce((score, incident) => score + (TAMPER_EVENT_WEIGHTS[incident._id.eventType] ?? 0), 0);
   } catch (error) {
-    log.warn(`appTamperingBlocklist - failed to count events: ${error.message}`);
+    log.warn(`appTamperingBlocklist - failed to compute tamper score: ${error.message}`);
     return 0;
   }
 }
@@ -121,8 +157,8 @@ async function waitForDaemonSynced() {
 }
 
 /**
- * Core check: if our txhash is in the blocklist AND we have more than
- * TAMPERING_EVENT_THRESHOLD events, DOS the node. Otherwise, if we previously
+ * Core check: if our txhash is in the blocklist AND the weighted tamper score
+ * exceeds TAMPER_SCORE_THRESHOLD, DOS the node. Otherwise, if we previously
  * DOSed it, clear the DOS. This service owns the DOS message it sets and only
  * clears it when its own condition is no longer true.
  */
@@ -143,10 +179,10 @@ async function enforceBlocklist() {
     return;
   }
 
-  const [myTxhash, blocklist, eventCount] = await Promise.all([
+  const [myTxhash, blocklist, tamperScore] = await Promise.all([
     getMyTxhash(),
     fetchBlocklist(),
-    countTamperingEvents(),
+    computeTamperScore(),
   ]);
 
   if (!myTxhash) {
@@ -155,13 +191,13 @@ async function enforceBlocklist() {
   }
 
   const listed = Array.isArray(blocklist) && blocklist.includes(myTxhash);
-  const exceedsThreshold = eventCount > TAMPERING_EVENT_THRESHOLD;
+  const exceedsThreshold = tamperScore > TAMPER_SCORE_THRESHOLD;
   const shouldDos = listed && exceedsThreshold;
 
-  log.info(`appTamperingBlocklist - txhash=${myTxhash} listed=${listed} events=${eventCount} shouldDos=${shouldDos}`);
+  log.info(`appTamperingBlocklist - txhash=${myTxhash} listed=${listed} score=${tamperScore} shouldDos=${shouldDos}`);
 
   if (shouldDos) {
-    const message = `${DOS_MESSAGE_PREFIX}: ${eventCount} events, txhash ${myTxhash}`;
+    const message = `${DOS_MESSAGE_PREFIX}: tamper score ${tamperScore}, txhash ${myTxhash}`;
     fluxNetworkHelper.setStickyDosMessage(message);
     fluxNetworkHelper.setStickyDosStateValue(100);
     ourDosActive = true;
@@ -170,7 +206,7 @@ async function enforceBlocklist() {
   }
 
   if (ourDosActive || isOurStickyDos()) {
-    log.info(`appTamperingBlocklist - clearing sticky DOS (listed=${listed}, events=${eventCount})`);
+    log.info(`appTamperingBlocklist - clearing sticky DOS (listed=${listed}, score=${tamperScore})`);
     fluxNetworkHelper.clearStickyDosMessage();
     ourDosActive = false;
   }
@@ -238,9 +274,10 @@ module.exports = {
   stop,
   enforceBlocklist,
   fetchBlocklist,
-  countTamperingEvents,
+  computeTamperScore,
   getMyTxhash,
   isDosActive,
-  TAMPERING_EVENT_THRESHOLD,
+  TAMPER_SCORE_THRESHOLD,
+  TAMPER_EVENT_WEIGHTS,
   DOS_MESSAGE_PREFIX,
 };

--- a/ZelBack/src/services/appTamperingBlocklistService.js
+++ b/ZelBack/src/services/appTamperingBlocklistService.js
@@ -6,7 +6,6 @@ const fluxNetworkHelper = require('./fluxNetworkHelper');
 const generalService = require('./generalService');
 const daemonServiceMiscRpcs = require('./daemonService/daemonServiceMiscRpcs');
 const benchmarkService = require('./benchmarkService');
-const appTamperingDetectionService = require('./appTamperingDetectionService');
 
 const BLOCKLIST_URL = `${config.github.rawBaseUrl}/helpers/tamperingblockednodes.json`;
 const CHECK_INTERVAL_MS = 12 * 60 * 60 * 1000; // 12 hours
@@ -75,9 +74,7 @@ async function isArcaneOs() {
 /**
  * Tamper score over incident documents (30-day TTL bounds the window).
  * Each schemaVersion>=1 document already IS one deduplicated incident with a
- * severity stamped at write time, so scoring is a plain sum: severity,
- * discounted for incidents flagged duringBootStorm (any reboot with a late
- * data disk produces per-app mount/volume noise — discounted, never dropped).
+ * severity stamped at write time, so scoring is a plain sum of severities.
  * Pre-schema rows are excluded on purpose: they are row-per-observation noise
  * with no severity or boot context, exactly the data a raw countDocuments({})
  * once let cross the enforcement gate on honest nodes; they age out via TTL.
@@ -89,19 +86,10 @@ async function computeTamperScore() {
     const database = db.db(config.database.local.database);
     const pipeline = [
       { $match: { schemaVersion: { $gte: 1 } } },
-      { $project: {
-        _id: 0, severity: 1, duringBootStorm: 1, eventType: 1,
-      } },
+      { $project: { _id: 0, severity: 1 } },
     ];
     const incidents = await dbHelper.aggregateInDatabase(database, tamperingEventsCollection, pipeline);
-    return incidents.reduce((score, incident) => {
-      // The storm discount applies only to the boot-race event family; a
-      // container_vanished right after boot scores full weight (see
-      // BOOT_STORM_DISCOUNT_TYPES for why).
-      const discounted = incident.duringBootStorm
-        && appTamperingDetectionService.BOOT_STORM_DISCOUNT_TYPES.includes(incident.eventType);
-      return score + (incident.severity ?? 0) * (discounted ? appTamperingDetectionService.BOOT_STORM_DISCOUNT : 1);
-    }, 0);
+    return incidents.reduce((score, incident) => score + (incident.severity ?? 0), 0);
   } catch (error) {
     log.warn(`appTamperingBlocklist - failed to compute tamper score: ${error.message}`);
     return 0;

--- a/ZelBack/src/services/appTamperingBlocklistService.js
+++ b/ZelBack/src/services/appTamperingBlocklistService.js
@@ -76,8 +76,9 @@ async function isArcaneOs() {
  * Each schemaVersion>=1 document already IS one deduplicated incident with a
  * severity stamped at write time, so scoring is a plain sum of severities.
  * Pre-schema rows are excluded on purpose: they are row-per-observation noise
- * with no severity or boot context, exactly the data a raw countDocuments({})
- * once let cross the enforcement gate on honest nodes; they age out via TTL.
+ * with no severity, exactly the data a raw countDocuments({}) once let cross
+ * the enforcement gate on honest nodes. The startup purge removes them; the
+ * filter here covers anything written before that purge has run.
  */
 async function computeTamperScore() {
   try {

--- a/ZelBack/src/services/appTamperingDetectionService.js
+++ b/ZelBack/src/services/appTamperingDetectionService.js
@@ -1,16 +1,21 @@
 const config = require('config');
+const os = require('os');
 const fs = require('fs').promises;
 const log = require('../lib/log');
 const dbHelper = require('./dbHelper');
 const messageHelper = require('./messageHelper');
+const generalService = require('./generalService');
+const daemonServiceFluxnodeRpcs = require('./daemonService/daemonServiceFluxnodeRpcs');
+const { localAppsInformation } = require('./utils/appConstants');
 
-// All tamper-feature behaviour (episode dedup, boot identity, event taxonomy)
+// All tamper-feature behaviour (incident rollup, boot identity, severities)
 // deliberately lives inside this service rather than at the emitting call
 // sites: the call sites (appReconciler, crontabAndMountsCleanup,
 // syncthingFolderStateMachine) sit in files under heavy parallel rework on the
 // v9 branch, while this file is identical across branches. Centralizing here
 // keeps the feature rebase-safe and guarantees every emitter gets the same
-// semantics without call-site edits.
+// semantics without call-site edits. Call sites still pass plain
+// (appName, eventType, details); everything else is derived here.
 
 const tamperingEventsCollection = config.database.local.collections.appTamperingEvents;
 const nodeStartupTrackerCollection = config.database.local.collections.nodeStartupTracker;
@@ -22,18 +27,62 @@ const BOOT_HISTORY_KEY = 'bootHistory';
 // cadence (~4h), comfortably beyond the collection's 30-day event TTL.
 const BOOT_HISTORY_MAX = 200;
 
-// One row per (appName, eventType) per hour. The reconciler re-attempts a
-// failed recreation on a seconds-scale backoff and re-sweeps hourly, so a
-// single persistent fault (unpullable image, missing volume) used to insert
-// hundreds of rows for one incident, drowning genuine signal and inflating
-// the enforcement count. Suppressed repeats are dropped, not counted, until
-// the phase-1 incident schema adds first/last-seen rollups.
-const EPISODE_WINDOW_MS = 60 * 60 * 1000;
-// `${appName}|${eventType}` -> epoch ms of the last inserted row. In-memory
-// on purpose: a process restart clears it, and per-boot events (mount races
-// on a late data disk) should record once per boot.
-const episodeMarkers = new Map();
-const EPISODE_MARKERS_MAX = 1000;
+// One incident document per (appName, eventType) per hour bucket. The
+// reconciler re-attempts a failed recreation on a seconds-scale backoff and
+// re-sweeps hourly, so a single persistent fault used to insert hundreds of
+// rows for one incident; the rollup collapses those into a count. The time
+// bucket is load-bearing: keyed on bootId alone, a node up for weeks would
+// fold every same-type event across that whole span into one document,
+// erasing distinct incidents.
+const INCIDENT_BUCKET_MS = 60 * 60 * 1000;
+
+// Events recorded within this window after a machine boot are flagged
+// duringBootStorm and down-weighted in scoring — never dropped. Any reboot
+// with a late data disk legitimately produces mount/volume events for every
+// app; outright suppression would instead hand tamperers a laundering trick
+// (tamper, then reboot, and the evidence goes out with the boot noise).
+const BOOT_STORM_WINDOW_MS = 30 * 60 * 1000;
+const BOOT_STORM_DISCOUNT = 0.25;
+
+// Per-type severity, stamped on each incident at write time so scoring reads
+// stored values rather than re-deriving them. recreation_failed is an
+// operational fault (registry, image pull, disk) and node_reboot is an
+// observation feeding operator-level analysis — both are recorded for
+// visibility but carry no tamper weight, because punishing them would
+// penalize honest nodes for infra noise. container_vanished weighs highest:
+// containers persist as `exited` across a clean reboot, so a
+// positively-confirmed missing container is the strongest local indicator of
+// host-side interference this data has. The mount/volume/network types are
+// real signals but dominated by boot races, hence low severity plus the
+// boot-storm discount.
+const EVENT_SEVERITY = {
+  container_vanished: 3,
+  network_pruned: 1,
+  network_detached: 1,
+  mount_vanished: 1,
+  volume_missing: 1,
+  recreation_failed: 0,
+  node_reboot: 0,
+};
+
+const EVENTS_DEFAULT_LIMIT = 500;
+const EVENTS_MAX_LIMIT = 1000;
+
+// Identity lookups are best-effort: an event must still record while the
+// daemon is down, just unattributed. Failures back off rather than hammering
+// a dead daemon on every event.
+const IDENTITY_RETRY_MS = 5 * 60 * 1000;
+const ATTRIBUTION_TTL_MS = 60 * 60 * 1000;
+
+// Boot context, set once by checkNodeReboot() during startup. Until it runs
+// (or on hosts without a readable boot_id) events fall back to an 'unknown'
+// boot in their incident key and are never flagged as boot storm.
+let currentBootId = null;
+let bootStormUntilMs = 0;
+
+let nodeIdentityCache = null;
+let identityRetryAfterMs = 0;
+const appAttributionCache = new Map(); // appName -> { ownerZelid, appHash, cachedAt }
 
 /**
  * Returns true when a Docker/daemon error message indicates a missing network
@@ -54,68 +103,189 @@ function isNetworkMissingError(errorMessage) {
 }
 
 /**
- * Drop episode markers whose window has already elapsed so the map cannot
- * grow unbounded on a node with many flapping apps.
- * @param {number} now - Current epoch ms
+ * Node identity (collateral outpoint, ip, operator pubkey/payout) from the
+ * daemon's own fluxnode status, cached for the process lifetime. Returns null
+ * while the daemon is unreachable — events record unattributed and the next
+ * event after the backoff retries.
+ * @returns {Promise<object|null>}
  */
-function pruneExpiredEpisodeMarkers(now) {
-  episodeMarkers.forEach((recordedAt, key) => {
-    if (now - recordedAt >= EPISODE_WINDOW_MS) episodeMarkers.delete(key);
-  });
+async function getNodeIdentity() {
+  if (nodeIdentityCache) return nodeIdentityCache;
+  if (Date.now() < identityRetryAfterMs) return null;
+  try {
+    const status = await daemonServiceFluxnodeRpcs.getFluxNodeStatus();
+    if (!status || status.status !== 'success' || !status.data) {
+      throw new Error('fluxnode status unavailable');
+    }
+    const node = status.data;
+    let nodeTxid = node.txhash ?? null;
+    let nodeOutidx = node.outidx ?? null;
+    if ((nodeTxid === null || nodeOutidx === null) && node.collateral) {
+      const collateralInfo = generalService.getCollateralInfo(node.collateral);
+      nodeTxid = collateralInfo.txhash;
+      nodeOutidx = collateralInfo.txindex;
+    }
+    nodeIdentityCache = {
+      nodeTxid,
+      nodeOutidx,
+      nodeIp: node.ip ?? null,
+      pubkey: node.pubkey ?? null,
+      paymentAddress: node.payment_address ?? null,
+    };
+    return nodeIdentityCache;
+  } catch (error) {
+    identityRetryAfterMs = Date.now() + IDENTITY_RETRY_MS;
+    log.debug(`appTamperingDetection - node identity unavailable: ${error.message}`);
+    return null;
+  }
 }
 
 /**
- * Record a tampering event. Inserts one row per (appName, eventType) episode:
- * repeat calls inside EPISODE_WINDOW_MS after a successful insert are dropped,
- * so retry storms collapse into a single row while distinct incidents in later
- * windows still record. Documents expire 30 days after detectedAt (TTL index).
+ * Reduce an emitted app name to the main app name used in the installed-apps
+ * database. Call sites pass either a spec name ('MyApp') or a docker
+ * identifier ('fluxcomponent_MyApp' / 'zelMyApp'); component and app names
+ * are alphanumeric, so everything after the first underscore is the app.
+ * @param {string} appName
+ * @returns {string}
+ */
+function deriveMainAppName(appName) {
+  let name = appName;
+  if (name.startsWith('zel')) name = name.slice(3);
+  else if (name.startsWith('flux')) name = name.slice(4);
+  const underscore = name.indexOf('_');
+  if (underscore !== -1) name = name.slice(underscore + 1);
+  return name;
+}
+
+/**
+ * Owner/spec-hash attribution for an app from the local installed-apps
+ * database, cached per emitted name. Tries the name as passed first (a real
+ * app name may itself start with 'flux'), then the derived main app name.
+ * Best-effort: returns null fields when the app cannot be found.
+ * @param {string} appName - Name exactly as passed by the emitter
+ * @returns {Promise<object|null>}
+ */
+async function getAppAttribution(appName) {
+  if (!appName || appName === SYSTEM_APP_NAME) return null;
+  const cached = appAttributionCache.get(appName);
+  if (cached && Date.now() - cached.cachedAt < ATTRIBUTION_TTL_MS) return cached;
+  try {
+    const db = dbHelper.databaseConnection();
+    if (!db) return null;
+    const appsDatabase = db.db(config.database.appslocal.database);
+    const projection = { projection: { _id: 0, owner: 1, hash: 1 } };
+    let app = await dbHelper.findOneInDatabase(
+      appsDatabase, localAppsInformation, { name: appName }, projection,
+    );
+    if (!app) {
+      const mainName = deriveMainAppName(appName);
+      if (mainName !== appName) {
+        app = await dbHelper.findOneInDatabase(
+          appsDatabase, localAppsInformation, { name: mainName }, projection,
+        );
+      }
+    }
+    const attribution = {
+      ownerZelid: app?.owner ?? null,
+      appHash: app?.hash ?? null,
+      cachedAt: Date.now(),
+    };
+    appAttributionCache.set(appName, attribution);
+    return attribution;
+  } catch (error) {
+    log.debug(`appTamperingDetection - attribution lookup failed for ${appName}: ${error.message}`);
+    return null;
+  }
+}
+
+/**
+ * Record a tampering event as an incident rollup (schemaVersion 1).
+ * One document per (appName, eventType, incidentKey) where incidentKey is
+ * the boot_id plus an hourly time bucket; repeat calls increment `count` and
+ * advance `lastSeen`, so retry storms collapse while the incident keeps its
+ * full observation tally. Each document carries node identity, operator
+ * identity, app attribution, severity and boot-storm context so fleet-level
+ * consumers can attribute and weigh it without joining local state.
+ * Documents expire 30 days after lastSeen (TTL index).
  * @param {string} appName - Application name (or SYSTEM_APP_NAME)
- * @param {string} eventType - One of: container_vanished, recreation_failed,
- *   network_pruned, network_detached, mount_vanished, volume_missing,
- *   node_reboot
- * @param {string} details - Free-text context about the event
+ * @param {string} eventType - One of the EVENT_SEVERITY keys
+ * @param {string} details - Free-text context (stored once per incident)
  */
 async function recordEvent(appName, eventType, details) {
   try {
-    const now = Date.now();
-    const episodeKey = `${appName}|${eventType}`;
-    const lastRecordedAt = episodeMarkers.get(episodeKey);
-    if (lastRecordedAt !== undefined && now - lastRecordedAt < EPISODE_WINDOW_MS) {
-      log.debug(`appTamperingDetection - ${eventType} for ${appName} already recorded this episode, skipping`);
-      return;
-    }
     const db = dbHelper.databaseConnection();
     if (!db) {
       log.warn('appTamperingDetection - DB not available, skipping event');
       return;
     }
     const database = db.db(config.database.local.database);
-    const doc = {
-      appName,
-      eventType,
-      details,
-      detectedAt: new Date(),
+    const now = new Date();
+    const incidentKey = `${currentBootId ?? 'unknown'}:${Math.floor(now.getTime() / INCIDENT_BUCKET_MS)}`;
+    const duringBootStorm = now.getTime() < bootStormUntilMs;
+    const [identity, attribution] = await Promise.all([
+      getNodeIdentity(),
+      getAppAttribution(appName),
+    ]);
+    const query = { appName, eventType, incidentKey };
+    const update = {
+      $setOnInsert: {
+        schemaVersion: 1,
+        appName,
+        eventType,
+        incidentKey,
+        severity: EVENT_SEVERITY[eventType] ?? 0,
+        duringBootStorm,
+        bootId: currentBootId,
+        uptimeSecAtEvent: Math.round(os.uptime()),
+        firstSeen: now,
+        detailsSample: details,
+        nodeTxid: identity?.nodeTxid ?? null,
+        nodeOutidx: identity?.nodeOutidx ?? null,
+        nodeIp: identity?.nodeIp ?? null,
+        pubkey: identity?.pubkey ?? null,
+        paymentAddress: identity?.paymentAddress ?? null,
+        ownerZelid: attribution?.ownerZelid ?? null,
+        appHash: attribution?.appHash ?? null,
+      },
+      $set: { lastSeen: now },
+      $inc: { count: 1 },
     };
-    await dbHelper.insertOneToDatabase(database, tamperingEventsCollection, doc);
-    // Marked only after a successful insert: a failed write must not consume
-    // the episode, otherwise the event would be silently lost for an hour.
-    episodeMarkers.set(episodeKey, now);
-    if (episodeMarkers.size > EPISODE_MARKERS_MAX) pruneExpiredEpisodeMarkers(now);
-    log.info(`appTamperingDetection - recorded ${eventType} for ${appName}`);
+    let result;
+    try {
+      result = await dbHelper.findOneAndUpdateInDatabase(
+        database, tamperingEventsCollection, query, update, { upsert: true },
+      );
+    } catch (error) {
+      // Two concurrent upserts racing on a brand-new incident key can trip
+      // the unique index; the loser retries once and lands as the increment.
+      if (error && error.code === 11000) {
+        result = await dbHelper.findOneAndUpdateInDatabase(
+          database, tamperingEventsCollection, query, update, { upsert: true },
+        );
+      } else {
+        throw error;
+      }
+    }
+    // Insert detection across driver result shapes: v6 returns the pre-image
+    // doc or null; older shapes return { value, lastErrorObject }.
+    const inserted = !result || result.value === null || result?.lastErrorObject?.updatedExisting === false;
+    if (inserted) {
+      log.info(`appTamperingDetection - recorded ${eventType} for ${appName}${duringBootStorm ? ' (boot storm)' : ''}`);
+    } else {
+      log.debug(`appTamperingDetection - ${eventType} for ${appName} repeated, incident count incremented`);
+    }
   } catch (error) {
     log.error(`appTamperingDetection - failed to record event: ${error.message}`);
   }
 }
 
-const EVENTS_DEFAULT_LIMIT = 500;
-const EVENTS_MAX_LIMIT = 1000;
-
 /**
- * GET API handler. Returns tampering events, optionally filtered by appname,
- * sorted by most recent first. Results are capped: the route is public, so an
- * uncapped no-arg query would dump the whole collection to anyone. A stable
- * paging key arrives with the phase-1 schema (_id is stripped today); until
- * then newest-first plus `limit` is the supported access pattern.
+ * GET API handler. Returns tampering incidents, optionally filtered by
+ * appname, most recent first. Results are capped: the route is public, so an
+ * uncapped no-arg query would dump the whole collection to anyone. Documents
+ * include _id as a stable paging/identity key. Pre-schema rows (detectedAt,
+ * no lastSeen) sort after current-schema incidents until they age out via
+ * their 30-day TTL.
  * Route: GET /apps/tamperingevents/:appname? (query: ?limit=1..1000)
  * @param {object} req - Express request
  * @param {object} res - Express response
@@ -131,11 +301,9 @@ async function getEvents(req, res) {
     const db = dbHelper.databaseConnection();
     const database = db.db(config.database.local.database);
     const query = appname ? { appName: appname } : {};
-    const projection = {
-      projection: { _id: 0 }, sort: { detectedAt: -1 }, limit,
-    };
+    const options = { sort: { lastSeen: -1, detectedAt: -1 }, limit };
     const results = await dbHelper.findInDatabase(
-      database, tamperingEventsCollection, query, projection,
+      database, tamperingEventsCollection, query, options,
     );
     const message = messageHelper.createDataMessage(results);
     res.json(message);
@@ -151,8 +319,10 @@ async function getEvents(req, res) {
  * restart using the kernel boot identity (/proc/sys/kernel/random/boot_id — a
  * UUID regenerated on every boot, stable across process restarts). On a
  * genuine reboot it records a single `node_reboot` observation under the
- * synthetic __system__ app and appends the boot to a rolling history, so
- * consumers can derive a reboot *rate/cadence* instead of a single interval.
+ * synthetic __system__ app, appends the boot to a rolling history so
+ * consumers can derive a reboot rate/cadence, and opens the boot-storm
+ * window that down-weights the mount/volume/network noise any boot with a
+ * late data disk produces.
  *
  * This replaces a wall-clock `frequent_restart` heuristic that measured
  * process-start gaps: a crash-loop or the serviceManager boot-retry looked
@@ -186,19 +356,20 @@ async function checkNodeReboot() {
       log.warn(`appTamperingDetection - legacy frequent_restart purge failed: ${error.message}`);
     }
 
-    let currentBootId = null;
+    let bootId = null;
     try {
       const bootIdPath = config.system?.bootIdPath ?? '/proc/sys/kernel/random/boot_id';
-      currentBootId = (await fs.readFile(bootIdPath, 'utf8')).trim();
+      bootId = (await fs.readFile(bootIdPath, 'utf8')).trim();
     } catch (error) {
-      currentBootId = null;
+      bootId = null;
     }
-    if (!currentBootId) {
+    if (!bootId) {
       // Without a boot identity, reboot vs restart is guesswork — recording
       // anything here would reintroduce the noise this check exists to remove.
       log.warn('appTamperingDetection - boot_id unreadable, skipping reboot check');
       return;
     }
+    currentBootId = bootId;
 
     const now = new Date();
     const previous = await dbHelper.findOneInDatabase(
@@ -206,25 +377,29 @@ async function checkNodeReboot() {
     );
     const previousBootId = previous && previous.bootId ? previous.bootId : null;
 
-    if (previousBootId && previousBootId !== currentBootId) {
-      const previousStart = previous.at ? new Date(previous.at).toISOString() : 'unknown';
-      await recordEvent(
-        SYSTEM_APP_NAME,
-        'node_reboot',
-        `Machine rebooted: boot_id ${previousBootId.slice(0, 8)} -> ${currentBootId.slice(0, 8)}, previous FluxOS start ${previousStart}`,
-      );
-    }
-
     if (previousBootId !== currentBootId) {
-      // First sighting of this boot_id (reboot, first run, or upgrade from the
-      // pre-boot_id marker). A same-boot_id process restart adds no entry, so
-      // the history reflects machine boots only.
+      // First sighting of this boot_id: genuine reboot, first run, or upgrade
+      // from the pre-boot_id marker. All three open the boot-storm window —
+      // when we cannot prove the machine did NOT just boot, erring toward the
+      // discount protects honest nodes and costs a tamperer nothing (the
+      // events still record). A same-boot_id process restart opens nothing:
+      // disks and Docker have been up throughout, so its events are real.
+      bootStormUntilMs = Date.now() + BOOT_STORM_WINDOW_MS;
       await dbHelper.findOneAndUpdateInDatabase(
         database,
         nodeStartupTrackerCollection,
         { _id: BOOT_HISTORY_KEY },
         { $push: { boots: { $each: [{ bootId: currentBootId, at: now }], $slice: -BOOT_HISTORY_MAX } } },
         { upsert: true },
+      );
+    }
+
+    if (previousBootId && previousBootId !== currentBootId) {
+      const previousStart = previous.at ? new Date(previous.at).toISOString() : 'unknown';
+      await recordEvent(
+        SYSTEM_APP_NAME,
+        'node_reboot',
+        `Machine rebooted: boot_id ${previousBootId.slice(0, 8)} -> ${currentBootId.slice(0, 8)}, previous FluxOS start ${previousStart}`,
       );
     }
 
@@ -245,7 +420,11 @@ module.exports = {
   getEvents,
   isNetworkMissingError,
   checkNodeReboot,
-  EPISODE_WINDOW_MS,
+  deriveMainAppName,
+  EVENT_SEVERITY,
+  BOOT_STORM_DISCOUNT,
+  BOOT_STORM_WINDOW_MS,
+  INCIDENT_BUCKET_MS,
   BOOT_HISTORY_MAX,
   SYSTEM_APP_NAME,
 };

--- a/ZelBack/src/services/appTamperingDetectionService.js
+++ b/ZelBack/src/services/appTamperingDetectionService.js
@@ -134,7 +134,9 @@ async function getNodeIdentity() {
     }
     nodeIdentityCache = {
       nodeTxid,
-      nodeOutidx,
+      // getzelnodestatus returns outidx as a string; keep the stored type
+      // numeric so fleet-level queries never juggle '0' vs 0
+      nodeOutidx: nodeOutidx === null ? null : Number(nodeOutidx),
       nodeIp: node.ip ?? null,
       pubkey: node.pubkey ?? null,
       paymentAddress: node.payment_address ?? null,

--- a/ZelBack/src/services/appTamperingDetectionService.js
+++ b/ZelBack/src/services/appTamperingDetectionService.js
@@ -174,6 +174,18 @@ async function checkNodeReboot() {
     }
     const database = db.db(config.database.local.database);
 
+    // The retired frequent_restart heuristic self-fired on the serviceManager
+    // boot retry, so live nodes carry noise rows under that type. Sweep them
+    // until every row written before the boot_id rework has aged past the
+    // 30-day TTL; after that this purge deletes nothing and can be removed.
+    try {
+      await dbHelper.removeDocumentsFromCollection(
+        database, tamperingEventsCollection, { eventType: 'frequent_restart' },
+      );
+    } catch (error) {
+      log.warn(`appTamperingDetection - legacy frequent_restart purge failed: ${error.message}`);
+    }
+
     let currentBootId = null;
     try {
       const bootIdPath = config.system?.bootIdPath ?? '/proc/sys/kernel/random/boot_id';

--- a/ZelBack/src/services/appTamperingDetectionService.js
+++ b/ZelBack/src/services/appTamperingDetectionService.js
@@ -322,9 +322,7 @@ async function recordEvent(appName, eventType, details) {
  * GET API handler. Returns tampering incidents, optionally filtered by
  * appname, most recent first. Results are capped: the route is public, so an
  * uncapped no-arg query would dump the whole collection to anyone. Documents
- * include _id as a stable paging/identity key. Pre-schema rows (detectedAt,
- * no lastSeen) sort after current-schema incidents until they age out via
- * their 30-day TTL.
+ * include _id as a stable paging/identity key.
  * Route: GET /apps/tamperingevents/:appname? (query: ?limit=1..1000)
  * @param {object} req - Express request
  * @param {object} res - Express response
@@ -380,16 +378,18 @@ async function checkNodeReboot() {
     }
     const database = db.db(config.database.local.database);
 
-    // The retired frequent_restart heuristic self-fired on the serviceManager
-    // boot retry, so live nodes carry noise rows under that type. Sweep them
-    // until every row written before the boot_id rework has aged past the
-    // 30-day TTL; after that this purge deletes nothing and can be removed.
+    // Pre-schema rows (no schemaVersion) are row-per-observation noise with
+    // no identity, severity or dedup — nothing consumes them, but the public
+    // API would keep serving them for up to 30 days of TTL. Sweeping them at
+    // startup gives an upgraded node an honest collection from its first
+    // boot. A no-op on every boot after that; removable once the fleet has
+    // upgraded past the incident schema.
     try {
       await dbHelper.removeDocumentsFromCollection(
-        database, tamperingEventsCollection, { eventType: 'frequent_restart' },
+        database, tamperingEventsCollection, { schemaVersion: { $exists: false } },
       );
     } catch (error) {
-      log.warn(`appTamperingDetection - legacy frequent_restart purge failed: ${error.message}`);
+      log.warn(`appTamperingDetection - pre-schema row purge failed: ${error.message}`);
     }
 
     // Started here (not lazily from recordEvent) so incidents written during

--- a/ZelBack/src/services/appTamperingDetectionService.js
+++ b/ZelBack/src/services/appTamperingDetectionService.js
@@ -73,6 +73,12 @@ const EVENTS_MAX_LIMIT = 1000;
 // a dead daemon on every event.
 const IDENTITY_RETRY_MS = 5 * 60 * 1000;
 const ATTRIBUTION_TTL_MS = 60 * 60 * 1000;
+// node_reboot always fires seconds after boot — before fluxd's RPC is up —
+// so without a later pass, reboot incidents would systematically carry null
+// identity (observed on the first live deploy). The backfill retries on this
+// interval until the daemon answers, stamps every unattributed incident, and
+// stops.
+const IDENTITY_BACKFILL_INTERVAL_MS = 5 * 60 * 1000;
 
 // Boot context, set once by checkNodeReboot() during startup. Until it runs
 // (or on hosts without a readable boot_id) events fall back to an 'unknown'
@@ -82,6 +88,7 @@ let bootStormUntilMs = 0;
 
 let nodeIdentityCache = null;
 let identityRetryAfterMs = 0;
+let identityBackfillTimer = null;
 const appAttributionCache = new Map(); // appName -> { ownerZelid, appHash, cachedAt }
 
 /**
@@ -138,6 +145,49 @@ async function getNodeIdentity() {
     log.debug(`appTamperingDetection - node identity unavailable: ${error.message}`);
     return null;
   }
+}
+
+/**
+ * Stamp node/operator identity onto incidents that recorded while the daemon
+ * was unreachable, retrying every IDENTITY_BACKFILL_INTERVAL_MS until it
+ * answers, then stopping for good. Keyed off nodeTxid: null — identity is
+ * constant for the life of the process, so one pass settles everything
+ * written before the daemon came up. Safe to call repeatedly (single timer).
+ */
+function startIdentityBackfill() {
+  if (identityBackfillTimer) return;
+  const attempt = async () => {
+    try {
+      const identity = await getNodeIdentity();
+      if (!identity || !identity.nodeTxid) return; // daemon not ready — next tick retries
+      const db = dbHelper.databaseConnection();
+      if (!db) return;
+      const database = db.db(config.database.local.database);
+      const result = await dbHelper.updateInDatabase(
+        database,
+        tamperingEventsCollection,
+        { schemaVersion: { $gte: 1 }, nodeTxid: null },
+        {
+          $set: {
+            nodeTxid: identity.nodeTxid,
+            nodeOutidx: identity.nodeOutidx,
+            nodeIp: identity.nodeIp,
+            pubkey: identity.pubkey,
+            paymentAddress: identity.paymentAddress,
+          },
+        },
+      );
+      const updated = result?.modifiedCount ?? 0;
+      if (updated > 0) log.info(`appTamperingDetection - backfilled identity onto ${updated} incident(s)`);
+      clearInterval(identityBackfillTimer);
+      identityBackfillTimer = null;
+    } catch (error) {
+      log.debug(`appTamperingDetection - identity backfill attempt failed: ${error.message}`);
+    }
+  };
+  identityBackfillTimer = setInterval(attempt, IDENTITY_BACKFILL_INTERVAL_MS);
+  if (identityBackfillTimer.unref) identityBackfillTimer.unref();
+  attempt();
 }
 
 /**
@@ -356,6 +406,11 @@ async function checkNodeReboot() {
       log.warn(`appTamperingDetection - legacy frequent_restart purge failed: ${error.message}`);
     }
 
+    // Started here (not lazily from recordEvent) so incidents written during
+    // boot — node_reboot above all — get their identity even on a node quiet
+    // enough that no later event ever triggers a lookup.
+    startIdentityBackfill();
+
     let bootId = null;
     try {
       const bootIdPath = config.system?.bootIdPath ?? '/proc/sys/kernel/random/boot_id';
@@ -420,11 +475,13 @@ module.exports = {
   getEvents,
   isNetworkMissingError,
   checkNodeReboot,
+  startIdentityBackfill,
   deriveMainAppName,
   EVENT_SEVERITY,
   BOOT_STORM_DISCOUNT,
   BOOT_STORM_WINDOW_MS,
   INCIDENT_BUCKET_MS,
+  IDENTITY_BACKFILL_INTERVAL_MS,
   BOOT_HISTORY_MAX,
   SYSTEM_APP_NAME,
 };

--- a/ZelBack/src/services/appTamperingDetectionService.js
+++ b/ZelBack/src/services/appTamperingDetectionService.js
@@ -70,9 +70,11 @@ const ATTRIBUTION_TTL_MS = 60 * 60 * 1000;
 // stamps every unattributed incident, and stops.
 const IDENTITY_BACKFILL_INTERVAL_MS = 5 * 60 * 1000;
 
-// Boot context, set once by checkNodeReboot() during startup. Until it runs
-// (or on hosts without a readable boot_id) events fall back to an 'unknown'
-// boot in their incident key.
+// Boot context, set by checkNodeReboot() during startup. serviceManager awaits
+// checkNodeReboot() before starting any tamper-event emitter (reconciler,
+// mount/crontab sweep, syncthing), so recordEvent sees a real bootId in normal
+// operation. The 'unknown' fallback only covers a host where boot_id itself is
+// unreadable.
 let currentBootId = null;
 
 let nodeIdentityCache = null;
@@ -132,6 +134,10 @@ async function getNodeIdentity() {
     };
     return nodeIdentityCache;
   } catch (error) {
+    // A concurrent caller (or the backfill) may have populated the cache while
+    // this RPC was in flight; prefer that over returning null and writing an
+    // unattributed row the one-shot backfill may already have stopped covering.
+    if (nodeIdentityCache) return nodeIdentityCache;
     identityRetryAfterMs = Date.now() + IDENTITY_RETRY_MS;
     log.debug(`appTamperingDetection - node identity unavailable: ${error.message}`);
     return null;
@@ -331,6 +337,9 @@ async function getEvents(req, res) {
   try {
     let { appname } = req.params;
     appname = appname || req.query.appname;
+    // The route is public: coerce to a string so a bracket-notation query
+    // (?appname[$gt]=) can't smuggle a Mongo operator object into the filter.
+    if (appname !== undefined && appname !== null) appname = String(appname);
     const requestedLimit = Number.parseInt(req.query.limit, 10);
     const limit = Number.isNaN(requestedLimit)
       ? EVENTS_DEFAULT_LIMIT

--- a/ZelBack/src/services/appTamperingDetectionService.js
+++ b/ZelBack/src/services/appTamperingDetectionService.js
@@ -43,6 +43,15 @@ const INCIDENT_BUCKET_MS = 60 * 60 * 1000;
 // (tamper, then reboot, and the evidence goes out with the boot noise).
 const BOOT_STORM_WINDOW_MS = 30 * 60 * 1000;
 const BOOT_STORM_DISCOUNT = 0.25;
+// Only the event types a boot race can actually produce are discounted inside
+// the storm window. container_vanished is deliberately absent: containers
+// persist as `exited` across a clean reboot, and a late-disk docker daemon
+// surfaces as docker-unreachable (deferred, never recorded) — so a missing
+// container is tamper signal even seconds after boot. Discounting it would
+// hand kill-style tampering a 4x discount for rebooting first, and unlike
+// persistent damage (a deleted volume re-records at full weight in the next
+// hourly bucket) a healed one-shot vanish never re-records.
+const BOOT_STORM_DISCOUNT_TYPES = ['mount_vanished', 'volume_missing', 'network_pruned', 'recreation_failed'];
 
 // Per-type severity, stamped on each incident at write time so scoring reads
 // stored values rather than re-deriving them. recreation_failed is an
@@ -481,6 +490,7 @@ module.exports = {
   deriveMainAppName,
   EVENT_SEVERITY,
   BOOT_STORM_DISCOUNT,
+  BOOT_STORM_DISCOUNT_TYPES,
   BOOT_STORM_WINDOW_MS,
   INCIDENT_BUCKET_MS,
   IDENTITY_BACKFILL_INTERVAL_MS,

--- a/ZelBack/src/services/appTamperingDetectionService.js
+++ b/ZelBack/src/services/appTamperingDetectionService.js
@@ -20,7 +20,6 @@ const { localAppsInformation } = require('./utils/appConstants');
 const tamperingEventsCollection = config.database.local.collections.appTamperingEvents;
 const nodeStartupTrackerCollection = config.database.local.collections.nodeStartupTracker;
 
-const SYSTEM_APP_NAME = '__system__';
 const STARTUP_MARKER_KEY = 'lastStartup';
 const BOOT_HISTORY_KEY = 'bootHistory';
 // ~200 boots covers >1 month even at the fastest observed abusive reboot
@@ -36,34 +35,18 @@ const BOOT_HISTORY_MAX = 200;
 // erasing distinct incidents.
 const INCIDENT_BUCKET_MS = 60 * 60 * 1000;
 
-// Events recorded within this window after a machine boot are flagged
-// duringBootStorm and down-weighted in scoring — never dropped. Any reboot
-// with a late data disk legitimately produces mount/volume events for every
-// app; outright suppression would instead hand tamperers a laundering trick
-// (tamper, then reboot, and the evidence goes out with the boot noise).
-const BOOT_STORM_WINDOW_MS = 30 * 60 * 1000;
-const BOOT_STORM_DISCOUNT = 0.25;
-// Only the event types a boot race can actually produce are discounted inside
-// the storm window. container_vanished is deliberately absent: containers
-// persist as `exited` across a clean reboot, and a late-disk docker daemon
-// surfaces as docker-unreachable (deferred, never recorded) — so a missing
-// container is tamper signal even seconds after boot. Discounting it would
-// hand kill-style tampering a 4x discount for rebooting first, and unlike
-// persistent damage (a deleted volume re-records at full weight in the next
-// hourly bucket) a healed one-shot vanish never re-records.
-const BOOT_STORM_DISCOUNT_TYPES = ['mount_vanished', 'volume_missing', 'network_pruned', 'recreation_failed'];
-
 // Per-type severity, stamped on each incident at write time so scoring reads
 // stored values rather than re-deriving them. recreation_failed is an
-// operational fault (registry, image pull, disk) and node_reboot is an
-// observation feeding operator-level analysis — both are recorded for
-// visibility but carry no tamper weight, because punishing them would
-// penalize honest nodes for infra noise. container_vanished weighs highest:
+// operational fault (registry, image pull, disk) — recorded for visibility
+// but zero-weighted, because punishing it would penalize honest nodes for
+// infra noise. container_vanished weighs highest:
 // containers persist as `exited` across a clean reboot, so a
 // positively-confirmed missing container is the strongest local indicator of
-// host-side interference this data has. The mount/volume/network types are
-// real signals but dominated by boot races, hence low severity plus the
-// boot-storm discount.
+// host-side interference this data has. The mount/volume/network types carry
+// low weight because they cannot distinguish interference from an unhealthy
+// host — fleet-wide they are dominated by persistent faults on broken nodes —
+// and a persistent fault re-records in every hourly bucket, so anything real
+// accumulates weight without needing a high per-incident severity.
 const EVENT_SEVERITY = {
   container_vanished: 3,
   network_pruned: 1,
@@ -71,7 +54,6 @@ const EVENT_SEVERITY = {
   mount_vanished: 1,
   volume_missing: 1,
   recreation_failed: 0,
-  node_reboot: 0,
 };
 
 const EVENTS_DEFAULT_LIMIT = 500;
@@ -82,18 +64,16 @@ const EVENTS_MAX_LIMIT = 1000;
 // a dead daemon on every event.
 const IDENTITY_RETRY_MS = 5 * 60 * 1000;
 const ATTRIBUTION_TTL_MS = 60 * 60 * 1000;
-// node_reboot always fires seconds after boot — before fluxd's RPC is up —
-// so without a later pass, reboot incidents would systematically carry null
-// identity (observed on the first live deploy). The backfill retries on this
-// interval until the daemon answers, stamps every unattributed incident, and
-// stops.
+// The boot-sweep harvest (mount/volume checks) fires before fluxd's RPC is
+// up, so without a later pass its incidents would systematically carry null
+// identity. The backfill retries on this interval until the daemon answers,
+// stamps every unattributed incident, and stops.
 const IDENTITY_BACKFILL_INTERVAL_MS = 5 * 60 * 1000;
 
 // Boot context, set once by checkNodeReboot() during startup. Until it runs
 // (or on hosts without a readable boot_id) events fall back to an 'unknown'
-// boot in their incident key and are never flagged as boot storm.
+// boot in their incident key.
 let currentBootId = null;
-let bootStormUntilMs = 0;
 
 let nodeIdentityCache = null;
 let identityRetryAfterMs = 0;
@@ -227,7 +207,7 @@ function deriveMainAppName(appName) {
  * @returns {Promise<object|null>}
  */
 async function getAppAttribution(appName) {
-  if (!appName || appName === SYSTEM_APP_NAME) return null;
+  if (!appName) return null;
   const cached = appAttributionCache.get(appName);
   if (cached && Date.now() - cached.cachedAt < ATTRIBUTION_TTL_MS) return cached;
   try {
@@ -265,10 +245,10 @@ async function getAppAttribution(appName) {
  * the boot_id plus an hourly time bucket; repeat calls increment `count` and
  * advance `lastSeen`, so retry storms collapse while the incident keeps its
  * full observation tally. Each document carries node identity, operator
- * identity, app attribution, severity and boot-storm context so fleet-level
- * consumers can attribute and weigh it without joining local state.
+ * identity, app attribution and severity so fleet-level consumers can
+ * attribute and weigh it without joining local state.
  * Documents expire 30 days after lastSeen (TTL index).
- * @param {string} appName - Application name (or SYSTEM_APP_NAME)
+ * @param {string} appName - Application name
  * @param {string} eventType - One of the EVENT_SEVERITY keys
  * @param {string} details - Free-text context (stored once per incident)
  */
@@ -282,7 +262,6 @@ async function recordEvent(appName, eventType, details) {
     const database = db.db(config.database.local.database);
     const now = new Date();
     const incidentKey = `${currentBootId ?? 'unknown'}:${Math.floor(now.getTime() / INCIDENT_BUCKET_MS)}`;
-    const duringBootStorm = now.getTime() < bootStormUntilMs;
     const [identity, attribution] = await Promise.all([
       getNodeIdentity(),
       getAppAttribution(appName),
@@ -295,7 +274,6 @@ async function recordEvent(appName, eventType, details) {
         eventType,
         incidentKey,
         severity: EVENT_SEVERITY[eventType] ?? 0,
-        duringBootStorm,
         bootId: currentBootId,
         uptimeSecAtEvent: Math.round(os.uptime()),
         firstSeen: now,
@@ -331,7 +309,7 @@ async function recordEvent(appName, eventType, details) {
     // doc or null; older shapes return { value, lastErrorObject }.
     const inserted = !result || result.value === null || result?.lastErrorObject?.updatedExisting === false;
     if (inserted) {
-      log.info(`appTamperingDetection - recorded ${eventType} for ${appName}${duringBootStorm ? ' (boot storm)' : ''}`);
+      log.info(`appTamperingDetection - recorded ${eventType} for ${appName}`);
     } else {
       log.debug(`appTamperingDetection - ${eventType} for ${appName} repeated, incident count incremented`);
     }
@@ -379,11 +357,8 @@ async function getEvents(req, res) {
  * Startup check: distinguishes a genuine machine reboot from a mere process
  * restart using the kernel boot identity (/proc/sys/kernel/random/boot_id — a
  * UUID regenerated on every boot, stable across process restarts). On a
- * genuine reboot it records a single `node_reboot` observation under the
- * synthetic __system__ app, appends the boot to a rolling history so
- * consumers can derive a reboot rate/cadence, and opens the boot-storm
- * window that down-weights the mount/volume/network noise any boot with a
- * late data disk produces.
+ * genuine reboot it appends the boot to a rolling history in
+ * nodestartuptracker so consumers can derive a reboot rate/cadence.
  *
  * This replaces a wall-clock `frequent_restart` heuristic that measured
  * process-start gaps: a crash-loop or the serviceManager boot-retry looked
@@ -418,8 +393,9 @@ async function checkNodeReboot() {
     }
 
     // Started here (not lazily from recordEvent) so incidents written during
-    // boot — node_reboot above all — get their identity even on a node quiet
-    // enough that no later event ever triggers a lookup.
+    // boot — the boot-sweep mount/volume harvest fires before fluxd's RPC is
+    // up — get their identity even on a node quiet enough that no later event
+    // ever triggers a lookup.
     startIdentityBackfill();
 
     let bootId = null;
@@ -445,28 +421,23 @@ async function checkNodeReboot() {
 
     if (previousBootId !== currentBootId) {
       // First sighting of this boot_id: genuine reboot, first run, or upgrade
-      // from the pre-boot_id marker. All three open the boot-storm window —
-      // when we cannot prove the machine did NOT just boot, erring toward the
-      // discount protects honest nodes and costs a tamperer nothing (the
-      // events still record). A same-boot_id process restart opens nothing:
-      // disks and Docker have been up throughout, so its events are real.
-      bootStormUntilMs = Date.now() + BOOT_STORM_WINDOW_MS;
+      // from the pre-boot_id marker. All three land in the boot history; a
+      // same-boot_id process restart does not, keeping the history a record
+      // of machine boots rather than FluxOS restarts. `bootedAt` is the
+      // machine's boot moment (uptime-derived) — cadence consumers want the
+      // boot period itself, free of FluxOS's variable start lag; `at` is when
+      // FluxOS first saw the boot.
+      const bootedAt = new Date(now.getTime() - Math.round(os.uptime() * 1000));
       await dbHelper.findOneAndUpdateInDatabase(
         database,
         nodeStartupTrackerCollection,
         { _id: BOOT_HISTORY_KEY },
-        { $push: { boots: { $each: [{ bootId: currentBootId, at: now }], $slice: -BOOT_HISTORY_MAX } } },
+        { $push: { boots: { $each: [{ bootId: currentBootId, bootedAt, at: now }], $slice: -BOOT_HISTORY_MAX } } },
         { upsert: true },
       );
-    }
-
-    if (previousBootId && previousBootId !== currentBootId) {
-      const previousStart = previous.at ? new Date(previous.at).toISOString() : 'unknown';
-      await recordEvent(
-        SYSTEM_APP_NAME,
-        'node_reboot',
-        `Machine rebooted: boot_id ${previousBootId.slice(0, 8)} -> ${currentBootId.slice(0, 8)}, previous FluxOS start ${previousStart}`,
-      );
+      if (previousBootId) {
+        log.info(`appTamperingDetection - machine reboot: boot_id ${previousBootId.slice(0, 8)} -> ${currentBootId.slice(0, 8)}`);
+      }
     }
 
     await dbHelper.findOneAndUpdateInDatabase(
@@ -489,11 +460,7 @@ module.exports = {
   startIdentityBackfill,
   deriveMainAppName,
   EVENT_SEVERITY,
-  BOOT_STORM_DISCOUNT,
-  BOOT_STORM_DISCOUNT_TYPES,
-  BOOT_STORM_WINDOW_MS,
   INCIDENT_BUCKET_MS,
   IDENTITY_BACKFILL_INTERVAL_MS,
   BOOT_HISTORY_MAX,
-  SYSTEM_APP_NAME,
 };

--- a/ZelBack/src/services/appTamperingDetectionService.js
+++ b/ZelBack/src/services/appTamperingDetectionService.js
@@ -1,14 +1,39 @@
 const config = require('config');
+const fs = require('fs').promises;
 const log = require('../lib/log');
 const dbHelper = require('./dbHelper');
 const messageHelper = require('./messageHelper');
 
+// All tamper-feature behaviour (episode dedup, boot identity, event taxonomy)
+// deliberately lives inside this service rather than at the emitting call
+// sites: the call sites (appReconciler, crontabAndMountsCleanup,
+// syncthingFolderStateMachine) sit in files under heavy parallel rework on the
+// v9 branch, while this file is identical across branches. Centralizing here
+// keeps the feature rebase-safe and guarantees every emitter gets the same
+// semantics without call-site edits.
+
 const tamperingEventsCollection = config.database.local.collections.appTamperingEvents;
 const nodeStartupTrackerCollection = config.database.local.collections.nodeStartupTracker;
 
-const FREQUENT_RESTART_THRESHOLD_MS = 60 * 60 * 1000; // 1 hour
-const STARTUP_MARKER_KEY = 'lastStartup';
 const SYSTEM_APP_NAME = '__system__';
+const STARTUP_MARKER_KEY = 'lastStartup';
+const BOOT_HISTORY_KEY = 'bootHistory';
+// ~200 boots covers >1 month even at the fastest observed abusive reboot
+// cadence (~4h), comfortably beyond the collection's 30-day event TTL.
+const BOOT_HISTORY_MAX = 200;
+
+// One row per (appName, eventType) per hour. The reconciler re-attempts a
+// failed recreation on a seconds-scale backoff and re-sweeps hourly, so a
+// single persistent fault (unpullable image, missing volume) used to insert
+// hundreds of rows for one incident, drowning genuine signal and inflating
+// the enforcement count. Suppressed repeats are dropped, not counted, until
+// the phase-1 incident schema adds first/last-seen rollups.
+const EPISODE_WINDOW_MS = 60 * 60 * 1000;
+// `${appName}|${eventType}` -> epoch ms of the last inserted row. In-memory
+// on purpose: a process restart clears it, and per-boot events (mount races
+// on a late data disk) should record once per boot.
+const episodeMarkers = new Map();
+const EPISODE_MARKERS_MAX = 1000;
 
 /**
  * Returns true when a Docker/daemon error message indicates a missing network
@@ -29,16 +54,36 @@ function isNetworkMissingError(errorMessage) {
 }
 
 /**
- * Record a tampering event as a new row in the events collection.
- * Each call inserts a new document so the full history per app is preserved.
- * Documents expire automatically 30 days after detectedAt (TTL index).
- * @param {string} appName - Application name
- * @param {string} eventType - One of: container_vanished, network_pruned,
- *   mount_vanished, crontab_wiped, recreation_failed, network_detached
+ * Drop episode markers whose window has already elapsed so the map cannot
+ * grow unbounded on a node with many flapping apps.
+ * @param {number} now - Current epoch ms
+ */
+function pruneExpiredEpisodeMarkers(now) {
+  episodeMarkers.forEach((recordedAt, key) => {
+    if (now - recordedAt >= EPISODE_WINDOW_MS) episodeMarkers.delete(key);
+  });
+}
+
+/**
+ * Record a tampering event. Inserts one row per (appName, eventType) episode:
+ * repeat calls inside EPISODE_WINDOW_MS after a successful insert are dropped,
+ * so retry storms collapse into a single row while distinct incidents in later
+ * windows still record. Documents expire 30 days after detectedAt (TTL index).
+ * @param {string} appName - Application name (or SYSTEM_APP_NAME)
+ * @param {string} eventType - One of: container_vanished, recreation_failed,
+ *   network_pruned, network_detached, mount_vanished, volume_missing,
+ *   node_reboot
  * @param {string} details - Free-text context about the event
  */
 async function recordEvent(appName, eventType, details) {
   try {
+    const now = Date.now();
+    const episodeKey = `${appName}|${eventType}`;
+    const lastRecordedAt = episodeMarkers.get(episodeKey);
+    if (lastRecordedAt !== undefined && now - lastRecordedAt < EPISODE_WINDOW_MS) {
+      log.debug(`appTamperingDetection - ${eventType} for ${appName} already recorded this episode, skipping`);
+      return;
+    }
     const db = dbHelper.databaseConnection();
     if (!db) {
       log.warn('appTamperingDetection - DB not available, skipping event');
@@ -52,16 +97,26 @@ async function recordEvent(appName, eventType, details) {
       detectedAt: new Date(),
     };
     await dbHelper.insertOneToDatabase(database, tamperingEventsCollection, doc);
+    // Marked only after a successful insert: a failed write must not consume
+    // the episode, otherwise the event would be silently lost for an hour.
+    episodeMarkers.set(episodeKey, now);
+    if (episodeMarkers.size > EPISODE_MARKERS_MAX) pruneExpiredEpisodeMarkers(now);
     log.info(`appTamperingDetection - recorded ${eventType} for ${appName}`);
   } catch (error) {
     log.error(`appTamperingDetection - failed to record event: ${error.message}`);
   }
 }
 
+const EVENTS_DEFAULT_LIMIT = 500;
+const EVENTS_MAX_LIMIT = 1000;
+
 /**
- * GET API handler. Returns all tampering events, optionally filtered by appname,
- * sorted by most recent first.
- * Route: GET /apps/tamperingevents/:appname?
+ * GET API handler. Returns tampering events, optionally filtered by appname,
+ * sorted by most recent first. Results are capped: the route is public, so an
+ * uncapped no-arg query would dump the whole collection to anyone. A stable
+ * paging key arrives with the phase-1 schema (_id is stripped today); until
+ * then newest-first plus `limit` is the supported access pattern.
+ * Route: GET /apps/tamperingevents/:appname? (query: ?limit=1..1000)
  * @param {object} req - Express request
  * @param {object} res - Express response
  */
@@ -69,10 +124,16 @@ async function getEvents(req, res) {
   try {
     let { appname } = req.params;
     appname = appname || req.query.appname;
+    const requestedLimit = Number.parseInt(req.query.limit, 10);
+    const limit = Number.isNaN(requestedLimit)
+      ? EVENTS_DEFAULT_LIMIT
+      : Math.min(Math.max(requestedLimit, 1), EVENTS_MAX_LIMIT);
     const db = dbHelper.databaseConnection();
     const database = db.db(config.database.local.database);
     const query = appname ? { appName: appname } : {};
-    const projection = { projection: { _id: 0 }, sort: { detectedAt: -1 } };
+    const projection = {
+      projection: { _id: 0 }, sort: { detectedAt: -1 }, limit,
+    };
     const results = await dbHelper.findInDatabase(
       database, tamperingEventsCollection, query, projection,
     );
@@ -86,43 +147,84 @@ async function getEvents(req, res) {
 }
 
 /**
- * Compares the current time to the previous recorded startup time. If the
- * gap is less than one hour, records a `frequent_restart` tampering event
- * under a synthetic system app name. Always updates the startup marker to
- * "now" before returning. Called once per FluxOS startup.
+ * Startup check: distinguishes a genuine machine reboot from a mere process
+ * restart using the kernel boot identity (/proc/sys/kernel/random/boot_id — a
+ * UUID regenerated on every boot, stable across process restarts). On a
+ * genuine reboot it records a single `node_reboot` observation under the
+ * synthetic __system__ app and appends the boot to a rolling history, so
+ * consumers can derive a reboot *rate/cadence* instead of a single interval.
+ *
+ * This replaces a wall-clock `frequent_restart` heuristic that measured
+ * process-start gaps: a crash-loop or the serviceManager boot-retry looked
+ * like a reboot (false positive), any reboot cycle slower than its 1h window
+ * was invisible (false negative), and clock skew across a hard reboot both
+ * evaded it and reset its baseline. boot_id comparison is immune to all three.
+ *
+ * The AppSyncOrchestrator heartbeat doc (same collection) also carries a
+ * machineBootId, but it is written only once that service starts — later in
+ * boot than this check runs — and is owned by it; reading it here would tie
+ * correctness to startup ordering. This service owns its own marker instead.
  */
-async function checkFrequentRestart() {
+async function checkNodeReboot() {
   try {
     const db = dbHelper.databaseConnection();
     if (!db) {
-      log.warn('appTamperingDetection - DB not available, skipping frequent-restart check');
+      log.warn('appTamperingDetection - DB not available, skipping reboot check');
       return;
     }
     const database = db.db(config.database.local.database);
+
+    let currentBootId = null;
+    try {
+      const bootIdPath = config.system?.bootIdPath ?? '/proc/sys/kernel/random/boot_id';
+      currentBootId = (await fs.readFile(bootIdPath, 'utf8')).trim();
+    } catch (error) {
+      currentBootId = null;
+    }
+    if (!currentBootId) {
+      // Without a boot identity, reboot vs restart is guesswork — recording
+      // anything here would reintroduce the noise this check exists to remove.
+      log.warn('appTamperingDetection - boot_id unreadable, skipping reboot check');
+      return;
+    }
+
     const now = new Date();
     const previous = await dbHelper.findOneInDatabase(
       database, nodeStartupTrackerCollection, { _id: STARTUP_MARKER_KEY },
     );
-    if (previous && previous.at) {
-      const delta = now.getTime() - new Date(previous.at).getTime();
-      if (delta >= 0 && delta < FREQUENT_RESTART_THRESHOLD_MS) {
-        const deltaSec = Math.floor(delta / 1000);
-        await recordEvent(
-          SYSTEM_APP_NAME,
-          'frequent_restart',
-          `FluxOS restarted ${deltaSec}s after previous start`,
-        );
-      }
+    const previousBootId = previous && previous.bootId ? previous.bootId : null;
+
+    if (previousBootId && previousBootId !== currentBootId) {
+      const previousStart = previous.at ? new Date(previous.at).toISOString() : 'unknown';
+      await recordEvent(
+        SYSTEM_APP_NAME,
+        'node_reboot',
+        `Machine rebooted: boot_id ${previousBootId.slice(0, 8)} -> ${currentBootId.slice(0, 8)}, previous FluxOS start ${previousStart}`,
+      );
     }
+
+    if (previousBootId !== currentBootId) {
+      // First sighting of this boot_id (reboot, first run, or upgrade from the
+      // pre-boot_id marker). A same-boot_id process restart adds no entry, so
+      // the history reflects machine boots only.
+      await dbHelper.findOneAndUpdateInDatabase(
+        database,
+        nodeStartupTrackerCollection,
+        { _id: BOOT_HISTORY_KEY },
+        { $push: { boots: { $each: [{ bootId: currentBootId, at: now }], $slice: -BOOT_HISTORY_MAX } } },
+        { upsert: true },
+      );
+    }
+
     await dbHelper.findOneAndUpdateInDatabase(
       database,
       nodeStartupTrackerCollection,
       { _id: STARTUP_MARKER_KEY },
-      { $set: { at: now } },
+      { $set: { at: now, bootId: currentBootId } },
       { upsert: true },
     );
   } catch (error) {
-    log.error(`appTamperingDetection - checkFrequentRestart failed: ${error.message}`);
+    log.error(`appTamperingDetection - checkNodeReboot failed: ${error.message}`);
   }
 }
 
@@ -130,7 +232,8 @@ module.exports = {
   recordEvent,
   getEvents,
   isNetworkMissingError,
-  checkFrequentRestart,
-  FREQUENT_RESTART_THRESHOLD_MS,
+  checkNodeReboot,
+  EPISODE_WINDOW_MS,
+  BOOT_HISTORY_MAX,
   SYSTEM_APP_NAME,
 };

--- a/ZelBack/src/services/appTamperingDetectionService.js
+++ b/ZelBack/src/services/appTamperingDetectionService.js
@@ -34,7 +34,7 @@ function isNetworkMissingError(errorMessage) {
  * Documents expire automatically 30 days after detectedAt (TTL index).
  * @param {string} appName - Application name
  * @param {string} eventType - One of: container_vanished, network_pruned,
- *   mount_vanished, crontab_wiped, recreation_failed
+ *   mount_vanished, crontab_wiped, recreation_failed, network_detached
  * @param {string} details - Free-text context about the event
  */
 async function recordEvent(appName, eventType, details) {

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -1473,6 +1473,34 @@ async function getFluxDockerNetworkSubnets() {
 }
 
 /**
+ * Returns the lowest free third octet for a new flux app network
+ * (172.23.<octet>.0/24). It scans EVERY docker network's subnet (not just flux
+ * ones) because docker enforces subnet uniqueness across all networks - a non-flux
+ * network sitting on a 172.23.x block must be treated as used or the create would
+ * fail. The optional excludeOctets lets a caller skip octets it has already lost a
+ * create race on this attempt, so a bounded collision retry keeps advancing to a
+ * genuinely free octet rather than re-picking the same one. Deterministic and
+ * reports exhaustion definitively (null) rather than guessing.
+ * @param {Set<number>} [excludeOctets] octets to treat as used (already tried/lost)
+ * @returns {Promise<number|null>} lowest free octet in 1..255, or null if none free
+ */
+async function getFreeFluxAppNetworkOctet(excludeOctets = new Set()) {
+  const networks = await docker.listNetworks();
+  const used = new Set(excludeOctets);
+  networks.forEach((network) => {
+    const configs = (network.IPAM && network.IPAM.Config) || [];
+    configs.forEach((cfg) => {
+      const match = /^172\.23\.(\d{1,3})\.0\/24$/.exec((cfg && cfg.Subnet) || '');
+      if (match) used.add(Number(match[1]));
+    });
+  });
+  for (let octet = 1; octet <= 255; octet += 1) {
+    if (!used.has(octet)) return octet;
+  }
+  return null;
+}
+
+/**
  * Creates flux application docker network if doesn't exist
  *
  * @returns {object} response
@@ -1878,6 +1906,7 @@ module.exports = {
   getDockerContainerOnly,
   getFluxDockerNetworkPhysicalInterfaceNames,
   getFluxDockerNetworkSubnets,
+  getFreeFluxAppNetworkOctet,
   migrateContainerRestartPolicies,
   pruneContainers,
   pruneImages,

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -1288,10 +1288,9 @@ async function appDockerImageRemove(idOrName) {
  * carries it (or carries it without an IP). Such a container runs with no IP, no
  * embedded DNS (it cannot resolve sibling components by name) and no published
  * ports, and a plain start never repairs it - only a recreate, which allocates a
- * fresh endpoint, clears the stale state. These helpers surface that condition so
- * callers (the reconciler) can detect and heal it. parseContainerNetworkAttachment
- * is the pure classifier over a Docker inspect object; getContainerNetworkAttachment
- * is the inspect-and-classify wrapper.
+ * fresh endpoint, clears the stale state. This pure classifier over a Docker
+ * inspect object surfaces that condition so callers (the reconciler, which
+ * already holds the inspect) can detect and heal it.
  *
  * @param {object} info - a Docker container inspect object
  * @returns {{managed: boolean, running: boolean, networkMode: (string|null), attached: boolean}}
@@ -1314,14 +1313,9 @@ function parseContainerNetworkAttachment(info) {
   };
 }
 
-async function getContainerNetworkAttachment(idOrName) {
-  const info = await dockerContainerInspect(idOrName);
-  return parseContainerNetworkAttachment(info);
-}
-
 /**
  * Whether a container is running but not attached to its own managed network -
- * the unrecoverable-by-restart state described in getContainerNetworkAttachment.
+ * the unrecoverable-by-restart state described in parseContainerNetworkAttachment.
  * A non-managed (host/none/bridge) container is never considered detached.
  *
  * @param {{managed: boolean, running: boolean, attached: boolean}} attachment
@@ -1882,7 +1876,6 @@ module.exports = {
   getAppContainerObjects,
   getAppNameByContainerIp,
   parseContainerNetworkAttachment,
-  getContainerNetworkAttachment,
   isContainerDetachedFromNetwork,
   dockerNetworkExists,
   waitForDocker,

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -1333,6 +1333,25 @@ function isContainerDetachedFromNetwork(attachment) {
 }
 
 /**
+ * Whether a docker network exists, by name. Used to distinguish a stale endpoint
+ * (network present, container not attached - recreatable) from a pruned network
+ * (network gone - a recreate would fail on a missing NetworkMode). Any inspect
+ * failure is treated as "does not exist".
+ *
+ * @param {string} networkName
+ * @returns {Promise<boolean>}
+ */
+async function dockerNetworkExists(networkName) {
+  if (!networkName) return false;
+  try {
+    await docker.getNetwork(networkName).inspect();
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
+
+/**
  * Pauses app's docker.
  *
  * @param {string} idOrName
@@ -1865,5 +1884,6 @@ module.exports = {
   parseContainerNetworkAttachment,
   getContainerNetworkAttachment,
   isContainerDetachedFromNetwork,
+  dockerNetworkExists,
   waitForDocker,
 };

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -1298,7 +1298,7 @@ async function appDockerImageRemove(idOrName) {
  *   running  - the container task is running
  *   attached - the NetworkMode network is present in Networks with an IP
  */
-function parseContainerNetworkAttachment(info) {
+function classifyContainerNetworkAttachment(info) {
   const networkMode = info && info.HostConfig ? info.HostConfig.NetworkMode || null : null;
   const running = !!(info && info.State && info.State.Running);
   const managed = typeof networkMode === 'string' && networkMode.startsWith('fluxDockerNetwork_');
@@ -1315,7 +1315,7 @@ function parseContainerNetworkAttachment(info) {
 
 /**
  * Whether a container is running but not attached to its own managed network -
- * the unrecoverable-by-restart state described in parseContainerNetworkAttachment.
+ * the unrecoverable-by-restart state described in classifyContainerNetworkAttachment.
  * A non-managed (host/none/bridge) container is never considered detached.
  *
  * @param {{managed: boolean, running: boolean, attached: boolean}} attachment
@@ -1327,21 +1327,35 @@ function isContainerDetachedFromNetwork(attachment) {
 }
 
 /**
- * Whether a docker network exists, by name. Used to distinguish a stale endpoint
- * (network present, container not attached - recreatable) from a pruned network
- * (network gone - a recreate would fail on a missing NetworkMode). Any inspect
- * failure is treated as "does not exist".
+ * Reads whether a docker network is present, by name. Used to distinguish a
+ * stale endpoint (network present, container not attached - recreatable) from a
+ * pruned network (network gone - a recreate would fail on a missing NetworkMode).
+ *
+ * A failed inspect is ambiguous - the network may be genuinely gone, or the one
+ * call may have failed while docker is fine - and the caller acts destructively
+ * on the answer, so absence is never inferred from an error. On an inspect
+ * failure we probe the daemon with a list call and use its ANSWER, not just its
+ * success (the same pattern the reconciler's dockerActual uses):
+ *   - list throws          -> 'unknown'  (docker is unhappy: the caller defers)
+ *   - the network IS listed -> 'exists'  (the inspect failure was transient)
+ *   - NOT listed            -> 'absent'  (docker itself confirms absence)
  *
  * @param {string} networkName
- * @returns {Promise<boolean>}
+ * @returns {Promise<'exists'|'absent'|'unknown'>}
  */
-async function dockerNetworkExists(networkName) {
-  if (!networkName) return false;
+async function dockerNetworkState(networkName) {
+  if (!networkName) return 'absent';
   try {
     await docker.getNetwork(networkName).inspect();
-    return true;
+    return 'exists';
   } catch (err) {
-    return false;
+    let networks;
+    try {
+      networks = await docker.listNetworks();
+    } catch (probeErr) {
+      return 'unknown';
+    }
+    return networks.some((n) => n.Name === networkName) ? 'exists' : 'absent';
   }
 }
 
@@ -1875,8 +1889,8 @@ module.exports = {
   getAppContainerNames,
   getAppContainerObjects,
   getAppNameByContainerIp,
-  parseContainerNetworkAttachment,
+  classifyContainerNetworkAttachment,
   isContainerDetachedFromNetwork,
-  dockerNetworkExists,
+  dockerNetworkState,
   waitForDocker,
 };

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -1276,6 +1276,63 @@ async function appDockerImageRemove(idOrName) {
 }
 
 /**
+ * Reads a container's network attachment against its own configured NetworkMode.
+ *
+ * A Flux app component container is created with NetworkMode =
+ * fluxDockerNetwork_<app> and a matching endpoint in NetworkSettings.Networks
+ * (see appDockerCreate). A start that fails "programming external connectivity"
+ * - e.g. a host-port bind conflict during a restart after an unclean reboot -
+ * can leave libnetwork holding a stale endpoint for that container: the next
+ * `docker start` then brings the task up attached to NO network at all.
+ * NetworkMode still names the network, but NetworkSettings.Networks no longer
+ * carries it (or carries it without an IP). Such a container runs with no IP, no
+ * embedded DNS (it cannot resolve sibling components by name) and no published
+ * ports, and a plain start never repairs it - only a recreate, which allocates a
+ * fresh endpoint, clears the stale state. These helpers surface that condition so
+ * callers (the reconciler) can detect and heal it. parseContainerNetworkAttachment
+ * is the pure classifier over a Docker inspect object; getContainerNetworkAttachment
+ * is the inspect-and-classify wrapper.
+ *
+ * @param {object} info - a Docker container inspect object
+ * @returns {{managed: boolean, running: boolean, networkMode: (string|null), attached: boolean}}
+ *   managed  - NetworkMode is a fluxDockerNetwork_* (we own its networking)
+ *   running  - the container task is running
+ *   attached - the NetworkMode network is present in Networks with an IP
+ */
+function parseContainerNetworkAttachment(info) {
+  const networkMode = info && info.HostConfig ? info.HostConfig.NetworkMode || null : null;
+  const running = !!(info && info.State && info.State.Running);
+  const managed = typeof networkMode === 'string' && networkMode.startsWith('fluxDockerNetwork_');
+  let attached = false;
+  if (managed) {
+    const networks = (info && info.NetworkSettings && info.NetworkSettings.Networks) || {};
+    const endpoint = networks[networkMode];
+    attached = !!(endpoint && endpoint.IPAddress);
+  }
+  return {
+    managed, running, networkMode, attached,
+  };
+}
+
+async function getContainerNetworkAttachment(idOrName) {
+  const info = await dockerContainerInspect(idOrName);
+  return parseContainerNetworkAttachment(info);
+}
+
+/**
+ * Whether a container is running but not attached to its own managed network -
+ * the unrecoverable-by-restart state described in getContainerNetworkAttachment.
+ * A non-managed (host/none/bridge) container is never considered detached.
+ *
+ * @param {{managed: boolean, running: boolean, attached: boolean}} attachment
+ * @returns {boolean}
+ */
+function isContainerDetachedFromNetwork(attachment) {
+  if (!attachment) return false;
+  return !!(attachment.managed && attachment.running && !attachment.attached);
+}
+
+/**
  * Pauses app's docker.
  *
  * @param {string} idOrName
@@ -1805,5 +1862,8 @@ module.exports = {
   getAppContainerNames,
   getAppContainerObjects,
   getAppNameByContainerIp,
+  parseContainerNetworkAttachment,
+  getContainerNetworkAttachment,
+  isContainerDetachedFromNetwork,
   waitForDocker,
 };

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -186,8 +186,9 @@ async function startFluxFunctions() {
     await ensureIndex(database.collection(config.database.local.collections.completedPayments), { paymentId: 1 });
     await ensureIndex(database.collection(config.database.local.collections.completedPayments), { createdAt: 1 }, { expireAfterSeconds: 7 * 24 * 60 * 60 });
     // legacy pre-incident-schema rows expire via detectedAt; current incident
-    // documents expire via lastSeen. Drop the detectedAt pair once every
-    // pre-schema row has aged past the 30-day TTL.
+    // documents expire via lastSeen. The tamper service purges pre-schema
+    // rows at startup, so the detectedAt pair only matters where old code
+    // still writes; drop it once the fleet is past the incident schema.
     await ensureIndex(
       database.collection(config.database.local.collections.appTamperingEvents),
       { detectedAt: 1 },

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -185,6 +185,9 @@ async function startFluxFunctions() {
     await ensureIndex(database.collection(config.database.local.collections.activePaymentRequests), { createdAt: 1 }, { expireAfterSeconds: 3600 });
     await ensureIndex(database.collection(config.database.local.collections.completedPayments), { paymentId: 1 });
     await ensureIndex(database.collection(config.database.local.collections.completedPayments), { createdAt: 1 }, { expireAfterSeconds: 7 * 24 * 60 * 60 });
+    // legacy pre-incident-schema rows expire via detectedAt; current incident
+    // documents expire via lastSeen. Drop the detectedAt pair once every
+    // pre-schema row has aged past the 30-day TTL.
     await ensureIndex(
       database.collection(config.database.local.collections.appTamperingEvents),
       { detectedAt: 1 },
@@ -194,6 +197,24 @@ async function startFluxFunctions() {
       database.collection(config.database.local.collections.appTamperingEvents),
       { appName: 1, detectedAt: -1 },
       { name: 'appName_detectedAt' },
+    );
+    await ensureIndex(
+      database.collection(config.database.local.collections.appTamperingEvents),
+      { lastSeen: 1 },
+      { expireAfterSeconds: 30 * 24 * 60 * 60, name: 'lastSeen_ttl' }, // 30 days
+    );
+    // upsert key of the incident rollup; unique so concurrent recorders
+    // cannot double-insert an incident. Partial: legacy rows lack incidentKey
+    // and would otherwise collide on null.
+    await ensureIndex(
+      database.collection(config.database.local.collections.appTamperingEvents),
+      { appName: 1, eventType: 1, incidentKey: 1 },
+      { unique: true, partialFilterExpression: { incidentKey: { $exists: true } }, name: 'incident_upsert' },
+    );
+    await ensureIndex(
+      database.collection(config.database.local.collections.appTamperingEvents),
+      { appName: 1, eventType: 1, lastSeen: -1 },
+      { name: 'appName_eventType_lastSeen' },
     );
     await appTamperingDetectionService.checkNodeReboot();
     // appsRuntimeState (localzelapps): merge any pre-unique-index duplicate docs,

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -195,7 +195,7 @@ async function startFluxFunctions() {
       { appName: 1, detectedAt: -1 },
       { name: 'appName_detectedAt' },
     );
-    await appTamperingDetectionService.checkFrequentRestart();
+    await appTamperingDetectionService.checkNodeReboot();
     // appsRuntimeState (localzelapps): merge any pre-unique-index duplicate docs,
     // then enforce one doc per component identifier
     await appsRuntimeState.prepareCollection();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flux",
-  "version": "8.16.1",
+  "version": "8.17.0",
   "description": "Flux, Your Gateway to a Decentralized World",
   "repository": {
     "type": "git",

--- a/tests/unit/appInstaller.test.js
+++ b/tests/unit/appInstaller.test.js
@@ -2,6 +2,27 @@ const { expect } = require('chai');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
 
+// The full-install dockerService stub, shared by every proxyquire setup that
+// drives registerAppLocally. Pass overrides for the few tests that need a
+// specific return (e.g. a distinct getAppIdentifier or a shared pruneContainers
+// spy). Fresh sinon stubs per call, so each proxyquired module gets its own.
+const makeDockerServiceStub = (overrides = {}) => ({
+  dockerListContainers: sinon.stub().resolves([]),
+  pruneContainers: sinon.stub().resolves(),
+  pruneNetworks: sinon.stub().resolves(),
+  pruneVolumes: sinon.stub().resolves(),
+  pruneImages: sinon.stub().resolves(),
+  dockerNetworkState: sinon.stub().resolves('absent'),
+  getFreeFluxAppNetworkOctet: sinon.stub().resolves(1),
+  createFluxAppDockerNetwork: sinon.stub().resolves('network-created'),
+  getFluxDockerNetworkPhysicalInterfaceNames: sinon.stub().resolves([]),
+  appDockerCreate: sinon.stub().resolves(),
+  appDockerStart: sinon.stub().resolves('container-started'),
+  getAppIdentifier: sinon.stub().returns('testapp'),
+  dockerPullStream: sinon.stub().resolves('pulled'),
+  ...overrides,
+});
+
 describe('appInstaller tests', () => {
   let appInstaller;
   let verificationHelperStub;
@@ -141,19 +162,7 @@ describe('appInstaller tests', () => {
       '../geolocationService': {
         isStaticIP: sinon.stub().returns(true),
       },
-      '../dockerService': {
-        dockerListContainers: sinon.stub().resolves([]),
-        pruneContainers: sinon.stub().resolves(),
-        pruneNetworks: sinon.stub().resolves(),
-        pruneVolumes: sinon.stub().resolves(),
-        pruneImages: sinon.stub().resolves(),
-        createFluxAppDockerNetwork: sinon.stub().resolves('network-created'),
-        getFluxDockerNetworkPhysicalInterfaceNames: sinon.stub().resolves([]),
-        appDockerCreate: sinon.stub().resolves(),
-        appDockerStart: sinon.stub().resolves('container-started'),
-        getAppIdentifier: sinon.stub().returns('testapp'),
-        dockerPullStream: sinon.stub().yields(null, 'pulled'),
-      },
+      '../dockerService': makeDockerServiceStub({ dockerPullStream: sinon.stub().yields(null, 'pulled') }),
       './appUninstaller': {
         removeAppLocally: sinon.stub().resolves(),
       },
@@ -609,8 +618,6 @@ describe('appInstaller tests', () => {
         systemArchitecture: sinon.stub().resolves('amd64'), // Node is AMD64
       };
 
-      const registerAppLocallyStub = sinon.stub().resolves();
-
       const appInstallerForArchTest = proxyquire('../../ZelBack/src/services/appLifecycle/appInstaller', {
         config: configStub,
         '../verificationHelper': verificationHelperStub,
@@ -646,19 +653,7 @@ describe('appInstaller tests', () => {
         '../geolocationService': {
           isStaticIP: sinon.stub().returns(true),
         },
-        '../dockerService': {
-          dockerListContainers: sinon.stub().resolves([]),
-          pruneContainers: sinon.stub().resolves(),
-          pruneNetworks: sinon.stub().resolves(),
-          pruneVolumes: sinon.stub().resolves(),
-          pruneImages: sinon.stub().resolves(),
-          createFluxAppDockerNetwork: sinon.stub().resolves('network-created'),
-          getFluxDockerNetworkPhysicalInterfaceNames: sinon.stub().resolves([]),
-          appDockerCreate: sinon.stub().resolves(),
-          appDockerStart: sinon.stub().resolves('container-started'),
-          getAppIdentifier: sinon.stub().returns('multiarchapp'),
-          dockerPullStream: sinon.stub().resolves('pulled'),
-        },
+        '../dockerService': makeDockerServiceStub({ getAppIdentifier: sinon.stub().returns('multiarchapp') }),
         './appUninstaller': {
           removeAppLocally: sinon.stub().resolves(),
         },
@@ -842,19 +837,7 @@ describe('appInstaller tests', () => {
         '../geolocationService': {
           isStaticIP: sinon.stub().returns(true),
         },
-        '../dockerService': {
-          dockerListContainers: sinon.stub().resolves([]),
-          pruneContainers: sinon.stub().resolves(),
-          pruneNetworks: sinon.stub().resolves(),
-          pruneVolumes: sinon.stub().resolves(),
-          pruneImages: sinon.stub().resolves(),
-          createFluxAppDockerNetwork: sinon.stub().resolves('network-created'),
-          getFluxDockerNetworkPhysicalInterfaceNames: sinon.stub().resolves([]),
-          appDockerCreate: sinon.stub().resolves(),
-          appDockerStart: sinon.stub().resolves('container-started'),
-          getAppIdentifier: sinon.stub().returns('testapp'),
-          dockerPullStream: sinon.stub().resolves('pulled'),
-        },
+        '../dockerService': makeDockerServiceStub(),
         './appUninstaller': {
           removeAppLocally: sinon.stub().resolves(),
         },
@@ -966,19 +949,7 @@ describe('appInstaller tests', () => {
         '../geolocationService': {
           isStaticIP: sinon.stub().returns(true),
         },
-        '../dockerService': {
-          dockerListContainers: sinon.stub().resolves([]),
-          pruneContainers: sinon.stub().resolves(),
-          pruneNetworks: sinon.stub().resolves(),
-          pruneVolumes: sinon.stub().resolves(),
-          pruneImages: sinon.stub().resolves(),
-          createFluxAppDockerNetwork: sinon.stub().resolves('network-created'),
-          getFluxDockerNetworkPhysicalInterfaceNames: sinon.stub().resolves([]),
-          appDockerCreate: sinon.stub().resolves(),
-          appDockerStart: sinon.stub().resolves('container-started'),
-          getAppIdentifier: sinon.stub().returns('testapp'),
-          dockerPullStream: sinon.stub().resolves('pulled'),
-        },
+        '../dockerService': makeDockerServiceStub(),
         './appUninstaller': {
           removeAppLocally: sinon.stub().resolves(),
         },
@@ -1106,19 +1077,7 @@ describe('appInstaller tests', () => {
           getLocalSocketAddress: sinon.stub().resolves('1.2.3.4:16127'),
         },
         '../geolocationService': { isStaticIP: sinon.stub().returns(true) },
-        '../dockerService': {
-          dockerListContainers: sinon.stub().resolves([]),
-          pruneContainers: sinon.stub().resolves(),
-          pruneNetworks: sinon.stub().resolves(),
-          pruneVolumes: sinon.stub().resolves(),
-          pruneImages: sinon.stub().resolves(),
-          createFluxAppDockerNetwork: sinon.stub().resolves('network-created'),
-          getFluxDockerNetworkPhysicalInterfaceNames: sinon.stub().resolves([]),
-          appDockerCreate: sinon.stub().resolves(),
-          appDockerStart: sinon.stub().resolves('container-started'),
-          getAppIdentifier: sinon.stub().returns('testapp'),
-          dockerPullStream: sinon.stub().resolves('pulled'),
-        },
+        '../dockerService': makeDockerServiceStub(),
         './appUninstaller': { removeAppLocally: sinon.stub().resolves() },
         './advancedWorkflows': { createAppVolume: sinon.stub().resolves() },
         './appNetworkLinker': {
@@ -1214,21 +1173,19 @@ describe('appInstaller tests', () => {
         '../serviceHelper': { ensureString: sinon.stub().returnsArg(0), ensureNumber: sinon.stub().returnsArg(0), delay: sinon.stub().resolves() },
         '../generalService': { nodeTier: sinon.stub().resolves('cumulus'), checkSynced: sinon.stub().resolves(true) },
         '../daemonService/daemonServiceMiscRpcs': { isDaemonSynced: sinon.stub().returns({ status: 'success', data: { synced: true, height: 2094961 } }) },
-        '../fluxNetworkHelper': { getLocalSocketAddress: sinon.stub().resolves('192.168.1.1:16127'), getNumberOfPeers: sinon.stub().returns(15), isFirewallActive: sinon.stub().resolves(false), allowPort: sinon.stub().resolves({ status: true }), removeDockerContainerAccessToNonRoutable: sinon.stub().resolves(true) },
-        '../geolocationService': { isStaticIP: sinon.stub().returns(true) },
-        '../dockerService': {
-          dockerListContainers: sinon.stub().resolves([]),
-          pruneContainers: pruneContainersStub,
-          pruneNetworks: sinon.stub().resolves(),
-          pruneVolumes: sinon.stub().resolves(),
-          pruneImages: sinon.stub().resolves(),
-          createFluxAppDockerNetwork: sinon.stub().resolves('net'),
-          getFluxDockerNetworkPhysicalInterfaceNames: sinon.stub().resolves([]),
-          appDockerCreate: sinon.stub().resolves(),
-          appDockerStart: sinon.stub().resolves('ok'),
-          getAppIdentifier: sinon.stub().returns('testapp'),
-          dockerPullStream: sinon.stub().resolves('pulled'),
+        '../fluxNetworkHelper': {
+          getLocalSocketAddress: sinon.stub().resolves('192.168.1.1:16127'),
+          getNumberOfPeers: sinon.stub().returns(15),
+          isFirewallActive: sinon.stub().resolves(false),
+          allowPort: sinon.stub().resolves({ status: true }),
+          removeDockerContainerAccessToNonRoutable: sinon.stub().resolves(true),
         },
+        '../geolocationService': { isStaticIP: sinon.stub().returns(true) },
+        '../dockerService': makeDockerServiceStub({
+          pruneContainers: pruneContainersStub,
+          createFluxAppDockerNetwork: sinon.stub().resolves('net'),
+          appDockerStart: sinon.stub().resolves('ok'),
+        }),
         './appUninstaller': { removeAppLocally: sinon.stub().resolves() },
         './advancedWorkflows': { createAppVolume: sinon.stub().resolves() },
         '../fluxCommunicationMessagesSender': { broadcastMessageToOutgoing: sinon.stub().resolves(), broadcastMessageToIncoming: sinon.stub().resolves() },
@@ -1269,6 +1226,134 @@ describe('appInstaller tests', () => {
       // Decrypted enterprise app has a stopped component (MyComponent_enterpriseapp123 not running)
       // so pruneContainers should NOT be called
       expect(pruneContainersStub.called).to.be.false;
+    });
+  });
+
+  describe('ensureAppDockerNetwork tests', () => {
+    let appInstallerNet;
+    let dockerServiceStub;
+    let removeAccessStub;
+
+    beforeEach(() => {
+      process.env.NODE_CONFIG_DIR = `${process.cwd()}/tests/unit/globalconfig`;
+      dockerServiceStub = makeDockerServiceStub({ getFreeFluxAppNetworkOctet: sinon.stub().resolves(7) });
+      removeAccessStub = sinon.stub().resolves(true);
+      appInstallerNet = proxyquire('../../ZelBack/src/services/appLifecycle/appInstaller', {
+        '../serviceHelper': { ensureString: sinon.stub().returnsArg(0) },
+        '../dockerService': dockerServiceStub,
+        '../fluxNetworkHelper': { removeDockerContainerAccessToNonRoutable: removeAccessStub },
+        '../../lib/log': { info: sinon.stub(), warn: sinon.stub(), error: sinon.stub() },
+      });
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('returns early (no create, no firewall rebuild) when the network already exists', async () => {
+      dockerServiceStub.dockerNetworkState.resolves('exists');
+
+      const result = await appInstallerNet.ensureAppDockerNetwork('myapp');
+
+      expect(dockerServiceStub.getFreeFluxAppNetworkOctet.called).to.be.false;
+      expect(dockerServiceStub.createFluxAppDockerNetwork.called).to.be.false;
+      // intact network: its interface is already in DOCKER-USER, so no iptables churn
+      expect(dockerServiceStub.getFluxDockerNetworkPhysicalInterfaceNames.called).to.be.false;
+      expect(removeAccessStub.called).to.be.false;
+      expect(result).to.include('already exists');
+    });
+
+    it('creates the network on the lowest free octet when absent', async () => {
+      dockerServiceStub.getFreeFluxAppNetworkOctet.resolves(7);
+
+      await appInstallerNet.ensureAppDockerNetwork('myapp');
+
+      expect(dockerServiceStub.createFluxAppDockerNetwork.calledOnceWithExactly('myapp', 7)).to.be.true;
+      expect(removeAccessStub.calledOnce).to.be.true;
+    });
+
+    it('re-scans for the next free octet when a create collides', async () => {
+      dockerServiceStub.getFreeFluxAppNetworkOctet.onFirstCall().resolves(7);
+      dockerServiceStub.getFreeFluxAppNetworkOctet.onSecondCall().resolves(8);
+      dockerServiceStub.createFluxAppDockerNetwork.onFirstCall().resolves(undefined); // collision
+      dockerServiceStub.createFluxAppDockerNetwork.onSecondCall().resolves('network-created');
+
+      await appInstallerNet.ensureAppDockerNetwork('myapp');
+
+      expect(dockerServiceStub.createFluxAppDockerNetwork.getCall(0).args).to.deep.equal(['myapp', 7]);
+      expect(dockerServiceStub.createFluxAppDockerNetwork.getCall(1).args).to.deep.equal(['myapp', 8]);
+      // the lost octet is excluded from the next allocation so it never re-picks it
+      expect([...dockerServiceStub.getFreeFluxAppNetworkOctet.secondCall.args[0]]).to.include(7);
+    });
+
+    it('throws a clear error when no free subnet is available', async () => {
+      dockerServiceStub.getFreeFluxAppNetworkOctet.resolves(null);
+      let err;
+      try {
+        await appInstallerNet.ensureAppDockerNetwork('myapp');
+      } catch (e) { err = e; }
+
+      expect(err).to.be.an('error');
+      expect(err.message).to.include('No free 172.23.x.0/24 subnet available');
+      expect(dockerServiceStub.createFluxAppDockerNetwork.called).to.be.false;
+    });
+
+    it('pins the octet by name for legacy gateway-assignment apps', async () => {
+      // 'fdm' is in appsThatMightBeUsingOldGatewayIpAssignment; octet = 'm'.charCodeAt = 109
+      await appInstallerNet.ensureAppDockerNetwork('fdm');
+
+      expect(dockerServiceStub.getFreeFluxAppNetworkOctet.called).to.be.false;
+      expect(dockerServiceStub.createFluxAppDockerNetwork.calledOnceWithExactly('fdm', 'm'.charCodeAt(0))).to.be.true;
+    });
+
+    it('advances through EVERY free octet and gives up only on exhaustion, not a fixed count', async () => {
+      // Simulate a nearly-full node: octets 1..FREE are free, every create loses. Drive
+      // the allocator off the real exclude set so it must try all FREE octets before the
+      // space is exhausted. FREE is deliberately larger than any plausible fixed retry cap:
+      // a reintroduced cap (the finding-1 regression) would throw early and fail callCount.
+      const FREE = 20;
+      dockerServiceStub.getFreeFluxAppNetworkOctet = sinon.stub().callsFake(async (excluded = new Set()) => {
+        for (let octet = 1; octet <= FREE; octet += 1) {
+          if (!excluded.has(octet)) return octet;
+        }
+        return null;
+      });
+      dockerServiceStub.createFluxAppDockerNetwork.resolves(undefined); // every create loses
+      let err;
+      try {
+        await appInstallerNet.ensureAppDockerNetwork('myapp');
+      } catch (e) { err = e; }
+
+      // it attempted all FREE octets (never re-picking one) and only threw at true exhaustion
+      expect(dockerServiceStub.createFluxAppDockerNetwork.callCount).to.equal(FREE);
+      const attemptedOctets = dockerServiceStub.createFluxAppDockerNetwork.getCalls().map((c) => c.args[1]);
+      expect(attemptedOctets).to.deep.equal(Array.from({ length: FREE }, (_, i) => i + 1));
+      expect(err).to.be.an('error');
+      expect(err.message).to.include('No free 172.23.x.0/24 subnet available');
+    });
+
+    it('treats an unknown network state as not-present and attempts a create', async () => {
+      // dockerNetworkState returns 'unknown' on a transient docker glitch; the guard
+      // is `=== exists`, so unknown must fall through to an (idempotent) create rather
+      // than be mistaken for an existing network (which would skip the heal recreate).
+      dockerServiceStub.dockerNetworkState.resolves('unknown');
+      dockerServiceStub.getFreeFluxAppNetworkOctet.resolves(7);
+
+      await appInstallerNet.ensureAppDockerNetwork('myapp');
+
+      expect(dockerServiceStub.createFluxAppDockerNetwork.calledOnceWithExactly('myapp', 7)).to.be.true;
+    });
+
+    it('legacy app throws if its pinned octet cannot be created', async () => {
+      dockerServiceStub.createFluxAppDockerNetwork.resolves(undefined);
+      let err;
+      try {
+        await appInstallerNet.ensureAppDockerNetwork('fdm');
+      } catch (e) { err = e; }
+
+      expect(dockerServiceStub.getFreeFluxAppNetworkOctet.called).to.be.false;
+      expect(err).to.be.an('error');
+      expect(err.message).to.include('Not possible to create docker application network');
     });
   });
 });

--- a/tests/unit/appInstaller.test.js
+++ b/tests/unit/appInstaller.test.js
@@ -1355,5 +1355,29 @@ describe('appInstaller tests', () => {
       expect(err).to.be.an('error');
       expect(err.message).to.include('Not possible to create docker application network');
     });
+
+    it('reserves the legacy-pinned octets so a non-legacy app cannot squat one', async () => {
+      dockerServiceStub.getFreeFluxAppNetworkOctet.resolves(7);
+
+      await appInstallerNet.ensureAppDockerNetwork('myapp');
+
+      // the legacy octets are seeded into the exclude set on the very first allocation
+      // so the free-octet scan never hands one out: 'fdm'->'m'(109), 'health'->'h'(104),
+      // 'Jetpack2'->'2'(50).
+      const excluded = [...dockerServiceStub.getFreeFluxAppNetworkOctet.firstCall.args[0]];
+      expect(excluded).to.include('m'.charCodeAt(0));
+      expect(excluded).to.include('h'.charCodeAt(0));
+      expect(excluded).to.include('2'.charCodeAt(0));
+    });
+
+    it('streams an already-exists status on the early-return path', async () => {
+      dockerServiceStub.dockerNetworkState.resolves('exists');
+      const writes = [];
+      const res = { write: (chunk) => writes.push(chunk) };
+
+      await appInstallerNet.ensureAppDockerNetwork('myapp', res);
+
+      expect(writes.some((w) => w && w.status && w.status.includes('already exists'))).to.be.true;
+    });
   });
 });

--- a/tests/unit/appReconciler.test.js
+++ b/tests/unit/appReconciler.test.js
@@ -52,16 +52,20 @@ describe('appReconciler tests', () => {
       volumeService: {
         ensureMountPathsExist: sinon.stub().resolves(),
         ensureAppVolumeMounted: sinon.stub().resolves({ mounted: true, alreadyMounted: true }),
+        // the heal will not destroy a container whose volume it cannot verify
+        verifyAppVolumeMount: sinon.stub().resolves(true),
       },
       appsRuntimeState: {
         isOperatorStopped: sinon.stub().resolves(false),
         restartWaitMs: sinon.stub().resolves(0),
         recordRestart: sinon.stub().resolves(),
         recordExit: sinon.stub().resolves(),
-        // durable "I removed this container for a network heal" flag
+        // durable "I removed this container for a network heal" flag + its own ladder
         isNetworkHealRemoval: sinon.stub().resolves(false),
         setNetworkHealRemoval: sinon.stub().resolves(),
-        clearNetworkHealRemoval: sinon.stub().resolves(),
+        recordNetworkHealAttempt: sinon.stub().resolves(),
+        networkHealWaitMs: sinon.stub().resolves(0),
+        clearNetworkHeal: sinon.stub().resolves(),
       },
       appQueryService: {
         decryptEnterpriseApps: sinon.stub().callsFake(async (arr) => arr),
@@ -1005,35 +1009,73 @@ describe('appReconciler tests', () => {
     // A running container reported as detached from its own docker network (stale
     // libnetwork endpoint). isContainerDetachedFromNetwork is stubbed directly so
     // these tests drive the reconciler's control flow, not the classifier (covered
-    // by dockerService tests). The heal confirms in-pass (settle + re-inspect), so
-    // one reconcile call is a complete heal cycle.
+    // by dockerService tests).
+    //
+    // A heal needs the detach to (a) survive an in-pass re-inspect and (b) persist
+    // for DETACHED_PERSIST_MS of wall-clock. Date is faked so tests can cross that
+    // window without waiting; setTimeout is NOT faked, so the reconciler's own
+    // scheduleRetry timers never fire and each pass is driven explicitly.
+    let clock;
+
     beforeEach(() => {
+      clock = sinon.useFakeTimers({ toFake: ['Date'] });
       stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: true, Status: 'running', ExitCode: 0 } });
       stubs.dockerService.classifyContainerNetworkAttachment.returns({
         managed: true, running: true, networkMode: 'fluxDockerNetwork_App', attached: false,
       });
+      stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
     });
+
+    // first pass opens the persistence window; the second, past it, may act
+    const healPasses = async (id = 'www_App') => {
+      await appReconciler.reconcile(id);
+      clock.tick(61 * 1000);
+      await appReconciler.reconcile(id);
+    };
 
     it('leaves a running, properly-attached container alone and clears any heal state', async () => {
       stubs.dockerService.isContainerDetachedFromNetwork.returns(false);
       await appReconciler.reconcile('www_App');
       expect(stubs.dockerService.appDockerForceRemove.called).to.be.false;
       expect(stubs.containerHealthMonitor.recreateMissingContainers.called).to.be.false;
-      expect(stubs.appsRuntimeState.clearNetworkHealRemoval.calledWith('www_App'), 'attached is the proof a heal worked: clear the durable flag').to.be.true;
+      expect(stubs.appsRuntimeState.clearNetworkHeal.calledWith('www_App'), 'a healthy container clears the durable heal state').to.be.true;
+    });
+
+    it('clears the durable heal state for a container that merely EXISTS, even stopped', async () => {
+      // the flag means "absent because I removed it" - once the container is back it
+      // is stale, whatever its run state. Leaking it would divert a later, genuine
+      // disappearance away from the vanished path forever.
+      stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: false, Status: 'exited', ExitCode: 0 } });
+      stubs.dockerService.isContainerDetachedFromNetwork.returns(false);
+      stubs.appsRuntimeState.restartWaitMs.resolves(60 * 1000); // stay in backoff, never start
+
+      await appReconciler.reconcile('www_App');
+
+      expect(stubs.appsRuntimeState.clearNetworkHeal.calledWith('www_App')).to.be.true;
     });
 
     it('confirms in-pass before acting: a detached read that clears on re-inspect destroys nothing', async () => {
-      // detached on the first read, attached on the confirming re-read
-      stubs.dockerService.isContainerDetachedFromNetwork.onFirstCall().returns(true).onSecondCall().returns(false);
+      // a pass reads the attachment three times: the stale-state clear, the running
+      // branch, then the heal's confirming re-inspect. Detached for the first two,
+      // attached on the re-inspect - i.e. the first read was transient.
+      stubs.dockerService.isContainerDetachedFromNetwork.onCall(2).returns(false);
       await appReconciler.reconcile('www_App');
       expect(stubs.serviceHelper.delay.called, 'settles before re-reading').to.be.true;
       expect(stubs.dockerService.dockerContainerInspect.callCount, 're-inspects to confirm').to.be.at.least(2);
       expect(stubs.dockerService.appDockerForceRemove.called, 'a transient detached read must never destroy a healthy container').to.be.false;
     });
 
-    it('heals a confirmed detach: durable flag set before the remove, monitoring stopped, recreate, never uninstall', async () => {
-      stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
+    it('waits for the detach to persist before destroying anything', async () => {
+      await appReconciler.reconcile('www_App'); // confirmed detached, but only just now
+      expect(stubs.dockerService.appDockerForceRemove.called, 'a detach seen for the first time is not yet actionable').to.be.false;
+
+      clock.tick(61 * 1000);
       await appReconciler.reconcile('www_App');
+      expect(stubs.dockerService.appDockerForceRemove.called, 'a detach that persisted is healed').to.be.true;
+    });
+
+    it('heals a persisted detach: durable flag before the remove, monitoring stopped, soft-only recreate, never uninstall', async () => {
+      await healPasses();
       expect(
         stubs.appsRuntimeState.setNetworkHealRemoval.calledWith('www_App', true),
         'records the deliberate removal durably',
@@ -1044,14 +1086,78 @@ describe('appReconciler tests', () => {
       ).to.be.true;
       expect(stubs.appInspector.stopAppMonitoring.calledWith('www_App', true), 'stops the stats monitor before removing').to.be.true;
       expect(stubs.dockerService.appDockerForceRemove.calledWith('www_App', false), 'force-removes keeping bind-mounted data').to.be.true;
-      expect(stubs.containerHealthMonitor.recreateMissingContainers.calledOnceWith('www_App'), 'recreates once').to.be.true;
+      expect(
+        stubs.containerHealthMonitor.recreateMissingContainers.calledOnceWith('www_App', { softOnly: true }),
+        'the recreate must never be allowed to fall back to a hard install: that reformats the data volume',
+      ).to.be.true;
       expect(stubs.appUninstaller.removeAppLocally.called, 'the heal must NEVER uninstall the app').to.be.false;
     });
 
-    it('does not destroy the container when docker confirms its network is gone (records network_pruned)', async () => {
-      stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
-      stubs.dockerService.dockerNetworkState.resolves('absent');
+    it('refuses to destroy a container it could never recreate (v1-3 app with no compose spec)', async () => {
+      // recreateMissingContainers throws unconditionally on a spec with no compose
+      // array, and the heal never escalates - so removing such a container would
+      // destroy it permanently.
+      localSpec = { name: 'App', version: 3, containerData: '/data' };
+
+      await healPasses('App');
+
+      expect(stubs.dockerService.appDockerForceRemove.called, 'must not remove what it cannot recreate').to.be.false;
+      expect(stubs.appUninstaller.removeAppLocally.called).to.be.false;
+      const blocked = stubs.log.error.getCalls().some((c) => /must NOT be recreated/.test(c.args[0]));
+      expect(blocked, 'says loudly why it refused').to.be.true;
+    });
+
+    it('refuses to destroy a container whose data volume cannot be verified', async () => {
+      // the recreate is soft-only, so an unverifiable volume means it would fail
+      // AFTER the container was destroyed
+      stubs.volumeService.verifyAppVolumeMount.resolves(false);
+
+      await healPasses();
+
+      expect(stubs.dockerService.appDockerForceRemove.called, 'a container whose volume cannot be verified must be left alone').to.be.false;
+      expect(stubs.containerHealthMonitor.recreateMissingContainers.called).to.be.false;
+    });
+
+    it('aborts the remove if another operation took the container over during the confirmation', async () => {
+      // isManagedElsewhere is sampled at reconcile entry, but the heal spends seconds
+      // confirming - a redeploy/backup starting in that window must not have its
+      // container force-removed underneath it.
+      await appReconciler.reconcile('www_App'); // opens the persistence window
+      clock.tick(61 * 1000);
+      stubs.serviceHelper.delay.callsFake(async () => {
+        stubs.globalState.isOperationInProgress = () => true; // a redeploy starts mid-settle
+      });
+
       await appReconciler.reconcile('www_App');
+
+      expect(stubs.dockerService.appDockerForceRemove.called, 'must not actuate on a container another subsystem owns').to.be.false;
+    });
+
+    it('does not rebuild the whole node when many containers look detached at once', async () => {
+      // a dockerd restart can serve inspects before libnetwork restores endpoint IPs,
+      // and the reconnect sweep enqueues everything at that moment
+      localSpec = {
+        name: 'App',
+        version: 4,
+        compose: [{ name: 'www', containerData: '/data' }, { name: 'api', containerData: '/data' }, { name: 'db', containerData: '/data' }],
+      };
+
+      await appReconciler.reconcile('www_App');
+      await appReconciler.reconcile('api_App');
+      await appReconciler.reconcile('db_App');
+      clock.tick(61 * 1000);
+      await appReconciler.reconcile('www_App');
+      await appReconciler.reconcile('api_App');
+      await appReconciler.reconcile('db_App');
+
+      expect(stubs.dockerService.appDockerForceRemove.called, 'a node-wide detach is a docker fault, not N stale endpoints').to.be.false;
+      const storm = stubs.log.error.getCalls().some((c) => /docker-level fault/.test(c.args[0]));
+      expect(storm, 'says loudly that it refused a node-wide rebuild').to.be.true;
+    });
+
+    it('does not destroy the container when docker confirms its network is gone (records network_pruned)', async () => {
+      stubs.dockerService.dockerNetworkState.resolves('absent');
+      await healPasses();
       expect(stubs.dockerService.appDockerForceRemove.called, 'must not remove a container it cannot recreate').to.be.false;
       expect(stubs.containerHealthMonitor.recreateMissingContainers.called).to.be.false;
       const pruned = stubs.appTamperingDetectionService.recordEvent.getCalls().some((c) => c.args[1] === 'network_pruned');
@@ -1059,26 +1165,39 @@ describe('appReconciler tests', () => {
     });
 
     it('defers (destroys nothing, records nothing) when docker cannot say whether the network exists', async () => {
-      stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
       stubs.dockerService.dockerNetworkState.resolves('unknown');
-      await appReconciler.reconcile('www_App');
+      await healPasses();
       expect(stubs.dockerService.appDockerForceRemove.called, 'an unreadable network is not a missing network').to.be.false;
       const pruned = stubs.appTamperingDetectionService.recordEvent.getCalls().some((c) => c.args[1] === 'network_pruned');
       expect(pruned, 'must not record a false network_pruned on a transient docker error').to.be.false;
     });
 
-    it('paces heal attempts on the durable backoff ladder instead of counting them', async () => {
-      stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
-      stubs.appsRuntimeState.restartWaitMs.resolves(30 * 1000); // ladder says: not yet
-      await appReconciler.reconcile('www_App');
+    it('paces heal attempts on its own durable ladder, not the crash-restart one', async () => {
+      stubs.appsRuntimeState.networkHealWaitMs.resolves(30 * 1000); // the heal ladder says: not yet
+      await healPasses();
       expect(stubs.dockerService.appDockerForceRemove.called, 'no destructive action while backing off').to.be.false;
       expect(stubs.appsRuntimeState.setNetworkHealRemoval.called).to.be.false;
+      expect(
+        stubs.appsRuntimeState.recordRestart.called,
+        'a heal must not write to the crash ladder: it would hold down the container it just fixed',
+      ).to.be.false;
+    });
+
+    it('does not remove the container if the heal cannot be recorded durably', async () => {
+      // the durable flag is what stops a restart mid-heal from uninstalling the app,
+      // and the ladder is what stops the retries hammering - without them, no remove
+      stubs.appsRuntimeState.setNetworkHealRemoval.rejects(new Error('db unavailable'));
+
+      await healPasses();
+
+      expect(stubs.dockerService.appDockerForceRemove.called, 'an unrecordable heal must not happen at all').to.be.false;
+      const noted = stubs.log.error.getCalls().some((c) => /cannot record the network heal/.test(c.args[0]));
+      expect(noted, 'logs and retries rather than throwing out of reconcile').to.be.true;
     });
 
     it('restores monitoring when the force-remove itself fails', async () => {
-      stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
       stubs.dockerService.appDockerForceRemove.rejects(new Error('device or resource busy'));
-      await appReconciler.reconcile('www_App');
+      await healPasses();
       expect(
         stubs.appInspector.startAppMonitoring.calledWith('www_App'),
         'the container is still there: it must not be left unmonitored',
@@ -1086,28 +1205,29 @@ describe('appReconciler tests', () => {
       expect(stubs.appUninstaller.removeAppLocally.called).to.be.false;
     });
 
-    it('a recreate failure retries but never uninstalls the app', async () => {
-      stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
+    it('a recreate failure retries, records the diagnostics, and never uninstalls the app', async () => {
       stubs.containerHealthMonitor.recreateMissingContainers.rejects(new Error('host port still in use'));
-      await appReconciler.reconcile('www_App');
+      await healPasses();
       expect(stubs.dockerService.appDockerForceRemove.called).to.be.true;
       expect(stubs.appUninstaller.removeAppLocally.called, 'a transient recreate failure must not uninstall').to.be.false;
+      const failed = stubs.appTamperingDetectionService.recordEvent.getCalls().some((c) => c.args[1] === 'recreation_failed');
+      expect(failed, 'a silently looping heal is an invisible outage: record the failure').to.be.true;
     });
 
     it('keeps retrying a broken heal at a bounded rate: no terminal give-up, no uninstall, one tamper event', async () => {
-      stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
       stubs.containerHealthMonitor.recreateMissingContainers.rejects(new Error('host port still in use'));
       // the container stays "running" (inspect stub), so each pass re-enters the
       // running-detached branch - as the hourly sweep would drive it
       for (let i = 0; i < 8; i += 1) {
         // eslint-disable-next-line no-await-in-loop
         await appReconciler.reconcile('www_App');
+        clock.tick(61 * 1000);
       }
       expect(stubs.appUninstaller.removeAppLocally.called, 'never uninstalls, however long it stays broken').to.be.false;
       expect(
         stubs.containerHealthMonitor.recreateMissingContainers.callCount,
-        'keeps trying (paced by the ladder) rather than parking in a terminal state',
-      ).to.equal(8);
+        'keeps trying (paced by its ladder) rather than parking in a terminal state',
+      ).to.be.at.least(6);
       // the durable tampering signal is recorded once per episode, not per attempt
       const detachedEvents = stubs.appTamperingDetectionService.recordEvent.getCalls().filter((c) => c.args[1] === 'network_detached').length;
       expect(detachedEvents, 'records network_detached once per episode, not per attempt').to.equal(1);
@@ -1127,6 +1247,21 @@ describe('appReconciler tests', () => {
       expect(vanished, 'our own removal must not be recorded as tampering').to.be.false;
       expect(stubs.containerHealthMonitor.recreateMissingContainers.called, 'recreates on the heal path').to.be.true;
       expect(stubs.appUninstaller.removeAppLocally.called, 'a failed recreate must not uninstall the app').to.be.false;
+    });
+
+    it('defers instead of guessing when the durable heal flag cannot be read', async () => {
+      // guessing "not a heal removal" is the destructive guess: it records a false
+      // tampering event and can uninstall the app on a failed recreate
+      stubs.appsRuntimeState.isNetworkHealRemoval.rejects(new Error('db unavailable'));
+      stubs.dockerService.dockerContainerInspect.rejects(new Error('no such container'));
+      stubs.dockerService.dockerListContainers.resolves([]);
+
+      await appReconciler.reconcile('www_App');
+
+      expect(stubs.containerHealthMonitor.recreateMissingContainers.called, 'no recreate on an unreadable state').to.be.false;
+      expect(stubs.appUninstaller.removeAppLocally.called, 'and above all, no uninstall').to.be.false;
+      const vanished = stubs.appTamperingDetectionService.recordEvent.getCalls().some((c) => c.args[1] === 'container_vanished');
+      expect(vanished, 'no false tampering event').to.be.false;
     });
 
     it('a container that vanished on its own (no heal flag) still takes the vanished path', async () => {

--- a/tests/unit/appReconciler.test.js
+++ b/tests/unit/appReconciler.test.js
@@ -33,11 +33,11 @@ describe('appReconciler tests', () => {
         // network-attachment helpers used by dockerActual + the running branch.
         // Default: a benign, attached container (not detached), so the heal path
         // stays dormant unless a test opts in.
-        parseContainerNetworkAttachment: sinon.stub().returns({
+        classifyContainerNetworkAttachment: sinon.stub().returns({
           managed: false, running: false, networkMode: null, attached: false,
         }),
         isContainerDetachedFromNetwork: sinon.stub().returns(false),
-        dockerNetworkExists: sinon.stub().resolves(true),
+        dockerNetworkState: sinon.stub().resolves('exists'),
       },
       globalState: {
         appsMonitored: {},
@@ -58,6 +58,10 @@ describe('appReconciler tests', () => {
         restartWaitMs: sinon.stub().resolves(0),
         recordRestart: sinon.stub().resolves(),
         recordExit: sinon.stub().resolves(),
+        // durable "I removed this container for a network heal" flag
+        isNetworkHealRemoval: sinon.stub().resolves(false),
+        setNetworkHealRemoval: sinon.stub().resolves(),
+        clearNetworkHealRemoval: sinon.stub().resolves(),
       },
       appQueryService: {
         decryptEnterpriseApps: sinon.stub().callsFake(async (arr) => arr),
@@ -522,13 +526,24 @@ describe('appReconciler tests', () => {
       clock.restore();
     });
 
-    it('does not schedule a retry after a successful start', async () => {
+    it('converges after a successful start: the verification pass re-checks but does not act again', async () => {
+      // a successful start schedules ONE verification pass (a container can come up
+      // detached from its network). That pass must find the container running and
+      // stop there - not start it again, and not keep re-arming itself.
       const clock = sinon.useFakeTimers({ toFake: ['setTimeout'] });
+      stubs.dockerService.appDockerStart.callsFake(async () => {
+        stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: true, Status: 'running', ExitCode: 0 } });
+      });
 
       await appReconciler.reconcile('www_App');
-
       expect(stubs.dockerService.appDockerStart.callCount).to.equal(1);
+
       clock.tick(60 * 1000);
+      await new Promise((resolve) => { setImmediate(() => { setImmediate(resolve); }); });
+      expect(stubs.dockerService.dockerContainerInspect.callCount, 'the verification pass ran').to.be.above(1);
+      expect(stubs.dockerService.appDockerStart.callCount, 'a running container is left alone').to.equal(1);
+
+      clock.tick(10 * 60 * 1000); // no further passes are armed once it is healthy
       await new Promise((resolve) => { setImmediate(() => { setImmediate(resolve); }); });
       expect(stubs.dockerService.appDockerStart.callCount).to.equal(1);
       clock.restore();
@@ -990,75 +1005,160 @@ describe('appReconciler tests', () => {
     // A running container reported as detached from its own docker network (stale
     // libnetwork endpoint). isContainerDetachedFromNetwork is stubbed directly so
     // these tests drive the reconciler's control flow, not the classifier (covered
-    // by dockerService tests).
+    // by dockerService tests). The heal confirms in-pass (settle + re-inspect), so
+    // one reconcile call is a complete heal cycle.
     beforeEach(() => {
       stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: true, Status: 'running', ExitCode: 0 } });
-      stubs.dockerService.parseContainerNetworkAttachment.returns({
+      stubs.dockerService.classifyContainerNetworkAttachment.returns({
         managed: true, running: true, networkMode: 'fluxDockerNetwork_App', attached: false,
       });
     });
 
-    it('leaves a running, properly-attached container alone', async () => {
+    it('leaves a running, properly-attached container alone and clears any heal state', async () => {
       stubs.dockerService.isContainerDetachedFromNetwork.returns(false);
       await appReconciler.reconcile('www_App');
       expect(stubs.dockerService.appDockerForceRemove.called).to.be.false;
       expect(stubs.containerHealthMonitor.recreateMissingContainers.called).to.be.false;
+      expect(stubs.appsRuntimeState.clearNetworkHealRemoval.calledWith('www_App'), 'attached is the proof a heal worked: clear the durable flag').to.be.true;
     });
 
-    it('debounces: does not act on the first detached observation', async () => {
+    it('confirms in-pass before acting: a detached read that clears on re-inspect destroys nothing', async () => {
+      // detached on the first read, attached on the confirming re-read
+      stubs.dockerService.isContainerDetachedFromNetwork.onFirstCall().returns(true).onSecondCall().returns(false);
+      await appReconciler.reconcile('www_App');
+      expect(stubs.serviceHelper.delay.called, 'settles before re-reading').to.be.true;
+      expect(stubs.dockerService.dockerContainerInspect.callCount, 're-inspects to confirm').to.be.at.least(2);
+      expect(stubs.dockerService.appDockerForceRemove.called, 'a transient detached read must never destroy a healthy container').to.be.false;
+    });
+
+    it('heals a confirmed detach: durable flag set before the remove, monitoring stopped, recreate, never uninstall', async () => {
       stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
       await appReconciler.reconcile('www_App');
-      expect(stubs.dockerService.appDockerForceRemove.called, 'no destructive action on first sighting').to.be.false;
-      expect(stubs.containerHealthMonitor.recreateMissingContainers.called).to.be.false;
-    });
-
-    it('recreates after two consecutive detached observations, stopping monitoring first and never uninstalling', async () => {
-      stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
-      await appReconciler.reconcile('www_App'); // obs 1 (debounce)
-      await appReconciler.reconcile('www_App'); // obs 2 (act)
+      expect(
+        stubs.appsRuntimeState.setNetworkHealRemoval.calledWith('www_App', true),
+        'records the deliberate removal durably',
+      ).to.be.true;
+      expect(
+        stubs.appsRuntimeState.setNetworkHealRemoval.calledBefore(stubs.dockerService.appDockerForceRemove),
+        'the flag must be durable BEFORE the container is removed, or a restart in the window reads the absence as tampering',
+      ).to.be.true;
       expect(stubs.appInspector.stopAppMonitoring.calledWith('www_App', true), 'stops the stats monitor before removing').to.be.true;
       expect(stubs.dockerService.appDockerForceRemove.calledWith('www_App', false), 'force-removes keeping bind-mounted data').to.be.true;
       expect(stubs.containerHealthMonitor.recreateMissingContainers.calledOnceWith('www_App'), 'recreates once').to.be.true;
       expect(stubs.appUninstaller.removeAppLocally.called, 'the heal must NEVER uninstall the app').to.be.false;
     });
 
-    it('does not destroy the container when its network is missing (records network_pruned)', async () => {
+    it('does not destroy the container when docker confirms its network is gone (records network_pruned)', async () => {
       stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
-      stubs.dockerService.dockerNetworkExists.resolves(false);
-      await appReconciler.reconcile('www_App'); // obs 1
-      await appReconciler.reconcile('www_App'); // obs 2 -> network gone -> skip destructive heal
+      stubs.dockerService.dockerNetworkState.resolves('absent');
+      await appReconciler.reconcile('www_App');
       expect(stubs.dockerService.appDockerForceRemove.called, 'must not remove a container it cannot recreate').to.be.false;
       expect(stubs.containerHealthMonitor.recreateMissingContainers.called).to.be.false;
       const pruned = stubs.appTamperingDetectionService.recordEvent.getCalls().some((c) => c.args[1] === 'network_pruned');
       expect(pruned, 'records a network_pruned event').to.be.true;
     });
 
+    it('defers (destroys nothing, records nothing) when docker cannot say whether the network exists', async () => {
+      stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
+      stubs.dockerService.dockerNetworkState.resolves('unknown');
+      await appReconciler.reconcile('www_App');
+      expect(stubs.dockerService.appDockerForceRemove.called, 'an unreadable network is not a missing network').to.be.false;
+      const pruned = stubs.appTamperingDetectionService.recordEvent.getCalls().some((c) => c.args[1] === 'network_pruned');
+      expect(pruned, 'must not record a false network_pruned on a transient docker error').to.be.false;
+    });
+
+    it('paces heal attempts on the durable backoff ladder instead of counting them', async () => {
+      stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
+      stubs.appsRuntimeState.restartWaitMs.resolves(30 * 1000); // ladder says: not yet
+      await appReconciler.reconcile('www_App');
+      expect(stubs.dockerService.appDockerForceRemove.called, 'no destructive action while backing off').to.be.false;
+      expect(stubs.appsRuntimeState.setNetworkHealRemoval.called).to.be.false;
+    });
+
+    it('restores monitoring when the force-remove itself fails', async () => {
+      stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
+      stubs.dockerService.appDockerForceRemove.rejects(new Error('device or resource busy'));
+      await appReconciler.reconcile('www_App');
+      expect(
+        stubs.appInspector.startAppMonitoring.calledWith('www_App'),
+        'the container is still there: it must not be left unmonitored',
+      ).to.be.true;
+      expect(stubs.appUninstaller.removeAppLocally.called).to.be.false;
+    });
+
     it('a recreate failure retries but never uninstalls the app', async () => {
       stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
       stubs.containerHealthMonitor.recreateMissingContainers.rejects(new Error('host port still in use'));
-      await appReconciler.reconcile('www_App'); // obs 1
-      await appReconciler.reconcile('www_App'); // obs 2 -> heal attempt -> recreate throws
+      await appReconciler.reconcile('www_App');
       expect(stubs.dockerService.appDockerForceRemove.called).to.be.true;
       expect(stubs.appUninstaller.removeAppLocally.called, 'a transient recreate failure must not uninstall').to.be.false;
     });
 
-    it('gives up after MAX attempts without ever uninstalling', async () => {
+    it('keeps retrying a broken heal at a bounded rate: no terminal give-up, no uninstall, one tamper event', async () => {
       stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
       stubs.containerHealthMonitor.recreateMissingContainers.rejects(new Error('host port still in use'));
-      // 1 debounce pass + several act passes; the container stays "running" (inspect
-      // stub), so each pass re-enters the running-detached branch.
+      // the container stays "running" (inspect stub), so each pass re-enters the
+      // running-detached branch - as the hourly sweep would drive it
       for (let i = 0; i < 8; i += 1) {
         // eslint-disable-next-line no-await-in-loop
         await appReconciler.reconcile('www_App');
       }
-      expect(stubs.appUninstaller.removeAppLocally.called, 'never uninstalls, even after giving up').to.be.false;
-      const gaveUp = stubs.log.error.getCalls().some((c) => /manual intervention/.test(c.args[0]));
-      expect(gaveUp, 'logs a give-up for manual intervention').to.be.true;
-      // bounded: at most MAX_NETWORK_HEAL_ATTEMPTS (3) recreate attempts, not one per pass
-      expect(stubs.containerHealthMonitor.recreateMissingContainers.callCount).to.be.at.most(3);
-      // the durable tampering signal is recorded once per episode, not per retry
+      expect(stubs.appUninstaller.removeAppLocally.called, 'never uninstalls, however long it stays broken').to.be.false;
+      expect(
+        stubs.containerHealthMonitor.recreateMissingContainers.callCount,
+        'keeps trying (paced by the ladder) rather than parking in a terminal state',
+      ).to.equal(8);
+      // the durable tampering signal is recorded once per episode, not per attempt
       const detachedEvents = stubs.appTamperingDetectionService.recordEvent.getCalls().filter((c) => c.args[1] === 'network_detached').length;
-      expect(detachedEvents, 'records network_detached once per episode, not per retry').to.equal(1);
+      expect(detachedEvents, 'records network_detached once per episode, not per attempt').to.equal(1);
+    });
+
+    it('a FluxOS restart mid-heal still recreates: the absence is ours, not tampering', async () => {
+      // fresh process: no in-memory heal state, container gone (removed just before
+      // the crash), but the durable flag survived
+      stubs.appsRuntimeState.isNetworkHealRemoval.resolves(true);
+      stubs.dockerService.dockerContainerInspect.rejects(new Error('no such container'));
+      stubs.dockerService.dockerListContainers.resolves([]); // docker up, container really absent
+      stubs.containerHealthMonitor.recreateMissingContainers.rejects(new Error('host port still in use'));
+
+      await appReconciler.reconcile('www_App');
+
+      const vanished = stubs.appTamperingDetectionService.recordEvent.getCalls().some((c) => c.args[1] === 'container_vanished');
+      expect(vanished, 'our own removal must not be recorded as tampering').to.be.false;
+      expect(stubs.containerHealthMonitor.recreateMissingContainers.called, 'recreates on the heal path').to.be.true;
+      expect(stubs.appUninstaller.removeAppLocally.called, 'a failed recreate must not uninstall the app').to.be.false;
+    });
+
+    it('a container that vanished on its own (no heal flag) still takes the vanished path', async () => {
+      stubs.appsRuntimeState.isNetworkHealRemoval.resolves(false);
+      stubs.dockerService.dockerContainerInspect.rejects(new Error('no such container'));
+      stubs.dockerService.dockerListContainers.resolves([]);
+
+      await appReconciler.reconcile('www_App');
+
+      const vanished = stubs.appTamperingDetectionService.recordEvent.getCalls().some((c) => c.args[1] === 'container_vanished');
+      expect(vanished, 'a genuine vanish is still a tampering signal').to.be.true;
+    });
+  });
+
+  describe('post-start attachment verification', () => {
+    it('re-checks a container shortly after starting it, instead of waiting for the hourly sweep', async () => {
+      const clock = sinon.useFakeTimers({ toFake: ['setTimeout'] });
+      try {
+        await appReconciler.reconcile('www_App'); // stopped -> start
+        expect(stubs.dockerService.appDockerStart.calledOnce).to.be.true;
+        const inspectsAfterStart = stubs.dockerService.dockerContainerInspect.callCount;
+
+        clock.tick(30 * 1000); // the post-start verification pass
+        await new Promise((resolve) => { setImmediate(resolve); });
+
+        expect(
+          stubs.dockerService.dockerContainerInspect.callCount,
+          'the start is when a container can come up detached, so it must be looked at again',
+        ).to.be.above(inspectsAfterStart);
+      } finally {
+        clock.restore();
+      }
     });
   });
 });

--- a/tests/unit/appReconciler.test.js
+++ b/tests/unit/appReconciler.test.js
@@ -1056,6 +1056,9 @@ describe('appReconciler tests', () => {
       expect(gaveUp, 'logs a give-up for manual intervention').to.be.true;
       // bounded: at most MAX_NETWORK_HEAL_ATTEMPTS (3) recreate attempts, not one per pass
       expect(stubs.containerHealthMonitor.recreateMissingContainers.callCount).to.be.at.most(3);
+      // the durable tampering signal is recorded once per episode, not per retry
+      const detachedEvents = stubs.appTamperingDetectionService.recordEvent.getCalls().filter((c) => c.args[1] === 'network_detached').length;
+      expect(detachedEvents, 'records network_detached once per episode, not per retry').to.equal(1);
     });
   });
 });

--- a/tests/unit/appReconciler.test.js
+++ b/tests/unit/appReconciler.test.js
@@ -26,9 +26,18 @@ describe('appReconciler tests', () => {
         getDockerContainerOnly: sinon.stub().resolves(undefined),
         appDockerStart: sinon.stub().resolves(),
         appDockerStop: sinon.stub().resolves(),
+        appDockerForceRemove: sinon.stub().resolves(),
         getAppIdentifier: (id) => `flux${id}`,
         getAppDockerNameIdentifier: (id) => `/flux${id}`,
         getBaseAppName: (id) => (id.startsWith('flux') ? id.slice(4) : id),
+        // network-attachment helpers used by dockerActual + the running branch.
+        // Default: a benign, attached container (not detached), so the heal path
+        // stays dormant unless a test opts in.
+        parseContainerNetworkAttachment: sinon.stub().returns({
+          managed: false, running: false, networkMode: null, attached: false,
+        }),
+        isContainerDetachedFromNetwork: sinon.stub().returns(false),
+        dockerNetworkExists: sinon.stub().resolves(true),
       },
       globalState: {
         appsMonitored: {},
@@ -39,7 +48,7 @@ describe('appReconciler tests', () => {
         bootContainerStateSettled: true,
         waitForBootContainerStateSettled: () => Promise.resolve(),
       },
-      appInspector: { startAppMonitoring: sinon.stub() },
+      appInspector: { startAppMonitoring: sinon.stub(), stopAppMonitoring: sinon.stub() },
       volumeService: {
         ensureMountPathsExist: sinon.stub().resolves(),
         ensureAppVolumeMounted: sinon.stub().resolves({ mounted: true, alreadyMounted: true }),
@@ -974,6 +983,79 @@ describe('appReconciler tests', () => {
       await reachedInspect[1].promise;
       expect(resolvers).to.have.lengthOf(2); // one re-run, not two
       resolvers[1]();
+    });
+  });
+
+  describe('network-detach heal', () => {
+    // A running container reported as detached from its own docker network (stale
+    // libnetwork endpoint). isContainerDetachedFromNetwork is stubbed directly so
+    // these tests drive the reconciler's control flow, not the classifier (covered
+    // by dockerService tests).
+    beforeEach(() => {
+      stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: true, Status: 'running', ExitCode: 0 } });
+      stubs.dockerService.parseContainerNetworkAttachment.returns({
+        managed: true, running: true, networkMode: 'fluxDockerNetwork_App', attached: false,
+      });
+    });
+
+    it('leaves a running, properly-attached container alone', async () => {
+      stubs.dockerService.isContainerDetachedFromNetwork.returns(false);
+      await appReconciler.reconcile('www_App');
+      expect(stubs.dockerService.appDockerForceRemove.called).to.be.false;
+      expect(stubs.containerHealthMonitor.recreateMissingContainers.called).to.be.false;
+    });
+
+    it('debounces: does not act on the first detached observation', async () => {
+      stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
+      await appReconciler.reconcile('www_App');
+      expect(stubs.dockerService.appDockerForceRemove.called, 'no destructive action on first sighting').to.be.false;
+      expect(stubs.containerHealthMonitor.recreateMissingContainers.called).to.be.false;
+    });
+
+    it('recreates after two consecutive detached observations, stopping monitoring first and never uninstalling', async () => {
+      stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
+      await appReconciler.reconcile('www_App'); // obs 1 (debounce)
+      await appReconciler.reconcile('www_App'); // obs 2 (act)
+      expect(stubs.appInspector.stopAppMonitoring.calledWith('www_App', true), 'stops the stats monitor before removing').to.be.true;
+      expect(stubs.dockerService.appDockerForceRemove.calledWith('www_App', false), 'force-removes keeping bind-mounted data').to.be.true;
+      expect(stubs.containerHealthMonitor.recreateMissingContainers.calledOnceWith('www_App'), 'recreates once').to.be.true;
+      expect(stubs.appUninstaller.removeAppLocally.called, 'the heal must NEVER uninstall the app').to.be.false;
+    });
+
+    it('does not destroy the container when its network is missing (records network_pruned)', async () => {
+      stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
+      stubs.dockerService.dockerNetworkExists.resolves(false);
+      await appReconciler.reconcile('www_App'); // obs 1
+      await appReconciler.reconcile('www_App'); // obs 2 -> network gone -> skip destructive heal
+      expect(stubs.dockerService.appDockerForceRemove.called, 'must not remove a container it cannot recreate').to.be.false;
+      expect(stubs.containerHealthMonitor.recreateMissingContainers.called).to.be.false;
+      const pruned = stubs.appTamperingDetectionService.recordEvent.getCalls().some((c) => c.args[1] === 'network_pruned');
+      expect(pruned, 'records a network_pruned event').to.be.true;
+    });
+
+    it('a recreate failure retries but never uninstalls the app', async () => {
+      stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
+      stubs.containerHealthMonitor.recreateMissingContainers.rejects(new Error('host port still in use'));
+      await appReconciler.reconcile('www_App'); // obs 1
+      await appReconciler.reconcile('www_App'); // obs 2 -> heal attempt -> recreate throws
+      expect(stubs.dockerService.appDockerForceRemove.called).to.be.true;
+      expect(stubs.appUninstaller.removeAppLocally.called, 'a transient recreate failure must not uninstall').to.be.false;
+    });
+
+    it('gives up after MAX attempts without ever uninstalling', async () => {
+      stubs.dockerService.isContainerDetachedFromNetwork.returns(true);
+      stubs.containerHealthMonitor.recreateMissingContainers.rejects(new Error('host port still in use'));
+      // 1 debounce pass + several act passes; the container stays "running" (inspect
+      // stub), so each pass re-enters the running-detached branch.
+      for (let i = 0; i < 8; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await appReconciler.reconcile('www_App');
+      }
+      expect(stubs.appUninstaller.removeAppLocally.called, 'never uninstalls, even after giving up').to.be.false;
+      const gaveUp = stubs.log.error.getCalls().some((c) => /manual intervention/.test(c.args[0]));
+      expect(gaveUp, 'logs a give-up for manual intervention').to.be.true;
+      // bounded: at most MAX_NETWORK_HEAL_ATTEMPTS (3) recreate attempts, not one per pass
+      expect(stubs.containerHealthMonitor.recreateMissingContainers.callCount).to.be.at.most(3);
     });
   });
 });

--- a/tests/unit/appTamperingBlocklistService.test.js
+++ b/tests/unit/appTamperingBlocklistService.test.js
@@ -35,7 +35,10 @@ describe('appTamperingBlocklistService tests', () => {
       './generalService': generalServiceStub,
       './daemonService/daemonServiceMiscRpcs': daemonMiscStub,
       './benchmarkService': benchmarkServiceStub,
-      './appTamperingDetectionService': { BOOT_STORM_DISCOUNT: 0.25 },
+      './appTamperingDetectionService': {
+        BOOT_STORM_DISCOUNT: 0.25,
+        BOOT_STORM_DISCOUNT_TYPES: ['mount_vanished', 'volume_missing', 'network_pruned', 'recreation_failed'],
+      },
     });
   }
 
@@ -82,7 +85,7 @@ describe('appTamperingBlocklistService tests', () => {
   // outside any boot storm, i.e. a tamper score of exactly n.
   function setTamperScore(n) {
     const incidents = Array.from({ length: n }, () => ({
-      severity: 1, duringBootStorm: false,
+      eventType: 'mount_vanished', severity: 1, duringBootStorm: false,
     }));
     dbHelperStub.aggregateInDatabase = sinon.stub().resolves(incidents);
   }
@@ -126,10 +129,10 @@ describe('appTamperingBlocklistService tests', () => {
 
     it('sums stored severities across incidents', async () => {
       dbHelperStub.aggregateInDatabase = sinon.stub().resolves([
-        { severity: 3, duringBootStorm: false },
-        { severity: 1, duringBootStorm: false },
-        { severity: 1, duringBootStorm: false },
-        { severity: 0, duringBootStorm: false }, // operational/observational
+        { eventType: 'container_vanished', severity: 3, duringBootStorm: false },
+        { eventType: 'network_pruned', severity: 1, duringBootStorm: false },
+        { eventType: 'network_detached', severity: 1, duringBootStorm: false },
+        { eventType: 'recreation_failed', severity: 0, duringBootStorm: false }, // operational
       ]);
 
       const result = await service.computeTamperScore();
@@ -137,11 +140,11 @@ describe('appTamperingBlocklistService tests', () => {
       expect(result).to.equal(5);
     });
 
-    it('discounts incidents flagged duringBootStorm', async () => {
+    it('discounts boot-race incidents flagged duringBootStorm', async () => {
       dbHelperStub.aggregateInDatabase = sinon.stub().resolves([
-        { severity: 1, duringBootStorm: true },
-        { severity: 1, duringBootStorm: true },
-        { severity: 3, duringBootStorm: false },
+        { eventType: 'mount_vanished', severity: 1, duringBootStorm: true },
+        { eventType: 'volume_missing', severity: 1, duringBootStorm: true },
+        { eventType: 'container_vanished', severity: 3, duringBootStorm: false },
       ]);
 
       const result = await service.computeTamperScore();
@@ -149,9 +152,22 @@ describe('appTamperingBlocklistService tests', () => {
       expect(result).to.equal(3.5); // 2 × (1 × 0.25) + 3
     });
 
+    it('never discounts container_vanished, even inside the boot-storm window', async () => {
+      // Containers persist as exited across a clean reboot, so a vanished
+      // container is tamper signal regardless of the window — a reboot must
+      // not buy kill-style tampering a discount.
+      dbHelperStub.aggregateInDatabase = sinon.stub().resolves([
+        { eventType: 'container_vanished', severity: 3, duringBootStorm: true },
+      ]);
+
+      const result = await service.computeTamperScore();
+
+      expect(result).to.equal(3);
+    });
+
     it('treats a missing severity as zero', async () => {
       dbHelperStub.aggregateInDatabase = sinon.stub().resolves([
-        { duringBootStorm: false },
+        { eventType: 'mount_vanished', duringBootStorm: false },
       ]);
 
       const result = await service.computeTamperScore();

--- a/tests/unit/appTamperingBlocklistService.test.js
+++ b/tests/unit/appTamperingBlocklistService.test.js
@@ -45,12 +45,9 @@ describe('appTamperingBlocklistService tests', () => {
 
     dbHelperStub = {
       databaseConnection: sinon.stub().returns({
-        db: sinon.stub().returns({
-          collection: sinon.stub().returns({
-            countDocuments: sinon.stub().resolves(0),
-          }),
-        }),
+        db: sinon.stub().returns({ name: 'mockdb' }),
       }),
+      aggregateInDatabase: sinon.stub().resolves([]),
     };
 
     fluxNetworkHelperStub = {
@@ -80,15 +77,13 @@ describe('appTamperingBlocklistService tests', () => {
     sinon.restore();
   });
 
-  // Helper: set documents returned by the mongo countDocuments stub
-  function setEventCount(n) {
-    dbHelperStub.databaseConnection = sinon.stub().returns({
-      db: sinon.stub().returns({
-        collection: sinon.stub().returns({
-          countDocuments: sinon.stub().resolves(n),
-        }),
-      }),
-    });
+  // Helper: make the incident aggregation return n distinct weight-1
+  // (mount_vanished) incidents, i.e. a tamper score of exactly n.
+  function setTamperScore(n) {
+    const incidents = Array.from({ length: n }, (_, i) => ({
+      _id: { eventType: 'mount_vanished', appName: `app${i}`, day: '2026-07-16' },
+    }));
+    dbHelperStub.aggregateInDatabase = sinon.stub().resolves(incidents);
   }
 
   describe('fetchBlocklist', () => {
@@ -118,33 +113,55 @@ describe('appTamperingBlocklistService tests', () => {
     });
   });
 
-  describe('countTamperingEvents', () => {
-    it('returns the count from mongo', async () => {
-      setEventCount(42);
+  describe('computeTamperScore', () => {
+    it('groups rows into distinct (eventType, appName, day) incidents', async () => {
+      setTamperScore(1);
 
-      const result = await service.countTamperingEvents();
+      await service.computeTamperScore();
 
-      expect(result).to.equal(42);
+      const pipeline = dbHelperStub.aggregateInDatabase.firstCall.args[2];
+      const groupId = pipeline[0].$group._id;
+      expect(groupId).to.have.keys(['eventType', 'appName', 'day']);
+    });
+
+    it('sums per-type weights across incidents', async () => {
+      dbHelperStub.aggregateInDatabase = sinon.stub().resolves([
+        { _id: { eventType: 'container_vanished', appName: 'a', day: '2026-07-16' } }, // 3
+        { _id: { eventType: 'network_pruned', appName: 'a', day: '2026-07-16' } }, // 1
+        { _id: { eventType: 'network_detached', appName: 'b', day: '2026-07-16' } }, // 1
+        { _id: { eventType: 'mount_vanished', appName: 'b', day: '2026-07-16' } }, // 1
+        { _id: { eventType: 'volume_missing', appName: 'c', day: '2026-07-16' } }, // 1
+      ]);
+
+      const result = await service.computeTamperScore();
+
+      expect(result).to.equal(7);
+    });
+
+    it('gives operational and observational event types zero weight', async () => {
+      dbHelperStub.aggregateInDatabase = sinon.stub().resolves([
+        { _id: { eventType: 'recreation_failed', appName: 'a', day: '2026-07-16' } },
+        { _id: { eventType: 'node_reboot', appName: '__system__', day: '2026-07-16' } },
+        { _id: { eventType: 'frequent_restart', appName: '__system__', day: '2026-07-16' } },
+      ]);
+
+      const result = await service.computeTamperScore();
+
+      expect(result).to.equal(0);
     });
 
     it('returns 0 when DB is unavailable', async () => {
       dbHelperStub.databaseConnection = sinon.stub().returns(null);
 
-      const result = await service.countTamperingEvents();
+      const result = await service.computeTamperScore();
 
       expect(result).to.equal(0);
     });
 
     it('returns 0 on mongo errors', async () => {
-      dbHelperStub.databaseConnection = sinon.stub().returns({
-        db: sinon.stub().returns({
-          collection: sinon.stub().returns({
-            countDocuments: sinon.stub().rejects(new Error('mongo boom')),
-          }),
-        }),
-      });
+      dbHelperStub.aggregateInDatabase = sinon.stub().rejects(new Error('mongo boom'));
 
-      const result = await service.countTamperingEvents();
+      const result = await service.computeTamperScore();
 
       expect(result).to.equal(0);
     });
@@ -195,25 +212,25 @@ describe('appTamperingBlocklistService tests', () => {
 
     it('does nothing when txhash is not on the blocklist', async () => {
       serviceHelperStub.axiosGet.resolves({ data: ['otherhash'] });
-      setEventCount(100);
+      setTamperScore(100);
 
       await service.enforceBlocklist();
 
       expect(fluxNetworkHelperStub.setStickyDosMessage.called).to.be.false;
     });
 
-    it('does nothing when listed but events <= threshold', async () => {
+    it('does nothing when listed but score <= threshold', async () => {
       serviceHelperStub.axiosGet.resolves({ data: [MOCK_TXHASH] });
-      setEventCount(10); // threshold is >10, so exactly 10 should NOT trigger
+      setTamperScore(10); // threshold is >10, so exactly 10 should NOT trigger
 
       await service.enforceBlocklist();
 
       expect(fluxNetworkHelperStub.setStickyDosMessage.called).to.be.false;
     });
 
-    it('sets sticky DOS when listed AND events > threshold', async () => {
+    it('sets sticky DOS when listed AND score > threshold', async () => {
       serviceHelperStub.axiosGet.resolves({ data: [MOCK_TXHASH] });
-      setEventCount(11);
+      setTamperScore(11);
 
       await service.enforceBlocklist();
 
@@ -229,7 +246,7 @@ describe('appTamperingBlocklistService tests', () => {
     it('clears sticky DOS on next tick when condition no longer holds', async () => {
       // First tick: set DOS
       serviceHelperStub.axiosGet.resolves({ data: [MOCK_TXHASH] });
-      setEventCount(15);
+      setTamperScore(15);
       await service.enforceBlocklist();
       expect(service.isDosActive()).to.be.true;
 
@@ -241,13 +258,13 @@ describe('appTamperingBlocklistService tests', () => {
       expect(service.isDosActive()).to.be.false;
     });
 
-    it('clears sticky DOS when events drop to <= threshold', async () => {
+    it('clears sticky DOS when the score drops to <= threshold', async () => {
       serviceHelperStub.axiosGet.resolves({ data: [MOCK_TXHASH] });
-      setEventCount(15);
+      setTamperScore(15);
       await service.enforceBlocklist();
       expect(service.isDosActive()).to.be.true;
 
-      setEventCount(5);
+      setTamperScore(5);
       await service.enforceBlocklist();
 
       sinon.assert.called(fluxNetworkHelperStub.clearStickyDosMessage);
@@ -256,10 +273,10 @@ describe('appTamperingBlocklistService tests', () => {
 
     it('clears an orphaned sticky DOS message owned by this service', async () => {
       // ourDosActive is false, but sticky owned by us (prefix match) from prior run
-      const ours = `${service.DOS_MESSAGE_PREFIX}: 42 events, txhash xyz`;
+      const ours = `${service.DOS_MESSAGE_PREFIX}: tamper score 42, txhash xyz`;
       fluxNetworkHelperStub.getStickyDosMessage = sinon.stub().returns(ours);
       serviceHelperStub.axiosGet.resolves({ data: [] });
-      setEventCount(0);
+      setTamperScore(0);
 
       await service.enforceBlocklist();
 
@@ -270,7 +287,7 @@ describe('appTamperingBlocklistService tests', () => {
       // Some other module set sticky for an unrelated reason
       fluxNetworkHelperStub.getStickyDosMessage = sinon.stub().returns('some other module sticky reason');
       serviceHelperStub.axiosGet.resolves({ data: [] });
-      setEventCount(0);
+      setTamperScore(0);
 
       await service.enforceBlocklist();
 
@@ -324,7 +341,7 @@ describe('appTamperingBlocklistService tests', () => {
     it('enforceBlocklist is a no-op when bench reports systemsecure=true', async () => {
       const arcaneService = makeArcaneService();
       serviceHelperStub.axiosGet.resolves({ data: [MOCK_TXHASH] });
-      setEventCount(100);
+      setTamperScore(100);
 
       await arcaneService.enforceBlocklist();
 
@@ -357,7 +374,7 @@ describe('appTamperingBlocklistService tests', () => {
       benchmarkServiceStub.getBenchmarks = sinon.stub().rejects(new Error('bench down'));
       const svc = loadService();
       serviceHelperStub.axiosGet.resolves({ data: [MOCK_TXHASH] });
-      setEventCount(100);
+      setTamperScore(100);
 
       await svc.enforceBlocklist();
 
@@ -369,7 +386,7 @@ describe('appTamperingBlocklistService tests', () => {
       benchmarkServiceStub.getBenchmarks = sinon.stub().resolves({ status: 'error' });
       const svc = loadService();
       serviceHelperStub.axiosGet.resolves({ data: [MOCK_TXHASH] });
-      setEventCount(100);
+      setTamperScore(100);
 
       await svc.enforceBlocklist();
 
@@ -384,7 +401,7 @@ describe('appTamperingBlocklistService tests', () => {
       });
       const svc = loadService();
       serviceHelperStub.axiosGet.resolves({ data: [MOCK_TXHASH] });
-      setEventCount(100);
+      setTamperScore(100);
 
       await svc.enforceBlocklist();
 
@@ -398,7 +415,7 @@ describe('appTamperingBlocklistService tests', () => {
       process.env.FLUXOS_PATH = '/fake/arcane/path';
       try {
         serviceHelperStub.axiosGet.resolves({ data: [MOCK_TXHASH] });
-        setEventCount(100);
+        setTamperScore(100);
         const svc = loadService();
 
         await svc.enforceBlocklist();

--- a/tests/unit/appTamperingBlocklistService.test.js
+++ b/tests/unit/appTamperingBlocklistService.test.js
@@ -35,6 +35,7 @@ describe('appTamperingBlocklistService tests', () => {
       './generalService': generalServiceStub,
       './daemonService/daemonServiceMiscRpcs': daemonMiscStub,
       './benchmarkService': benchmarkServiceStub,
+      './appTamperingDetectionService': { BOOT_STORM_DISCOUNT: 0.25 },
     });
   }
 
@@ -77,11 +78,11 @@ describe('appTamperingBlocklistService tests', () => {
     sinon.restore();
   });
 
-  // Helper: make the incident aggregation return n distinct weight-1
-  // (mount_vanished) incidents, i.e. a tamper score of exactly n.
+  // Helper: make the incident aggregation return n severity-1 incidents
+  // outside any boot storm, i.e. a tamper score of exactly n.
   function setTamperScore(n) {
-    const incidents = Array.from({ length: n }, (_, i) => ({
-      _id: { eventType: 'mount_vanished', appName: `app${i}`, day: '2026-07-16' },
+    const incidents = Array.from({ length: n }, () => ({
+      severity: 1, duringBootStorm: false,
     }));
     dbHelperStub.aggregateInDatabase = sinon.stub().resolves(incidents);
   }
@@ -114,35 +115,43 @@ describe('appTamperingBlocklistService tests', () => {
   });
 
   describe('computeTamperScore', () => {
-    it('groups rows into distinct (eventType, appName, day) incidents', async () => {
+    it('scores only current-schema incident documents', async () => {
       setTamperScore(1);
 
       await service.computeTamperScore();
 
       const pipeline = dbHelperStub.aggregateInDatabase.firstCall.args[2];
-      const groupId = pipeline[0].$group._id;
-      expect(groupId).to.have.keys(['eventType', 'appName', 'day']);
+      expect(pipeline[0]).to.deep.equal({ $match: { schemaVersion: { $gte: 1 } } });
     });
 
-    it('sums per-type weights across incidents', async () => {
+    it('sums stored severities across incidents', async () => {
       dbHelperStub.aggregateInDatabase = sinon.stub().resolves([
-        { _id: { eventType: 'container_vanished', appName: 'a', day: '2026-07-16' } }, // 3
-        { _id: { eventType: 'network_pruned', appName: 'a', day: '2026-07-16' } }, // 1
-        { _id: { eventType: 'network_detached', appName: 'b', day: '2026-07-16' } }, // 1
-        { _id: { eventType: 'mount_vanished', appName: 'b', day: '2026-07-16' } }, // 1
-        { _id: { eventType: 'volume_missing', appName: 'c', day: '2026-07-16' } }, // 1
+        { severity: 3, duringBootStorm: false },
+        { severity: 1, duringBootStorm: false },
+        { severity: 1, duringBootStorm: false },
+        { severity: 0, duringBootStorm: false }, // operational/observational
       ]);
 
       const result = await service.computeTamperScore();
 
-      expect(result).to.equal(7);
+      expect(result).to.equal(5);
     });
 
-    it('gives operational and observational event types zero weight', async () => {
+    it('discounts incidents flagged duringBootStorm', async () => {
       dbHelperStub.aggregateInDatabase = sinon.stub().resolves([
-        { _id: { eventType: 'recreation_failed', appName: 'a', day: '2026-07-16' } },
-        { _id: { eventType: 'node_reboot', appName: '__system__', day: '2026-07-16' } },
-        { _id: { eventType: 'frequent_restart', appName: '__system__', day: '2026-07-16' } },
+        { severity: 1, duringBootStorm: true },
+        { severity: 1, duringBootStorm: true },
+        { severity: 3, duringBootStorm: false },
+      ]);
+
+      const result = await service.computeTamperScore();
+
+      expect(result).to.equal(3.5); // 2 × (1 × 0.25) + 3
+    });
+
+    it('treats a missing severity as zero', async () => {
+      dbHelperStub.aggregateInDatabase = sinon.stub().resolves([
+        { duringBootStorm: false },
       ]);
 
       const result = await service.computeTamperScore();

--- a/tests/unit/appTamperingBlocklistService.test.js
+++ b/tests/unit/appTamperingBlocklistService.test.js
@@ -35,10 +35,6 @@ describe('appTamperingBlocklistService tests', () => {
       './generalService': generalServiceStub,
       './daemonService/daemonServiceMiscRpcs': daemonMiscStub,
       './benchmarkService': benchmarkServiceStub,
-      './appTamperingDetectionService': {
-        BOOT_STORM_DISCOUNT: 0.25,
-        BOOT_STORM_DISCOUNT_TYPES: ['mount_vanished', 'volume_missing', 'network_pruned', 'recreation_failed'],
-      },
     });
   }
 
@@ -81,11 +77,11 @@ describe('appTamperingBlocklistService tests', () => {
     sinon.restore();
   });
 
-  // Helper: make the incident aggregation return n severity-1 incidents
-  // outside any boot storm, i.e. a tamper score of exactly n.
+  // Helper: make the incident aggregation return n severity-1 incidents,
+  // i.e. a tamper score of exactly n.
   function setTamperScore(n) {
     const incidents = Array.from({ length: n }, () => ({
-      eventType: 'mount_vanished', severity: 1, duringBootStorm: false,
+      eventType: 'mount_vanished', severity: 1,
     }));
     dbHelperStub.aggregateInDatabase = sinon.stub().resolves(incidents);
   }
@@ -129,10 +125,10 @@ describe('appTamperingBlocklistService tests', () => {
 
     it('sums stored severities across incidents', async () => {
       dbHelperStub.aggregateInDatabase = sinon.stub().resolves([
-        { eventType: 'container_vanished', severity: 3, duringBootStorm: false },
-        { eventType: 'network_pruned', severity: 1, duringBootStorm: false },
-        { eventType: 'network_detached', severity: 1, duringBootStorm: false },
-        { eventType: 'recreation_failed', severity: 0, duringBootStorm: false }, // operational
+        { eventType: 'container_vanished', severity: 3 },
+        { eventType: 'network_pruned', severity: 1 },
+        { eventType: 'network_detached', severity: 1 },
+        { eventType: 'recreation_failed', severity: 0 }, // operational
       ]);
 
       const result = await service.computeTamperScore();
@@ -140,34 +136,22 @@ describe('appTamperingBlocklistService tests', () => {
       expect(result).to.equal(5);
     });
 
-    it('discounts boot-race incidents flagged duringBootStorm', async () => {
+    it('scores full weight regardless of stored duringBootStorm flags', async () => {
+      // Stored incidents may carry a duringBootStorm flag; it is inert —
+      // severities always sum in full.
       dbHelperStub.aggregateInDatabase = sinon.stub().resolves([
         { eventType: 'mount_vanished', severity: 1, duringBootStorm: true },
-        { eventType: 'volume_missing', severity: 1, duringBootStorm: true },
-        { eventType: 'container_vanished', severity: 3, duringBootStorm: false },
-      ]);
-
-      const result = await service.computeTamperScore();
-
-      expect(result).to.equal(3.5); // 2 × (1 × 0.25) + 3
-    });
-
-    it('never discounts container_vanished, even inside the boot-storm window', async () => {
-      // Containers persist as exited across a clean reboot, so a vanished
-      // container is tamper signal regardless of the window — a reboot must
-      // not buy kill-style tampering a discount.
-      dbHelperStub.aggregateInDatabase = sinon.stub().resolves([
         { eventType: 'container_vanished', severity: 3, duringBootStorm: true },
       ]);
 
       const result = await service.computeTamperScore();
 
-      expect(result).to.equal(3);
+      expect(result).to.equal(4);
     });
 
     it('treats a missing severity as zero', async () => {
       dbHelperStub.aggregateInDatabase = sinon.stub().resolves([
-        { eventType: 'mount_vanished', duringBootStorm: false },
+        { eventType: 'mount_vanished' },
       ]);
 
       const result = await service.computeTamperScore();

--- a/tests/unit/appTamperingDetectionService.test.js
+++ b/tests/unit/appTamperingDetectionService.test.js
@@ -195,7 +195,6 @@ describe('appTamperingDetectionService tests', () => {
       const ins = update.$setOnInsert;
       expect(ins.schemaVersion).to.equal(1);
       expect(ins.severity).to.equal(service.EVENT_SEVERITY.container_vanished);
-      expect(ins.duringBootStorm).to.be.false;
       expect(ins.firstSeen).to.be.instanceOf(Date);
       expect(ins.detailsSample).to.equal('details here');
       expect(ins.uptimeSecAtEvent).to.equal(3600);
@@ -266,12 +265,10 @@ describe('appTamperingDetectionService tests', () => {
       expect(ins.appHash).to.equal('spechash1');
     });
 
-    it('records null attribution for unknown apps and for __system__', async () => {
+    it('records null attribution for unknown apps', async () => {
       await service.recordEvent('ghostapp', 'container_vanished', 'x');
-      await service.recordEvent(service.SYSTEM_APP_NAME, 'node_reboot', 'x');
 
       expect(eventUpserts()[0].update.$setOnInsert.ownerZelid).to.be.null;
-      expect(eventUpserts()[1].update.$setOnInsert.ownerZelid).to.be.null;
     });
 
     it('uses the same incidentKey for repeats within the hour bucket', async () => {
@@ -339,45 +336,11 @@ describe('appTamperingDetectionService tests', () => {
     });
   });
 
-  describe('boot storm flagging', () => {
-    async function rebootNow() {
+  describe('boot context keying', () => {
+    it('keys incidents by the current boot_id once checkNodeReboot has run', async () => {
       dbHelperStub.findOneInDatabase = sinon.stub().callsFake(async (db, coll, query) => {
         if (coll === 'nodestartuptracker' && query._id === 'lastStartup') {
           return { _id: 'lastStartup', at: new Date(), bootId: PREVIOUS_BOOT_ID };
-        }
-        return null;
-      });
-      await service.checkNodeReboot();
-    }
-
-    it('flags events inside the window after a boot_id change', async () => {
-      sinon.useFakeTimers(new Date('2026-07-16T10:00:00Z'));
-      await rebootNow();
-
-      await service.recordEvent('myapp', 'mount_vanished', 'late disk');
-
-      const incident = eventUpserts().find((c) => c.query.eventType === 'mount_vanished');
-      expect(incident.update.$setOnInsert.duringBootStorm).to.be.true;
-      expect(incident.update.$setOnInsert.bootId).to.equal(CURRENT_BOOT_ID);
-      expect(incident.query.incidentKey).to.include(CURRENT_BOOT_ID);
-    });
-
-    it('stops flagging once the window has elapsed', async () => {
-      const clock = sinon.useFakeTimers(new Date('2026-07-16T10:00:00Z'));
-      await rebootNow();
-
-      clock.tick(service.BOOT_STORM_WINDOW_MS);
-      await service.recordEvent('myapp', 'mount_vanished', 'vanished while up');
-
-      const incident = eventUpserts().find((c) => c.query.eventType === 'mount_vanished');
-      expect(incident.update.$setOnInsert.duringBootStorm).to.be.false;
-    });
-
-    it('does NOT open the window on a same-boot_id process restart', async () => {
-      sinon.useFakeTimers(new Date('2026-07-16T10:00:00Z'));
-      dbHelperStub.findOneInDatabase = sinon.stub().callsFake(async (db, coll, query) => {
-        if (coll === 'nodestartuptracker' && query._id === 'lastStartup') {
-          return { _id: 'lastStartup', at: new Date(), bootId: CURRENT_BOOT_ID };
         }
         return null;
       });
@@ -386,7 +349,8 @@ describe('appTamperingDetectionService tests', () => {
       await service.recordEvent('myapp', 'mount_vanished', 'x');
 
       const incident = eventUpserts().find((c) => c.query.eventType === 'mount_vanished');
-      expect(incident.update.$setOnInsert.duringBootStorm).to.be.false;
+      expect(incident.update.$setOnInsert.bootId).to.equal(CURRENT_BOOT_ID);
+      expect(incident.query.incidentKey).to.include(CURRENT_BOOT_ID);
     });
   });
 
@@ -544,20 +508,14 @@ describe('appTamperingDetectionService tests', () => {
       });
     }
 
-    it('records a node_reboot incident when the boot_id changed', async () => {
-      const previousAt = new Date('2026-07-15T10:00:00Z');
-      setMarker({ _id: 'lastStartup', at: previousAt, bootId: PREVIOUS_BOOT_ID });
+    it('records a reboot only in the boot history, never as an incident', async () => {
+      setMarker({ _id: 'lastStartup', at: new Date('2026-07-15T10:00:00Z'), bootId: PREVIOUS_BOOT_ID });
 
       await service.checkNodeReboot();
 
-      const reboots = eventUpserts().filter((c) => c.query.eventType === 'node_reboot');
-      expect(reboots).to.have.lengthOf(1);
-      expect(reboots[0].query.appName).to.equal(service.SYSTEM_APP_NAME);
-      const ins = reboots[0].update.$setOnInsert;
-      expect(ins.severity).to.equal(0);
-      expect(ins.detailsSample).to.include(PREVIOUS_BOOT_ID.slice(0, 8));
-      expect(ins.detailsSample).to.include(CURRENT_BOOT_ID.slice(0, 8));
-      expect(ins.detailsSample).to.include(previousAt.toISOString());
+      expect(eventUpserts()).to.have.lengthOf(0);
+      expect(historyUpdates()).to.have.lengthOf(1);
+      expect(markerUpdates()).to.have.lengthOf(1);
     });
 
     it('does NOT record an incident on a same-boot_id process restart', async () => {
@@ -605,6 +563,9 @@ describe('appTamperingDetectionService tests', () => {
       const push = history[0].update.$push.boots;
       expect(push.$each[0].bootId).to.equal(CURRENT_BOOT_ID);
       expect(push.$each[0].at).to.be.instanceOf(Date);
+      // bootedAt = FluxOS start minus the stubbed 3600s of machine uptime
+      expect(push.$each[0].bootedAt).to.be.instanceOf(Date);
+      expect(push.$each[0].at.getTime() - push.$each[0].bootedAt.getTime()).to.equal(3600 * 1000);
       expect(push.$slice).to.equal(-service.BOOT_HISTORY_MAX);
       expect(history[0].options).to.deep.equal({ upsert: true });
     });

--- a/tests/unit/appTamperingDetectionService.test.js
+++ b/tests/unit/appTamperingDetectionService.test.js
@@ -38,6 +38,7 @@ describe('appTamperingDetectionService tests', () => {
       }),
       findOneInDatabase: sinon.stub().resolves(null),
       findOneAndUpdateInDatabase: sinon.stub().resolves({ value: null }),
+      removeDocumentsFromCollection: sinon.stub().resolves({ deletedCount: 0 }),
     };
 
     logStub = {
@@ -410,6 +411,24 @@ describe('appTamperingDetectionService tests', () => {
       expect(dbHelperStub.findOneAndUpdateInDatabase.called).to.be.false;
     });
 
+    it('purges legacy frequent_restart rows', async () => {
+      await service.checkNodeReboot();
+
+      sinon.assert.calledOnce(dbHelperStub.removeDocumentsFromCollection);
+      const { args } = dbHelperStub.removeDocumentsFromCollection.firstCall;
+      expect(args[1]).to.equal('apptamperingevents');
+      expect(args[2]).to.deep.equal({ eventType: 'frequent_restart' });
+    });
+
+    it('still tracks the boot when the legacy purge fails', async () => {
+      dbHelperStub.removeDocumentsFromCollection = sinon.stub().rejects(new Error('no permission'));
+
+      await service.checkNodeReboot();
+
+      expect(markerUpdates()).to.have.lengthOf(1);
+      sinon.assert.called(logStub.warn);
+    });
+
     it('no-ops when DB is unavailable', async () => {
       dbHelperStub.databaseConnection = sinon.stub().returns(null);
 
@@ -417,6 +436,7 @@ describe('appTamperingDetectionService tests', () => {
 
       expect(dbHelperStub.findOneInDatabase.called).to.be.false;
       expect(dbHelperStub.findOneAndUpdateInDatabase.called).to.be.false;
+      expect(dbHelperStub.removeDocumentsFromCollection.called).to.be.false;
     });
 
     it('swallows errors without throwing and logs them', async () => {

--- a/tests/unit/appTamperingDetectionService.test.js
+++ b/tests/unit/appTamperingDetectionService.test.js
@@ -7,28 +7,54 @@ describe('appTamperingDetectionService tests', () => {
   let dbHelperStub;
   let logStub;
   let fsReadFileStub;
-  let insertedDocs;
+  let fluxnodeRpcsStub;
+  let generalServiceStub;
+  let upsertCalls;
   let findResults;
   let lastFindArgs;
-  let databaseConnectionReturn;
+  let installedApps;
 
   const CURRENT_BOOT_ID = 'aaaaaaaa-1111-2222-3333-444444444444';
   const PREVIOUS_BOOT_ID = 'bbbbbbbb-5555-6666-7777-888888888888';
+  const NODE_STATUS = {
+    status: 'success',
+    data: {
+      txhash: 'deadbeefcafe',
+      outidx: 0,
+      ip: '65.108.1.2:16127',
+      pubkey: '04aabbcc',
+      payment_address: 't1payout',
+      collateral: 'COutPoint(deadbeefcafe, 0)',
+    },
+  };
+
+  function eventUpserts() {
+    return upsertCalls.filter((c) => c.coll === 'apptamperingevents');
+  }
+
+  function markerUpdates() {
+    return upsertCalls.filter((c) => c.coll === 'nodestartuptracker' && c.query._id === 'lastStartup');
+  }
+
+  function historyUpdates() {
+    return upsertCalls.filter((c) => c.coll === 'nodestartuptracker' && c.query._id === 'bootHistory');
+  }
 
   beforeEach(() => {
-    insertedDocs = [];
+    upsertCalls = [];
     findResults = [];
     lastFindArgs = null;
-
-    databaseConnectionReturn = {
-      db: sinon.stub().returns({ name: 'mockdb' }),
-    };
+    installedApps = {}; // name -> { owner, hash }
 
     dbHelperStub = {
-      databaseConnection: sinon.stub().callsFake(() => databaseConnectionReturn),
-      insertOneToDatabase: sinon.stub().callsFake(async (db, coll, doc) => {
-        insertedDocs.push({ db, coll, doc });
-        return { insertedId: 'mock-id' };
+      databaseConnection: sinon.stub().returns({
+        db: sinon.stub().callsFake((name) => ({ name })),
+      }),
+      findOneAndUpdateInDatabase: sinon.stub().callsFake(async (db, coll, query, update, options) => {
+        upsertCalls.push({
+          db, coll, query, update, options,
+        });
+        return null; // driver v6 upsert shape: null means a fresh insert
       }),
       findInDatabase: sinon.stub().callsFake(async (db, coll, query, options) => {
         lastFindArgs = {
@@ -36,8 +62,10 @@ describe('appTamperingDetectionService tests', () => {
         };
         return findResults;
       }),
-      findOneInDatabase: sinon.stub().resolves(null),
-      findOneAndUpdateInDatabase: sinon.stub().resolves({ value: null }),
+      findOneInDatabase: sinon.stub().callsFake(async (db, coll, query) => {
+        if (coll === 'zelappsinformation') return installedApps[query.name] || null;
+        return null; // startup marker by default absent
+      }),
       removeDocumentsFromCollection: sinon.stub().resolves({ deletedCount: 0 }),
     };
 
@@ -46,6 +74,8 @@ describe('appTamperingDetectionService tests', () => {
     };
 
     fsReadFileStub = sinon.stub().resolves(`${CURRENT_BOOT_ID}\n`);
+    fluxnodeRpcsStub = { getFluxNodeStatus: sinon.stub().resolves(NODE_STATUS) };
+    generalServiceStub = { getCollateralInfo: sinon.stub().returns({ txhash: 'colTx', txindex: 7 }) };
 
     service = proxyquire('../../ZelBack/src/services/appTamperingDetectionService', {
       config: {
@@ -57,6 +87,10 @@ describe('appTamperingDetectionService tests', () => {
               nodeStartupTracker: 'nodestartuptracker',
             },
           },
+          appslocal: {
+            database: 'localzelappsinformation',
+            collections: { appsInformation: 'zelappsinformation' },
+          },
         },
         system: {
           bootIdPath: '/proc/sys/kernel/random/boot_id',
@@ -65,8 +99,12 @@ describe('appTamperingDetectionService tests', () => {
       fs: {
         promises: { readFile: fsReadFileStub },
       },
+      os: { uptime: () => 3600 },
       './dbHelper': dbHelperStub,
       '../lib/log': logStub,
+      './generalService': generalServiceStub,
+      './daemonService/daemonServiceFluxnodeRpcs': fluxnodeRpcsStub,
+      './utils/appConstants': { localAppsInformation: 'zelappsinformation' },
       './messageHelper': {
         createDataMessage: (d) => ({ status: 'success', data: d }),
         createErrorMessage: (m) => ({ status: 'error', data: { message: m } }),
@@ -123,92 +161,231 @@ describe('appTamperingDetectionService tests', () => {
     });
   });
 
+  describe('deriveMainAppName', () => {
+    it('passes a plain app name through', () => {
+      expect(service.deriveMainAppName('MyApp')).to.equal('MyApp');
+    });
+
+    it('strips the flux docker prefix', () => {
+      expect(service.deriveMainAppName('fluxMyApp')).to.equal('MyApp');
+    });
+
+    it('strips the zel docker prefix', () => {
+      expect(service.deriveMainAppName('zelMyApp')).to.equal('MyApp');
+    });
+
+    it('reduces a component identifier to the main app name', () => {
+      expect(service.deriveMainAppName('fluxweb_MyApp')).to.equal('MyApp');
+      expect(service.deriveMainAppName('web_MyApp')).to.equal('MyApp');
+    });
+  });
+
   describe('recordEvent', () => {
-    it('inserts a new document with expected shape', async () => {
+    it('upserts an incident with the full schema on first sight', async () => {
       await service.recordEvent('myapp', 'container_vanished', 'details here');
 
-      expect(insertedDocs).to.have.lengthOf(1);
-      const { coll, doc } = insertedDocs[0];
-      expect(coll).to.equal('apptamperingevents');
-      expect(doc.appName).to.equal('myapp');
-      expect(doc.eventType).to.equal('container_vanished');
-      expect(doc.details).to.equal('details here');
-      expect(doc.detectedAt).to.be.instanceOf(Date);
+      expect(eventUpserts()).to.have.lengthOf(1);
+      const { query, update, options } = eventUpserts()[0];
+      expect(query.appName).to.equal('myapp');
+      expect(query.eventType).to.equal('container_vanished');
+      expect(query.incidentKey).to.be.a('string');
+      expect(options).to.deep.equal({ upsert: true });
+
+      const ins = update.$setOnInsert;
+      expect(ins.schemaVersion).to.equal(1);
+      expect(ins.severity).to.equal(service.EVENT_SEVERITY.container_vanished);
+      expect(ins.duringBootStorm).to.be.false;
+      expect(ins.firstSeen).to.be.instanceOf(Date);
+      expect(ins.detailsSample).to.equal('details here');
+      expect(ins.uptimeSecAtEvent).to.equal(3600);
+      expect(update.$set.lastSeen).to.be.instanceOf(Date);
+      expect(update.$inc).to.deep.equal({ count: 1 });
     });
 
-    it('suppresses repeat (appName, eventType) calls within the episode window', async () => {
+    it('stamps node and operator identity from the daemon status', async () => {
+      await service.recordEvent('myapp', 'container_vanished', 'x');
+
+      const ins = eventUpserts()[0].update.$setOnInsert;
+      expect(ins.nodeTxid).to.equal('deadbeefcafe');
+      expect(ins.nodeOutidx).to.equal(0);
+      expect(ins.nodeIp).to.equal('65.108.1.2:16127');
+      expect(ins.pubkey).to.equal('04aabbcc');
+      expect(ins.paymentAddress).to.equal('t1payout');
+    });
+
+    it('caches node identity across events (one RPC)', async () => {
+      await service.recordEvent('a', 'container_vanished', 'x');
+      await service.recordEvent('b', 'container_vanished', 'x');
+
+      sinon.assert.calledOnce(fluxnodeRpcsStub.getFluxNodeStatus);
+    });
+
+    it('falls back to collateral parsing when status lacks txhash/outidx', async () => {
+      fluxnodeRpcsStub.getFluxNodeStatus.resolves({
+        status: 'success',
+        data: { collateral: 'COutPoint(colTx, 7)', ip: '1.2.3.4' },
+      });
+
+      await service.recordEvent('myapp', 'container_vanished', 'x');
+
+      const ins = eventUpserts()[0].update.$setOnInsert;
+      expect(ins.nodeTxid).to.equal('colTx');
+      expect(ins.nodeOutidx).to.equal(7);
+    });
+
+    it('records unattributed when the daemon is unreachable, and backs off', async () => {
+      fluxnodeRpcsStub.getFluxNodeStatus.rejects(new Error('daemon down'));
+
+      await service.recordEvent('a', 'container_vanished', 'x');
+      await service.recordEvent('b', 'container_vanished', 'x');
+
+      expect(eventUpserts()).to.have.lengthOf(2);
+      expect(eventUpserts()[0].update.$setOnInsert.nodeTxid).to.be.null;
+      expect(eventUpserts()[0].update.$setOnInsert.pubkey).to.be.null;
+      sinon.assert.calledOnce(fluxnodeRpcsStub.getFluxNodeStatus); // backoff, no hammering
+    });
+
+    it('attributes the app owner and spec hash by exact name', async () => {
+      installedApps.myapp = { owner: '1ownerZelid', hash: 'spechash1' };
+
+      await service.recordEvent('myapp', 'container_vanished', 'x');
+
+      const ins = eventUpserts()[0].update.$setOnInsert;
+      expect(ins.ownerZelid).to.equal('1ownerZelid');
+      expect(ins.appHash).to.equal('spechash1');
+    });
+
+    it('attributes a component identifier via the derived main app name', async () => {
+      installedApps.MyApp = { owner: '1ownerZelid', hash: 'spechash1' };
+
+      await service.recordEvent('fluxweb_MyApp', 'mount_vanished', 'x');
+
+      const ins = eventUpserts()[0].update.$setOnInsert;
+      expect(ins.ownerZelid).to.equal('1ownerZelid');
+      expect(ins.appHash).to.equal('spechash1');
+    });
+
+    it('records null attribution for unknown apps and for __system__', async () => {
+      await service.recordEvent('ghostapp', 'container_vanished', 'x');
+      await service.recordEvent(service.SYSTEM_APP_NAME, 'node_reboot', 'x');
+
+      expect(eventUpserts()[0].update.$setOnInsert.ownerZelid).to.be.null;
+      expect(eventUpserts()[1].update.$setOnInsert.ownerZelid).to.be.null;
+    });
+
+    it('uses the same incidentKey for repeats within the hour bucket', async () => {
+      const clock = sinon.useFakeTimers(new Date('2026-07-16T10:00:00Z'));
+
       await service.recordEvent('myapp', 'mount_vanished', 'a');
+      clock.tick(10 * 60 * 1000);
       await service.recordEvent('myapp', 'mount_vanished', 'b');
-      await service.recordEvent('myapp', 'mount_vanished', 'c');
 
-      expect(insertedDocs).to.have.lengthOf(1);
-      expect(insertedDocs[0].doc.details).to.equal('a');
+      expect(eventUpserts()).to.have.lengthOf(2); // both reach the DB: count rolls up
+      expect(eventUpserts()[0].query.incidentKey).to.equal(eventUpserts()[1].query.incidentKey);
     });
 
-    it('records different event types for the same app independently', async () => {
-      await service.recordEvent('myapp', 'container_vanished', 'a');
-      await service.recordEvent('myapp', 'recreation_failed', 'b');
+    it('opens a new incident in the next hour bucket', async () => {
+      const clock = sinon.useFakeTimers(new Date('2026-07-16T10:00:00Z'));
 
-      expect(insertedDocs).to.have.lengthOf(2);
+      await service.recordEvent('myapp', 'mount_vanished', 'a');
+      clock.tick(service.INCIDENT_BUCKET_MS);
+      await service.recordEvent('myapp', 'mount_vanished', 'b');
+
+      expect(eventUpserts()[0].query.incidentKey).to.not.equal(eventUpserts()[1].query.incidentKey);
     });
 
-    it('records the same event type for different apps independently', async () => {
-      await service.recordEvent('app1', 'mount_vanished', 'a');
-      await service.recordEvent('app2', 'mount_vanished', 'b');
+    it('stamps severity 0 for operational and unknown event types', async () => {
+      await service.recordEvent('myapp', 'recreation_failed', 'x');
+      await service.recordEvent('myapp', 'some_future_type', 'x');
 
-      expect(insertedDocs).to.have.lengthOf(2);
+      expect(eventUpserts()[0].update.$setOnInsert.severity).to.equal(0);
+      expect(eventUpserts()[1].update.$setOnInsert.severity).to.equal(0);
     });
 
-    it('records again once the episode window has elapsed', async () => {
-      const clock = sinon.useFakeTimers(new Date('2026-07-16T00:00:00Z'));
+    it('retries once when concurrent upserts race on the unique index', async () => {
+      const dupErr = new Error('E11000 duplicate key');
+      dupErr.code = 11000;
+      dbHelperStub.findOneAndUpdateInDatabase = sinon.stub()
+        .onFirstCall().rejects(dupErr)
+        .callsFake(async (db, coll, query, update, options) => {
+          upsertCalls.push({
+            db, coll, query, update, options,
+          });
+          return { count: 1 };
+        });
 
-      await service.recordEvent('myapp', 'mount_vanished', 'first episode');
-      clock.tick(service.EPISODE_WINDOW_MS);
-      await service.recordEvent('myapp', 'mount_vanished', 'second episode');
+      await service.recordEvent('myapp', 'container_vanished', 'x');
 
-      expect(insertedDocs).to.have.lengthOf(2);
-    });
-
-    it('still suppresses just before the episode window elapses', async () => {
-      const clock = sinon.useFakeTimers(new Date('2026-07-16T00:00:00Z'));
-
-      await service.recordEvent('myapp', 'mount_vanished', 'first');
-      clock.tick(service.EPISODE_WINDOW_MS - 1);
-      await service.recordEvent('myapp', 'mount_vanished', 'still same episode');
-
-      expect(insertedDocs).to.have.lengthOf(1);
+      expect(eventUpserts()).to.have.lengthOf(1);
+      expect(logStub.error.called).to.be.false;
     });
 
     it('no-ops when DB is not available', async () => {
-      databaseConnectionReturn = null;
       dbHelperStub.databaseConnection = sinon.stub().returns(null);
 
       await service.recordEvent('myapp', 'container_vanished', 'x');
 
-      expect(dbHelperStub.insertOneToDatabase.called).to.be.false;
+      expect(dbHelperStub.findOneAndUpdateInDatabase.called).to.be.false;
     });
 
-    it('swallows insert errors without throwing and logs them', async () => {
-      dbHelperStub.insertOneToDatabase = sinon.stub().rejects(new Error('boom'));
+    it('swallows write errors without throwing and logs them', async () => {
+      dbHelperStub.findOneAndUpdateInDatabase = sinon.stub().rejects(new Error('boom'));
 
       await service.recordEvent('myapp', 'container_vanished', 'x');
 
       sinon.assert.calledOnce(logStub.error);
       expect(logStub.error.firstCall.args[0]).to.include('boom');
     });
+  });
 
-    it('does not consume the episode when the insert fails', async () => {
-      dbHelperStub.insertOneToDatabase = sinon.stub().rejects(new Error('boom'));
-      await service.recordEvent('myapp', 'container_vanished', 'lost');
-
-      dbHelperStub.insertOneToDatabase = sinon.stub().callsFake(async (db, coll, doc) => {
-        insertedDocs.push({ db, coll, doc });
-        return { insertedId: 'mock-id' };
+  describe('boot storm flagging', () => {
+    async function rebootNow() {
+      dbHelperStub.findOneInDatabase = sinon.stub().callsFake(async (db, coll, query) => {
+        if (coll === 'nodestartuptracker' && query._id === 'lastStartup') {
+          return { _id: 'lastStartup', at: new Date(), bootId: PREVIOUS_BOOT_ID };
+        }
+        return null;
       });
-      await service.recordEvent('myapp', 'container_vanished', 'retried');
+      await service.checkNodeReboot();
+    }
 
-      expect(insertedDocs).to.have.lengthOf(1);
-      expect(insertedDocs[0].doc.details).to.equal('retried');
+    it('flags events inside the window after a boot_id change', async () => {
+      sinon.useFakeTimers(new Date('2026-07-16T10:00:00Z'));
+      await rebootNow();
+
+      await service.recordEvent('myapp', 'mount_vanished', 'late disk');
+
+      const incident = eventUpserts().find((c) => c.query.eventType === 'mount_vanished');
+      expect(incident.update.$setOnInsert.duringBootStorm).to.be.true;
+      expect(incident.update.$setOnInsert.bootId).to.equal(CURRENT_BOOT_ID);
+      expect(incident.query.incidentKey).to.include(CURRENT_BOOT_ID);
+    });
+
+    it('stops flagging once the window has elapsed', async () => {
+      const clock = sinon.useFakeTimers(new Date('2026-07-16T10:00:00Z'));
+      await rebootNow();
+
+      clock.tick(service.BOOT_STORM_WINDOW_MS);
+      await service.recordEvent('myapp', 'mount_vanished', 'vanished while up');
+
+      const incident = eventUpserts().find((c) => c.query.eventType === 'mount_vanished');
+      expect(incident.update.$setOnInsert.duringBootStorm).to.be.false;
+    });
+
+    it('does NOT open the window on a same-boot_id process restart', async () => {
+      sinon.useFakeTimers(new Date('2026-07-16T10:00:00Z'));
+      dbHelperStub.findOneInDatabase = sinon.stub().callsFake(async (db, coll, query) => {
+        if (coll === 'nodestartuptracker' && query._id === 'lastStartup') {
+          return { _id: 'lastStartup', at: new Date(), bootId: CURRENT_BOOT_ID };
+        }
+        return null;
+      });
+      await service.checkNodeReboot();
+
+      await service.recordEvent('myapp', 'mount_vanished', 'x');
+
+      const incident = eventUpserts().find((c) => c.query.eventType === 'mount_vanished');
+      expect(incident.update.$setOnInsert.duringBootStorm).to.be.false;
     });
   });
 
@@ -219,9 +396,9 @@ describe('appTamperingDetectionService tests', () => {
       return res;
     }
 
-    it('returns all events when no appname filter, sorted by detectedAt desc', async () => {
+    it('returns events newest first, keeping _id as the stable paging key', async () => {
       findResults = [
-        { appName: 'a', eventType: 'x', detectedAt: new Date() },
+        { _id: 'x', appName: 'a', eventType: 'y' },
       ];
       const req = { params: {}, query: {} };
       const res = makeRes();
@@ -230,8 +407,8 @@ describe('appTamperingDetectionService tests', () => {
 
       expect(lastFindArgs.coll).to.equal('apptamperingevents');
       expect(lastFindArgs.query).to.deep.equal({});
-      expect(lastFindArgs.options.sort).to.deep.equal({ detectedAt: -1 });
-      expect(lastFindArgs.options.projection).to.deep.equal({ _id: 0 });
+      expect(lastFindArgs.options.sort).to.deep.equal({ lastSeen: -1, detectedAt: -1 });
+      expect(lastFindArgs.options.projection).to.equal(undefined);
       sinon.assert.calledWith(res.json, sinon.match({ status: 'success' }));
     });
 
@@ -310,105 +487,76 @@ describe('appTamperingDetectionService tests', () => {
   });
 
   describe('checkNodeReboot', () => {
-    function markerUpdates() {
-      return dbHelperStub.findOneAndUpdateInDatabase.getCalls()
-        .filter((c) => c.args[2] && c.args[2]._id === 'lastStartup');
-    }
-
-    function historyUpdates() {
-      return dbHelperStub.findOneAndUpdateInDatabase.getCalls()
-        .filter((c) => c.args[2] && c.args[2]._id === 'bootHistory');
-    }
-
-    it('records a node_reboot event when the boot_id changed', async () => {
-      const previousAt = new Date('2026-07-15T10:00:00Z');
-      dbHelperStub.findOneInDatabase = sinon.stub().resolves({
-        _id: 'lastStartup', at: previousAt, bootId: PREVIOUS_BOOT_ID,
+    function setMarker(marker) {
+      dbHelperStub.findOneInDatabase = sinon.stub().callsFake(async (db, coll, query) => {
+        if (coll === 'nodestartuptracker' && query._id === 'lastStartup') return marker;
+        return null;
       });
+    }
+
+    it('records a node_reboot incident when the boot_id changed', async () => {
+      const previousAt = new Date('2026-07-15T10:00:00Z');
+      setMarker({ _id: 'lastStartup', at: previousAt, bootId: PREVIOUS_BOOT_ID });
 
       await service.checkNodeReboot();
 
-      expect(insertedDocs).to.have.lengthOf(1);
-      const { doc } = insertedDocs[0];
-      expect(doc.appName).to.equal(service.SYSTEM_APP_NAME);
-      expect(doc.eventType).to.equal('node_reboot');
-      expect(doc.details).to.include(PREVIOUS_BOOT_ID.slice(0, 8));
-      expect(doc.details).to.include(CURRENT_BOOT_ID.slice(0, 8));
-      expect(doc.details).to.include(previousAt.toISOString());
+      const reboots = eventUpserts().filter((c) => c.query.eventType === 'node_reboot');
+      expect(reboots).to.have.lengthOf(1);
+      expect(reboots[0].query.appName).to.equal(service.SYSTEM_APP_NAME);
+      const ins = reboots[0].update.$setOnInsert;
+      expect(ins.severity).to.equal(0);
+      expect(ins.detailsSample).to.include(PREVIOUS_BOOT_ID.slice(0, 8));
+      expect(ins.detailsSample).to.include(CURRENT_BOOT_ID.slice(0, 8));
+      expect(ins.detailsSample).to.include(previousAt.toISOString());
     });
 
-    it('does NOT record an event on a same-boot_id process restart', async () => {
-      dbHelperStub.findOneInDatabase = sinon.stub().resolves({
-        _id: 'lastStartup', at: new Date(), bootId: CURRENT_BOOT_ID,
-      });
+    it('does NOT record an incident on a same-boot_id process restart', async () => {
+      setMarker({ _id: 'lastStartup', at: new Date(), bootId: CURRENT_BOOT_ID });
 
       await service.checkNodeReboot();
 
-      expect(insertedDocs).to.have.lengthOf(0);
+      expect(eventUpserts()).to.have.lengthOf(0);
       expect(historyUpdates()).to.have.lengthOf(0);
       expect(markerUpdates()).to.have.lengthOf(1);
     });
 
-    it('does NOT record an event on first-ever startup, but seeds marker and history', async () => {
-      dbHelperStub.findOneInDatabase = sinon.stub().resolves(null);
+    it('does NOT record an incident on first-ever startup, but seeds marker and history', async () => {
+      setMarker(null);
 
       await service.checkNodeReboot();
 
-      expect(insertedDocs).to.have.lengthOf(0);
+      expect(eventUpserts()).to.have.lengthOf(0);
       expect(historyUpdates()).to.have.lengthOf(1);
       const marker = markerUpdates();
       expect(marker).to.have.lengthOf(1);
-      expect(marker[0].args[3].$set.bootId).to.equal(CURRENT_BOOT_ID);
-      expect(marker[0].args[3].$set.at).to.be.instanceOf(Date);
-      expect(marker[0].args[4]).to.deep.equal({ upsert: true });
+      expect(marker[0].update.$set.bootId).to.equal(CURRENT_BOOT_ID);
+      expect(marker[0].update.$set.at).to.be.instanceOf(Date);
+      expect(marker[0].options).to.deep.equal({ upsert: true });
     });
 
-    it('does NOT record an event when upgrading from a marker without bootId', async () => {
+    it('does NOT record an incident when upgrading from a marker without bootId', async () => {
       // Pre-boot_id marker only carried `at`; reboot vs restart is unknowable.
-      dbHelperStub.findOneInDatabase = sinon.stub().resolves({
-        _id: 'lastStartup', at: new Date(Date.now() - 1000),
-      });
+      setMarker({ _id: 'lastStartup', at: new Date(Date.now() - 1000) });
 
       await service.checkNodeReboot();
 
-      expect(insertedDocs).to.have.lengthOf(0);
+      expect(eventUpserts()).to.have.lengthOf(0);
       expect(historyUpdates()).to.have.lengthOf(1);
       expect(markerUpdates()).to.have.lengthOf(1);
     });
 
     it('appends the new boot to the rolling history on reboot', async () => {
-      dbHelperStub.findOneInDatabase = sinon.stub().resolves({
-        _id: 'lastStartup', at: new Date(), bootId: PREVIOUS_BOOT_ID,
-      });
+      setMarker({ _id: 'lastStartup', at: new Date(), bootId: PREVIOUS_BOOT_ID });
 
       await service.checkNodeReboot();
 
       const history = historyUpdates();
       expect(history).to.have.lengthOf(1);
-      const push = history[0].args[3].$push.boots;
+      const push = history[0].update.$push.boots;
       expect(push.$each[0].bootId).to.equal(CURRENT_BOOT_ID);
       expect(push.$each[0].at).to.be.instanceOf(Date);
       expect(push.$slice).to.equal(-service.BOOT_HISTORY_MAX);
-      expect(history[0].args[4]).to.deep.equal({ upsert: true });
-    });
-
-    it('skips entirely when boot_id cannot be read', async () => {
-      fsReadFileStub.rejects(new Error('ENOENT'));
-
-      await service.checkNodeReboot();
-
-      expect(insertedDocs).to.have.lengthOf(0);
-      expect(dbHelperStub.findOneAndUpdateInDatabase.called).to.be.false;
-      sinon.assert.called(logStub.warn);
-    });
-
-    it('skips entirely when boot_id reads empty', async () => {
-      fsReadFileStub.resolves('  \n');
-
-      await service.checkNodeReboot();
-
-      expect(insertedDocs).to.have.lengthOf(0);
-      expect(dbHelperStub.findOneAndUpdateInDatabase.called).to.be.false;
+      expect(history[0].options).to.deep.equal({ upsert: true });
     });
 
     it('purges legacy frequent_restart rows', async () => {
@@ -427,6 +575,23 @@ describe('appTamperingDetectionService tests', () => {
 
       expect(markerUpdates()).to.have.lengthOf(1);
       sinon.assert.called(logStub.warn);
+    });
+
+    it('skips entirely when boot_id cannot be read', async () => {
+      fsReadFileStub.rejects(new Error('ENOENT'));
+
+      await service.checkNodeReboot();
+
+      expect(upsertCalls).to.have.lengthOf(0);
+      sinon.assert.called(logStub.warn);
+    });
+
+    it('skips entirely when boot_id reads empty', async () => {
+      fsReadFileStub.resolves('  \n');
+
+      await service.checkNodeReboot();
+
+      expect(upsertCalls).to.have.lengthOf(0);
     });
 
     it('no-ops when DB is unavailable', async () => {

--- a/tests/unit/appTamperingDetectionService.test.js
+++ b/tests/unit/appTamperingDetectionService.test.js
@@ -5,10 +5,15 @@ const proxyquire = require('proxyquire').noCallThru();
 describe('appTamperingDetectionService tests', () => {
   let service;
   let dbHelperStub;
+  let logStub;
+  let fsReadFileStub;
   let insertedDocs;
   let findResults;
   let lastFindArgs;
   let databaseConnectionReturn;
+
+  const CURRENT_BOOT_ID = 'aaaaaaaa-1111-2222-3333-444444444444';
+  const PREVIOUS_BOOT_ID = 'bbbbbbbb-5555-6666-7777-888888888888';
 
   beforeEach(() => {
     insertedDocs = [];
@@ -26,12 +31,20 @@ describe('appTamperingDetectionService tests', () => {
         return { insertedId: 'mock-id' };
       }),
       findInDatabase: sinon.stub().callsFake(async (db, coll, query, options) => {
-        lastFindArgs = { db, coll, query, options };
+        lastFindArgs = {
+          db, coll, query, options,
+        };
         return findResults;
       }),
       findOneInDatabase: sinon.stub().resolves(null),
       findOneAndUpdateInDatabase: sinon.stub().resolves({ value: null }),
     };
+
+    logStub = {
+      info: sinon.stub(), warn: sinon.stub(), error: sinon.stub(), debug: sinon.stub(),
+    };
+
+    fsReadFileStub = sinon.stub().resolves(`${CURRENT_BOOT_ID}\n`);
 
     service = proxyquire('../../ZelBack/src/services/appTamperingDetectionService', {
       config: {
@@ -44,11 +57,15 @@ describe('appTamperingDetectionService tests', () => {
             },
           },
         },
+        system: {
+          bootIdPath: '/proc/sys/kernel/random/boot_id',
+        },
+      },
+      fs: {
+        promises: { readFile: fsReadFileStub },
       },
       './dbHelper': dbHelperStub,
-      '../lib/log': {
-        info: sinon.stub(), warn: sinon.stub(), error: sinon.stub(),
-      },
+      '../lib/log': logStub,
       './messageHelper': {
         createDataMessage: (d) => ({ status: 'success', data: d }),
         createErrorMessage: (m) => ({ status: 'error', data: { message: m } }),
@@ -118,13 +135,47 @@ describe('appTamperingDetectionService tests', () => {
       expect(doc.detectedAt).to.be.instanceOf(Date);
     });
 
-    it('inserts a NEW row on every call (does not upsert)', async () => {
+    it('suppresses repeat (appName, eventType) calls within the episode window', async () => {
       await service.recordEvent('myapp', 'mount_vanished', 'a');
       await service.recordEvent('myapp', 'mount_vanished', 'b');
       await service.recordEvent('myapp', 'mount_vanished', 'c');
 
-      expect(insertedDocs).to.have.lengthOf(3);
-      expect(insertedDocs.map((x) => x.doc.details)).to.deep.equal(['a', 'b', 'c']);
+      expect(insertedDocs).to.have.lengthOf(1);
+      expect(insertedDocs[0].doc.details).to.equal('a');
+    });
+
+    it('records different event types for the same app independently', async () => {
+      await service.recordEvent('myapp', 'container_vanished', 'a');
+      await service.recordEvent('myapp', 'recreation_failed', 'b');
+
+      expect(insertedDocs).to.have.lengthOf(2);
+    });
+
+    it('records the same event type for different apps independently', async () => {
+      await service.recordEvent('app1', 'mount_vanished', 'a');
+      await service.recordEvent('app2', 'mount_vanished', 'b');
+
+      expect(insertedDocs).to.have.lengthOf(2);
+    });
+
+    it('records again once the episode window has elapsed', async () => {
+      const clock = sinon.useFakeTimers(new Date('2026-07-16T00:00:00Z'));
+
+      await service.recordEvent('myapp', 'mount_vanished', 'first episode');
+      clock.tick(service.EPISODE_WINDOW_MS);
+      await service.recordEvent('myapp', 'mount_vanished', 'second episode');
+
+      expect(insertedDocs).to.have.lengthOf(2);
+    });
+
+    it('still suppresses just before the episode window elapses', async () => {
+      const clock = sinon.useFakeTimers(new Date('2026-07-16T00:00:00Z'));
+
+      await service.recordEvent('myapp', 'mount_vanished', 'first');
+      clock.tick(service.EPISODE_WINDOW_MS - 1);
+      await service.recordEvent('myapp', 'mount_vanished', 'still same episode');
+
+      expect(insertedDocs).to.have.lengthOf(1);
     });
 
     it('no-ops when DB is not available', async () => {
@@ -136,11 +187,27 @@ describe('appTamperingDetectionService tests', () => {
       expect(dbHelperStub.insertOneToDatabase.called).to.be.false;
     });
 
-    it('swallows insert errors without throwing', async () => {
+    it('swallows insert errors without throwing and logs them', async () => {
       dbHelperStub.insertOneToDatabase = sinon.stub().rejects(new Error('boom'));
 
       await service.recordEvent('myapp', 'container_vanished', 'x');
-      // no assertion needed — test passes if no error thrown
+
+      sinon.assert.calledOnce(logStub.error);
+      expect(logStub.error.firstCall.args[0]).to.include('boom');
+    });
+
+    it('does not consume the episode when the insert fails', async () => {
+      dbHelperStub.insertOneToDatabase = sinon.stub().rejects(new Error('boom'));
+      await service.recordEvent('myapp', 'container_vanished', 'lost');
+
+      dbHelperStub.insertOneToDatabase = sinon.stub().callsFake(async (db, coll, doc) => {
+        insertedDocs.push({ db, coll, doc });
+        return { insertedId: 'mock-id' };
+      });
+      await service.recordEvent('myapp', 'container_vanished', 'retried');
+
+      expect(insertedDocs).to.have.lengthOf(1);
+      expect(insertedDocs[0].doc.details).to.equal('retried');
     });
   });
 
@@ -165,6 +232,51 @@ describe('appTamperingDetectionService tests', () => {
       expect(lastFindArgs.options.sort).to.deep.equal({ detectedAt: -1 });
       expect(lastFindArgs.options.projection).to.deep.equal({ _id: 0 });
       sinon.assert.calledWith(res.json, sinon.match({ status: 'success' }));
+    });
+
+    it('caps results at the default limit when none is requested', async () => {
+      const req = { params: {}, query: {} };
+      const res = makeRes();
+
+      await service.getEvents(req, res);
+
+      expect(lastFindArgs.options.limit).to.equal(500);
+    });
+
+    it('honours an explicit limit', async () => {
+      const req = { params: {}, query: { limit: '50' } };
+      const res = makeRes();
+
+      await service.getEvents(req, res);
+
+      expect(lastFindArgs.options.limit).to.equal(50);
+    });
+
+    it('clamps the limit to the maximum', async () => {
+      const req = { params: {}, query: { limit: '999999' } };
+      const res = makeRes();
+
+      await service.getEvents(req, res);
+
+      expect(lastFindArgs.options.limit).to.equal(1000);
+    });
+
+    it('clamps a non-positive limit up to 1', async () => {
+      const req = { params: {}, query: { limit: '-5' } };
+      const res = makeRes();
+
+      await service.getEvents(req, res);
+
+      expect(lastFindArgs.options.limit).to.equal(1);
+    });
+
+    it('falls back to the default limit on a non-numeric limit', async () => {
+      const req = { params: {}, query: { limit: 'lots' } };
+      const res = makeRes();
+
+      await service.getEvents(req, res);
+
+      expect(lastFindArgs.options.limit).to.equal(500);
     });
 
     it('filters by appname from params', async () => {
@@ -196,82 +308,124 @@ describe('appTamperingDetectionService tests', () => {
     });
   });
 
-  describe('checkFrequentRestart', () => {
-    it('records a frequent_restart event when previous start was under one hour ago', async () => {
-      const previousAt = new Date(Date.now() - (30 * 60 * 1000)); // 30 min ago
-      dbHelperStub.findOneInDatabase = sinon.stub().resolves({ _id: 'lastStartup', at: previousAt });
+  describe('checkNodeReboot', () => {
+    function markerUpdates() {
+      return dbHelperStub.findOneAndUpdateInDatabase.getCalls()
+        .filter((c) => c.args[2] && c.args[2]._id === 'lastStartup');
+    }
 
-      await service.checkFrequentRestart();
+    function historyUpdates() {
+      return dbHelperStub.findOneAndUpdateInDatabase.getCalls()
+        .filter((c) => c.args[2] && c.args[2]._id === 'bootHistory');
+    }
+
+    it('records a node_reboot event when the boot_id changed', async () => {
+      const previousAt = new Date('2026-07-15T10:00:00Z');
+      dbHelperStub.findOneInDatabase = sinon.stub().resolves({
+        _id: 'lastStartup', at: previousAt, bootId: PREVIOUS_BOOT_ID,
+      });
+
+      await service.checkNodeReboot();
 
       expect(insertedDocs).to.have.lengthOf(1);
       const { doc } = insertedDocs[0];
       expect(doc.appName).to.equal(service.SYSTEM_APP_NAME);
-      expect(doc.eventType).to.equal('frequent_restart');
-      expect(doc.details).to.match(/FluxOS restarted \d+s after previous start/);
+      expect(doc.eventType).to.equal('node_reboot');
+      expect(doc.details).to.include(PREVIOUS_BOOT_ID.slice(0, 8));
+      expect(doc.details).to.include(CURRENT_BOOT_ID.slice(0, 8));
+      expect(doc.details).to.include(previousAt.toISOString());
     });
 
-    it('does NOT record an event when previous start was over one hour ago', async () => {
-      const previousAt = new Date(Date.now() - (2 * 60 * 60 * 1000)); // 2 hours ago
-      dbHelperStub.findOneInDatabase = sinon.stub().resolves({ _id: 'lastStartup', at: previousAt });
+    it('does NOT record an event on a same-boot_id process restart', async () => {
+      dbHelperStub.findOneInDatabase = sinon.stub().resolves({
+        _id: 'lastStartup', at: new Date(), bootId: CURRENT_BOOT_ID,
+      });
 
-      await service.checkFrequentRestart();
+      await service.checkNodeReboot();
 
       expect(insertedDocs).to.have.lengthOf(0);
+      expect(historyUpdates()).to.have.lengthOf(0);
+      expect(markerUpdates()).to.have.lengthOf(1);
     });
 
-    it('does NOT record an event when previous start is exactly at threshold', async () => {
-      const previousAt = new Date(Date.now() - service.FREQUENT_RESTART_THRESHOLD_MS);
-      dbHelperStub.findOneInDatabase = sinon.stub().resolves({ _id: 'lastStartup', at: previousAt });
-
-      await service.checkFrequentRestart();
-
-      expect(insertedDocs).to.have.lengthOf(0);
-    });
-
-    it('does NOT record an event on first-ever startup (no previous marker)', async () => {
+    it('does NOT record an event on first-ever startup, but seeds marker and history', async () => {
       dbHelperStub.findOneInDatabase = sinon.stub().resolves(null);
 
-      await service.checkFrequentRestart();
+      await service.checkNodeReboot();
 
       expect(insertedDocs).to.have.lengthOf(0);
+      expect(historyUpdates()).to.have.lengthOf(1);
+      const marker = markerUpdates();
+      expect(marker).to.have.lengthOf(1);
+      expect(marker[0].args[3].$set.bootId).to.equal(CURRENT_BOOT_ID);
+      expect(marker[0].args[3].$set.at).to.be.instanceOf(Date);
+      expect(marker[0].args[4]).to.deep.equal({ upsert: true });
     });
 
-    it('ignores a negative delta (clock skew: previous marker in the future)', async () => {
-      const previousAt = new Date(Date.now() + (5 * 60 * 1000)); // 5 min in future
-      dbHelperStub.findOneInDatabase = sinon.stub().resolves({ _id: 'lastStartup', at: previousAt });
+    it('does NOT record an event when upgrading from a marker without bootId', async () => {
+      // Pre-boot_id marker only carried `at`; reboot vs restart is unknowable.
+      dbHelperStub.findOneInDatabase = sinon.stub().resolves({
+        _id: 'lastStartup', at: new Date(Date.now() - 1000),
+      });
 
-      await service.checkFrequentRestart();
+      await service.checkNodeReboot();
 
       expect(insertedDocs).to.have.lengthOf(0);
+      expect(historyUpdates()).to.have.lengthOf(1);
+      expect(markerUpdates()).to.have.lengthOf(1);
     });
 
-    it('always upserts the startup marker to now', async () => {
-      dbHelperStub.findOneInDatabase = sinon.stub().resolves(null);
+    it('appends the new boot to the rolling history on reboot', async () => {
+      dbHelperStub.findOneInDatabase = sinon.stub().resolves({
+        _id: 'lastStartup', at: new Date(), bootId: PREVIOUS_BOOT_ID,
+      });
 
-      await service.checkFrequentRestart();
+      await service.checkNodeReboot();
 
-      sinon.assert.calledOnce(dbHelperStub.findOneAndUpdateInDatabase);
-      const args = dbHelperStub.findOneAndUpdateInDatabase.firstCall.args;
-      expect(args[1]).to.equal('nodestartuptracker'); // collection
-      expect(args[2]).to.deep.equal({ _id: 'lastStartup' });
-      expect(args[3].$set.at).to.be.instanceOf(Date);
-      expect(args[4]).to.deep.equal({ upsert: true });
+      const history = historyUpdates();
+      expect(history).to.have.lengthOf(1);
+      const push = history[0].args[3].$push.boots;
+      expect(push.$each[0].bootId).to.equal(CURRENT_BOOT_ID);
+      expect(push.$each[0].at).to.be.instanceOf(Date);
+      expect(push.$slice).to.equal(-service.BOOT_HISTORY_MAX);
+      expect(history[0].args[4]).to.deep.equal({ upsert: true });
+    });
+
+    it('skips entirely when boot_id cannot be read', async () => {
+      fsReadFileStub.rejects(new Error('ENOENT'));
+
+      await service.checkNodeReboot();
+
+      expect(insertedDocs).to.have.lengthOf(0);
+      expect(dbHelperStub.findOneAndUpdateInDatabase.called).to.be.false;
+      sinon.assert.called(logStub.warn);
+    });
+
+    it('skips entirely when boot_id reads empty', async () => {
+      fsReadFileStub.resolves('  \n');
+
+      await service.checkNodeReboot();
+
+      expect(insertedDocs).to.have.lengthOf(0);
+      expect(dbHelperStub.findOneAndUpdateInDatabase.called).to.be.false;
     });
 
     it('no-ops when DB is unavailable', async () => {
       dbHelperStub.databaseConnection = sinon.stub().returns(null);
 
-      await service.checkFrequentRestart();
+      await service.checkNodeReboot();
 
       expect(dbHelperStub.findOneInDatabase.called).to.be.false;
       expect(dbHelperStub.findOneAndUpdateInDatabase.called).to.be.false;
     });
 
-    it('swallows errors without throwing', async () => {
+    it('swallows errors without throwing and logs them', async () => {
       dbHelperStub.findOneInDatabase = sinon.stub().rejects(new Error('mongo down'));
 
-      await service.checkFrequentRestart();
-      // test passes if no exception propagates
+      await service.checkNodeReboot();
+
+      sinon.assert.calledOnce(logStub.error);
+      expect(logStub.error.firstCall.args[0]).to.include('mongo down');
     });
   });
 });

--- a/tests/unit/appTamperingDetectionService.test.js
+++ b/tests/unit/appTamperingDetectionService.test.js
@@ -67,6 +67,7 @@ describe('appTamperingDetectionService tests', () => {
         return null; // startup marker by default absent
       }),
       removeDocumentsFromCollection: sinon.stub().resolves({ deletedCount: 0 }),
+      updateInDatabase: sinon.stub().resolves({ modifiedCount: 0 }),
     };
 
     logStub = {
@@ -386,6 +387,55 @@ describe('appTamperingDetectionService tests', () => {
 
       const incident = eventUpserts().find((c) => c.query.eventType === 'mount_vanished');
       expect(incident.update.$setOnInsert.duringBootStorm).to.be.false;
+    });
+  });
+
+  describe('identity backfill', () => {
+    it('stamps identity onto unattributed incidents once the daemon answers, then stops', async () => {
+      const clock = sinon.useFakeTimers(new Date('2026-07-16T10:00:00Z'));
+      fluxnodeRpcsStub.getFluxNodeStatus.rejects(new Error('daemon starting'));
+
+      await service.checkNodeReboot(); // starts the backfill; immediate attempt fails
+      await clock.tickAsync(0);
+      expect(dbHelperStub.updateInDatabase.called).to.be.false;
+
+      fluxnodeRpcsStub.getFluxNodeStatus.resolves(NODE_STATUS);
+      await clock.tickAsync(service.IDENTITY_BACKFILL_INTERVAL_MS);
+
+      sinon.assert.calledOnce(dbHelperStub.updateInDatabase);
+      const call = dbHelperStub.updateInDatabase.firstCall;
+      expect(call.args[1]).to.equal('apptamperingevents');
+      expect(call.args[2]).to.deep.equal({ schemaVersion: { $gte: 1 }, nodeTxid: null });
+      expect(call.args[3].$set.nodeTxid).to.equal('deadbeefcafe');
+      expect(call.args[3].$set.pubkey).to.equal('04aabbcc');
+      expect(call.args[3].$set.paymentAddress).to.equal('t1payout');
+
+      // stopped for good: further intervals do not fire another update
+      await clock.tickAsync(2 * service.IDENTITY_BACKFILL_INTERVAL_MS);
+      sinon.assert.calledOnce(dbHelperStub.updateInDatabase);
+    });
+
+    it('keeps retrying while the daemon stays unreachable', async () => {
+      const clock = sinon.useFakeTimers(new Date('2026-07-16T10:00:00Z'));
+      fluxnodeRpcsStub.getFluxNodeStatus.rejects(new Error('daemon down'));
+
+      await service.checkNodeReboot();
+      await clock.tickAsync(2 * service.IDENTITY_BACKFILL_INTERVAL_MS);
+
+      expect(dbHelperStub.updateInDatabase.called).to.be.false;
+      expect(fluxnodeRpcsStub.getFluxNodeStatus.callCount).to.be.greaterThan(1);
+    });
+
+    it('does not start a second timer when called repeatedly', async () => {
+      const clock = sinon.useFakeTimers(new Date('2026-07-16T10:00:00Z'));
+      fluxnodeRpcsStub.getFluxNodeStatus.rejects(new Error('daemon down'));
+
+      service.startIdentityBackfill();
+      service.startIdentityBackfill();
+      await clock.tickAsync(service.IDENTITY_BACKFILL_INTERVAL_MS);
+
+      // one immediate attempt + one interval tick — not doubled
+      expect(fluxnodeRpcsStub.getFluxNodeStatus.callCount).to.equal(2);
     });
   });
 

--- a/tests/unit/appTamperingDetectionService.test.js
+++ b/tests/unit/appTamperingDetectionService.test.js
@@ -570,13 +570,13 @@ describe('appTamperingDetectionService tests', () => {
       expect(history[0].options).to.deep.equal({ upsert: true });
     });
 
-    it('purges legacy frequent_restart rows', async () => {
+    it('purges all pre-schema rows at startup', async () => {
       await service.checkNodeReboot();
 
       sinon.assert.calledOnce(dbHelperStub.removeDocumentsFromCollection);
       const { args } = dbHelperStub.removeDocumentsFromCollection.firstCall;
       expect(args[1]).to.equal('apptamperingevents');
-      expect(args[2]).to.deep.equal({ eventType: 'frequent_restart' });
+      expect(args[2]).to.deep.equal({ schemaVersion: { $exists: false } });
     });
 
     it('still tracks the boot when the legacy purge fails', async () => {

--- a/tests/unit/appTamperingDetectionService.test.js
+++ b/tests/unit/appTamperingDetectionService.test.js
@@ -20,7 +20,7 @@ describe('appTamperingDetectionService tests', () => {
     status: 'success',
     data: {
       txhash: 'deadbeefcafe',
-      outidx: 0,
+      outidx: '0', // the daemon RPC returns outidx as a string
       ip: '65.108.1.2:16127',
       pubkey: '04aabbcc',
       payment_address: 't1payout',

--- a/tests/unit/appTamperingDetectionService.test.js
+++ b/tests/unit/appTamperingDetectionService.test.js
@@ -245,6 +245,28 @@ describe('appTamperingDetectionService tests', () => {
       sinon.assert.calledOnce(fluxnodeRpcsStub.getFluxNodeStatus); // backoff, no hammering
     });
 
+    it('uses a concurrently-populated identity cache when its own RPC fails (daemon flap)', async () => {
+      // Race: this event enters getNodeIdentity with the cache empty, a
+      // concurrent call populates it, then this event's own RPC rejects. The
+      // catch must prefer the now-populated cache over writing a null-identity
+      // row that the one-shot backfill may already have stopped covering.
+      let rejectSecond;
+      const secondRpc = new Promise((_, reject) => { rejectSecond = reject; });
+      fluxnodeRpcsStub.getFluxNodeStatus = sinon.stub()
+        .onFirstCall().resolves(NODE_STATUS)
+        .onSecondCall().returns(secondRpc);
+
+      const first = service.recordEvent('a', 'container_vanished', 'x'); // populates cache
+      const second = service.recordEvent('b', 'container_vanished', 'x'); // RPC left pending
+      await first;
+      rejectSecond(new Error('daemon flap'));
+      await second;
+
+      const bUpsert = eventUpserts().find((c) => c.query.appName === 'b');
+      expect(bUpsert.update.$setOnInsert.nodeTxid).to.equal('deadbeefcafe');
+      expect(bUpsert.update.$setOnInsert.pubkey).to.equal('04aabbcc');
+    });
+
     it('attributes the app owner and spec hash by exact name', async () => {
       installedApps.myapp = { owner: '1ownerZelid', hash: 'spechash1' };
 
@@ -292,6 +314,18 @@ describe('appTamperingDetectionService tests', () => {
       expect(eventUpserts()[0].query.incidentKey).to.not.equal(eventUpserts()[1].query.incidentKey);
     });
 
+    it('keys under "unknown" and stamps bootId:null before checkNodeReboot has run', async () => {
+      // This block never calls checkNodeReboot(), so currentBootId is still
+      // null — the same fallback state as a host with an unreadable boot_id.
+      // In production serviceManager awaits checkNodeReboot() before any
+      // emitter, so this path is a safety net; it must still key deterministically.
+      await service.recordEvent('myapp', 'mount_vanished', 'x');
+
+      const { query, update } = eventUpserts()[0];
+      expect(query.incidentKey).to.match(/^unknown:\d+$/);
+      expect(update.$setOnInsert.bootId).to.be.null;
+    });
+
     it('stamps severity 0 for operational and unknown event types', async () => {
       await service.recordEvent('myapp', 'recreation_failed', 'x');
       await service.recordEvent('myapp', 'some_future_type', 'x');
@@ -316,6 +350,46 @@ describe('appTamperingDetectionService tests', () => {
 
       expect(eventUpserts()).to.have.lengthOf(1);
       expect(logStub.error.called).to.be.false;
+    });
+
+    it('rolls up a repeat (v6 non-null pre-image) as inserted=false, no fresh-insert log', async () => {
+      // The real mongodb v6 driver returns the matched pre-image document (not
+      // null) when the upsert hits an existing incident; the default mock
+      // returns null (insert). Model the repeat and pin the count-rollup branch.
+      dbHelperStub.findOneAndUpdateInDatabase = sinon.stub().callsFake(async (db, coll, query, update, options) => {
+        upsertCalls.push({
+          db, coll, query, update, options,
+        });
+        return { _id: 'existing', count: 1 }; // v6 pre-image of the matched doc
+      });
+
+      await service.recordEvent('myapp', 'container_vanished', 'x');
+
+      expect(eventUpserts()[0].update.$inc).to.deep.equal({ count: 1 });
+      expect(logStub.debug.calledWithMatch(/repeated, incident count incremented/)).to.be.true;
+      expect(logStub.info.calledWithMatch(/recorded container_vanished/)).to.be.false;
+    });
+
+    it('reads insert vs repeat from the legacy { value, lastErrorObject } driver shape', async () => {
+      dbHelperStub.findOneAndUpdateInDatabase = sinon.stub()
+        .onFirstCall().callsFake(async (db, coll, query, update, options) => {
+          upsertCalls.push({
+            db, coll, query, update, options,
+          });
+          return { value: null, lastErrorObject: { updatedExisting: false } }; // insert
+        })
+        .onSecondCall().callsFake(async (db, coll, query, update, options) => {
+          upsertCalls.push({
+            db, coll, query, update, options,
+          });
+          return { value: { _id: 'e', count: 1 }, lastErrorObject: { updatedExisting: true } }; // repeat
+        });
+
+      await service.recordEvent('myapp', 'container_vanished', 'insert');
+      await service.recordEvent('myapp', 'container_vanished', 'repeat');
+
+      expect(logStub.info.calledWithMatch(/recorded container_vanished/)).to.be.true;
+      expect(logStub.debug.calledWithMatch(/repeated, incident count incremented/)).to.be.true;
     });
 
     it('no-ops when DB is not available', async () => {
@@ -487,6 +561,18 @@ describe('appTamperingDetectionService tests', () => {
       await service.getEvents(req, res);
 
       expect(lastFindArgs.query).to.deep.equal({ appName: 'otherapp' });
+    });
+
+    it('coerces an object appname query param to a string (NoSQL operator guard)', async () => {
+      // Express extended parser turns ?appname[$gt]= into an object; it must
+      // not reach the mongo filter as a field-level operator.
+      const req = { params: {}, query: { appname: { $gt: '' } } };
+      const res = makeRes();
+
+      await service.getEvents(req, res);
+
+      expect(lastFindArgs.query.appName).to.be.a('string');
+      expect(lastFindArgs.query.appName).to.equal('[object Object]');
     });
 
     it('returns an error message when the query throws', async () => {

--- a/tests/unit/appsRuntimeState.test.js
+++ b/tests/unit/appsRuntimeState.test.js
@@ -323,8 +323,28 @@ describe('appsRuntimeState tests', () => {
 
     it('clears the flag', async () => {
       await appsRuntimeState.setNetworkHealRemoval('www_App', true);
-      await appsRuntimeState.clearNetworkHealRemoval('www_App');
+      await appsRuntimeState.clearNetworkHeal('www_App');
       expect(await appsRuntimeState.isNetworkHealRemoval('www_App')).to.be.false;
+    });
+
+    it('a read failure throws rather than reporting "not a heal removal"', async () => {
+      // reading false on a DB blip is the DESTRUCTIVE guess: the reconciler would
+      // treat its own removal as a vanished container and can uninstall the app.
+      const failing = proxyquire('../../ZelBack/src/services/appManagement/appsRuntimeState', {
+        '../../lib/log': logStub,
+        '../dbHelper': {
+          databaseConnection: () => ({ db: () => ({}) }),
+          findOneInDatabase: async () => { throw new Error('db unavailable'); },
+          updateOneInDatabase: async () => {},
+          removeDocumentsFromCollection: async () => {},
+        },
+        '../dockerService': { getBaseAppName: (id) => id },
+      });
+
+      let thrown = null;
+      await failing.isNetworkHealRemoval('www_App').catch((e) => { thrown = e; });
+
+      expect(thrown, 'must not silently answer false').to.be.an('error');
     });
 
     it('is dropped with the rest of the component state on uninstall', async () => {
@@ -351,6 +371,36 @@ describe('appsRuntimeState tests', () => {
       });
 
       expect(await restarted.isNetworkHealRemoval('www_App')).to.be.true;
+    });
+  });
+
+  describe('network heal ladder (separate from the crash-restart ladder)', () => {
+    it('allows the first attempt immediately, then paces the next ones', async () => {
+      expect(await appsRuntimeState.networkHealWaitMs('www_App')).to.equal(0);
+
+      await appsRuntimeState.recordNetworkHealAttempt('www_App');
+      expect(await appsRuntimeState.networkHealWaitMs('www_App'), 'the second attempt waits').to.be.above(0);
+    });
+
+    it('does not touch the crash-restart backoff', async () => {
+      // sharing restartHistory would hold down the very container the heal just
+      // recreated (a g: component is created, not started, so the next pass reads the
+      // ladder the heal grew) - and would block a heal for a crash-looping container
+      await appsRuntimeState.recordNetworkHealAttempt('www_App');
+      await appsRuntimeState.recordNetworkHealAttempt('www_App');
+
+      expect(await appsRuntimeState.restartWaitMs('www_App'), 'the restart ladder is untouched').to.equal(0);
+      expect(store.get('www_App').restartHistory).to.equal(undefined);
+    });
+
+    it('is reset once the container is healthy, so a later episode starts from the bottom', async () => {
+      await appsRuntimeState.recordNetworkHealAttempt('www_App');
+      await appsRuntimeState.recordNetworkHealAttempt('www_App');
+      expect(await appsRuntimeState.networkHealWaitMs('www_App')).to.be.above(0);
+
+      await appsRuntimeState.clearNetworkHeal('www_App');
+
+      expect(await appsRuntimeState.networkHealWaitMs('www_App')).to.equal(0);
     });
   });
 

--- a/tests/unit/appsRuntimeState.test.js
+++ b/tests/unit/appsRuntimeState.test.js
@@ -311,6 +311,49 @@ describe('appsRuntimeState tests', () => {
     });
   });
 
+  describe('networkHealRemoval (durable "I removed this container on purpose")', () => {
+    it('persists the flag and reads it back', async () => {
+      await appsRuntimeState.setNetworkHealRemoval('www_App', true);
+      expect(await appsRuntimeState.isNetworkHealRemoval('www_App')).to.be.true;
+    });
+
+    it('defaults to false for an unknown component', async () => {
+      expect(await appsRuntimeState.isNetworkHealRemoval('nope_App')).to.be.false;
+    });
+
+    it('clears the flag', async () => {
+      await appsRuntimeState.setNetworkHealRemoval('www_App', true);
+      await appsRuntimeState.clearNetworkHealRemoval('www_App');
+      expect(await appsRuntimeState.isNetworkHealRemoval('www_App')).to.be.false;
+    });
+
+    it('is dropped with the rest of the component state on uninstall', async () => {
+      await appsRuntimeState.setNetworkHealRemoval('www_App', true);
+      await appsRuntimeState.remove('www_App');
+      expect(await appsRuntimeState.isNetworkHealRemoval('www_App')).to.be.false;
+    });
+
+    it('survives a process restart: a fresh module instance reads the persisted flag', async () => {
+      // this is the whole point of the flag - an in-memory map would lose the fact
+      // that the reconciler removed the container itself, and the next process would
+      // read the absence as tampering
+      await appsRuntimeState.setNetworkHealRemoval('www_App', true);
+
+      const restarted = proxyquire('../../ZelBack/src/services/appManagement/appsRuntimeState', {
+        '../../lib/log': logStub,
+        '../dbHelper': {
+          databaseConnection: () => ({ db: () => ({}) }),
+          findOneInDatabase: async (_db, _coll, query) => store.get(query.identifier) || null,
+          updateOneInDatabase: async () => {},
+          removeDocumentsFromCollection: async () => {},
+        },
+        '../dockerService': { getBaseAppName: (id) => id.replace(/^flux/, '').replace(/^zel/, '') },
+      });
+
+      expect(await restarted.isNetworkHealRemoval('www_App')).to.be.true;
+    });
+  });
+
   describe('prepareCollection (merge-dedupe + unique index)', () => {
     // Fleet nodes wrote into this collection before the unique index existed, so
     // same-identifier twins may exist - and because every later updateOne matched

--- a/tests/unit/containerHealthMonitor.test.js
+++ b/tests/unit/containerHealthMonitor.test.js
@@ -142,6 +142,51 @@ describe('containerHealthMonitor tests', () => {
       const recreated = appInstallerStub.installApplicationHard.getCalls().map((c) => c.args[0].name);
       expect(recreated).to.deep.equal(['web', 'db']);
     });
+
+    describe('softOnly (the network-detach heal)', () => {
+      // A hard install runs createAppVolume: fallocate + mke2fs on the app's volume
+      // file, i.e. it REFORMATS the app's data. The heal deliberately force-removes a
+      // LIVE container whose data is intact, so it must never be able to trigger that
+      // fallback - a transient verifyAppVolumeMount failure would wipe user data.
+      it('throws instead of hard-installing a component whose volume cannot be verified', async () => {
+        volumeServiceStub.verifyAppVolumeMount.resolves(false);
+        let err;
+        try {
+          await containerHealthMonitor.recreateMissingContainers('web_testapp', { softOnly: true });
+        } catch (e) { err = e; }
+
+        expect(err).to.be.an('error');
+        expect(err.message).to.include('without reformatting its volume');
+        expect(appInstallerStub.installApplicationHard.called, 'must never reformat the data volume of a container it was asked to rebuild softly').to.be.false;
+      });
+
+      it('throws instead of hard-installing on the whole-app path', async () => {
+        volumeServiceStub.verifyAppVolumeMount.resolves(false);
+        let err;
+        try {
+          await containerHealthMonitor.recreateMissingContainers('testapp', { softOnly: true });
+        } catch (e) { err = e; }
+
+        expect(err).to.be.an('error');
+        expect(appInstallerStub.installApplicationHard.called).to.be.false;
+      });
+
+      it('still soft-installs normally when the volume is verified', async () => {
+        volumeServiceStub.verifyAppVolumeMount.resolves(true);
+
+        await containerHealthMonitor.recreateMissingContainers('web_testapp', { softOnly: true });
+
+        expect(appInstallerStub.installApplicationSoft.calledOnce).to.be.true;
+      });
+
+      it('leaves the default (vanished-container) path free to hard-install', async () => {
+        volumeServiceStub.verifyAppVolumeMount.resolves(false);
+
+        await containerHealthMonitor.recreateMissingContainers('web_testapp');
+
+        expect(appInstallerStub.installApplicationHard.calledOnce, 'a container that is gone anyway may still be rebuilt from scratch').to.be.true;
+      });
+    });
   });
 
 });

--- a/tests/unit/containerHealthMonitor.test.js
+++ b/tests/unit/containerHealthMonitor.test.js
@@ -45,6 +45,7 @@ describe('containerHealthMonitor tests', () => {
     appInstallerStub = {
       installApplicationHard: sinon.stub().resolves(),
       installApplicationSoft: sinon.stub().resolves(),
+      ensureAppDockerNetwork: sinon.stub().resolves('network-ready'),
     };
 
     appUninstallerStub = {
@@ -119,6 +120,15 @@ describe('containerHealthMonitor tests', () => {
       const [componentSpec, mainAppName] = appInstallerStub.installApplicationSoft.firstCall.args;
       expect(componentSpec.name).to.equal('web');
       expect(mainAppName).to.equal('testapp');
+    });
+
+    it('ensures the app docker network before recreating any container', async () => {
+      // A pruned per-app network (docker prune / daemon restart) is created only
+      // at install time; without this the recreate loops on "network not found".
+      volumeServiceStub.verifyAppVolumeMount.resolves(true);
+      await containerHealthMonitor.recreateMissingContainers('web_testapp');
+      expect(appInstallerStub.ensureAppDockerNetwork.calledOnceWith('testapp')).to.be.true;
+      expect(appInstallerStub.ensureAppDockerNetwork.calledBefore(appInstallerStub.installApplicationSoft)).to.be.true;
     });
 
     it('hard-installs a single component when its volume is gone', async () => {

--- a/tests/unit/dockerService.test.js
+++ b/tests/unit/dockerService.test.js
@@ -364,6 +364,71 @@ describe('dockerService tests', () => {
     });
   });
 
+  describe('getFreeFluxAppNetworkOctet tests', () => {
+    const net = (subnet) => ({ Name: 'fluxDockerNetwork_x', IPAM: { Config: [{ Subnet: subnet }] } });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('returns the lowest free octet (1) when only the base network exists', async () => {
+      sinon.stub(Dockerode.prototype, 'listNetworks').resolves([net('172.23.0.0/24')]);
+
+      await expect(dockerService.getFreeFluxAppNetworkOctet()).to.eventually.equal(1);
+    });
+
+    it('returns the first gap when low octets are already taken', async () => {
+      sinon.stub(Dockerode.prototype, 'listNetworks').resolves(
+        ['172.23.0.0/24', '172.23.1.0/24', '172.23.2.0/24', '172.23.4.0/24'].map(net),
+      );
+
+      await expect(dockerService.getFreeFluxAppNetworkOctet()).to.eventually.equal(3);
+    });
+
+    it('ignores subnets outside the 172.23.x.0/24 app range', async () => {
+      sinon.stub(Dockerode.prototype, 'listNetworks').resolves(
+        ['172.23.1.0/24', '10.0.0.0/24', null].map(net),
+      );
+
+      // only octet 1 is a used app subnet, so 2 is the lowest free
+      await expect(dockerService.getFreeFluxAppNetworkOctet()).to.eventually.equal(2);
+    });
+
+    it('returns null when every 172.23.x.0/24 block is taken', async () => {
+      const all = [];
+      for (let octet = 0; octet <= 255; octet += 1) all.push(net(`172.23.${octet}.0/24`));
+      sinon.stub(Dockerode.prototype, 'listNetworks').resolves(all);
+
+      await expect(dockerService.getFreeFluxAppNetworkOctet()).to.eventually.be.null;
+    });
+
+    it('counts NON-flux networks too (docker enforces global subnet uniqueness)', async () => {
+      sinon.stub(Dockerode.prototype, 'listNetworks').resolves([
+        { Name: 'bridge', IPAM: { Config: [{ Subnet: '172.23.1.0/24' }] } },
+        net('172.23.2.0/24'),
+      ]);
+
+      // octet 1 (a non-flux network) and 2 (flux) are both used -> 3 is lowest free
+      await expect(dockerService.getFreeFluxAppNetworkOctet()).to.eventually.equal(3);
+    });
+
+    it('treats excluded octets as used (collision-retry advancement)', async () => {
+      sinon.stub(Dockerode.prototype, 'listNetworks').resolves([net('172.23.0.0/24')]);
+
+      await expect(dockerService.getFreeFluxAppNetworkOctet(new Set([1, 2, 3]))).to.eventually.equal(4);
+    });
+
+    it('tolerates networks with no IPAM config', async () => {
+      sinon.stub(Dockerode.prototype, 'listNetworks').resolves([
+        { Name: 'host' },
+        { Name: 'none', IPAM: {} },
+        net('172.23.1.0/24'),
+      ]);
+
+      await expect(dockerService.getFreeFluxAppNetworkOctet()).to.eventually.equal(2);
+    });
+  });
+
   describe('dockerContainerStats tests', () => {
     it('should return a valid stats object', async () => {
       const containerName = 'website';

--- a/tests/unit/dockerService.test.js
+++ b/tests/unit/dockerService.test.js
@@ -258,6 +258,77 @@ describe('dockerService tests', () => {
     });
   });
 
+  describe('parseContainerNetworkAttachment / isContainerDetachedFromNetwork tests', () => {
+    it('reports attached when the managed network carries an IP', () => {
+      const attachment = dockerService.parseContainerNetworkAttachment({
+        HostConfig: { NetworkMode: 'fluxDockerNetwork_appx' },
+        State: { Running: true },
+        NetworkSettings: { Networks: { fluxDockerNetwork_appx: { IPAddress: '172.23.0.5' } } },
+      });
+
+      expect(attachment).to.deep.equal({
+        managed: true, running: true, networkMode: 'fluxDockerNetwork_appx', attached: true,
+      });
+      expect(dockerService.isContainerDetachedFromNetwork(attachment)).to.equal(false);
+    });
+
+    it('flags a running managed container with an empty Networks as detached', () => {
+      const attachment = dockerService.parseContainerNetworkAttachment({
+        HostConfig: { NetworkMode: 'fluxDockerNetwork_appx' },
+        State: { Running: true },
+        NetworkSettings: { Networks: {} },
+      });
+
+      expect(attachment.managed).to.equal(true);
+      expect(attachment.attached).to.equal(false);
+      expect(dockerService.isContainerDetachedFromNetwork(attachment)).to.equal(true);
+    });
+
+    it('flags detached when the endpoint exists but has no IP (half-programmed)', () => {
+      const attachment = dockerService.parseContainerNetworkAttachment({
+        HostConfig: { NetworkMode: 'fluxDockerNetwork_appx' },
+        State: { Running: true },
+        NetworkSettings: { Networks: { fluxDockerNetwork_appx: { IPAddress: '' } } },
+      });
+
+      expect(dockerService.isContainerDetachedFromNetwork(attachment)).to.equal(true);
+    });
+
+    it('does not flag a stopped container as detached', () => {
+      const attachment = dockerService.parseContainerNetworkAttachment({
+        HostConfig: { NetworkMode: 'fluxDockerNetwork_appx' },
+        State: { Running: false },
+        NetworkSettings: { Networks: {} },
+      });
+
+      expect(attachment.running).to.equal(false);
+      expect(dockerService.isContainerDetachedFromNetwork(attachment)).to.equal(false);
+    });
+
+    it('never flags a non-managed (host-networked) container as detached', () => {
+      const attachment = dockerService.parseContainerNetworkAttachment({
+        HostConfig: { NetworkMode: 'host' },
+        State: { Running: true },
+        NetworkSettings: { Networks: {} },
+      });
+
+      expect(attachment.managed).to.equal(false);
+      expect(dockerService.isContainerDetachedFromNetwork(attachment)).to.equal(false);
+    });
+
+    it('tolerates a partial/empty inspect object', () => {
+      const attachment = dockerService.parseContainerNetworkAttachment({});
+      expect(attachment).to.deep.equal({
+        managed: false, running: false, networkMode: null, attached: false,
+      });
+    });
+
+    it('isContainerDetachedFromNetwork tolerates missing input', () => {
+      expect(dockerService.isContainerDetachedFromNetwork(undefined)).to.equal(false);
+      expect(dockerService.isContainerDetachedFromNetwork(null)).to.equal(false);
+    });
+  });
+
   describe('dockerContainerStats tests', () => {
     it('should return a valid stats object', async () => {
       const containerName = 'website';

--- a/tests/unit/dockerService.test.js
+++ b/tests/unit/dockerService.test.js
@@ -258,9 +258,9 @@ describe('dockerService tests', () => {
     });
   });
 
-  describe('parseContainerNetworkAttachment / isContainerDetachedFromNetwork tests', () => {
+  describe('classifyContainerNetworkAttachment / isContainerDetachedFromNetwork tests', () => {
     it('reports attached when the managed network carries an IP', () => {
-      const attachment = dockerService.parseContainerNetworkAttachment({
+      const attachment = dockerService.classifyContainerNetworkAttachment({
         HostConfig: { NetworkMode: 'fluxDockerNetwork_appx' },
         State: { Running: true },
         NetworkSettings: { Networks: { fluxDockerNetwork_appx: { IPAddress: '172.23.0.5' } } },
@@ -273,7 +273,7 @@ describe('dockerService tests', () => {
     });
 
     it('flags a running managed container with an empty Networks as detached', () => {
-      const attachment = dockerService.parseContainerNetworkAttachment({
+      const attachment = dockerService.classifyContainerNetworkAttachment({
         HostConfig: { NetworkMode: 'fluxDockerNetwork_appx' },
         State: { Running: true },
         NetworkSettings: { Networks: {} },
@@ -285,7 +285,7 @@ describe('dockerService tests', () => {
     });
 
     it('flags detached when the endpoint exists but has no IP (half-programmed)', () => {
-      const attachment = dockerService.parseContainerNetworkAttachment({
+      const attachment = dockerService.classifyContainerNetworkAttachment({
         HostConfig: { NetworkMode: 'fluxDockerNetwork_appx' },
         State: { Running: true },
         NetworkSettings: { Networks: { fluxDockerNetwork_appx: { IPAddress: '' } } },
@@ -295,7 +295,7 @@ describe('dockerService tests', () => {
     });
 
     it('does not flag a stopped container as detached', () => {
-      const attachment = dockerService.parseContainerNetworkAttachment({
+      const attachment = dockerService.classifyContainerNetworkAttachment({
         HostConfig: { NetworkMode: 'fluxDockerNetwork_appx' },
         State: { Running: false },
         NetworkSettings: { Networks: {} },
@@ -306,7 +306,7 @@ describe('dockerService tests', () => {
     });
 
     it('never flags a non-managed (host-networked) container as detached', () => {
-      const attachment = dockerService.parseContainerNetworkAttachment({
+      const attachment = dockerService.classifyContainerNetworkAttachment({
         HostConfig: { NetworkMode: 'host' },
         State: { Running: true },
         NetworkSettings: { Networks: {} },
@@ -317,7 +317,7 @@ describe('dockerService tests', () => {
     });
 
     it('tolerates a partial/empty inspect object', () => {
-      const attachment = dockerService.parseContainerNetworkAttachment({});
+      const attachment = dockerService.classifyContainerNetworkAttachment({});
       expect(attachment).to.deep.equal({
         managed: false, running: false, networkMode: null, attached: false,
       });
@@ -326,6 +326,41 @@ describe('dockerService tests', () => {
     it('isContainerDetachedFromNetwork tolerates missing input', () => {
       expect(dockerService.isContainerDetachedFromNetwork(undefined)).to.equal(false);
       expect(dockerService.isContainerDetachedFromNetwork(null)).to.equal(false);
+    });
+  });
+
+  describe('dockerNetworkState tests', () => {
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('reports exists when the network inspects cleanly', async () => {
+      sinon.stub(Dockerode.prototype, 'getNetwork').returns({ inspect: sinon.stub().resolves({ Name: 'fluxDockerNetwork_appx' }) });
+
+      await expect(dockerService.dockerNetworkState('fluxDockerNetwork_appx')).to.eventually.equal('exists');
+    });
+
+    it('reports absent only when docker itself confirms the network is not listed', async () => {
+      sinon.stub(Dockerode.prototype, 'getNetwork').returns({ inspect: sinon.stub().rejects(new Error('no such network')) });
+      sinon.stub(Dockerode.prototype, 'listNetworks').resolves([{ Name: 'bridge' }, { Name: 'fluxDockerNetwork_other' }]);
+
+      await expect(dockerService.dockerNetworkState('fluxDockerNetwork_appx')).to.eventually.equal('absent');
+    });
+
+    it('reports exists when the inspect failed transiently but the network IS listed', async () => {
+      sinon.stub(Dockerode.prototype, 'getNetwork').returns({ inspect: sinon.stub().rejects(new Error('EAI_AGAIN')) });
+      sinon.stub(Dockerode.prototype, 'listNetworks').resolves([{ Name: 'fluxDockerNetwork_appx' }]);
+
+      await expect(dockerService.dockerNetworkState('fluxDockerNetwork_appx')).to.eventually.equal('exists');
+    });
+
+    it('reports unknown (never absent) when docker cannot answer at all', async () => {
+      // the caller destroys a container on "absent", so an unreachable daemon must
+      // never be read as a missing network
+      sinon.stub(Dockerode.prototype, 'getNetwork').returns({ inspect: sinon.stub().rejects(new Error('connect ENOENT /var/run/docker.sock')) });
+      sinon.stub(Dockerode.prototype, 'listNetworks').rejects(new Error('connect ENOENT /var/run/docker.sock'));
+
+      await expect(dockerService.dockerNetworkState('fluxDockerNetwork_appx')).to.eventually.equal('unknown');
     });
   });
 


### PR DESCRIPTION
## Release 8.17.0 — development → master

Rolls up 24 commits across three areas.

### 🛡️ App tampering — incident model (phase 1)
- New attributable, deduplicated, boot-aware incident schema replacing raw restart-row counting.
- Weighted distinct-incident tamper score; honest local event log with `boot_id` reboot tracking and episode dedup (capped API).
- Boot-storm discount limited to boot-race event types, then dropped entirely along with `__system__` reboot rows.
- Identity hardening: backfill identity onto incidents recorded before `fluxd` is up, store `nodeOutidx` as a number, harden the identity race and public-endpoint input.
- Startup migration: purge all pre-schema rows and sweep legacy `frequent_restart` rows.

### 🔧 App reconciler — network heal
- Heal containers running detached from their docker network, without uninstalling the app (debounced, single inspect).
- Only heal a detached container when its network still exists; never destroy a detached container the heal cannot rebuild.
- Recreate a pruned per-app docker network in the reconciler heal path; consolidate soft-register onto `ensureAppDockerNetwork` and reserve legacy octets.
- Pace the network heal on the durable backoff ladder; stop the stats monitor before force-removing a detached container.

### ✅ Tests & version
- Extensive unit coverage for the tampering model, reconciler heal, docker service, app installer, and runtime state.
- Version bump 8.16.1 → 8.17.0.
