### PR TITLE
fix(apps): unwedge the container reconciler, close the terminal crash paths, and make masterSlave elections resilient

### DIFF
--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -359,6 +359,10 @@ module.exports = {
     masterSlaveStaggerMs: 180000, // per-index delay before a standby may claim an unclaimed primary
     masterSlaveProbeTimeoutMs: 10000, // probing the previous primary's /apps/listrunningapps
     masterSlaveFdmTimeoutMs: 10000, // FDM /appips lookup
+    // cap on a reconciler recreate's provisioning (registry verify + image pull): a
+    // black-holed registry must fail the recreate, not wedge the component's
+    // reconcile single-flight for the TCP stack's worst case
+    recreateProvisionCapMs: 180000,
   },
   lockedSystemResources: {
     cpu: 10, // 1 cpu core

--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -355,7 +355,11 @@ module.exports = {
     imageUpdateDelayAfterRedeployMs: 120000,
     imageUpdateDelayBetweenComponentsMs: 1000,
     masterSlaveIntervalMs: 30000, // masterSlave (g:) FDM election cycle
-    masterSlaveMaxPassMs: 120000, // abandon a masterSlave pass wedged this long, so the next cycle still runs
+    masterSlaveMaxPassMs: 120000, // abandon a masterSlave pass SILENT this long (heartbeat-based), so the next cycle still runs
+    // The primary-promotion chmod -R over the whole appdata tree: generous (a cold
+    // walk of a huge tree is legitimate work) but finite, so a wedged walk surfaces
+    // as a failed fix instead of running forever.
+    permissionsFixTimeoutMs: 3600000,
     masterSlaveStaggerMs: 180000, // per-index delay before a standby may claim an unclaimed primary
     masterSlaveProbeTimeoutMs: 10000, // probing the previous primary's /apps/listrunningapps
     masterSlaveFdmTimeoutMs: 10000, // FDM /appips lookup

--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -355,6 +355,10 @@ module.exports = {
     imageUpdateDelayAfterRedeployMs: 120000,
     imageUpdateDelayBetweenComponentsMs: 1000,
     masterSlaveIntervalMs: 30000, // masterSlave (g:) FDM election cycle
+    masterSlaveMaxPassMs: 120000, // abandon a masterSlave pass wedged this long, so the next cycle still runs
+    masterSlaveStaggerMs: 180000, // per-index delay before a standby may claim an unclaimed primary
+    masterSlaveProbeTimeoutMs: 10000, // probing the previous primary's /apps/listrunningapps
+    masterSlaveFdmTimeoutMs: 10000, // FDM /appips lookup
   },
   lockedSystemResources: {
     cpu: 10, // 1 cpu core

--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -369,12 +369,13 @@ module.exports = {
     // ~40x the worst observed case. NOT applied to stop, which legitimately runs for
     // hours under a graceful shutdown and already declares its own grace via `t`.
     dockerRuntimeOpTimeoutMs: 120000,
-    // Absolute ceiling on a reconciler recreate's provisioning. The stall detector
-    // above owns the dead-registry case, so this only guards the residual non-pull
-    // steps (a sick disk mid volume-create, a hung docker create) from wedging the
-    // component's reconcile single-flight. Deliberately generous: a recreate failure
-    // with no container present escalates to removeAppLocally, so a ceiling that
-    // fired on a merely-slow pull would uninstall a healthy app.
+    // Absolute ceiling on a reconciler recreate's provisioning, so a wedged
+    // provision cannot hold the component's reconcile single-flight forever. The
+    // stall detector above is what distinguishes a dead transfer from a large one;
+    // this ceiling wraps the WHOLE provision, image pull included, so it can and
+    // will fire on an image that is downloading perfectly well. Hitting it is
+    // therefore treated as a node condition and never as a verdict on the app -
+    // the recreate is retried, never escalated to removal.
     recreateProvisionCapMs: 900000,
     // An in-flight reconcile older than this is stuck rather than slow, and every
     // reconcile request for that component is being silently dropped. Reporting

--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -359,10 +359,16 @@ module.exports = {
     masterSlaveStaggerMs: 180000, // per-index delay before a standby may claim an unclaimed primary
     masterSlaveProbeTimeoutMs: 10000, // probing the previous primary's /apps/listrunningapps
     masterSlaveFdmTimeoutMs: 10000, // FDM /appips lookup
-    // cap on a reconciler recreate's provisioning (registry verify + image pull): a
-    // black-holed registry must fail the recreate, not wedge the component's
-    // reconcile single-flight for the TCP stack's worst case
-    recreateProvisionCapMs: 180000,
+    // A pull whose progress stream goes silent this long is a dead transfer, not a
+    // slow one. Total pull time is unbounded while progress keeps flowing.
+    pullStallMs: 90000,
+    // Absolute ceiling on a reconciler recreate's provisioning. The stall detector
+    // above owns the dead-registry case, so this only guards the residual non-pull
+    // steps (a sick disk mid volume-create, a hung docker create) from wedging the
+    // component's reconcile single-flight. Deliberately generous: a recreate failure
+    // with no container present escalates to removeAppLocally, so a ceiling that
+    // fired on a merely-slow pull would uninstall a healthy app.
+    recreateProvisionCapMs: 900000,
   },
   lockedSystemResources: {
     cpu: 10, // 1 cpu core

--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -362,6 +362,13 @@ module.exports = {
     // A pull whose progress stream goes silent this long is a dead transfer, not a
     // slow one. Total pull time is unbounded while progress keeps flowing.
     pullStallMs: 90000,
+    // Ceiling on a short docker control-plane call (inspect, start). Mirrors
+    // kubelet's --runtime-request-timeout, which bounds runtime operations at 2min
+    // and exempts the long-running ones (pull, logs, exec, attach) - the same split
+    // used here. Measured docker start is ~2s p50 / ~3s p99 under load, so this is
+    // ~40x the worst observed case. NOT applied to stop, which legitimately runs for
+    // hours under a graceful shutdown and already declares its own grace via `t`.
+    dockerRuntimeOpTimeoutMs: 120000,
     // Absolute ceiling on a reconciler recreate's provisioning. The stall detector
     // above owns the dead-registry case, so this only guards the residual non-pull
     // steps (a sick disk mid volume-create, a hung docker create) from wedging the
@@ -369,6 +376,10 @@ module.exports = {
     // with no container present escalates to removeAppLocally, so a ceiling that
     // fired on a merely-slow pull would uninstall a healthy app.
     recreateProvisionCapMs: 900000,
+    // An in-flight reconcile older than this is stuck rather than slow, and every
+    // reconcile request for that component is being silently dropped. Reporting
+    // only - nothing is cancelled - so it sits above the recreate ceiling above.
+    reconcileStuckWarnMs: 1200000,
   },
   lockedSystemResources: {
     cpu: 10, // 1 cpu core

--- a/ZelBack/src/lib/socketIoHandlers/dockerTerminalHandler.js
+++ b/ZelBack/src/lib/socketIoHandlers/dockerTerminalHandler.js
@@ -42,6 +42,17 @@ async function dockerTerminalHandler(socket) {
       User: dockerUser,
     };
     container.exec(cmd, (err, exec) => {
+      // dockerode passes back a null exec when the daemon rejects the exec
+      // create (most commonly the container is not running - state created or
+      // exited). Without this guard the code below dereferences null
+      // (exec.start / exec.resize) and the resulting TypeError is thrown from
+      // inside this callback, which is unhandled and crashes the whole FluxOS
+      // process. Fail the terminal session cleanly instead.
+      if (err || !exec) {
+        log.error(`dockerTerminalHandler: exec create failed for ${nameOrId}: ${err ? err.message : 'no exec instance (is the container running?)'}`);
+        socket.emit('error', 'Error opening a terminal. Is the container running?');
+        return;
+      }
       const options = {
         Tty: true,
         stream: true,
@@ -57,9 +68,12 @@ async function dockerTerminalHandler(socket) {
       });
       /* eslint-disable no-shadow */
       exec.start(options, (err, stream) => {
-        if (err) {
-          log.error(err);
-          // socket.emit('error', 'Error executing the command.');
+        // Same defensive check as above: on failure stream can be null, and the
+        // stream.on(...) below would throw an unhandled TypeError out of this
+        // callback (crashing the process). Bail out cleanly instead.
+        if (err || !stream) {
+          log.error(`dockerTerminalHandler: exec start failed for ${nameOrId}: ${err ? err.message : 'no stream'}`);
+          socket.emit('error', 'Error executing the command.');
           return;
         }
         stream.on('data', (chunk) => {

--- a/ZelBack/src/lib/socketIoHandlers/dockerTerminalHandler.js
+++ b/ZelBack/src/lib/socketIoHandlers/dockerTerminalHandler.js
@@ -8,88 +8,101 @@ const log = require('../log');
 async function dockerTerminalHandler(socket) {
   const clientIp = socket.handshake.headers['x-forwarded-for']?.split(',')[0]?.trim() || socket.handshake.address;
 
+  // This listener is async, so anything that throws inside it is an unhandled
+  // rejection and takes the whole FluxOS process down. Every failure has to leave
+  // through socket.emit('error', ...) instead - hence the blanket catch.
   socket.on('exec', async (zelidauth, nameOrId, dockerCmd, dockerEnv, dockerUser) => {
-    const auth = {
-      zelidauth,
-    };
-    const container = await dockerService.getDockerContainerByIdOrName(nameOrId);
-    const mainAppName = nameOrId.split('_')[1] || nameOrId;
-    const authorized = await verificationHelperUtils.verifyAppOwnerOrHigherSession(auth, mainAppName);
-    if (authorized !== true) {
-      socket.emit('error', 'Not authorized.');
-      return;
-    }
-    if (!container) {
-      socket.emit('error', 'Container not found.');
-      return;
-    }
-
-    const parts = nameOrId.split('_');
-    const component = parts.length > 1 ? parts[0].replace(/^(zel|flux)/, '') || null : null;
-    const analyticsAppName = parts.length > 1 ? mainAppName : mainAppName.replace(/^(zel|flux)/, '');
-    trackTerminalSession(zelidauth, analyticsAppName, 'open', clientIp, component);
-    socket.on('disconnect', () => {
-      trackTerminalSession(zelidauth, analyticsAppName, 'close', clientIp, component);
-    });
-
-    const cmd = {
-      AttachStdout: true,
-      AttachStderr: true,
-      AttachStdin: true,
-      Tty: true,
-      Cmd: serviceHelper.commandStringToArray(dockerCmd),
-      Env: serviceHelper.commandStringToArray(dockerEnv),
-      User: dockerUser,
-    };
-    container.exec(cmd, (err, exec) => {
-      // dockerode passes back a null exec when the daemon rejects the exec
-      // create (most commonly the container is not running - state created or
-      // exited). Without this guard the code below dereferences null
-      // (exec.start / exec.resize) and the resulting TypeError is thrown from
-      // inside this callback, which is unhandled and crashes the whole FluxOS
-      // process. Fail the terminal session cleanly instead.
-      if (err || !exec) {
-        log.error(`dockerTerminalHandler: exec create failed for ${nameOrId}: ${err ? err.message : 'no exec instance (is the container running?)'}`);
-        socket.emit('error', 'Error opening a terminal. Is the container running?');
+    try {
+      const auth = {
+        zelidauth,
+      };
+      const mainAppName = nameOrId.split('_')[1] || nameOrId;
+      // Authorise BEFORE touching Docker: the lookup below is a remote-controlled
+      // operation on an attacker-supplied name, and must not be reachable by an
+      // unauthenticated caller.
+      const authorized = await verificationHelperUtils.verifyAppOwnerOrHigherSession(auth, mainAppName);
+      if (authorized !== true) {
+        socket.emit('error', 'Not authorized.');
         return;
       }
-      const options = {
-        Tty: true,
-        stream: true,
-        stdin: true,
-        stdout: true,
-        stderr: true,
-        hijack: true,
-      };
-      socket.on('resize', (data) => {
-        const { rows, cols } = data;
-        exec.resize({ h: rows, w: cols }, () => {
-        });
+      // getDockerContainerByIdOrName reads .Id off an undefined lookup result when
+      // the container is absent, so this rejects rather than returning null.
+      const container = await dockerService.getDockerContainerByIdOrName(nameOrId).catch(() => null);
+      if (!container) {
+        socket.emit('error', 'Container not found.');
+        return;
+      }
+
+      const parts = nameOrId.split('_');
+      const component = parts.length > 1 ? parts[0].replace(/^(zel|flux)/, '') || null : null;
+      const analyticsAppName = parts.length > 1 ? mainAppName : mainAppName.replace(/^(zel|flux)/, '');
+      trackTerminalSession(zelidauth, analyticsAppName, 'open', clientIp, component);
+      socket.on('disconnect', () => {
+        trackTerminalSession(zelidauth, analyticsAppName, 'close', clientIp, component);
       });
-      /* eslint-disable no-shadow */
-      exec.start(options, (err, stream) => {
-        // Same defensive check as above: on failure stream can be null, and the
-        // stream.on(...) below would throw an unhandled TypeError out of this
-        // callback (crashing the process). Bail out cleanly instead.
-        if (err || !stream) {
-          log.error(`dockerTerminalHandler: exec start failed for ${nameOrId}: ${err ? err.message : 'no stream'}`);
-          socket.emit('error', 'Error executing the command.');
+
+      const cmd = {
+        AttachStdout: true,
+        AttachStderr: true,
+        AttachStdin: true,
+        Tty: true,
+        Cmd: serviceHelper.commandStringToArray(dockerCmd),
+        Env: serviceHelper.commandStringToArray(dockerEnv),
+        User: dockerUser,
+      };
+      container.exec(cmd, (err, exec) => {
+        // dockerode passes back a null exec when the daemon rejects the exec
+        // create (most commonly the container is not running - state created or
+        // exited). Without this guard the code below dereferences null
+        // (exec.start / exec.resize) and the resulting TypeError is thrown from
+        // inside this callback, which is unhandled and crashes the whole FluxOS
+        // process. Fail the terminal session cleanly instead.
+        if (err || !exec) {
+          log.error(`dockerTerminalHandler: exec create failed for ${nameOrId}: ${err ? err.message : 'no exec instance (is the container running?)'}`);
+          socket.emit('error', 'Error opening a terminal. Is the container running?');
           return;
         }
-        stream.on('data', (chunk) => {
-          socket.emit('show', chunk.toString());
+        const options = {
+          Tty: true,
+          stream: true,
+          stdin: true,
+          stdout: true,
+          stderr: true,
+          hijack: true,
+        };
+        socket.on('resize', (data) => {
+          const { rows, cols } = data;
+          exec.resize({ h: rows, w: cols }, () => {
+          });
         });
-
-        socket.on('cmd', (data) => {
-          if (typeof data !== 'object') {
-            stream.write(data);
+        /* eslint-disable no-shadow */
+        exec.start(options, (err, stream) => {
+          // Same defensive check as above: on failure stream can be null, and the
+          // stream.on(...) below would throw an unhandled TypeError out of this
+          // callback (crashing the process). Bail out cleanly instead.
+          if (err || !stream) {
+            log.error(`dockerTerminalHandler: exec start failed for ${nameOrId}: ${err ? err.message : 'no stream'}`);
+            socket.emit('error', 'Error executing the command.');
+            return;
           }
+          stream.on('data', (chunk) => {
+            socket.emit('show', chunk.toString());
+          });
+
+          socket.on('cmd', (data) => {
+            if (typeof data !== 'object') {
+              stream.write(data);
+            }
+          });
+        });
+        socket.on('end', () => {
+          log.info('--------end---------');
         });
       });
-      socket.on('end', () => {
-        log.info('--------end---------');
-      });
-    });
+    } catch (error) {
+      log.error(`dockerTerminalHandler: ${nameOrId}: ${error.message}`);
+      socket.emit('error', 'Error opening a terminal.');
+    }
   });
 }
 

--- a/ZelBack/src/lib/socketIoHandlers/dockerTerminalHandler.js
+++ b/ZelBack/src/lib/socketIoHandlers/dockerTerminalHandler.js
@@ -26,6 +26,17 @@ async function dockerTerminalHandler(socket) {
         return undefined;
       }
     };
+    // Registered BEFORE the awaits below: a disconnect can land while auth and
+    // the docker lookups are still in flight (deterministically, for a client
+    // that emits 'exec' and closes), and a listener added after socket.io's
+    // single 'disconnect' emit never fires - leaking the hijacked stream and
+    // its exec for as long as the container lives.
+    let execStream = null;
+    let clientGone = false;
+    socket.on('disconnect', () => {
+      clientGone = true;
+      if (execStream) execStream.destroy();
+    });
     try {
       const auth = {
         zelidauth,
@@ -54,6 +65,10 @@ async function dockerTerminalHandler(socket) {
       socket.on('disconnect', () => {
         trackTerminalSession(zelidauth, analyticsAppName, 'close', clientIp, component);
       });
+
+      // the client may have gone away during the awaits above - do not create
+      // an exec nobody is attached to
+      if (clientGone || !socket.connected) return;
 
       const cmd = {
         AttachStdout: true,
@@ -112,9 +127,15 @@ async function dockerTerminalHandler(socket) {
             socket.emit('error', 'Terminal session error.');
           }));
 
-          // the client is gone: tear the exec stream down with it, so a hijacked
-          // docker socket can never outlive the terminal session it served
-          socket.on('disconnect', guard('stream teardown', () => stream.destroy()));
+          // Hand the stream to the disconnect teardown registered before the
+          // awaits, and close the race the other way: if the client vanished
+          // while exec.start was in flight, its disconnect has already fired
+          // and nothing else would ever destroy this stream.
+          execStream = stream;
+          if (clientGone || !socket.connected) {
+            stream.destroy();
+            return;
+          }
 
           // A keystroke racing the container's teardown fails ASYNCHRONOUSLY via
           // the stream's 'error' event (handled above) - a destroyed socket's

--- a/ZelBack/src/lib/socketIoHandlers/dockerTerminalHandler.js
+++ b/ZelBack/src/lib/socketIoHandlers/dockerTerminalHandler.js
@@ -103,8 +103,23 @@ async function dockerTerminalHandler(socket) {
             socket.emit('show', chunk.toString());
           }));
 
-          // the stream is destroyed the moment the container exits, so a keystroke
-          // arriving after that throws ERR_STREAM_DESTROYED out of this handler
+          // The hijacked stream is the raw upgraded docker socket, and node
+          // detaches its own error handler at upgrade - so without this listener
+          // a write racing the exec teardown (EPIPE on a keystroke as the shell
+          // exits) is an uncaught exception that exits the whole process.
+          stream.on('error', guard('stream error', (error) => {
+            log.error(`dockerTerminalHandler: stream error for ${nameOrId}: ${error.message}`);
+            socket.emit('error', 'Terminal session error.');
+          }));
+
+          // the client is gone: tear the exec stream down with it, so a hijacked
+          // docker socket can never outlive the terminal session it served
+          socket.on('disconnect', guard('stream teardown', () => stream.destroy()));
+
+          // A keystroke racing the container's teardown fails ASYNCHRONOUSLY via
+          // the stream's 'error' event (handled above) - a destroyed socket's
+          // write() just returns false. The type filter is what stops a
+          // non-string payload throwing synchronously out of write().
           socket.on('cmd', guard('cmd', (data) => {
             if (typeof data !== 'object') {
               stream.write(data);

--- a/ZelBack/src/lib/socketIoHandlers/dockerTerminalHandler.js
+++ b/ZelBack/src/lib/socketIoHandlers/dockerTerminalHandler.js
@@ -8,10 +8,24 @@ const log = require('../log');
 async function dockerTerminalHandler(socket) {
   const clientIp = socket.handshake.headers['x-forwarded-for']?.split(',')[0]?.trim() || socket.handshake.address;
 
-  // This listener is async, so anything that throws inside it is an unhandled
-  // rejection and takes the whole FluxOS process down. Every failure has to leave
-  // through socket.emit('error', ...) instead - hence the blanket catch.
+  // Anything that throws in a socket.io listener is unhandled and takes the whole
+  // FluxOS process down, so every failure here has to leave through
+  // socket.emit('error', ...) instead.
+  //
+  // The try/catch below only covers this listener's own body - the dockerode and
+  // socket callbacks registered inside it run LATER, after the try has exited, so
+  // they are each wrapped in `guard` rather than relying on it.
   socket.on('exec', async (zelidauth, nameOrId, dockerCmd, dockerEnv, dockerUser) => {
+    // wrap a callback that runs outside this listener's try/catch
+    const guard = (label, fn) => (...args) => {
+      try {
+        return fn(...args);
+      } catch (error) {
+        log.error(`dockerTerminalHandler: ${label} for ${nameOrId}: ${error.message}`);
+        socket.emit('error', 'Terminal session error.');
+        return undefined;
+      }
+    };
     try {
       const auth = {
         zelidauth,
@@ -50,7 +64,7 @@ async function dockerTerminalHandler(socket) {
         Env: serviceHelper.commandStringToArray(dockerEnv),
         User: dockerUser,
       };
-      container.exec(cmd, (err, exec) => {
+      container.exec(cmd, guard('exec create', (err, exec) => {
         // dockerode passes back a null exec when the daemon rejects the exec
         // create (most commonly the container is not running - state created or
         // exited). Without this guard the code below dereferences null
@@ -70,13 +84,13 @@ async function dockerTerminalHandler(socket) {
           stderr: true,
           hijack: true,
         };
-        socket.on('resize', (data) => {
+        socket.on('resize', guard('resize', (data) => {
           const { rows, cols } = data;
           exec.resize({ h: rows, w: cols }, () => {
           });
-        });
+        }));
         /* eslint-disable no-shadow */
-        exec.start(options, (err, stream) => {
+        exec.start(options, guard('exec start', (err, stream) => {
           // Same defensive check as above: on failure stream can be null, and the
           // stream.on(...) below would throw an unhandled TypeError out of this
           // callback (crashing the process). Bail out cleanly instead.
@@ -85,20 +99,22 @@ async function dockerTerminalHandler(socket) {
             socket.emit('error', 'Error executing the command.');
             return;
           }
-          stream.on('data', (chunk) => {
+          stream.on('data', guard('stream data', (chunk) => {
             socket.emit('show', chunk.toString());
-          });
+          }));
 
-          socket.on('cmd', (data) => {
+          // the stream is destroyed the moment the container exits, so a keystroke
+          // arriving after that throws ERR_STREAM_DESTROYED out of this handler
+          socket.on('cmd', guard('cmd', (data) => {
             if (typeof data !== 'object') {
               stream.write(data);
             }
-          });
-        });
+          }));
+        }));
         socket.on('end', () => {
           log.info('--------end---------');
         });
-      });
+      }));
     } catch (error) {
       log.error(`dockerTerminalHandler: ${nameOrId}: ${error.message}`);
       socket.emit('error', 'Error opening a terminal.');

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -1914,8 +1914,14 @@ async function applyPermissionsFix(appId) {
     log.info(`Applying permissions fix for app: ${appId}`);
 
     // Apply 777 permissions to entire app directory recursively
-    // This covers both appdata (primary mount) and all additional mounts at the same level
-    await serviceHelper.runCommand('chmod', { params: ['-R', '777', appPath], runAsRoot: true });
+    // This covers both appdata (primary mount) and all additional mounts at the same level.
+    // runCommand never rejects - failure comes back as result.error - and this result
+    // is the gate that keeps a node from being elected primary over data it could not
+    // fix. timeout: 0 because a recursive chmod over a large appdata tree legitimately
+    // outruns runCommand's 15-minute default, and a half-applied fix must read as
+    // failure, not be silently killed and reported as success.
+    const result = await serviceHelper.runCommand('chmod', { params: ['-R', '777', appPath], runAsRoot: true, timeout: 0 });
+    if (result.error) throw result.error;
 
     log.info(`Successfully applied permissions fix for app: ${appId} (includes appdata and all mount points)`);
     return true;
@@ -3531,10 +3537,12 @@ async function forceAppRemovals() {
  * @returns {Promise<void>}
  */
 async function masterSlaveApps(globalStateParam, installedApps, listRunningApps, receiveOnlySyncthingAppsCache, backupInProgressParam, restoreInProgressParam, https) {
+  // Declared outside the try so the finally can check ownership of the global
+  // flag against the pass that is current by the time it runs.
+  const thisPass = { abandoned: false, lastProgressAt: Date.now() };
   try {
     // eslint-disable-next-line no-param-reassign
     globalStateParam.masterSlaveAppsRunning = true;
-    const thisPass = { abandoned: false };
     currentMasterSlavePass = thisPass;
     // A wedged pass keeps running after the scheduler gives up on it; anything it
     // does from then on is based on a stale FDM/docker view and can fight the pass
@@ -3644,6 +3652,13 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
 
     // eslint-disable-next-line no-restricted-syntax
     for (const installedApp of appsInstalled.data) {
+      // Progress heartbeat for the scheduler's watchdog. Every awaited call in
+      // this loop is individually bounded (10s FDM regions, 10s peer probes), so
+      // a pass that is merely SLOW - many g: apps, degraded FDM - keeps beating
+      // and keeps its actuations, while a pass wedged on one dead await goes
+      // silent and is abandoned. Same principle as the pull stall detector:
+      // silence is the failure, not elapsed time.
+      thisPass.lastProgressAt = Date.now();
       let fdmOk = true;
       let identifier;
       let needsToBeChecked = false;
@@ -3782,6 +3797,10 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
 
                   // Check all nodes with lower index
                   for (let i = 0; i < index; i += 1) {
+                    // each probe is bounded at probeTimeoutMs; beat per probe so a
+                    // high-index node's long (but advancing) walk is not mistaken
+                    // for a wedged pass
+                    thisPass.lastProgressAt = Date.now();
                     const nodeToCheck = runningAppList[i];
                     if (!nodeToCheck) continue;
 
@@ -3969,8 +3988,14 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
   } catch (error) {
     log.error(`masterSlaveApps: ${error}`);
   } finally {
-    // eslint-disable-next-line no-param-reassign
-    globalStateParam.masterSlaveAppsRunning = false;
+    // Only the CURRENT pass owns the flag. An abandoned pass reaches this
+    // finally when it eventually unwedges - by then the watchdog has released
+    // the flag and a replacement pass may have set it true for itself; an
+    // unconditional clear here would clobber the live pass's lock.
+    if (currentMasterSlavePass === thisPass) {
+      // eslint-disable-next-line no-param-reassign
+      globalStateParam.masterSlaveAppsRunning = false;
+    }
   }
 }
 
@@ -4003,10 +4028,12 @@ function startMasterSlaveApps(globalStateParam, installedApps, listRunningApps, 
   let isRunning = false;
 
   const intervalMs = config.fluxapps.masterSlaveIntervalMs ?? 30 * 1000;
-  // A single pass legitimately makes several timed calls (FDM across regions,
-  // peer /listrunningapps probes), so allow generous headroom - but never let a
-  // wedged pass block elections forever. On timeout the guard is released and the
-  // next tick starts a fresh pass.
+  // The watchdog judges a pass by SILENCE, not total elapsed time (the pull
+  // stall detector's principle): a pass with many g: apps or degraded FDM
+  // legitimately runs past any fixed budget while still advancing, and
+  // abandoning it drops the very elections it exists to make. The pass beats
+  // a heartbeat between its bounded awaits; only a heartbeat older than this
+  // means it is wedged on a single dead call.
   const maxPassMs = config.fluxapps.masterSlaveMaxPassMs ?? Math.max(intervalMs * 4, 2 * 60 * 1000);
 
   const runPass = async () => {
@@ -4020,8 +4047,22 @@ function startMasterSlaveApps(globalStateParam, installedApps, listRunningApps, 
     try {
       let timer;
       const pass = masterSlaveApps(globalStateParam, installedApps, listRunningApps, receiveOnlySyncthingAppsCache, backupInProgressParam, restoreInProgressParam, https);
+      // Deadline-extension timer: fires when the pass's heartbeat has been
+      // silent for maxPassMs, re-arming for the remainder whenever the pass
+      // has beaten in the meantime. A wedged pass is still abandoned exactly
+      // maxPassMs after its last sign of life.
       const watchdog = new Promise((_, reject) => {
-        timer = setTimeout(() => reject(new Error(`pass exceeded ${maxPassMs}ms`)), maxPassMs);
+        const arm = (delayMs) => {
+          timer = setTimeout(() => {
+            const idleMs = Date.now() - (currentMasterSlavePass ? currentMasterSlavePass.lastProgressAt : 0);
+            if (idleMs >= maxPassMs) {
+              reject(new Error(`pass made no progress for ${Math.round(idleMs / 1000)}s`));
+            } else {
+              arm(maxPassMs - idleMs);
+            }
+          }, delayMs);
+        };
+        arm(maxPassMs);
       });
       try {
         await Promise.race([pass, watchdog]);
@@ -4033,9 +4074,11 @@ function startMasterSlaveApps(globalStateParam, installedApps, listRunningApps, 
       // timeout (and any unexpected throw) so a stuck pass can never tear down
       // or permanently block the interval.
       // Invalidate the abandoned pass so it cannot mutate if it later unwedges,
-      // and release the global lock it will never reach its own `finally` to clear
-      // (appInstaller gates performDockerCleanup on it). Single-flight means the
-      // pass registered as current is exactly the one this watchdog raced.
+      // and release the global lock it may never reach its own `finally` to clear
+      // (appInstaller gates performDockerCleanup on it; a pass wedged on a
+      // BOUNDED call does unwedge and reach its finally, where the ownership
+      // check keeps it from clobbering a replacement's lock). Single-flight
+      // means the pass registered as current is exactly the one this raced.
       if (currentMasterSlavePass) currentMasterSlavePass.abandoned = true;
       // eslint-disable-next-line no-param-reassign
       globalStateParam.masterSlaveAppsRunning = false;

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -54,6 +54,13 @@ const monotonicMs = () => Number(process.hrtime.bigint() / 1000000n);
 let currentMasterSlavePass = null;
 const mastersRunningGSyncthingApps = new Map();
 const timeTostartNewMasterApp = new Map();
+// Components already reported as operator-stopped, so the exclusion is announced
+// on entry (and again after a restart) instead of every 30s cycle. An operator
+// stop is durable in the DB, so without a line here a g: app sits unelected
+// indefinitely with the election loop emitting nothing at all - indistinguishable
+// in the logs from a loop that has died, which is exactly how it has been
+// misread. Cleared when the lock lifts so a later stop announces again.
+const operatorStoppedNoted = new Set();
 // One primary-promotion chain (folder flips + recursive permissions fix) per
 // component at a time - the 30s scheduler dispatches without await, and the fix
 // legitimately runs for minutes on a large tree.
@@ -3837,6 +3844,16 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
       }
     }
 
+    // Remove stale entries from operatorStoppedNoted (silently - the entry is a
+    // reporting latch, not state anyone acts on, and the app going away is not
+    // itself an election event worth a line)
+    // eslint-disable-next-line no-restricted-syntax
+    for (const identifier of operatorStoppedNoted) {
+      if (!validIdentifiers.has(identifier)) {
+        operatorStoppedNoted.delete(identifier);
+      }
+    }
+
     // eslint-disable-next-line no-restricted-syntax
     for (const installedApp of appsInstalled.data) {
       // Progress heartbeat for the scheduler's watchdog. The network calls in
@@ -3877,9 +3894,14 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
         // operator explicitly stopped this g: component; don't elect or act on it
         // eslint-disable-next-line no-await-in-loop
         if (await appsRuntimeState.isOperatorStopped(identifier)) {
+          if (!operatorStoppedNoted.has(identifier)) {
+            operatorStoppedNoted.add(identifier);
+            log.info(`masterSlaveApps: ${identifier} is operator-stopped - excluded from primary election until it is started`);
+          }
           // eslint-disable-next-line no-continue
           continue;
         }
+        operatorStoppedNoted.delete(identifier);
         // Get master IP from FDM using the new /appips endpoint
         // eslint-disable-next-line no-await-in-loop
         const fdmResult = await getMasterIpFromFdm(installedApp.name, axiosOptions);

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -925,10 +925,17 @@ async function softRegisterAppLocally(appSpecs, componentSpecs, res) {
   // from clearing installationInProgress - the flag belongs to the OTHER
   // operation here, not to this flow.
   if (globalState.removalInProgress) {
-    throw new Error('Another application is undergoing removal');
+    const busyError = new Error('Another application is undergoing removal');
+    // typed so callers can tell a transient flag collision (defer, the next
+    // pass retries) from a real registration failure - the reinstall path's
+    // catch removes the whole app on a real failure and must not on this
+    busyError.busyCollision = 'removal';
+    throw busyError;
   }
   if (globalState.installationInProgress) {
-    throw new Error('Another application is undergoing installation');
+    const busyError = new Error('Another application is undergoing installation');
+    busyError.busyCollision = 'installation';
+    throw busyError;
   }
   try {
     globalState.installationInProgress = true;
@@ -1335,7 +1342,7 @@ async function softRedeploy(appSpecs, res) {
       const appRedeployResponse = messageHelper.createWarningMessage('Another application is undergoing removal');
       if (res) {
         res.write(serviceHelper.ensureString(appRedeployResponse));
-        if (res.flush) res.flush();
+        res.end();
       }
       return;
     }
@@ -1344,7 +1351,7 @@ async function softRedeploy(appSpecs, res) {
       const appRedeployResponse = messageHelper.createWarningMessage('Another application is undergoing installation');
       if (res) {
         res.write(serviceHelper.ensureString(appRedeployResponse));
-        if (res.flush) res.flush();
+        res.end();
       }
       return;
     }
@@ -1353,7 +1360,7 @@ async function softRedeploy(appSpecs, res) {
       const appRedeployResponse = messageHelper.createWarningMessage('Another application is undergoing soft redeploy');
       if (res) {
         res.write(serviceHelper.ensureString(appRedeployResponse));
-        if (res.flush) res.flush();
+        res.end();
       }
       return;
     }
@@ -1362,7 +1369,7 @@ async function softRedeploy(appSpecs, res) {
       const appRedeployResponse = messageHelper.createWarningMessage('Another application is undergoing hard redeploy');
       if (res) {
         res.write(serviceHelper.ensureString(appRedeployResponse));
-        if (res.flush) res.flush();
+        res.end();
       }
       return;
     }
@@ -1443,6 +1450,18 @@ async function softRedeploy(appSpecs, res) {
       res.write(serviceHelper.ensureString(errorResponse));
       if (res.flush) res.flush();
     }
+    if (error.busyCollision === 'removal') {
+      // a removal owns the app-state world right now - and it may be THIS
+      // app's own deliberate removal, whose row must stay deleted
+      // (removeAppLocally deletes the row last and is not gated on
+      // softRedeployInProgress). Restoring or marking here could resurrect a
+      // removed app; removing would race the remover. Hands off: if the
+      // removal was unrelated, the app is left rowless - a recoverable
+      // orphan the next redeploy or reinstall pass re-adopts.
+      log.warn(`softRedeploy - ${appSpecs.name} deferred (${error.message}); leaving state to the removal in progress`);
+      if (res) res.end();
+      return;
+    }
     // A failed soft redeploy never removes an app this node holds (see
     // softRegisterAppLocally's catch for the full contract). This catch spans
     // the whole flow, so it can fire in the rowless window between the
@@ -1489,7 +1508,7 @@ async function hardRedeploy(appSpecs, res) {
       const appRedeployResponse = messageHelper.createWarningMessage('Another application is undergoing removal');
       if (res) {
         res.write(serviceHelper.ensureString(appRedeployResponse));
-        if (res.flush) res.flush();
+        res.end();
       }
       return;
     }
@@ -1498,7 +1517,7 @@ async function hardRedeploy(appSpecs, res) {
       const appRedeployResponse = messageHelper.createWarningMessage('Another application is undergoing installation');
       if (res) {
         res.write(serviceHelper.ensureString(appRedeployResponse));
-        if (res.flush) res.flush();
+        res.end();
       }
       return;
     }
@@ -1507,7 +1526,7 @@ async function hardRedeploy(appSpecs, res) {
       const appRedeployResponse = messageHelper.createWarningMessage('Another application is undergoing soft redeploy');
       if (res) {
         res.write(serviceHelper.ensureString(appRedeployResponse));
-        if (res.flush) res.flush();
+        res.end();
       }
       return;
     }
@@ -1516,7 +1535,7 @@ async function hardRedeploy(appSpecs, res) {
       const appRedeployResponse = messageHelper.createWarningMessage('Another application is undergoing hard redeploy');
       if (res) {
         res.write(serviceHelper.ensureString(appRedeployResponse));
-        if (res.flush) res.flush();
+        res.end();
       }
       return;
     }
@@ -1565,7 +1584,7 @@ async function softRedeployComponent(appName, componentName, res) {
       const appRedeployResponse = messageHelper.createWarningMessage('Another application is undergoing removal');
       if (res) {
         res.write(serviceHelper.ensureString(appRedeployResponse));
-        if (res.flush) res.flush();
+        res.end();
       }
       return;
     }
@@ -1574,7 +1593,7 @@ async function softRedeployComponent(appName, componentName, res) {
       const appRedeployResponse = messageHelper.createWarningMessage('Another application is undergoing installation');
       if (res) {
         res.write(serviceHelper.ensureString(appRedeployResponse));
-        if (res.flush) res.flush();
+        res.end();
       }
       return;
     }
@@ -1583,7 +1602,7 @@ async function softRedeployComponent(appName, componentName, res) {
       const appRedeployResponse = messageHelper.createWarningMessage('Another application is undergoing soft redeploy');
       if (res) {
         res.write(serviceHelper.ensureString(appRedeployResponse));
-        if (res.flush) res.flush();
+        res.end();
       }
       return;
     }
@@ -1592,7 +1611,7 @@ async function softRedeployComponent(appName, componentName, res) {
       const appRedeployResponse = messageHelper.createWarningMessage('Another application is undergoing hard redeploy');
       if (res) {
         res.write(serviceHelper.ensureString(appRedeployResponse));
-        if (res.flush) res.flush();
+        res.end();
       }
       return;
     }
@@ -1684,7 +1703,7 @@ async function hardRedeployComponent(appName, componentName, res) {
       const appRedeployResponse = messageHelper.createWarningMessage('Another application is undergoing removal');
       if (res) {
         res.write(serviceHelper.ensureString(appRedeployResponse));
-        if (res.flush) res.flush();
+        res.end();
       }
       return;
     }
@@ -1693,7 +1712,7 @@ async function hardRedeployComponent(appName, componentName, res) {
       const appRedeployResponse = messageHelper.createWarningMessage('Another application is undergoing installation');
       if (res) {
         res.write(serviceHelper.ensureString(appRedeployResponse));
-        if (res.flush) res.flush();
+        res.end();
       }
       return;
     }
@@ -1702,7 +1721,7 @@ async function hardRedeployComponent(appName, componentName, res) {
       const appRedeployResponse = messageHelper.createWarningMessage('Another application is undergoing soft redeploy');
       if (res) {
         res.write(serviceHelper.ensureString(appRedeployResponse));
-        if (res.flush) res.flush();
+        res.end();
       }
       return;
     }
@@ -1711,7 +1730,7 @@ async function hardRedeployComponent(appName, componentName, res) {
       const appRedeployResponse = messageHelper.createWarningMessage('Another application is undergoing hard redeploy');
       if (res) {
         res.write(serviceHelper.ensureString(appRedeployResponse));
-        if (res.flush) res.flush();
+        res.end();
       }
       return;
     }
@@ -3550,10 +3569,19 @@ async function reinstallOldApplications() {
               await appDockerRestart(appSpecifications.name);
             } catch (error) {
               log.error(error);
-              log.warn(`REMOVAL REASON: Redeployment error - ${appSpecifications.name} failed during redeployment: ${error.message}`);
-              // eslint-disable-next-line no-await-in-loop
-              await appUninstaller.removeAppLocally(appSpecifications.name, null, true, true, true); // remove entire app
-              log.info(`Cleanup completed for ${appSpecifications.name} after redeployment failure`);
+              if (error.busyCollision) {
+                // a transient collision with another operation's flag, not a
+                // failed install: the components stay soft-uninstalled with
+                // the row and their data volumes intact, and the next
+                // reinstall pass completes the update. Removing here would
+                // destroy preserved data over a timing collision.
+                log.warn(`Redeployment of ${appSpecifications.name} deferred (${error.message}); keeping the app for the next pass`);
+              } else {
+                log.warn(`REMOVAL REASON: Redeployment error - ${appSpecifications.name} failed during redeployment: ${error.message}`);
+                // eslint-disable-next-line no-await-in-loop
+                await appUninstaller.removeAppLocally(appSpecifications.name, null, true, true, true); // remove entire app
+                log.info(`Cleanup completed for ${appSpecifications.name} after redeployment failure`);
+              }
             }
           }
         }

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -848,6 +848,33 @@ async function localAppSpecExists(appName) {
   }
 }
 
+// Restore the app's local spec row after this flow's own teardown deleted it
+// (the soft uninstall removes the row; the register's insert is what puts it
+// back). Keeping a failed redeploy is only coherent with the row present -
+// the reconciler converges what it can see - so a failure landing in that
+// window re-inserts the spec the flow was applying. The write mirrors the
+// register's insert (enterprise specs store blanked compose/contacts).
+// Returns false when the insert failed; the caller then leaves the app as an
+// orphan rather than destroying data - a mounted volume with no row is
+// recoverable, a deleted one is not.
+async function restoreLocalAppSpecRow(appSpecs) {
+  try {
+    const dbopen = dbHelper.databaseConnection();
+    const appsDatabase = dbopen.db(config.database.appslocal.database);
+    const isEnterprise = Boolean(appSpecs.version >= 8 && appSpecs.enterprise);
+    const dbSpecs = JSON.parse(JSON.stringify(appSpecs));
+    if (isEnterprise) {
+      dbSpecs.compose = [];
+      dbSpecs.contacts = [];
+    }
+    const insertResult = await dbHelper.insertOneToDatabase(appsDatabase, localAppsInformation, dbSpecs);
+    return !!insertResult;
+  } catch (error) {
+    log.error(`restoreLocalAppSpecRow - failed to restore the local record of ${appSpecs.name}: ${error.message}`);
+    return false;
+  }
+}
+
 // During a soft redeploy the app's synced data is preserved on disk, so the
 // components the redeploy touched are marked already-synced in
 // receiveOnlySyncthingAppsCache (the same marking the success path performs).
@@ -911,16 +938,12 @@ async function softRegisterAppLocally(appSpecs, componentSpecs, res) {
     globalState.installationInProgress = true;
     const tier = await generalService.nodeTier().catch((error) => log.error(error));
     if (!tier) {
-      // the flag was just set above - leaving it latched on this return would
-      // starve every operation gated on isOperationInProgress node-wide
-      globalState.installationInProgress = false;
-      const rStatus = messageHelper.createErrorMessage('Failed to get Node Tier');
-      log.error(rStatus);
-      if (res) {
-        res.write(serviceHelper.ensureString(rStatus));
-        res.end();
-      }
-      return;
+      // routed through the catch below: the caller's teardown may already
+      // have deleted the local row at this point, so a bare return would
+      // strand the app half-redeployed - no row, nothing keeping, removing,
+      // or converging it. The catch clears the flag, restores the row and
+      // keeps, like any other mid-registration failure.
+      throw new Error('Failed to get Node Tier');
     }
     const appSpecifications = appSpecs;
     const appComponent = componentSpecs;
@@ -1112,31 +1135,38 @@ async function softRegisterAppLocally(appSpecs, componentSpecs, res) {
       res.write(serviceHelper.ensureString(errorResponse));
       if (res.flush) res.flush();
     }
-    // A failed soft redeploy never removes an app the reconciler can still
-    // see. The data volume was deliberately preserved (that is what makes the
-    // redeploy soft), so removal destroys established data over what is
-    // usually a node-local failure - a wedged daemon, a port that would not
-    // map, a resource query that blipped. With its local row present the spec
-    // and volume stay; the reconciler retries the install with the CURRENT
-    // spec on its backoff ladder, so a transient failure self-heals and a
-    // genuinely bad update converges to kept-down-with-data, the same contract
-    // as a failed recreate. A down instance stops broadcasting apprunning, so
-    // the network replaces it elsewhere through the normal spawner machinery.
-    // The kept app's g:/r: components must be re-marked synced, or the sync
-    // layer's first-encounter handling clears their data. Without the row
-    // (this catch can fire before the re-insert), keeping would orphan the
-    // volume - fall back to the full removal, which re-resolves the spec
-    // globally and cleans up.
-    if (await localAppSpecExists(appSpecs.name)) {
-      log.warn(`softRegisterAppLocally - ${appSpecs.name} failed during soft registration (${error.message}); keeping the app and its data for the reconciler, NOT removing`);
-      markSyncthingAppsSynced(appSpecs, componentSpecs);
-      if (res) res.end();
-      return;
+    // A failed soft redeploy NEVER removes the app. The data volume was
+    // deliberately preserved (that is what makes the redeploy soft), so
+    // removal destroys established data over what is usually a node-local
+    // failure - a wedged daemon, a port that would not map, a resource query
+    // that blipped. The spec and volume stay; the reconciler retries the
+    // install with the CURRENT spec on its backoff ladder, so a transient
+    // failure self-heals and a genuinely bad update converges to
+    // kept-down-with-data, the same contract as a failed recreate. A down
+    // instance stops broadcasting apprunning, so the network replaces it
+    // elsewhere through the normal spawner machinery. Keeping is only
+    // coherent with the local row present (the reconciler converges what it
+    // can see), and every soft register runs over an app that was installed
+    // here - so when this catch fires in the window between the caller's
+    // teardown deleting the row and the re-insert above, restore the row.
+    // The kept app's g:/r: components are then re-marked synced, or the sync
+    // layer's first-encounter handling clears their data.
+    if (!(await localAppSpecExists(appSpecs.name))) {
+      if (!(await restoreLocalAppSpecRow(appSpecs))) {
+        // no row and no way to write one: leave the app alone. An orphaned
+        // volume is recoverable (a later redeploy or reinstall re-adopts it);
+        // removing it here would destroy the only copy over a DB failure. No
+        // synced-mark either - a mark without a row would make an empty later
+        // install eligible for g: primary.
+        log.error(`softRegisterAppLocally - CRITICAL: ${appSpecs.name} failed during soft registration (${error.message}) and its local record could not be restored; leaving the app and its data untouched`);
+        if (res) res.end();
+        return;
+      }
+      log.warn(`softRegisterAppLocally - restored the local record of ${appSpecs.name} deleted by this redeploy's teardown`);
     }
-    log.warn(`softRegisterAppLocally - ${appSpecs.name} failed before its local record was restored (${error.message}); falling back to full local removal`);
-    // eslint-disable-next-line global-require
-    const appUninstaller = require('./appUninstaller');
-    appUninstaller.removeAppLocally(appSpecs.name, res, true);
+    log.warn(`softRegisterAppLocally - ${appSpecs.name} failed during soft registration (${error.message}); keeping the app and its data for the reconciler, NOT removing`);
+    markSyncthingAppsSynced(appSpecs, componentSpecs);
+    if (res) res.end();
   }
 }
 
@@ -1302,6 +1332,7 @@ async function softRemoveAppLocally(app, res) {
  * @param {object} res - Response object
  */
 async function softRedeploy(appSpecs, res) {
+  let hadLocalRow = false;
   try {
     if (globalState.removalInProgress) {
       log.warn('Another application is undergoing removal');
@@ -1370,6 +1401,12 @@ async function softRedeploy(appSpecs, res) {
       }
     }
 
+    // Read before the teardown so the catch can tell "this redeploy's own
+    // teardown deleted the row" (restore and keep - the data volume is still
+    // mounted) from "the app was never here" (fall back to removal). The
+    // keep-biased error default of the read is right here too: restoring
+    // beats removing on a guess.
+    hadLocalRow = await localAppSpecExists(appSpecs.name);
     globalState.softRedeployInProgress = true;
     log.info('Starting softRedeploy');
     try {
@@ -1398,19 +1435,30 @@ async function softRedeploy(appSpecs, res) {
     log.info('Error on softRedeploy');
     log.error(error);
     globalState.softRedeployInProgress = false;
-    // A failed soft redeploy never removes an app the reconciler can still see
-    // (see softRegisterAppLocally's catch for the full contract). This catch
-    // additionally fires for throws BEFORE the soft uninstall touched anything
-    // ('Flux App not found', spec formatting) - the row check handles those
-    // correctly too: row present + nothing torn down = keep is a no-op beyond
-    // the cache re-mark of components whose data is untouched; row absent on a
-    // node that never had the app = removeAppLocally on nothing to remove.
+    // A failed soft redeploy never removes an app this node holds (see
+    // softRegisterAppLocally's catch for the full contract). This catch spans
+    // the whole flow, so it can fire in the rowless window between the
+    // teardown's row delete and the register's re-insert (the redeploy delay,
+    // the requirements check) - restore the row and keep, exactly as the
+    // register's catch does. Only an app that was never locally installed
+    // (hadLocalRow false: 'Flux App not found', spec formatting) falls back
+    // to the full removal, which re-resolves the spec globally and cleans up
+    // local remnants - nothing of value exists here to keep.
     if (await localAppSpecExists(appSpecs.name)) {
       log.warn(`softRedeploy - ${appSpecs.name} failed (${error.message}); keeping the app and its data for the reconciler, NOT removing`);
       markSyncthingAppsSynced(appSpecs, undefined);
       return;
     }
-    log.warn(`softRedeploy - ${appSpecs.name} failed before its local record was restored (${error.message}); falling back to full local removal`);
+    if (hadLocalRow) {
+      if (await restoreLocalAppSpecRow(appSpecs)) {
+        log.warn(`softRedeploy - ${appSpecs.name} failed (${error.message}); restored the local record deleted by this redeploy's teardown, keeping the app and its data, NOT removing`);
+        markSyncthingAppsSynced(appSpecs, undefined);
+      } else {
+        log.error(`softRedeploy - CRITICAL: ${appSpecs.name} failed (${error.message}) and its local record could not be restored; leaving the app and its data untouched`);
+      }
+      return;
+    }
+    log.warn(`softRedeploy - ${appSpecs.name} failed and was never locally installed (${error.message}); removing local remnants`);
     // eslint-disable-next-line global-require
     const appUninstaller = require('./appUninstaller');
     await appUninstaller.removeAppLocally(appSpecs.name, res, true, true, true);

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -421,14 +421,6 @@ async function createAppVolume(appSpecifications, appName, isComponent, res) {
   const identifier = isComponent ? `${appSpecifications.name}_${appName}` : appName;
   const appId = dockerService.getAppIdentifier(identifier);
 
-  // A volume being created is by definition NOT synced: a surviving cache
-  // entry for this id describes a previous incarnation's on-disk state (e.g.
-  // a redeploy keep-mark re-planted while a same-app removal raced it) and
-  // would let this empty fresh install skip the new-install receiveonly
-  // protection and read as instantly ready for g: primary. Drop it so the
-  // sync layer treats the install as the clean slate it is.
-  globalState.receiveOnlySyncthingAppsCache.delete(appId);
-
   const searchSpace = {
     status: 'Searching available space...',
   };
@@ -532,6 +524,16 @@ async function createAppVolume(appSpecifications, appName, isComponent, res) {
       volumeFile = path.join(appVolumesPath, `${appId}FLUXFSVOL`);
     }
 
+    // The point of no return: past here the previous incarnation's on-disk
+    // state is gone, so a surviving cache entry for this id is stale by
+    // definition (e.g. a redeploy keep-mark re-planted while a same-app
+    // removal raced it) and would let this empty fresh install skip the
+    // new-install receiveonly protection and read as instantly ready for g:
+    // primary. Dropped HERE and not at entry: a pre-flight abort (resources
+    // query, space checks) leaves the existing volume and its data untouched,
+    // and stripping the mark there would hand intact data to the
+    // not-in-cache skip/second-encounter chain, which clears it.
+    globalState.receiveOnlySyncthingAppsCache.delete(appId);
     await execAsRoot('fallocate', ['-l', `${appSpecifications.hdd}G`, volumeFile]);
     const allocateSpace2 = {
       status: 'Space allocated',

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -1450,18 +1450,6 @@ async function softRedeploy(appSpecs, res) {
       res.write(serviceHelper.ensureString(errorResponse));
       if (res.flush) res.flush();
     }
-    if (error.busyCollision === 'removal') {
-      // a removal owns the app-state world right now - and it may be THIS
-      // app's own deliberate removal, whose row must stay deleted
-      // (removeAppLocally deletes the row last and is not gated on
-      // softRedeployInProgress). Restoring or marking here could resurrect a
-      // removed app; removing would race the remover. Hands off: if the
-      // removal was unrelated, the app is left rowless - a recoverable
-      // orphan the next redeploy or reinstall pass re-adopts.
-      log.warn(`softRedeploy - ${appSpecs.name} deferred (${error.message}); leaving state to the removal in progress`);
-      if (res) res.end();
-      return;
-    }
     // A failed soft redeploy never removes an app this node holds (see
     // softRegisterAppLocally's catch for the full contract). This catch spans
     // the whole flow, so it can fire in the rowless window between the

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -915,26 +915,22 @@ async function softRegisterAppLocally(appSpecs, componentSpecs, res) {
   // get applications specifics from app messages database
   // check if hash is in blockchain
   // register and launch according to specifications in message
-  // throw without catching
+  //
+  // The busy guards sit OUTSIDE the try and THROW: a soft register runs in
+  // the window where the caller's teardown already deleted the local row, so
+  // a bare return here would let the redeploy log success around an app with
+  // no row, no containers and an orphaned volume (the spawner is not gated on
+  // softRedeployInProgress, so a racing install can take the flag during the
+  // redeploy delay). Throwing from outside the try also keeps the catch below
+  // from clearing installationInProgress - the flag belongs to the OTHER
+  // operation here, not to this flow.
+  if (globalState.removalInProgress) {
+    throw new Error('Another application is undergoing removal');
+  }
+  if (globalState.installationInProgress) {
+    throw new Error('Another application is undergoing installation');
+  }
   try {
-    if (globalState.removalInProgress) {
-      const rStatus = messageHelper.createErrorMessage('Another application is undergoing removal');
-      log.error(rStatus);
-      if (res) {
-        res.write(serviceHelper.ensureString(rStatus));
-        res.end();
-      }
-      return;
-    }
-    if (globalState.installationInProgress) {
-      const rStatus = messageHelper.createErrorMessage('Another application is undergoing installation');
-      log.error(rStatus);
-      if (res) {
-        res.write(serviceHelper.ensureString(rStatus));
-        res.end();
-      }
-      return;
-    }
     globalState.installationInProgress = true;
     const tier = await generalService.nodeTier().catch((error) => log.error(error));
     if (!tier) {
@@ -1435,6 +1431,18 @@ async function softRedeploy(appSpecs, res) {
     log.info('Error on softRedeploy');
     log.error(error);
     globalState.softRedeployInProgress = false;
+    // surface the failure on the streamed response; every branch below either
+    // ends it here or hands it to removeAppLocally, which ends it - a keep
+    // that leaves the stream open hangs the API client to a gateway timeout
+    if (res) {
+      const errorResponse = messageHelper.createErrorMessage(
+        error.message || error,
+        error.name,
+        error.code,
+      );
+      res.write(serviceHelper.ensureString(errorResponse));
+      if (res.flush) res.flush();
+    }
     // A failed soft redeploy never removes an app this node holds (see
     // softRegisterAppLocally's catch for the full contract). This catch spans
     // the whole flow, so it can fire in the rowless window between the
@@ -1447,6 +1455,7 @@ async function softRedeploy(appSpecs, res) {
     if (await localAppSpecExists(appSpecs.name)) {
       log.warn(`softRedeploy - ${appSpecs.name} failed (${error.message}); keeping the app and its data for the reconciler, NOT removing`);
       markSyncthingAppsSynced(appSpecs, undefined);
+      if (res) res.end();
       return;
     }
     if (hadLocalRow) {
@@ -1456,6 +1465,7 @@ async function softRedeploy(appSpecs, res) {
       } else {
         log.error(`softRedeploy - CRITICAL: ${appSpecs.name} failed (${error.message}) and its local record could not be restored; leaving the app and its data untouched`);
       }
+      if (res) res.end();
       return;
     }
     log.warn(`softRedeploy - ${appSpecs.name} failed and was never locally installed (${error.message}); removing local remnants`);

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -1062,6 +1062,16 @@ async function softRegisterAppLocally(appSpecs, componentSpecs, res) {
       res.write(serviceHelper.ensureString(errorResponse));
       if (res.flush) res.flush();
     }
+    // A node condition - a daemon or provision step not ANSWERING (stamped by
+    // the runtime-op bounds and the recreate ceiling) - is never grounds to
+    // destroy an app and its data: the spec and volume stay in place and the
+    // reconciler's recreate path converges when the node recovers. Removal
+    // here is for a redeploy the node genuinely rejected.
+    if (error.dockerRuntimeTimedOut || error.provisionTimedOut) {
+      log.warn(`softRegisterAppLocally - ${appSpecs.name} failed on a node condition (${error.message}); leaving the app for the reconciler, NOT removing`);
+      if (res) res.end();
+      return;
+    }
     const removeStatus = messageHelper.createErrorMessage(`Error occured. Initiating Flux App ${appSpecs.name} removal`);
     log.info(removeStatus);
     log.warn(`REMOVAL REASON: Soft registration failure - ${appSpecs.name} failed during soft registration: ${error.message} (softRegisterAppLocally)`);
@@ -3931,21 +3941,23 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                     }
                   }
                 } else if (timeTostartNewMasterApp.has(identifier) && timeTostartNewMasterApp.get(identifier) <= Date.now()) {
+                  // A chain for this component is still running: keep the matured
+                  // slot so the next tick retries the moment it clears - and skip
+                  // the probe walk below, which a kept slot would otherwise re-pay
+                  // (index x 10s) on every pass for the life of the chain.
+                  if (permissionsFixInFlight.has(appId)) {
+                    log.info(`masterSlaveApps: promotion chain for ${identifier} still running, keeping its scheduled slot`);
+                    // eslint-disable-next-line no-continue
+                    continue;
+                  }
                   // Scheduled start time has arrived, check if lower-index nodes are running
                   // eslint-disable-next-line no-await-in-loop
                   const lowerNodeRunning = await checkLowerIndexNodesRunning();
                   if (!lowerNodeRunning) {
                     if (superseded()) return;
-                    // a chain for this component is still running - keep the matured
-                    // slot so the next tick retries the moment it clears, instead of
-                    // consuming the slot for a dispatch the guard will no-op
-                    if (permissionsFixInFlight.has(appId)) {
-                      log.info(`masterSlaveApps: promotion chain for ${identifier} still running, keeping its scheduled slot`);
-                    } else {
-                      requestMasterStartWithPermissionsFix(identifier, appId, superseded);
-                      log.info(`masterSlaveApps: starting docker component:${identifier} index: ${index} that was scheduled to start at ${timeTostartNewMasterApp.get(identifier).toString()}`);
-                      timeTostartNewMasterApp.delete(identifier);
-                    }
+                    requestMasterStartWithPermissionsFix(identifier, appId, superseded);
+                    log.info(`masterSlaveApps: starting docker component:${identifier} index: ${index} that was scheduled to start at ${timeTostartNewMasterApp.get(identifier).toString()}`);
+                    timeTostartNewMasterApp.delete(identifier);
                   } else {
                     log.info(`masterSlaveApps: not starting app:${installedApp.name} index: ${index} - lower-index node is already running`);
                     timeTostartNewMasterApp.delete(identifier);

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -829,6 +829,25 @@ async function createAppVolume(appSpecifications, appName, isComponent, res) {
   }
 }
 
+// Whether this app still has its local spec row. The keep-on-failure path is
+// only coherent while the reconciler can SEE the app: a soft redeploy that
+// failed after the soft uninstall deleted the row but before the register
+// re-inserted it must fall back to the full local removal - keeping without a
+// row would orphan the still-mounted volume with no owner (nothing converges
+// an app that is not in the local DB), while removeAppLocally re-resolves the
+// spec globally and cleans volume, network and broadcast. An indeterminate
+// read keeps: never destroy on a guess.
+async function localAppSpecExists(appName) {
+  try {
+    const dbopen = dbHelper.databaseConnection();
+    const appsDatabase = dbopen.db(config.database.appslocal.database);
+    const app = await dbHelper.findOneInDatabase(appsDatabase, localAppsInformation, { name: appName }, {});
+    return !!app;
+  } catch (error) {
+    return true;
+  }
+}
+
 // During a soft redeploy the app's synced data is preserved on disk, so the
 // components the redeploy touched are marked already-synced in
 // receiveOnlySyncthingAppsCache (the same marking the success path performs).
@@ -892,6 +911,9 @@ async function softRegisterAppLocally(appSpecs, componentSpecs, res) {
     globalState.installationInProgress = true;
     const tier = await generalService.nodeTier().catch((error) => log.error(error));
     if (!tier) {
+      // the flag was just set above - leaving it latched on this return would
+      // starve every operation gated on isOperationInProgress node-wide
+      globalState.installationInProgress = false;
       const rStatus = messageHelper.createErrorMessage('Failed to get Node Tier');
       log.error(rStatus);
       if (res) {
@@ -1090,21 +1112,31 @@ async function softRegisterAppLocally(appSpecs, componentSpecs, res) {
       res.write(serviceHelper.ensureString(errorResponse));
       if (res.flush) res.flush();
     }
-    // A failed soft redeploy NEVER removes the app. The data volume was
-    // deliberately preserved (that is what makes the redeploy soft), so
-    // removal here destroys established data over what is usually a node-local
-    // failure - a wedged daemon, a port that would not map, a resource query
-    // that blipped. The spec and volume stay; the reconciler retries the
-    // install with the CURRENT spec on its backoff ladder, so a transient
-    // failure self-heals and a genuinely bad update converges to
-    // kept-down-with-data, the same contract as a failed recreate. A down
-    // instance stops broadcasting apprunning, so the network replaces it
-    // elsewhere through the normal spawner machinery - no removal needed for
-    // availability. The kept app's g:/r: components must be re-marked synced,
-    // or the sync layer's first-encounter handling clears their data.
-    log.warn(`softRegisterAppLocally - ${appSpecs.name} failed during soft registration (${error.message}); keeping the app and its data for the reconciler, NOT removing`);
-    markSyncthingAppsSynced(appSpecs, componentSpecs);
-    if (res) res.end();
+    // A failed soft redeploy never removes an app the reconciler can still
+    // see. The data volume was deliberately preserved (that is what makes the
+    // redeploy soft), so removal destroys established data over what is
+    // usually a node-local failure - a wedged daemon, a port that would not
+    // map, a resource query that blipped. With its local row present the spec
+    // and volume stay; the reconciler retries the install with the CURRENT
+    // spec on its backoff ladder, so a transient failure self-heals and a
+    // genuinely bad update converges to kept-down-with-data, the same contract
+    // as a failed recreate. A down instance stops broadcasting apprunning, so
+    // the network replaces it elsewhere through the normal spawner machinery.
+    // The kept app's g:/r: components must be re-marked synced, or the sync
+    // layer's first-encounter handling clears their data. Without the row
+    // (this catch can fire before the re-insert), keeping would orphan the
+    // volume - fall back to the full removal, which re-resolves the spec
+    // globally and cleans up.
+    if (await localAppSpecExists(appSpecs.name)) {
+      log.warn(`softRegisterAppLocally - ${appSpecs.name} failed during soft registration (${error.message}); keeping the app and its data for the reconciler, NOT removing`);
+      markSyncthingAppsSynced(appSpecs, componentSpecs);
+      if (res) res.end();
+      return;
+    }
+    log.warn(`softRegisterAppLocally - ${appSpecs.name} failed before its local record was restored (${error.message}); falling back to full local removal`);
+    // eslint-disable-next-line global-require
+    const appUninstaller = require('./appUninstaller');
+    appUninstaller.removeAppLocally(appSpecs.name, res, true);
   }
 }
 
@@ -1366,17 +1398,22 @@ async function softRedeploy(appSpecs, res) {
     log.info('Error on softRedeploy');
     log.error(error);
     globalState.softRedeployInProgress = false;
-    // A failed soft redeploy NEVER removes the app: the data volume was
-    // deliberately preserved, and this catch fires for node-local failures too
-    // (a requirements query that blipped, a port that would not map). The spec
-    // and volume stay; the reconciler retries the install with the current
-    // spec on its backoff ladder, so a transient failure self-heals and a
-    // genuinely bad update converges to kept-down-with-data - and a down
-    // instance is replaced elsewhere by the spawner through the normal
-    // apprunning machinery. The kept app's g:/r: components are re-marked
-    // synced so the sync layer's first-encounter handling cannot clear them.
-    log.warn(`softRedeploy - ${appSpecs.name} failed (${error.message}); keeping the app and its data for the reconciler, NOT removing`);
-    markSyncthingAppsSynced(appSpecs, undefined);
+    // A failed soft redeploy never removes an app the reconciler can still see
+    // (see softRegisterAppLocally's catch for the full contract). This catch
+    // additionally fires for throws BEFORE the soft uninstall touched anything
+    // ('Flux App not found', spec formatting) - the row check handles those
+    // correctly too: row present + nothing torn down = keep is a no-op beyond
+    // the cache re-mark of components whose data is untouched; row absent on a
+    // node that never had the app = removeAppLocally on nothing to remove.
+    if (await localAppSpecExists(appSpecs.name)) {
+      log.warn(`softRedeploy - ${appSpecs.name} failed (${error.message}); keeping the app and its data for the reconciler, NOT removing`);
+      markSyncthingAppsSynced(appSpecs, undefined);
+      return;
+    }
+    log.warn(`softRedeploy - ${appSpecs.name} failed before its local record was restored (${error.message}); falling back to full local removal`);
+    // eslint-disable-next-line global-require
+    const appUninstaller = require('./appUninstaller');
+    await appUninstaller.removeAppLocally(appSpecs.name, res, true, true, true);
   }
 }
 

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -42,6 +42,10 @@ const appNetworkLinker = require('./appNetworkLinker');
 const isArcane = Boolean(process.env.FLUXOS_PATH);
 
 // Master/slave app tracking
+// Bumped whenever the scheduler abandons a wedged pass. A pass captures this on
+// entry and re-checks it before every mutating action, so a pass that unwedges
+// minutes later cannot act on a view of the world that has since been replaced.
+let masterSlavePassGeneration = 0;
 const mastersRunningGSyncthingApps = new Map();
 const timeTostartNewMasterApp = new Map();
 
@@ -3525,6 +3529,16 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
   try {
     // eslint-disable-next-line no-param-reassign
     globalStateParam.masterSlaveAppsRunning = true;
+    const generation = masterSlavePassGeneration;
+    // A wedged pass keeps running after the scheduler gives up on it; anything it
+    // does from then on is based on a stale FDM/docker view and can fight the pass
+    // that replaced it (flipping a live primary's syncthing folder to receiveonly,
+    // or issuing a start/stop that has since been reversed).
+    const superseded = () => {
+      if (generation === masterSlavePassGeneration) return false;
+      log.warn(`masterSlaveApps: pass superseded (generation ${generation} -> ${masterSlavePassGeneration}), dropping pending action`);
+      return true;
+    };
     // do not run if installationInProgress or removalInProgress or softRedeployInProgress or hardRedeployInProgress
     if (globalStateParam.installationInProgress || globalStateParam.removalInProgress || globalStateParam.softRedeployInProgress || globalStateParam.hardRedeployInProgress) {
       return;
@@ -3578,9 +3592,13 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
       rejectUnauthorized: false,
     });
     const axiosOptions = {
-      timeout: 10000,
+      timeout: config.fluxapps.masterSlaveFdmTimeoutMs ?? 10000,
       httpsAgent: agent,
     };
+    // A standby waits index * this before it may claim an unclaimed primary, so
+    // lower-index nodes get first refusal instead of every holder racing to start.
+    const staggerMs = config.fluxapps.masterSlaveStaggerMs ?? 3 * 60 * 1000;
+    const probeTimeoutMs = config.fluxapps.masterSlaveProbeTimeoutMs ?? 10 * 1000;
 
     // Cleanup stale entries from maps to prevent memory leaks
     const validIdentifiers = new Set();
@@ -3754,7 +3772,7 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                   if (index <= 0) return false; // Index 0 or not found, no lower nodes to check
 
                   const { CancelToken } = axios;
-                  const timeout = 10 * 1000;
+                  const timeout = probeTimeoutMs;
 
                   // Check all nodes with lower index
                   for (let i = 0; i < index; i += 1) {
@@ -3795,6 +3813,7 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
 
                 if (index === 0 && !mastersRunningGSyncthingApps.has(identifier)) {
                   // Index 0: Start immediately if no history
+                  if (superseded()) return;
                   requestMasterStartWithPermissionsFix(identifier, appId);
                   log.info(`masterSlaveApps: starting docker component:${identifier} index: ${index}`);
                 } else if (!timeTostartNewMasterApp.has(identifier) && mastersRunningGSyncthingApps.has(identifier) && !ipsMatch(mastersRunningGSyncthingApps.get(identifier), localSocketAddr)) {
@@ -3802,7 +3821,7 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                   const { CancelToken } = axios;
                   const source = CancelToken.source();
                   let isResolved = false;
-                  const timeout = 10 * 1000; // 10 seconds
+                  const timeout = probeTimeoutMs;
                   setTimeout(() => {
                     if (!isResolved) {
                       source.cancel('Operation canceled by the user.');
@@ -3835,7 +3854,8 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                   }
                   // Previous master is not running, determine next primary
                   if (index === 0) {
-                    requestMasterStartWithPermissionsFix(identifier, appId);
+                    if (superseded()) return;
+                  requestMasterStartWithPermissionsFix(identifier, appId);
                     log.info(`masterSlaveApps: starting docker component:${identifier} index: ${index}`);
                   } else {
                     const previousMasterIndex = runningAppList.findIndex((x) => ipsMatch(x.ip, mastersRunningGSyncthingApps.get(identifier)));
@@ -3843,19 +3863,20 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                     if (previousMasterIndex >= 0) {
                       log.info(`masterSlaveApps: app:${installedApp.name} had primary running at index: ${previousMasterIndex}`);
                       if (index > previousMasterIndex) {
-                        timetoStartApp += (index - 1) * 3 * 60 * 1000;
+                        timetoStartApp += (index - 1) * staggerMs;
                       } else {
-                        timetoStartApp += index * 3 * 60 * 1000;
+                        timetoStartApp += index * staggerMs;
                       }
                     } else {
-                      timetoStartApp += index * 3 * 60 * 1000;
+                      timetoStartApp += index * staggerMs;
                     }
                     if (timetoStartApp <= Date.now()) {
                       // Time to start, but check if lower-index nodes are running
                       // eslint-disable-next-line no-await-in-loop
                       const lowerNodeRunning = await checkLowerIndexNodesRunning();
                       if (!lowerNodeRunning) {
-                        requestMasterStartWithPermissionsFix(identifier, appId);
+                        if (superseded()) return;
+                  requestMasterStartWithPermissionsFix(identifier, appId);
                         log.info(`masterSlaveApps: starting docker component:${identifier} index: ${index}`);
                       }
                     } else {
@@ -3868,7 +3889,8 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                   // eslint-disable-next-line no-await-in-loop
                   const lowerNodeRunning = await checkLowerIndexNodesRunning();
                   if (!lowerNodeRunning) {
-                    requestMasterStartWithPermissionsFix(identifier, appId);
+                    if (superseded()) return;
+                  requestMasterStartWithPermissionsFix(identifier, appId);
                     log.info(`masterSlaveApps: starting docker component:${identifier} index: ${index} that was scheduled to start at ${timeTostartNewMasterApp.get(identifier).toString()}`);
                     timeTostartNewMasterApp.delete(identifier);
                   } else {
@@ -3877,7 +3899,7 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                   }
                 } else if (index > 0 && !mastersRunningGSyncthingApps.has(identifier) && !timeTostartNewMasterApp.has(identifier)) {
                   // Non-primary node with no history - schedule start based on index
-                  const timetoStartApp = Date.now() + (index * 3 * 60 * 1000);
+                  const timetoStartApp = Date.now() + (index * staggerMs);
                   log.info(`masterSlaveApps: scheduling app:${installedApp.name} index: ${index} to start at ${timetoStartApp.toString()}`);
                   timeTostartNewMasterApp.set(identifier, timetoStartApp);
                 } else {
@@ -3894,6 +3916,7 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
               if (!ipsMatch(localSocketAddr, ip) && runningAppsNames.includes(identifier)) {
                 // Stop only the g: component on this standby node. Non-g siblings (e.g. a DB
                 // cluster component that needs all instances running) must keep running.
+                if (superseded()) return;
                 appReconciler.setControllerDesired(identifier, 'stopped', 'masterSlave standby');
                 log.info(`masterSlaveApps: requesting stop of component:${identifier} - primary runs on ip:${ip}, localSocketAddr is: ${localSocketAddr}`);
               } else if (ipsMatch(localSocketAddr, ip) && !runningAppsNames.includes(identifier)) {
@@ -3925,6 +3948,7 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                 }
 
                 if (isReady) {
+                  if (superseded()) return;
                   requestMasterStartWithPermissionsFix(identifier, appId);
                   log.info(`masterSlaveApps: starting docker component:${identifier}`);
                 } else {
@@ -3976,8 +4000,8 @@ function startMasterSlaveApps(globalStateParam, installedApps, listRunningApps, 
   // A single pass legitimately makes several timed calls (FDM across regions,
   // peer /listrunningapps probes), so allow generous headroom - but never let a
   // wedged pass block elections forever. On timeout the guard is released and the
-  // next tick starts a fresh pass; the abandoned pass is harmless (declare-only).
-  const maxPassMs = Math.max(intervalMs * 4, 2 * 60 * 1000);
+  // next tick starts a fresh pass.
+  const maxPassMs = config.fluxapps.masterSlaveMaxPassMs ?? Math.max(intervalMs * 4, 2 * 60 * 1000);
 
   const runPass = async () => {
     // Single-flight: skip if the previous pass is still in flight so passes never
@@ -4002,6 +4026,12 @@ function startMasterSlaveApps(globalStateParam, installedApps, listRunningApps, 
       // masterSlaveApps swallows its own errors; this catches the watchdog
       // timeout (and any unexpected throw) so a stuck pass can never tear down
       // or permanently block the interval.
+      // Invalidate the abandoned pass so it cannot mutate if it later unwedges,
+      // and release the global lock it will never reach its own `finally` to clear
+      // (appInstaller gates performDockerCleanup on it).
+      masterSlavePassGeneration += 1;
+      // eslint-disable-next-line no-param-reassign
+      globalStateParam.masterSlaveAppsRunning = false;
       log.error(`startMasterSlaveApps: ${error.message} - releasing guard so the next tick runs a fresh pass`);
     } finally {
       isRunning = false;

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -421,6 +421,14 @@ async function createAppVolume(appSpecifications, appName, isComponent, res) {
   const identifier = isComponent ? `${appSpecifications.name}_${appName}` : appName;
   const appId = dockerService.getAppIdentifier(identifier);
 
+  // A volume being created is by definition NOT synced: a surviving cache
+  // entry for this id describes a previous incarnation's on-disk state (e.g.
+  // a redeploy keep-mark re-planted while a same-app removal raced it) and
+  // would let this empty fresh install skip the new-install receiveonly
+  // protection and read as instantly ready for g: primary. Drop it so the
+  // sync layer treats the install as the clean slate it is.
+  globalState.receiveOnlySyncthingAppsCache.delete(appId);
+
   const searchSpace = {
     status: 'Searching available space...',
   };
@@ -3560,10 +3568,12 @@ async function reinstallOldApplications() {
               if (error.busyCollision) {
                 // a transient collision with another operation's flag, not a
                 // failed install: the components stay soft-uninstalled with
-                // the row and their data volumes intact, and the next
-                // reinstall pass completes the update. Removing here would
-                // destroy preserved data over a timing collision.
-                log.warn(`Redeployment of ${appSpecifications.name} deferred (${error.message}); keeping the app for the next pass`);
+                // the row and their data volumes intact. The row already
+                // carries the new spec (re-inserted before the component
+                // loop), so the reconciler recreates the missing components
+                // over the preserved volumes. Removing here would destroy
+                // preserved data over a timing collision.
+                log.warn(`Redeployment of ${appSpecifications.name} deferred (${error.message}); keeping the app for the reconciler`);
               } else {
                 log.warn(`REMOVAL REASON: Redeployment error - ${appSpecifications.name} failed during redeployment: ${error.message}`);
                 // eslint-disable-next-line no-await-in-loop

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -3936,9 +3936,16 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                   const lowerNodeRunning = await checkLowerIndexNodesRunning();
                   if (!lowerNodeRunning) {
                     if (superseded()) return;
-                  requestMasterStartWithPermissionsFix(identifier, appId, superseded);
-                    log.info(`masterSlaveApps: starting docker component:${identifier} index: ${index} that was scheduled to start at ${timeTostartNewMasterApp.get(identifier).toString()}`);
-                    timeTostartNewMasterApp.delete(identifier);
+                    // a chain for this component is still running - keep the matured
+                    // slot so the next tick retries the moment it clears, instead of
+                    // consuming the slot for a dispatch the guard will no-op
+                    if (permissionsFixInFlight.has(appId)) {
+                      log.info(`masterSlaveApps: promotion chain for ${identifier} still running, keeping its scheduled slot`);
+                    } else {
+                      requestMasterStartWithPermissionsFix(identifier, appId, superseded);
+                      log.info(`masterSlaveApps: starting docker component:${identifier} index: ${index} that was scheduled to start at ${timeTostartNewMasterApp.get(identifier).toString()}`);
+                      timeTostartNewMasterApp.delete(identifier);
+                    }
                   } else {
                     log.info(`masterSlaveApps: not starting app:${installedApp.name} index: ${index} - lower-index node is already running`);
                     timeTostartNewMasterApp.delete(identifier);

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -829,13 +829,6 @@ async function createAppVolume(appSpecifications, appName, isComponent, res) {
   }
 }
 
-/**
- * To soft register an app locally (with data volume already in existence). Performs pre-installation checks - database in place, Flux Docker network in place and if app already installed. Then registers app in database and performs soft install. If registration fails, the app is removed locally.
- * @param {object} appSpecs App specifications.
- * @param {object} componentSpecs Component specifications.
- * @param {object} res Response.
- * @returns {void} Return statement is only used here to interrupt the function and nothing is returned.
- */
 // During a soft redeploy the app's synced data is preserved on disk, so the
 // components the redeploy touched are marked already-synced in
 // receiveOnlySyncthingAppsCache (the same marking the success path performs).
@@ -864,6 +857,13 @@ function markSyncthingAppsSynced(appSpecs, componentSpecs) {
   }
 }
 
+/**
+ * To soft register an app locally (with data volume already in existence). Performs pre-installation checks - database in place, Flux Docker network in place and if app already installed. Then registers app in database and performs soft install. If registration fails, the app is removed locally.
+ * @param {object} appSpecs App specifications.
+ * @param {object} componentSpecs Component specifications.
+ * @param {object} res Response.
+ * @returns {void} Return statement is only used here to interrupt the function and nothing is returned.
+ */
 async function softRegisterAppLocally(appSpecs, componentSpecs, res) {
   // cpu, ram, hdd were assigned to correct tiered specs.
   // get applications specifics from app messages database

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -3941,9 +3941,87 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
   } finally {
     // eslint-disable-next-line no-param-reassign
     globalStateParam.masterSlaveAppsRunning = false;
-    await serviceHelper.delay(config.fluxapps.masterSlaveIntervalMs ?? 30 * 1000);
-    masterSlaveApps(globalStateParam, installedApps, listRunningApps, receiveOnlySyncthingAppsCache, backupInProgressParam, restoreInProgressParam, https);
   }
+}
+
+/**
+ * Interval-based scheduler for masterSlaveApps, replacing the previous recursive
+ * self-reschedule (a `masterSlaveApps(...)` call inside the function's own
+ * `finally`). That pattern was fragile in two ways, and either could permanently
+ * stop g: primary election with no recovery - leaving g: syncthing apps stuck in
+ * the `created` state (never elected) until a manual restart:
+ *   - a throw from the reschedule tail / an unhandled rejection in the recursion
+ *     chain broke the chain, and
+ *   - a pass that never settles (e.g. a docker or FDM call wedged while a
+ *     container was being torn down mid-failover) meant the `finally` - and thus
+ *     the only reschedule - never ran.
+ * A setInterval (level-triggered, self-healing) fires independently of any pass,
+ * mirroring syncthingApps(); the per-pass timeout below additionally guarantees a
+ * wedged pass can never hold the single-flight guard forever.
+ *
+ * @param {object} globalStateParam
+ * @param {Function} installedApps
+ * @param {Function} listRunningApps
+ * @param {Map} receiveOnlySyncthingAppsCache
+ * @param {Array} backupInProgressParam
+ * @param {Array} restoreInProgressParam
+ * @param {object} https
+ * @returns {{ stop: Function, isActive: Function }}
+ */
+function startMasterSlaveApps(globalStateParam, installedApps, listRunningApps, receiveOnlySyncthingAppsCache, backupInProgressParam, restoreInProgressParam, https) {
+  let intervalId = null;
+  let isRunning = false;
+
+  const intervalMs = config.fluxapps.masterSlaveIntervalMs ?? 30 * 1000;
+  // A single pass legitimately makes several timed calls (FDM across regions,
+  // peer /listrunningapps probes), so allow generous headroom - but never let a
+  // wedged pass block elections forever. On timeout the guard is released and the
+  // next tick starts a fresh pass; the abandoned pass is harmless (declare-only).
+  const maxPassMs = Math.max(intervalMs * 4, 2 * 60 * 1000);
+
+  const runPass = async () => {
+    // Single-flight: skip if the previous pass is still in flight so passes never
+    // overlap (a slow pass just yields the tick, same as the old sequential gap).
+    if (isRunning) {
+      log.info('masterSlaveApps: previous pass still running, skipping this iteration');
+      return;
+    }
+    isRunning = true;
+    try {
+      let timer;
+      const pass = masterSlaveApps(globalStateParam, installedApps, listRunningApps, receiveOnlySyncthingAppsCache, backupInProgressParam, restoreInProgressParam, https);
+      const watchdog = new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`pass exceeded ${maxPassMs}ms`)), maxPassMs);
+      });
+      try {
+        await Promise.race([pass, watchdog]);
+      } finally {
+        clearTimeout(timer);
+      }
+    } catch (error) {
+      // masterSlaveApps swallows its own errors; this catches the watchdog
+      // timeout (and any unexpected throw) so a stuck pass can never tear down
+      // or permanently block the interval.
+      log.error(`startMasterSlaveApps: ${error.message} - releasing guard so the next tick runs a fresh pass`);
+    } finally {
+      isRunning = false;
+    }
+  };
+
+  // Run immediately, then keep running on a fixed interval.
+  runPass();
+  intervalId = setInterval(runPass, intervalMs);
+
+  return {
+    stop: () => {
+      if (intervalId) {
+        clearInterval(intervalId);
+        intervalId = null;
+        log.info('masterSlaveApps: scheduler stopped');
+      }
+    },
+    isActive: () => intervalId !== null,
+  };
 }
 
 module.exports = {
@@ -3979,5 +4057,6 @@ module.exports = {
   checkAndRemoveEnterpriseAppsOnNonArcane,
   forceAppRemovals,
   masterSlaveApps,
+  startMasterSlaveApps,
   appDockerStart,
 };

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -3,7 +3,6 @@ const util = require('util');
 const df = require('node-df');
 const fs = require('node:fs');
 const path = require('node:path');
-const nodecmd = require('node-cmd');
 const axios = require('axios');
 const dbHelper = require('../dbHelper');
 const log = require('../../lib/log');
@@ -42,15 +41,17 @@ const appNetworkLinker = require('./appNetworkLinker');
 const isArcane = Boolean(process.env.FLUXOS_PATH);
 
 // Master/slave app tracking
-// Bumped whenever the scheduler abandons a wedged pass. A pass captures this on
-// entry and re-checks it before every mutating action, so a pass that unwedges
-// minutes later cannot act on a view of the world that has since been replaced.
-let masterSlavePassGeneration = 0;
+// The election pass the scheduler's watchdog is currently racing. Abandonment is
+// per-pass: the watchdog marks the pass it raced, and only that pass's pending
+// superseded()-guarded actions (the controller-state writes and folder flips) go
+// inert. A single shared epoch here would also invalidate still-in-flight start
+// chains dispatched by passes that completed normally - dropping the very start
+// the election exists to issue.
+let currentMasterSlavePass = null;
 const mastersRunningGSyncthingApps = new Map();
 const timeTostartNewMasterApp = new Map();
 
 // Promisified functions
-const cmdAsync = util.promisify(nodecmd.run);
 
 /**
  * Runs a command as root via execFile (no shell, args passed as params) and
@@ -1914,8 +1915,7 @@ async function applyPermissionsFix(appId) {
 
     // Apply 777 permissions to entire app directory recursively
     // This covers both appdata (primary mount) and all additional mounts at the same level
-    const execPERM = `sudo chmod -R 777 ${appPath}`;
-    await cmdAsync(execPERM);
+    await serviceHelper.runCommand('chmod', { params: ['-R', '777', appPath], runAsRoot: true });
 
     log.info(`Successfully applied permissions fix for app: ${appId} (includes appdata and all mount points)`);
     return true;
@@ -3534,14 +3534,15 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
   try {
     // eslint-disable-next-line no-param-reassign
     globalStateParam.masterSlaveAppsRunning = true;
-    const generation = masterSlavePassGeneration;
+    const thisPass = { abandoned: false };
+    currentMasterSlavePass = thisPass;
     // A wedged pass keeps running after the scheduler gives up on it; anything it
     // does from then on is based on a stale FDM/docker view and can fight the pass
     // that replaced it (flipping a live primary's syncthing folder to receiveonly,
     // or issuing a start/stop that has since been reversed).
     const superseded = () => {
-      if (generation === masterSlavePassGeneration) return false;
-      log.warn(`masterSlaveApps: pass superseded (generation ${generation} -> ${masterSlavePassGeneration}), dropping pending action`);
+      if (!thisPass.abandoned) return false;
+      log.warn('masterSlaveApps: pass was abandoned by the scheduler watchdog, dropping pending action');
       return true;
     };
     // do not run if installationInProgress or removalInProgress or softRedeployInProgress or hardRedeployInProgress
@@ -4033,8 +4034,9 @@ function startMasterSlaveApps(globalStateParam, installedApps, listRunningApps, 
       // or permanently block the interval.
       // Invalidate the abandoned pass so it cannot mutate if it later unwedges,
       // and release the global lock it will never reach its own `finally` to clear
-      // (appInstaller gates performDockerCleanup on it).
-      masterSlavePassGeneration += 1;
+      // (appInstaller gates performDockerCleanup on it). Single-flight means the
+      // pass registered as current is exactly the one this watchdog raced.
+      if (currentMasterSlavePass) currentMasterSlavePass.abandoned = true;
       // eslint-disable-next-line no-param-reassign
       globalStateParam.masterSlaveAppsRunning = false;
       log.error(`startMasterSlaveApps: ${error.message} - releasing guard so the next tick runs a fresh pass`);

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -40,6 +40,10 @@ const appNetworkLinker = require('./appNetworkLinker');
 
 const isArcane = Boolean(process.env.FLUXOS_PATH);
 
+// Monotonic milliseconds for durations/heartbeats: wall-clock (Date.now) steps
+// under NTP, and a stepped clock must never fake or hide a pass's progress.
+const monotonicMs = () => Number(process.hrtime.bigint() / 1000000n);
+
 // Master/slave app tracking
 // The election pass the scheduler's watchdog is currently racing. Abandonment is
 // per-pass: the watchdog marks the pass it raced, and only that pass's pending
@@ -50,6 +54,10 @@ const isArcane = Boolean(process.env.FLUXOS_PATH);
 let currentMasterSlavePass = null;
 const mastersRunningGSyncthingApps = new Map();
 const timeTostartNewMasterApp = new Map();
+// One primary-promotion chain (folder flips + recursive permissions fix) per
+// component at a time - the 30s scheduler dispatches without await, and the fix
+// legitimately runs for minutes on a large tree.
+const permissionsFixInFlight = new Set();
 
 // Promisified functions
 
@@ -1917,10 +1925,11 @@ async function applyPermissionsFix(appId) {
     // This covers both appdata (primary mount) and all additional mounts at the same level.
     // runCommand never rejects - failure comes back as result.error - and this result
     // is the gate that keeps a node from being elected primary over data it could not
-    // fix. timeout: 0 because a recursive chmod over a large appdata tree legitimately
-    // outruns runCommand's 15-minute default, and a half-applied fix must read as
-    // failure, not be silently killed and reported as success.
-    const result = await serviceHelper.runCommand('chmod', { params: ['-R', '777', appPath], runAsRoot: true, timeout: 0 });
+    // fix. The budget is generous (a cold walk of a huge tree outruns runCommand's
+    // 15-minute default legitimately) but finite: a wedged walk must eventually
+    // surface as a failed fix, and a killed half-applied fix must read as failure.
+    const timeout = config.fluxapps.permissionsFixTimeoutMs ?? 60 * 60 * 1000;
+    const result = await serviceHelper.runCommand('chmod', { params: ['-R', '777', appPath], runAsRoot: true, timeout });
     if (result.error) throw result.error;
 
     log.info(`Successfully applied permissions fix for app: ${appId} (includes appdata and all mount points)`);
@@ -2080,6 +2089,15 @@ async function appDockerRestart(appname) {
  * @returns {Promise<void>}
  */
 async function requestMasterStartWithPermissionsFix(appname, appId, superseded = () => false) {
+  // The scheduler re-decides every 30s and dispatches this chain without await,
+  // and the permissions fix legitimately runs for minutes on a large tree - so
+  // without this guard every tick would stack another full-tree chmod on top of
+  // the one still walking, each dirtying the inodes the previous is fixing.
+  if (permissionsFixInFlight.has(appId)) {
+    log.info(`Preparing masterSlave primary ${appname}: previous permissions-fix chain still running, skipping this dispatch`);
+    return;
+  }
+  permissionsFixInFlight.add(appId);
   try {
     log.info(`Preparing masterSlave primary ${appname}: fixing permissions before start`);
 
@@ -2113,6 +2131,8 @@ async function requestMasterStartWithPermissionsFix(appname, appId, superseded =
   } catch (error) {
     log.error(`Error preparing masterSlave primary ${appname}: ${error.message}`);
     // leave it stopped if the permissions-fix workflow failed
+  } finally {
+    permissionsFixInFlight.delete(appId);
   }
 }
 
@@ -3539,7 +3559,7 @@ async function forceAppRemovals() {
 async function masterSlaveApps(globalStateParam, installedApps, listRunningApps, receiveOnlySyncthingAppsCache, backupInProgressParam, restoreInProgressParam, https) {
   // Declared outside the try so the finally can check ownership of the global
   // flag against the pass that is current by the time it runs.
-  const thisPass = { abandoned: false, lastProgressAt: Date.now() };
+  const thisPass = { abandoned: false, lastProgressAt: monotonicMs() };
   try {
     // eslint-disable-next-line no-param-reassign
     globalStateParam.masterSlaveAppsRunning = true;
@@ -3652,13 +3672,14 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
 
     // eslint-disable-next-line no-restricted-syntax
     for (const installedApp of appsInstalled.data) {
-      // Progress heartbeat for the scheduler's watchdog. Every awaited call in
-      // this loop is individually bounded (10s FDM regions, 10s peer probes), so
-      // a pass that is merely SLOW - many g: apps, degraded FDM - keeps beating
-      // and keeps its actuations, while a pass wedged on one dead await goes
-      // silent and is abandoned. Same principle as the pull stall detector:
-      // silence is the failure, not elapsed time.
-      thisPass.lastProgressAt = Date.now();
+      // Progress heartbeat for the scheduler's watchdog. The network calls in
+      // this loop are individually bounded (10s FDM regions, 10s peer probes),
+      // so a pass that is merely SLOW - many g: apps, degraded FDM - keeps
+      // beating and keeps its actuations, while a pass wedged on one dead await
+      // (including the unbounded DB read below) goes silent and is abandoned.
+      // Same principle as the pull stall detector: silence is the failure, not
+      // elapsed time.
+      thisPass.lastProgressAt = monotonicMs();
       let fdmOk = true;
       let identifier;
       let needsToBeChecked = false;
@@ -3800,7 +3821,7 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                     // each probe is bounded at probeTimeoutMs; beat per probe so a
                     // high-index node's long (but advancing) walk is not mistaken
                     // for a wedged pass
-                    thisPass.lastProgressAt = Date.now();
+                    thisPass.lastProgressAt = monotonicMs();
                     const nodeToCheck = runningAppList[i];
                     if (!nodeToCheck) continue;
 
@@ -4054,11 +4075,13 @@ function startMasterSlaveApps(globalStateParam, installedApps, listRunningApps, 
       const watchdog = new Promise((_, reject) => {
         const arm = (delayMs) => {
           timer = setTimeout(() => {
-            const idleMs = Date.now() - (currentMasterSlavePass ? currentMasterSlavePass.lastProgressAt : 0);
+            const idleMs = monotonicMs() - (currentMasterSlavePass ? currentMasterSlavePass.lastProgressAt : 0);
             if (idleMs >= maxPassMs) {
               reject(new Error(`pass made no progress for ${Math.round(idleMs / 1000)}s`));
             } else {
-              arm(maxPassMs - idleMs);
+              // clamped: the sources are monotonic, but a nonsense delta must
+              // degrade to a prompt re-check, never a 32-bit setTimeout overflow
+              arm(Math.min(maxPassMs, Math.max(1, maxPassMs - idleMs)));
             }
           }, delayMs);
         };

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -2073,7 +2073,7 @@ async function appDockerRestart(appname) {
  * @param {string} appId - Application ID for syncthing folder
  * @returns {Promise<void>}
  */
-async function requestMasterStartWithPermissionsFix(appname, appId) {
+async function requestMasterStartWithPermissionsFix(appname, appId, superseded = () => false) {
   try {
     log.info(`Preparing masterSlave primary ${appname}: fixing permissions before start`);
 
@@ -2096,6 +2096,11 @@ async function requestMasterStartWithPermissionsFix(appname, appId) {
       return;
     }
 
+    // This chain is dispatched without await, so it outlives the pass that started
+    // it: the permissions fix and two syncthing folder flips take real time, and the
+    // watchdog can abandon that pass meanwhile. Guarding only the dispatch would let
+    // this stale write land on top of the decision that replaced it.
+    if (superseded()) return;
     // hand the run-state decision to the reconciler (the single container actuator)
     appReconciler.setControllerDesired(appname, 'running', 'masterSlave primary (synced)');
     log.info(`Requested start for masterSlave primary ${appname}`);
@@ -3814,7 +3819,7 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                 if (index === 0 && !mastersRunningGSyncthingApps.has(identifier)) {
                   // Index 0: Start immediately if no history
                   if (superseded()) return;
-                  requestMasterStartWithPermissionsFix(identifier, appId);
+                  requestMasterStartWithPermissionsFix(identifier, appId, superseded);
                   log.info(`masterSlaveApps: starting docker component:${identifier} index: ${index}`);
                 } else if (!timeTostartNewMasterApp.has(identifier) && mastersRunningGSyncthingApps.has(identifier) && !ipsMatch(mastersRunningGSyncthingApps.get(identifier), localSocketAddr)) {
                   // There was a previous master (not me), and it's no longer on FDM
@@ -3855,7 +3860,7 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                   // Previous master is not running, determine next primary
                   if (index === 0) {
                     if (superseded()) return;
-                  requestMasterStartWithPermissionsFix(identifier, appId);
+                  requestMasterStartWithPermissionsFix(identifier, appId, superseded);
                     log.info(`masterSlaveApps: starting docker component:${identifier} index: ${index}`);
                   } else {
                     const previousMasterIndex = runningAppList.findIndex((x) => ipsMatch(x.ip, mastersRunningGSyncthingApps.get(identifier)));
@@ -3876,7 +3881,7 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                       const lowerNodeRunning = await checkLowerIndexNodesRunning();
                       if (!lowerNodeRunning) {
                         if (superseded()) return;
-                  requestMasterStartWithPermissionsFix(identifier, appId);
+                  requestMasterStartWithPermissionsFix(identifier, appId, superseded);
                         log.info(`masterSlaveApps: starting docker component:${identifier} index: ${index}`);
                       }
                     } else {
@@ -3890,7 +3895,7 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                   const lowerNodeRunning = await checkLowerIndexNodesRunning();
                   if (!lowerNodeRunning) {
                     if (superseded()) return;
-                  requestMasterStartWithPermissionsFix(identifier, appId);
+                  requestMasterStartWithPermissionsFix(identifier, appId, superseded);
                     log.info(`masterSlaveApps: starting docker component:${identifier} index: ${index} that was scheduled to start at ${timeTostartNewMasterApp.get(identifier).toString()}`);
                     timeTostartNewMasterApp.delete(identifier);
                   } else {
@@ -3949,7 +3954,7 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
 
                 if (isReady) {
                   if (superseded()) return;
-                  requestMasterStartWithPermissionsFix(identifier, appId);
+                  requestMasterStartWithPermissionsFix(identifier, appId, superseded);
                   log.info(`masterSlaveApps: starting docker component:${identifier}`);
                 } else {
                   log.info(`masterSlaveApps: app:${installedApp.name} is registered as primary on FDM but not ready yet (syncthing not synced), skipping start for this cycle`);

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -836,6 +836,34 @@ async function createAppVolume(appSpecifications, appName, isComponent, res) {
  * @param {object} res Response.
  * @returns {void} Return statement is only used here to interrupt the function and nothing is returned.
  */
+// During a soft redeploy the app's synced data is preserved on disk, so the
+// components the redeploy touched are marked already-synced in
+// receiveOnlySyncthingAppsCache (the same marking the success path performs).
+// The cache is in-memory (empty after a FluxOS restart), and without an entry
+// the syncthing state machine treats the surviving folder as a first encounter
+// - whose second-encounter handling REQUESTS A DATA CLEAR. So a failed redeploy
+// that keeps the app installed must mark the same scope the success path would
+// have: one component when the redeploy was per-component, all of them when it
+// was app-wide.
+function markSyncthingAppsSynced(appSpecs, componentSpecs) {
+  const components = appSpecs.version >= 4 && Array.isArray(appSpecs.compose)
+    ? (componentSpecs ? [componentSpecs] : appSpecs.compose).map((comp) => ({ containerData: comp.containerData, identifier: `${comp.name}_${appSpecs.name}` }))
+    : [{ containerData: appSpecs.containerData, identifier: appSpecs.name }];
+  // eslint-disable-next-line no-restricted-syntax
+  for (const comp of components) {
+    const hasSyncthingData = comp.containerData && (comp.containerData.includes('g:') || comp.containerData.includes('r:'));
+    if (hasSyncthingData) {
+      const appId = dockerService.getAppIdentifier(comp.identifier);
+      globalState.receiveOnlySyncthingAppsCache.set(appId, {
+        restarted: true,
+        numberOfExecutionsRequired: 4,
+        numberOfExecutions: 10,
+      });
+      log.info(`Restored syncthing cache for ${appId} during soft redeploy`);
+    }
+  }
+}
+
 async function softRegisterAppLocally(appSpecs, componentSpecs, res) {
   // cpu, ram, hdd were assigned to correct tiered specs.
   // get applications specifics from app messages database
@@ -1062,13 +1090,17 @@ async function softRegisterAppLocally(appSpecs, componentSpecs, res) {
       res.write(serviceHelper.ensureString(errorResponse));
       if (res.flush) res.flush();
     }
-    // A node condition - a daemon or provision step not ANSWERING (stamped by
-    // the runtime-op bounds and the recreate ceiling) - is never grounds to
-    // destroy an app and its data: the spec and volume stay in place and the
-    // reconciler's recreate path converges when the node recovers. Removal
-    // here is for a redeploy the node genuinely rejected.
+    // A node condition - the daemon not ANSWERING - is never grounds to destroy
+    // an app and its data: the spec and volume stay in place and the reconciler
+    // converges when the node recovers. On this path the reachable stamp today
+    // is a bounded docker start timing out (the creates are deliberately
+    // unbounded here); provisionTimedOut is honoured for the same reason should
+    // a ceiling ever wrap this flow. Removal below is for a redeploy the node
+    // genuinely rejected. The kept app's g:/r: components must be re-marked
+    // synced, or the sync layer's first-encounter handling clears their data.
     if (error.dockerRuntimeTimedOut || error.provisionTimedOut) {
       log.warn(`softRegisterAppLocally - ${appSpecs.name} failed on a node condition (${error.message}); leaving the app for the reconciler, NOT removing`);
+      markSyncthingAppsSynced(appSpecs, componentSpecs);
       if (res) res.end();
       return;
     }

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -1090,30 +1090,21 @@ async function softRegisterAppLocally(appSpecs, componentSpecs, res) {
       res.write(serviceHelper.ensureString(errorResponse));
       if (res.flush) res.flush();
     }
-    // A node condition - the daemon not ANSWERING - is never grounds to destroy
-    // an app and its data: the spec and volume stay in place and the reconciler
-    // converges when the node recovers. On this path the reachable stamp today
-    // is a bounded docker start timing out (the creates are deliberately
-    // unbounded here); provisionTimedOut is honoured for the same reason should
-    // a ceiling ever wrap this flow. Removal below is for a redeploy the node
-    // genuinely rejected. The kept app's g:/r: components must be re-marked
-    // synced, or the sync layer's first-encounter handling clears their data.
-    if (error.dockerRuntimeTimedOut || error.provisionTimedOut) {
-      log.warn(`softRegisterAppLocally - ${appSpecs.name} failed on a node condition (${error.message}); leaving the app for the reconciler, NOT removing`);
-      markSyncthingAppsSynced(appSpecs, componentSpecs);
-      if (res) res.end();
-      return;
-    }
-    const removeStatus = messageHelper.createErrorMessage(`Error occured. Initiating Flux App ${appSpecs.name} removal`);
-    log.info(removeStatus);
-    log.warn(`REMOVAL REASON: Soft registration failure - ${appSpecs.name} failed during soft registration: ${error.message} (softRegisterAppLocally)`);
-    if (res) {
-      res.write(serviceHelper.ensureString(removeStatus));
-      if (res.flush) res.flush();
-    }
-    // eslint-disable-next-line global-require
-    const appUninstaller = require('./appUninstaller');
-    appUninstaller.removeAppLocally(appSpecs.name, res, true);
+    // A failed soft redeploy NEVER removes the app. The data volume was
+    // deliberately preserved (that is what makes the redeploy soft), so
+    // removal here destroys established data over what is usually a node-local
+    // failure - a wedged daemon, a port that would not map, a resource query
+    // that blipped. The spec and volume stay; the reconciler retries the
+    // install with the CURRENT spec on its backoff ladder, so a transient
+    // failure self-heals and a genuinely bad update converges to
+    // kept-down-with-data, the same contract as a failed recreate. A down
+    // instance stops broadcasting apprunning, so the network replaces it
+    // elsewhere through the normal spawner machinery - no removal needed for
+    // availability. The kept app's g:/r: components must be re-marked synced,
+    // or the sync layer's first-encounter handling clears their data.
+    log.warn(`softRegisterAppLocally - ${appSpecs.name} failed during soft registration (${error.message}); keeping the app and its data for the reconciler, NOT removing`);
+    markSyncthingAppsSynced(appSpecs, componentSpecs);
+    if (res) res.end();
   }
 }
 
@@ -1374,12 +1365,18 @@ async function softRedeploy(appSpecs, res) {
   } catch (error) {
     log.info('Error on softRedeploy');
     log.error(error);
-    log.warn(`REMOVAL REASON: Soft redeploy failure - ${appSpecs.name} failed during soft redeploy: ${error.message} (softRedeploy)`);
     globalState.softRedeployInProgress = false;
-    // eslint-disable-next-line global-require
-    const appUninstaller = require('./appUninstaller');
-    await appUninstaller.removeAppLocally(appSpecs.name, res, true, true, true);
-    log.info(`Cleanup completed for ${appSpecs.name} after soft redeploy failure`);
+    // A failed soft redeploy NEVER removes the app: the data volume was
+    // deliberately preserved, and this catch fires for node-local failures too
+    // (a requirements query that blipped, a port that would not map). The spec
+    // and volume stay; the reconciler retries the install with the current
+    // spec on its backoff ladder, so a transient failure self-heals and a
+    // genuinely bad update converges to kept-down-with-data - and a down
+    // instance is replaced elsewhere by the spawner through the normal
+    // apprunning machinery. The kept app's g:/r: components are re-marked
+    // synced so the sync layer's first-encounter handling cannot clear them.
+    log.warn(`softRedeploy - ${appSpecs.name} failed (${error.message}); keeping the app and its data for the reconciler, NOT removing`);
+    markSyncthingAppsSynced(appSpecs, undefined);
   }
 }
 
@@ -1555,10 +1552,15 @@ async function softRedeployComponent(appName, componentName, res) {
       globalState.softRedeployInProgress = false;
     } catch (error) {
       log.error(error);
-      log.warn(`REMOVAL REASON: Soft redeploy failure - ${appName} being removed after component ${fullComponentName} failed during soft redeploy: ${error.message} (softRedeployComponent)`);
       globalState.softRedeployInProgress = false;
-      await appUninstaller.removeAppLocally(appName, res, true, true, true);
-      log.info(`Cleanup completed for ${appName} after component ${fullComponentName} soft redeploy failure`);
+      // A failed soft redeploy NEVER removes - and especially not the WHOLE app
+      // over one component. The data volumes were deliberately preserved; the
+      // reconciler retries the component's install with the current spec on its
+      // backoff ladder. Re-marked synced so the sync layer's first-encounter
+      // handling cannot clear the surviving data. The error still surfaces to
+      // the caller - the redeploy did fail.
+      log.warn(`softRedeployComponent - ${fullComponentName} failed (${error.message}); keeping ${appName} and its data for the reconciler, NOT removing`);
+      markSyncthingAppsSynced(appSpecifications, componentSpec);
       throw error;
     }
   } catch (error) {

--- a/ZelBack/src/services/appLifecycle/appInstaller.js
+++ b/ZelBack/src/services/appLifecycle/appInstaller.js
@@ -243,7 +243,8 @@ async function setupApplicationPorts(appSpecifications, appName, isComponent, re
  * @param {object} fullAppSpecs - Full app specifications
  * @returns {Promise<void>}
  */
-async function verifyAndPullImage(appSpecifications, appName, isComponent, res, fullAppSpecs) {
+async function verifyAndPullImage(appSpecifications, appName, isComponent, res, fullAppSpecs, options = {}) {
+  const allowLocalImageFallback = options.allowLocalImageFallback || false;
   // check image and its architecture
   const architecture = await systemArchitecture();
   if (!supportedArchitectures.includes(architecture)) {
@@ -296,8 +297,21 @@ async function verifyAndPullImage(appSpecifications, appName, isComponent, res, 
   // if dockerhub, this is now registry-1.docker.io instead of hub.docker.com
   pullConfig.provider = imgVerifier.provider;
 
-  // eslint-disable-next-line no-unused-vars
-  await dockerPullStreamPromise(pullConfig, res);
+  try {
+    await dockerPullStreamPromise(pullConfig, res);
+  } catch (error) {
+    // Pull-first keeps a recreate fresh (a same-tag pull is a cheap manifest
+    // check); the local image only substitutes when the registry cannot be
+    // REACHED and the bits are already here, so the stale-run window is exactly
+    // the outage's duration and never a policy. A registry that answers that the
+    // image is bad is a statement about the image, not this node - that rethrows.
+    // Opt-in, so a fresh install never silently proceeds on someone else's layers.
+    const localImagePresent = allowLocalImageFallback
+      && error.registryErrorClass === 'transient'
+      && await dockerService.appDockerImageSize(appSpecifications.repotag) > 0;
+    if (!localImagePresent) throw error;
+    log.warn(`verifyAndPullImage - registry unreachable for ${appSpecifications.repotag}; continuing from the local image`);
+  }
 
   const pullStatus = {
     status: isComponent ? `Pulling component ${appSpecifications.name} of Flux App ${appName}` : `Pulling global Flux App ${appName} was successful`,
@@ -823,7 +837,7 @@ async function checkOrbitAppHealth(appSpecifications, appName, isComponent, res)
  * @param {boolean} test - Whether this is a test installation
  * @returns {Promise<void>} Installation result
  */
-async function installApplicationHard(appSpecifications, appName, isComponent, res, fullAppSpecs, test = false) {
+async function installApplicationHard(appSpecifications, appName, isComponent, res, fullAppSpecs, test = false, options = {}) {
   // Verify the apps this app must be networked with (networkWith token) are
   // installed locally and owned by the same owner. Enforced here too — not just
   // in registerAppLocally — so direct callers that bypass it (container health
@@ -835,7 +849,7 @@ async function installApplicationHard(appSpecifications, appName, isComponent, r
   await setupApplicationPorts(appSpecifications, appName, isComponent, res, test);
 
   // Verify and pull Docker image
-  await verifyAndPullImage(appSpecifications, appName, isComponent, res, fullAppSpecs);
+  await verifyAndPullImage(appSpecifications, appName, isComponent, res, fullAppSpecs, options);
 
   // Dynamic require to avoid circular dependency
   // eslint-disable-next-line global-require
@@ -925,7 +939,7 @@ async function installApplicationHard(appSpecifications, appName, isComponent, r
  * @param {object} fullAppSpecs Full app specifications.
  * @returns {Promise<void>} Return statement is only used here to interrupt the function and nothing is returned.
  */
-async function installApplicationSoft(appSpecifications, appName, isComponent, res, fullAppSpecs) {
+async function installApplicationSoft(appSpecifications, appName, isComponent, res, fullAppSpecs, options = {}) {
   // Verify the apps this app must be networked with (networkWith token) are
   // installed locally and owned by the same owner. Enforced here too — not just
   // in softRegisterAppLocally — so direct callers that bypass it (container
@@ -937,7 +951,7 @@ async function installApplicationSoft(appSpecifications, appName, isComponent, r
   await setupApplicationPorts(appSpecifications, appName, isComponent, res);
 
   // Verify and pull Docker image
-  await verifyAndPullImage(appSpecifications, appName, isComponent, res, fullAppSpecs);
+  await verifyAndPullImage(appSpecifications, appName, isComponent, res, fullAppSpecs, options);
 
   const createApp = {
     status: isComponent ? `Creating component ${appSpecifications.name} of local Flux App ${appName}` : `Creating local Flux App ${appName}`,

--- a/ZelBack/src/services/appLifecycle/appInstaller.js
+++ b/ZelBack/src/services/appLifecycle/appInstaller.js
@@ -417,6 +417,13 @@ async function ensureAppDockerNetwork(appName, res) {
       if (octet === null) {
         throw new Error(`Flux App network of ${appName} failed to initiate. No free 172.23.x.0/24 subnet available on this node.`);
       }
+      // The create is awaited UNBOUNDED on purpose: a rejection here always means
+      // the daemon ANSWERED (subnet taken, name conflict), which is what makes
+      // advancing to the next octet safe. A client-side timeout would break that
+      // contract - the create could still land with this app's name, and a second
+      // create for the same name duplicates it (dockerd accepts duplicate names),
+      // leaving the name ambiguous and the app unstartable with no self-heal. A
+      // daemon wedged here is bounded one level up by the provision ceiling.
       // eslint-disable-next-line no-await-in-loop
       fluxNet = await dockerService.createFluxAppDockerNetwork(appName, octet).catch((error) => log.error(error));
       if (!fluxNet) tried.add(octet);

--- a/ZelBack/src/services/appLifecycle/appInstaller.js
+++ b/ZelBack/src/services/appLifecycle/appInstaller.js
@@ -287,30 +287,55 @@ async function verifyAndPullImage(appSpecifications, appName, isComponent, res, 
     pullConfig.authToken = authToken;
   }
 
-  await imgVerifier.verifyImage();
-  imgVerifier.throwIfError();
+  // Pull-first keeps a recreate fresh (a same-tag pull is a cheap manifest check).
+  // The local image only substitutes when the registry cannot be REACHED and the
+  // bits are already here, so the stale-run window is exactly the outage's duration
+  // and never a policy. A registry that answers that the image is bad is a statement
+  // about the image, not about this node, and still fails. Opt-in, so a fresh
+  // install never silently proceeds on layers someone else left behind.
+  const canRunFromLocalImage = async (error) => allowLocalImageFallback
+    && error.registryErrorClass === 'transient'
+    && await dockerService.appDockerImageSize(appSpecifications.repotag) > 0;
 
-  if (!imgVerifier.supported) {
-    throw new Error(`Architecture ${architecture} not supported by ${appSpecifications.repotag}`);
+  let registryReachable = true;
+
+  await imgVerifier.verifyImage();
+  try {
+    imgVerifier.throwIfError();
+  } catch (error) {
+    // The verifier already records WHY the lookup failed; carry that forward so the
+    // decision below can tell "we never reached the registry" from "the registry
+    // answered about this image". No HTTP status at all means nothing answered.
+    const meta = imgVerifier.lookupErrorMeta;
+    const unreachable = meta && (
+      meta.errorType === 'network'
+      || meta.errorType === 'rate_limit'
+      || meta.errorType === 'server_error'
+      || meta.httpStatus === null
+      || meta.httpStatus === undefined
+    );
+    if (unreachable) error.registryErrorClass = 'transient';
+    if (!await canRunFromLocalImage(error)) throw error;
+    registryReachable = false;
+    log.warn(`verifyAndPullImage - registry unreachable for ${appSpecifications.repotag}; continuing from the local image`);
   }
 
-  // if dockerhub, this is now registry-1.docker.io instead of hub.docker.com
-  pullConfig.provider = imgVerifier.provider;
+  // A registry we could not reach cannot have told us the architecture is wrong, and
+  // there is nothing to pull - the image we are about to run is the one already here.
+  if (registryReachable) {
+    if (!imgVerifier.supported) {
+      throw new Error(`Architecture ${architecture} not supported by ${appSpecifications.repotag}`);
+    }
 
-  try {
-    await dockerPullStreamPromise(pullConfig, res);
-  } catch (error) {
-    // Pull-first keeps a recreate fresh (a same-tag pull is a cheap manifest
-    // check); the local image only substitutes when the registry cannot be
-    // REACHED and the bits are already here, so the stale-run window is exactly
-    // the outage's duration and never a policy. A registry that answers that the
-    // image is bad is a statement about the image, not this node - that rethrows.
-    // Opt-in, so a fresh install never silently proceeds on someone else's layers.
-    const localImagePresent = allowLocalImageFallback
-      && error.registryErrorClass === 'transient'
-      && await dockerService.appDockerImageSize(appSpecifications.repotag) > 0;
-    if (!localImagePresent) throw error;
-    log.warn(`verifyAndPullImage - registry unreachable for ${appSpecifications.repotag}; continuing from the local image`);
+    // if dockerhub, this is now registry-1.docker.io instead of hub.docker.com
+    pullConfig.provider = imgVerifier.provider;
+
+    try {
+      await dockerPullStreamPromise(pullConfig, res);
+    } catch (error) {
+      if (!await canRunFromLocalImage(error)) throw error;
+      log.warn(`verifyAndPullImage - registry unreachable for ${appSpecifications.repotag}; continuing from the local image`);
+    }
   }
 
   const pullStatus = {

--- a/ZelBack/src/services/appLifecycle/appInstaller.js
+++ b/ZelBack/src/services/appLifecycle/appInstaller.js
@@ -422,8 +422,11 @@ async function ensureAppDockerNetwork(appName, res) {
       // advancing to the next octet safe. A client-side timeout would break that
       // contract - the create could still land with this app's name, and a second
       // create for the same name duplicates it (dockerd accepts duplicate names),
-      // leaving the name ambiguous and the app unstartable with no self-heal. A
-      // daemon wedged here is bounded one level up by the provision ceiling.
+      // leaving the name ambiguous and the app unstartable with no self-heal. On
+      // the reconciler's recreate paths a wedge here is bounded by the provision
+      // ceiling; on the install paths it is not bounded at all - a pre-existing
+      // gap (installationInProgress has no watchdog) owned by the
+      // operation-registry redesign.
       // eslint-disable-next-line no-await-in-loop
       fluxNet = await dockerService.createFluxAppDockerNetwork(appName, octet).catch((error) => log.error(error));
       if (!fluxNet) tried.add(octet);

--- a/ZelBack/src/services/appLifecycle/appInstaller.js
+++ b/ZelBack/src/services/appLifecycle/appInstaller.js
@@ -309,20 +309,35 @@ async function verifyAndPullImage(appSpecifications, appName, isComponent, res, 
   // and never a policy. A registry that answers that the image is bad is a statement
   // about the image, not about this node, and still fails. Opt-in, so a fresh
   // install never silently proceeds on layers someone else left behind.
-  const canRunFromLocalImage = async (error) => allowLocalImageFallback
-    && error.registryErrorClass === 'transient'
-    && await dockerService.appDockerImageSize(appSpecifications.repotag) > 0;
+  const canRunFromLocalImage = async (error) => {
+    const transient = error.registryErrorClass === 'transient';
+    const localBytes = transient && allowLocalImageFallback
+      ? await dockerService.appDockerImageSize(appSpecifications.repotag)
+      : 0;
+    const usable = allowLocalImageFallback && transient && localBytes > 0;
+    if (!usable) {
+      // Say which condition ruled it out: a recreate that fails here goes on to be
+      // kept-but-down, and "why did it not use the copy it already had" is the first
+      // question anyone asks of that.
+      log.warn(`verifyAndPullImage - not falling back to the local image for ${appSpecifications.repotag}: `
+        + `fallbackAllowed=${allowLocalImageFallback} transient=${transient} localBytes=${localBytes} (${error.message})`);
+    }
+    return usable;
+  };
 
   let registryReachable = true;
 
   await imgVerifier.verifyImage();
+  // Read the failure metadata BEFORE throwing: throwIfError() calls resetErrors() in
+  // its own `finally`, so errorMeta is already null by the time the catch below runs.
+  const verifyErrorMeta = imgVerifier.errorMeta;
   try {
     imgVerifier.throwIfError();
   } catch (error) {
-    // The verifier already records WHY the lookup failed; carry that forward so the
-    // decision below can tell "we never reached the registry" from "the registry
-    // answered about this image". No HTTP status at all means nothing answered.
-    if (isRegistryUnreachable(imgVerifier.errorMeta)) error.registryErrorClass = 'transient';
+    // The verifier records WHY the lookup failed; carry that forward so the decision
+    // below can tell "we never reached the registry" from "the registry answered
+    // about this image". No HTTP status at all means nothing answered.
+    if (isRegistryUnreachable(verifyErrorMeta)) error.registryErrorClass = 'transient';
     if (!await canRunFromLocalImage(error)) throw error;
     registryReachable = false;
     log.warn(`verifyAndPullImage - registry unreachable for ${appSpecifications.repotag}; continuing from the local image`);

--- a/ZelBack/src/services/appLifecycle/appInstaller.js
+++ b/ZelBack/src/services/appLifecycle/appInstaller.js
@@ -243,22 +243,6 @@ async function setupApplicationPorts(appSpecifications, appName, isComponent, re
  * @param {object} fullAppSpecs - Full app specifications
  * @returns {Promise<void>}
  */
-/**
- * Did the registry fail to ANSWER, as opposed to answering about the image? Only the
- * former is safe to ride out on a local copy. Reads the metadata ImageVerifier
- * already records for a failed lookup; a missing httpStatus means nothing replied,
- * which is the same class as a connection error. Anything else - a 4xx, a rejected
- * manifest - is the registry talking about the image, and is permanent.
- *
- * @param {object|null} errorMeta ImageVerifier.errorMeta
- * @returns {boolean}
- */
-function isRegistryUnreachable(errorMeta) {
-  if (!errorMeta) return false;
-  if (['network', 'rate_limit', 'server_error'].includes(errorMeta.errorType)) return true;
-  return errorMeta.httpStatus === null || errorMeta.httpStatus === undefined;
-}
-
 async function verifyAndPullImage(appSpecifications, appName, isComponent, res, fullAppSpecs, options = {}) {
   const allowLocalImageFallback = options.allowLocalImageFallback || false;
   // check image and its architecture
@@ -328,16 +312,12 @@ async function verifyAndPullImage(appSpecifications, appName, isComponent, res, 
   let registryReachable = true;
 
   await imgVerifier.verifyImage();
-  // Read the failure metadata BEFORE throwing: throwIfError() calls resetErrors() in
-  // its own `finally`, so errorMeta is already null by the time the catch below runs.
-  const verifyErrorMeta = imgVerifier.errorMeta;
   try {
+    // throwIfError stamps registryErrorClass on the throw - the verifier's own
+    // transient/permanent verdict, so a definitive answer about the image (bad
+    // arch, over size, not whitelisted) can never read as "registry unreachable".
     imgVerifier.throwIfError();
   } catch (error) {
-    // The verifier records WHY the lookup failed; carry that forward so the decision
-    // below can tell "we never reached the registry" from "the registry answered
-    // about this image". No HTTP status at all means nothing answered.
-    if (isRegistryUnreachable(verifyErrorMeta)) error.registryErrorClass = 'transient';
     if (!await canRunFromLocalImage(error)) throw error;
     registryReachable = false;
     log.warn(`verifyAndPullImage - registry unreachable for ${appSpecifications.repotag}; continuing from the local image`);
@@ -1358,7 +1338,6 @@ module.exports = {
   ensureAppDockerNetwork,
   installApplicationHard,
   installApplicationSoft,
-  isRegistryUnreachable,
   installAppLocally,
   checkAppRequirements,
   testAppInstall,

--- a/ZelBack/src/services/appLifecycle/appInstaller.js
+++ b/ZelBack/src/services/appLifecycle/appInstaller.js
@@ -243,6 +243,22 @@ async function setupApplicationPorts(appSpecifications, appName, isComponent, re
  * @param {object} fullAppSpecs - Full app specifications
  * @returns {Promise<void>}
  */
+/**
+ * Did the registry fail to ANSWER, as opposed to answering about the image? Only the
+ * former is safe to ride out on a local copy. Reads the metadata ImageVerifier
+ * already records for a failed lookup; a missing httpStatus means nothing replied,
+ * which is the same class as a connection error. Anything else - a 4xx, a rejected
+ * manifest - is the registry talking about the image, and is permanent.
+ *
+ * @param {object|null} errorMeta ImageVerifier.errorMeta
+ * @returns {boolean}
+ */
+function isRegistryUnreachable(errorMeta) {
+  if (!errorMeta) return false;
+  if (['network', 'rate_limit', 'server_error'].includes(errorMeta.errorType)) return true;
+  return errorMeta.httpStatus === null || errorMeta.httpStatus === undefined;
+}
+
 async function verifyAndPullImage(appSpecifications, appName, isComponent, res, fullAppSpecs, options = {}) {
   const allowLocalImageFallback = options.allowLocalImageFallback || false;
   // check image and its architecture
@@ -306,15 +322,7 @@ async function verifyAndPullImage(appSpecifications, appName, isComponent, res, 
     // The verifier already records WHY the lookup failed; carry that forward so the
     // decision below can tell "we never reached the registry" from "the registry
     // answered about this image". No HTTP status at all means nothing answered.
-    const meta = imgVerifier.lookupErrorMeta;
-    const unreachable = meta && (
-      meta.errorType === 'network'
-      || meta.errorType === 'rate_limit'
-      || meta.errorType === 'server_error'
-      || meta.httpStatus === null
-      || meta.httpStatus === undefined
-    );
-    if (unreachable) error.registryErrorClass = 'transient';
+    if (isRegistryUnreachable(imgVerifier.errorMeta)) error.registryErrorClass = 'transient';
     if (!await canRunFromLocalImage(error)) throw error;
     registryReachable = false;
     log.warn(`verifyAndPullImage - registry unreachable for ${appSpecifications.repotag}; continuing from the local image`);
@@ -1335,6 +1343,7 @@ module.exports = {
   ensureAppDockerNetwork,
   installApplicationHard,
   installApplicationSoft,
+  isRegistryUnreachable,
   installAppLocally,
   checkAppRequirements,
   testAppInstall,

--- a/ZelBack/src/services/appManagement/appsRuntimeState.js
+++ b/ZelBack/src/services/appManagement/appsRuntimeState.js
@@ -80,6 +80,24 @@ async function setFields(rawIdentifier, fields) {
 }
 
 /**
+ * Marks that docker has accepted at least one start of this component on this
+ * node. Durable, and cleared only by remove().
+ *
+ * This is what separates an established component from a fresh install that
+ * vanished before it ever ran — the distinction the reconciler needs before it
+ * will destroy an app and its data over a failed rebuild.
+ *
+ * @param {string} identifier
+ */
+async function setEverStarted(identifier) {
+  try {
+    await setFields(identifier, { hasEverStarted: true });
+  } catch (err) {
+    log.error(`appsRuntimeState - failed to record start for ${identifier}: ${err.message}`);
+  }
+}
+
+/**
  * Sets the operator stop lock. This is the highest-priority desired-state
  * input — when true the reconciler must never auto-start the component. A
  * deliberate (re)start (operatorStopped=false, also install/redeploy) clears
@@ -354,6 +372,7 @@ async function prepareCollection() {
 module.exports = {
   prepareCollection,
   getState,
+  setEverStarted,
   setOperatorStopped,
   isOperatorStopped,
   recordRestart,

--- a/ZelBack/src/services/appManagement/appsRuntimeState.js
+++ b/ZelBack/src/services/appManagement/appsRuntimeState.js
@@ -53,6 +53,23 @@ async function getState(rawIdentifier) {
   }
 }
 
+/**
+ * Returns the runtime-state document like getState, but a read failure THROWS
+ * instead of degrading to null. For callers whose null branch is destructive:
+ * through getState a DB error is indistinguishable from "no document", so a
+ * transient read blip would read as "this component never ran here" and
+ * authorise destroying it. A read failure must be a failure, so the caller
+ * can defer instead of guess.
+ *
+ * @param {string} identifier
+ * @returns {Promise<object|null>} - throws if the state cannot be read
+ */
+async function getStateStrict(rawIdentifier) {
+  const identifier = canonical(rawIdentifier);
+  const database = collection();
+  return dbHelper.findOneInDatabase(database, appsRuntimeState, { identifier }, { projection: { _id: 0 } });
+}
+
 function isDuplicateKeyError(err) {
   return err && (err.code === 11000 || /E11000/.test(err.message || ''));
 }
@@ -372,6 +389,7 @@ async function prepareCollection() {
 module.exports = {
   prepareCollection,
   getState,
+  getStateStrict,
   setEverStarted,
   setOperatorStopped,
   isOperatorStopped,

--- a/ZelBack/src/services/appManagement/appsRuntimeState.js
+++ b/ZelBack/src/services/appManagement/appsRuntimeState.js
@@ -104,13 +104,20 @@ async function setFields(rawIdentifier, fields) {
  * vanished before it ever ran — the distinction the reconciler needs before it
  * will destroy an app and its data over a failed rebuild.
  *
+ * Returns whether the write landed: the reconciler memoises the mark per
+ * process, and memoising a write that was swallowed here would leave the
+ * component deletable for the life of the process with no retry.
+ *
  * @param {string} identifier
+ * @returns {Promise<boolean>}
  */
 async function setEverStarted(identifier) {
   try {
     await setFields(identifier, { hasEverStarted: true });
+    return true;
   } catch (err) {
     log.error(`appsRuntimeState - failed to record start for ${identifier}: ${err.message}`);
+    return false;
   }
 }
 

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -105,6 +105,16 @@ const MANAGED_RETRY_MS = 5000;
 // won't spam, and keep deferring until it mounts
 const VOLUME_MOUNT_RETRY_MS = 30 * 1000;
 
+// A recreate is a full provision (registry verify + image pull), and a registry can
+// black-hole rather than refuse (dead IP behind a stale DNS cache): unbounded, one
+// hung pull wedges this component's reconcile single-flight forever - every later
+// trigger coalesces into a pass that never runs. Cap the provision so the pass
+// always terminates; the cap is a recreate failure like any other and the paced
+// retry re-drives it. A capped provision that completes detached later is harmless:
+// the next pass finds the container and starts it (the same level-based contract as
+// the recreate-failed-but-container-exists re-check).
+const RECREATE_PROVISION_CAP_MS = config.fluxapps.recreateProvisionCapMs ?? 3 * 60 * 1000;
+
 // identifiers whose missing backing image was already recorded as a tampering
 // event, so the paced retries don't re-record it every cycle
 const volumeMissingNoted = new Set();
@@ -366,7 +376,24 @@ async function recreateMissing(identifier) {
 
   await appTamperingDetectionService.recordEvent(mainAppName, 'container_vanished', `Container ${identifier} missing, not found in Docker`);
   try {
-    await containerHealthMonitor.recreateMissingContainers(identifier);
+    const abortController = new AbortController();
+    const capTimer = setTimeout(() => abortController.abort(), RECREATE_PROVISION_CAP_MS);
+    if (capTimer.unref) capTimer.unref();
+    const provision = containerHealthMonitor.recreateMissingContainers(identifier);
+    // a capped provision keeps running detached; its eventual rejection must land
+    // here, not as an unhandledRejection
+    provision.catch(() => {});
+    try {
+      // the race ends the PASS at the cap even if a sub-step ignores the signal
+      await Promise.race([
+        provision,
+        new Promise((_, reject) => {
+          abortController.signal.addEventListener('abort', () => reject(new Error(`recreate provisioning exceeded ${Math.round(RECREATE_PROVISION_CAP_MS / 1000)}s, aborted`)), { once: true });
+        }),
+      ]);
+    } finally {
+      clearTimeout(capTimer);
+    }
     appInspector.startAppMonitoring(identifier, globalState.appsMonitored);
     log.info(`appReconciler - recreated missing container ${identifier}`);
     fluxEventBus.publish('reconciler:actuated', { identifier, action: 'recreated' });

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -515,7 +515,11 @@ async function recreateMissing(identifier) {
       scheduleRetry(identifier, MANAGED_RETRY_MS);
       return;
     }
-    if (err.provisionTimedOut || (runtimeState && runtimeState.hasEverStarted)) {
+    // dockerRuntimeTimedOut joins provisionTimedOut here: a bounded docker call
+    // timing out INSIDE the provision settles the pass early with the same
+    // meaning as the ceiling - the daemon did not answer. Reading it as a
+    // recreate failure would let a wedged daemon delete a never-started app.
+    if (err.provisionTimedOut || err.dockerRuntimeTimedOut || (runtimeState && runtimeState.hasEverStarted)) {
       await appsRuntimeState.recordRestart(identifier);
       const wait = Math.max(await appsRuntimeState.restartWaitMs(identifier), MANAGED_RETRY_MS);
       log.warn(`appReconciler - ${identifier} could not be recreated but has run here before; keeping it (down) and retrying in ${Math.round(wait / 1000)}s`);

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -306,10 +306,29 @@ async function getLocalComponentSpec(identifier) {
  *                               healthy app.
  *   - container NOT listed   -> docker itself confirms absence: vanished.
  */
+// Marking is durable, so it only ever needs to happen once per component per
+// process; the set keeps a steady-state reconcile from writing on every pass.
+const everStartedMarked = new Set();
+
+/**
+ * Record that docker has run this component here. Called from every point that
+ * observes it running - not just the reconciler's own start - because an app that
+ * has been up since installation would otherwise never be marked, and would stay
+ * eligible for deletion by a failed rebuild.
+ */
+async function markEverStarted(identifier) {
+  if (everStartedMarked.has(identifier)) return;
+  everStartedMarked.add(identifier);
+  await appsRuntimeState.setEverStarted(identifier);
+}
+
 async function dockerActual(identifier) {
   try {
     const info = await dockerService.dockerContainerInspect(identifier);
     const everRan = info.State && info.State.Status !== 'created';
+    // docker's own record that this component has run here: covers an app that has
+    // been up since install and would otherwise never be marked established
+    if (everRan) markEverStarted(identifier).catch(() => {});
     // docker's record of the last death - the truth even when the die event was
     // missed (reboot, FluxOS restart, stream gap). Zero value (0001-01-01) means
     // the container never finished.
@@ -400,12 +419,20 @@ async function recreateMissing(identifier) {
       await Promise.race([
         provision,
         new Promise((_, reject) => {
-          abortController.signal.addEventListener('abort', () => reject(new Error(`recreate provisioning exceeded ${Math.round(RECREATE_PROVISION_CAP_MS / 1000)}s, aborted`)), { once: true });
+          abortController.signal.addEventListener('abort', () => {
+            const capError = new Error(`recreate provisioning exceeded ${Math.round(RECREATE_PROVISION_CAP_MS / 1000)}s, aborted`);
+            // the ceiling wraps the whole provision, image pull included, so it can
+            // fire on a large image that is downloading perfectly well. That is a
+            // statement about this node right now, never a verdict on the app.
+            capError.provisionTimedOut = true;
+            reject(capError);
+          }, { once: true });
         }),
       ]);
     } finally {
       clearTimeout(capTimer);
     }
+    await markEverStarted(identifier);
     appInspector.startAppMonitoring(identifier, globalState.appsMonitored);
     log.info(`appReconciler - recreated missing container ${identifier}`);
     fluxEventBus.publish('reconciler:actuated', { identifier, action: 'recreated' });
@@ -438,7 +465,7 @@ async function recreateMissing(identifier) {
     // its data across the fleet. Only a fresh install that vanished before it ever
     // ran is removed, which is the case this removal was written for.
     const runtimeState = await appsRuntimeState.getState(identifier);
-    if (runtimeState && runtimeState.hasEverStarted) {
+    if (err.provisionTimedOut || (runtimeState && runtimeState.hasEverStarted)) {
       await appsRuntimeState.recordRestart(identifier);
       const wait = Math.max(await appsRuntimeState.restartWaitMs(identifier), MANAGED_RETRY_MS);
       log.warn(`appReconciler - ${identifier} could not be recreated but has run here before; keeping it (down) and retrying in ${Math.round(wait / 1000)}s`);
@@ -947,9 +974,7 @@ async function reconcile(rawIdentifier) {
     scheduleRetry(identifier, MANAGED_RETRY_MS);
     return;
   }
-  // docker accepted the start: from here this component is established on this
-  // node, and a later failed rebuild must not be allowed to destroy it
-  await appsRuntimeState.setEverStarted(identifier);
+  await markEverStarted(identifier);
   appInspector.startAppMonitoring(identifier, globalState.appsMonitored);
   log.info(`appReconciler - ${identifier} restarted`);
   fluxEventBus.publish('reconciler:actuated', { identifier, action: 'started', exitCode: actual.exitCode });

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -1184,6 +1184,12 @@ function clearControllerDesired(rawIdentifier) {
   const identifier = canonical(rawIdentifier);
   controllerDesired.delete(identifier);
   dataDesired.delete(identifier);
+  // The uninstall that triggers this also deleted the component's durable runtime
+  // state, including the hasEverStarted flag the memo below stands in for. Keeping
+  // the memo would stop a reinstalled component from ever being re-marked, so it
+  // would spend the rest of this process eligible for deletion by a failed rebuild -
+  // silently undoing the protection, for every app redeployed since FluxOS started.
+  everStartedMarked.delete(identifier);
 }
 
 // --- lifecycle -----------------------------------------------------------

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -49,6 +49,14 @@ const dataDesired = new Map();
 const DATA_CLEAR_SETTLE_MS = 500;
 
 const inFlight = new Set(); // ids currently reconciling (per-key single-flight)
+// When each in-flight pass started, and when we last complained about it. A pass
+// that never settles never leaves inFlight, and from then on every enqueue for that
+// component is dropped silently - crash events, hourly sweeps, and the masterSlave
+// election's setControllerDesired alike. Production lost a component that way for
+// 18.5 hours without a single log line. This does not cancel or release anything;
+// it only makes the condition audible. Monotonic so a clock step cannot hide it.
+const inFlightSince = new Map();
+const inFlightWarnedAt = new Map();
 const dirty = new Set(); // ids re-requested while in flight -> reconcile again
 const bootPending = new Set(); // ids enqueued before the boot gate opened
 const backoffTimers = new Map(); // id -> scheduled retry timeout
@@ -114,6 +122,10 @@ const VOLUME_MOUNT_RETRY_MS = 30 * 1000;
 // the next pass finds the container and starts it (the same level-based contract as
 // the recreate-failed-but-container-exists re-check).
 const RECREATE_PROVISION_CAP_MS = config.fluxapps.recreateProvisionCapMs ?? 3 * 60 * 1000;
+
+// An in-flight pass older than this is stuck, not slow: it must sit above the
+// recreate ceiling above, which bounds the longest legitimate pass.
+const STUCK_RECONCILE_MS = config.fluxapps.reconcileStuckWarnMs ?? 20 * 60 * 1000;
 
 // identifiers whose missing backing image was already recorded as a tampering
 // event, so the paced retries don't re-record it every cycle
@@ -948,6 +960,8 @@ function runReconcile(identifier) {
     .catch((err) => log.error(`appReconciler - reconcile ${identifier} failed: ${err.message}`))
     .finally(() => {
       inFlight.delete(identifier);
+      inFlightSince.delete(identifier);
+      inFlightWarnedAt.delete(identifier);
       // one completed pass (actuated or deferred) is all the boot drain needs
       if (bootDraining.delete(identifier) && bootDraining.size === 0) {
         settleBootDrain('all boot reconciles completed a pass');
@@ -957,6 +971,26 @@ function runReconcile(identifier) {
         setImmediate(() => enqueue(identifier));
       }
     });
+}
+
+/**
+ * Report an in-flight pass that has outlived any legitimate one, so a component
+ * whose reconciles are being silently coalesced away is visible. Deliberately
+ * inert: the pass keeps its guard (reconcile mutates data, so releasing it early
+ * would let a start race a wipe) - the point is that the operator finds out in
+ * minutes rather than never. Re-warns once per window so a long stall keeps
+ * signalling instead of scrolling past once.
+ */
+function warnIfStuck(identifier) {
+  const startedAt = inFlightSince.get(identifier);
+  if (!startedAt) return;
+  const elapsedMs = Number((process.hrtime.bigint() - startedAt) / 1000000n);
+  if (elapsedMs < STUCK_RECONCILE_MS) return;
+  const lastWarned = inFlightWarnedAt.get(identifier);
+  if (lastWarned && elapsedMs - lastWarned < STUCK_RECONCILE_MS) return;
+  inFlightWarnedAt.set(identifier, elapsedMs);
+  log.error(`appReconciler - ${identifier} has been reconciling for ${Math.round(elapsedMs / 1000)}s; reconcile requests for it are being dropped`);
+  fluxEventBus.publish('reconciler:stuck', { identifier, elapsedMs });
 }
 
 /**
@@ -971,10 +1005,12 @@ function enqueue(rawIdentifier) {
     return;
   }
   if (inFlight.has(identifier)) {
+    warnIfStuck(identifier);
     dirty.add(identifier);
     return;
   }
   inFlight.add(identifier);
+  inFlightSince.set(identifier, process.hrtime.bigint());
   runReconcile(identifier);
 }
 

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -522,7 +522,8 @@ async function recreateMissing(identifier) {
     if (err.provisionTimedOut || err.dockerRuntimeTimedOut || (runtimeState && runtimeState.hasEverStarted)) {
       await appsRuntimeState.recordRestart(identifier);
       const wait = Math.max(await appsRuntimeState.restartWaitMs(identifier), MANAGED_RETRY_MS);
-      log.warn(`appReconciler - ${identifier} could not be recreated but has run here before; keeping it (down) and retrying in ${Math.round(wait / 1000)}s`);
+      const keepReason = (runtimeState && runtimeState.hasEverStarted) ? 'it has run here before' : 'the failure is a node condition';
+      log.warn(`appReconciler - ${identifier} could not be recreated but ${keepReason}; keeping it (down) and retrying in ${Math.round(wait / 1000)}s`);
       fluxEventBus.publish('reconciler:actuated', { identifier, action: 'recreateFailedKept', waitMs: wait });
       scheduleRetry(identifier, wait);
       return;

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -310,6 +310,14 @@ async function getLocalComponentSpec(identifier) {
 // process; the set keeps a steady-state reconcile from writing on every pass.
 const everStartedMarked = new Set();
 
+// A provision abandoned by the ceiling keeps running: Promise.race ends the PASS,
+// not the work. The pass's single-flight key is released, so without this the next
+// pass can take the appdata-clear branch and rm -rf the very directory the detached
+// provision is building into - or create a container the current desired state says
+// must be stopped. Membership here defers only the destructive branches; stops,
+// controller verdicts and the stuck-pass report all keep working.
+const detachedProvisions = new Set();
+
 /**
  * Record that docker has run this component here. Called from every point that
  * observes it running - not just the reconciler's own start - because an app that
@@ -429,6 +437,19 @@ async function recreateMissing(identifier) {
           }, { once: true });
         }),
       ]);
+    } catch (raceError) {
+      // Only a pass the ceiling ABANDONED leaves work running behind it. Track that
+      // one, and re-reconcile when it eventually lands so the current desired state
+      // decides what happens to whatever it built. Doing this for a provision that
+      // completed inside its pass would re-enqueue every successful recreate.
+      if (raceError.provisionTimedOut) {
+        detachedProvisions.add(identifier);
+        provision.finally(() => {
+          detachedProvisions.delete(identifier);
+          enqueue(identifier);
+        }).catch(() => {});
+      }
+      throw raceError;
     } finally {
       clearTimeout(capTimer);
     }
@@ -835,6 +856,17 @@ async function reconcile(rawIdentifier) {
   // loss window). Stop first - an rm -rf under a live container corrupts it - then
   // wipe, then drop the flag. The wipe path is keyed by the on-disk (flux-prefixed)
   // folder name, while the stop takes the bare id (dockerService re-prefixes).
+  // A provision from an abandoned pass may be creating volumes and containers under
+  // this very path right now. Wiping it, or launching a second provision alongside
+  // the first, is exactly the race the single-flight exists to prevent - defer until
+  // the detached one lands, which re-enqueues us.
+  if (detachedProvisions.has(identifier)) {
+    log.warn(`appReconciler - ${identifier} has a provision still running from an abandoned pass; deferring`);
+    fluxEventBus.publish('reconciler:actuated', { identifier, action: 'provisionDetached' });
+    scheduleRetry(identifier, MANAGED_RETRY_MS);
+    return;
+  }
+
   if (dataDesired.get(identifier) === 'clear') {
     try {
       if (actual.running) {
@@ -843,6 +875,15 @@ async function reconcile(rawIdentifier) {
         fluxEventBus.publish('reconciler:actuated', { identifier, action: 'stopped', reason: 'dataClear' });
       }
       await serviceHelper.delay(DATA_CLEAR_SETTLE_MS);
+      // `actual` was sampled before the stop and the settle delay; re-read rather
+      // than delete under whatever is true now. An rm -rf beneath a live container
+      // corrupts it, so an unexpected runner aborts the wipe instead of racing it.
+      const beforeWipe = await dockerActual(identifier);
+      if (beforeWipe.running) {
+        log.error(`appReconciler - ${identifier} is running again at the point of the appdata clear; aborting the wipe and retrying`);
+        scheduleRetry(identifier, MANAGED_RETRY_MS);
+        return;
+      }
       await dockerOperations.appDeleteDataInMountPoint(dockerService.getAppIdentifier(identifier));
     } catch (err) {
       // A failed stop/wipe is the only actuation path here that would otherwise drop

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -431,7 +431,22 @@ async function recreateMissing(identifier) {
     if (appTamperingDetectionService.isNetworkMissingError(err.message)) {
       await appTamperingDetectionService.recordEvent(mainAppName, 'network_pruned', `Docker network missing during recreation: ${err.message}`);
     }
-    log.warn(`REMOVAL REASON: Container recreation failure - ${mainAppName} (appReconciler)`);
+    // A component that docker has started here before is NOT destroyed over a
+    // failed rebuild - an image that has become unpullable, a bad update, or a
+    // registry that is merely unreachable right now. It degrades to DOWN and backs
+    // off, so a transient registry problem can never delete an established app and
+    // its data across the fleet. Only a fresh install that vanished before it ever
+    // ran is removed, which is the case this removal was written for.
+    const runtimeState = await appsRuntimeState.getState(identifier);
+    if (runtimeState && runtimeState.hasEverStarted) {
+      await appsRuntimeState.recordRestart(identifier);
+      const wait = Math.max(await appsRuntimeState.restartWaitMs(identifier), MANAGED_RETRY_MS);
+      log.warn(`appReconciler - ${identifier} could not be recreated but has run here before; keeping it (down) and retrying in ${Math.round(wait / 1000)}s`);
+      fluxEventBus.publish('reconciler:actuated', { identifier, action: 'recreateFailedKept', waitMs: wait });
+      scheduleRetry(identifier, wait);
+      return;
+    }
+    log.warn(`REMOVAL REASON: Container recreation failure (never ran here) - ${mainAppName} (appReconciler)`);
     await appUninstaller.removeAppLocally(mainAppName, null, false, true, true);
   }
 }
@@ -932,6 +947,9 @@ async function reconcile(rawIdentifier) {
     scheduleRetry(identifier, MANAGED_RETRY_MS);
     return;
   }
+  // docker accepted the start: from here this component is established on this
+  // node, and a later failed rebuild must not be allowed to destroy it
+  await appsRuntimeState.setEverStarted(identifier);
   appInspector.startAppMonitoring(identifier, globalState.appsMonitored);
   log.info(`appReconciler - ${identifier} restarted`);
   fluxEventBus.publish('reconciler:actuated', { identifier, action: 'started', exitCode: actual.exitCode });

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -314,8 +314,9 @@ const everStartedMarked = new Set();
 // not the work. The pass's single-flight key is released, so without this the next
 // pass can take the appdata-clear branch and rm -rf the very directory the detached
 // provision is building into - or create a container the current desired state says
-// must be stopped. Membership here defers only the destructive branches; stops,
-// controller verdicts and the stuck-pass report all keep working.
+// must be stopped. Membership defers the whole actuation (stops included - a stop
+// issued mid-provision races the provision's own create/start step) until the
+// detached work settles and re-enqueues; every deferred pass says so in the log.
 const detachedProvisions = new Set();
 
 /**
@@ -887,9 +888,12 @@ async function reconcile(rawIdentifier) {
       // `actual` was sampled before the stop and the settle delay; re-read rather
       // than delete under whatever is true now. An rm -rf beneath a live container
       // corrupts it, so an unexpected runner aborts the wipe instead of racing it.
+      // "Cannot tell" (docker unreachable, or inspect failed with the container
+      // still listed) aborts too: the wipe needs a positive answer that nothing
+      // is running, not the absence of one.
       const beforeWipe = await dockerActual(identifier);
-      if (beforeWipe.running) {
-        log.error(`appReconciler - ${identifier} is running again at the point of the appdata clear; aborting the wipe and retrying`);
+      if (beforeWipe.running || !beforeWipe.reachable || beforeWipe.indeterminate) {
+        log.error(`appReconciler - ${identifier} is running again (or docker cannot confirm it stopped) at the point of the appdata clear; aborting the wipe and retrying`);
         scheduleRetry(identifier, MANAGED_RETRY_MS);
         return;
       }

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -327,8 +327,14 @@ const detachedProvisions = new Set();
  */
 async function markEverStarted(identifier) {
   if (everStartedMarked.has(identifier)) return;
-  everStartedMarked.add(identifier);
-  await appsRuntimeState.setEverStarted(identifier);
+  // Memoise only a write that landed. setEverStarted swallows a DB failure to
+  // false, and memoising that failure would block every later attempt for the
+  // life of the process - leaving an established component deletable by a
+  // failed rebuild, which is exactly what the flag exists to prevent. Left
+  // un-memoised, the next observation pass retries the write.
+  if (await appsRuntimeState.setEverStarted(identifier)) {
+    everStartedMarked.add(identifier);
+  }
 }
 
 async function dockerActual(identifier) {
@@ -407,6 +413,56 @@ async function effectiveDesiredRunning(identifier, spec, exitCode) {
 }
 
 /**
+ * Runs a container (re)provision under the recreate ceiling: the PASS ends at
+ * RECREATE_PROVISION_CAP_MS even if a sub-step ignores the abort signal, so a
+ * hung provision can never hold the per-key single-flight. The abandoned
+ * provision keeps running detached; it is tracked in detachedProvisions so no
+ * later pass can wipe or double-provision under it, and its eventual settlement
+ * re-enqueues the component so the current desired state decides what happens
+ * to whatever it built. A pass ended by the ceiling throws with
+ * provisionTimedOut set — a statement about this node right now, never a
+ * verdict on the app (the ceiling wraps the whole provision, image pull
+ * included, so it can fire on a large image that is downloading perfectly well).
+ */
+async function runCappedProvision(identifier, startProvision) {
+  const abortController = new AbortController();
+  const capTimer = setTimeout(() => abortController.abort(), RECREATE_PROVISION_CAP_MS);
+  if (capTimer.unref) capTimer.unref();
+  const provision = startProvision();
+  // a capped provision keeps running detached; its eventual rejection must land
+  // here, not as an unhandledRejection
+  provision.catch(() => {});
+  try {
+    // the race ends the PASS at the cap even if a sub-step ignores the signal
+    await Promise.race([
+      provision,
+      new Promise((_, reject) => {
+        abortController.signal.addEventListener('abort', () => {
+          const capError = new Error(`recreate provisioning exceeded ${Math.round(RECREATE_PROVISION_CAP_MS / 1000)}s, aborted`);
+          capError.provisionTimedOut = true;
+          reject(capError);
+        }, { once: true });
+      }),
+    ]);
+  } catch (raceError) {
+    // Only a pass the ceiling ABANDONED leaves work running behind it. Track that
+    // one, and re-reconcile when it eventually lands so the current desired state
+    // decides what happens to whatever it built. Doing this for a provision that
+    // completed inside its pass would re-enqueue every successful recreate.
+    if (raceError.provisionTimedOut) {
+      detachedProvisions.add(identifier);
+      provision.finally(() => {
+        detachedProvisions.delete(identifier);
+        enqueue(identifier);
+      }).catch(() => {});
+    }
+    throw raceError;
+  } finally {
+    clearTimeout(capTimer);
+  }
+}
+
+/**
  * Recreates a vanished container (no Docker event fires for absence), recording
  * the tampering signals and falling back to local removal on failure — the
  * behavior previously in containerHealthMonitor.monitorAndRecoverApps.
@@ -416,44 +472,7 @@ async function recreateMissing(identifier) {
 
   await appTamperingDetectionService.recordEvent(mainAppName, 'container_vanished', `Container ${identifier} missing, not found in Docker`);
   try {
-    const abortController = new AbortController();
-    const capTimer = setTimeout(() => abortController.abort(), RECREATE_PROVISION_CAP_MS);
-    if (capTimer.unref) capTimer.unref();
-    const provision = containerHealthMonitor.recreateMissingContainers(identifier);
-    // a capped provision keeps running detached; its eventual rejection must land
-    // here, not as an unhandledRejection
-    provision.catch(() => {});
-    try {
-      // the race ends the PASS at the cap even if a sub-step ignores the signal
-      await Promise.race([
-        provision,
-        new Promise((_, reject) => {
-          abortController.signal.addEventListener('abort', () => {
-            const capError = new Error(`recreate provisioning exceeded ${Math.round(RECREATE_PROVISION_CAP_MS / 1000)}s, aborted`);
-            // the ceiling wraps the whole provision, image pull included, so it can
-            // fire on a large image that is downloading perfectly well. That is a
-            // statement about this node right now, never a verdict on the app.
-            capError.provisionTimedOut = true;
-            reject(capError);
-          }, { once: true });
-        }),
-      ]);
-    } catch (raceError) {
-      // Only a pass the ceiling ABANDONED leaves work running behind it. Track that
-      // one, and re-reconcile when it eventually lands so the current desired state
-      // decides what happens to whatever it built. Doing this for a provision that
-      // completed inside its pass would re-enqueue every successful recreate.
-      if (raceError.provisionTimedOut) {
-        detachedProvisions.add(identifier);
-        provision.finally(() => {
-          detachedProvisions.delete(identifier);
-          enqueue(identifier);
-        }).catch(() => {});
-      }
-      throw raceError;
-    } finally {
-      clearTimeout(capTimer);
-    }
+    await runCappedProvision(identifier, () => containerHealthMonitor.recreateMissingContainers(identifier));
     await markEverStarted(identifier);
     appInspector.startAppMonitoring(identifier, globalState.appsMonitored);
     log.info(`appReconciler - recreated missing container ${identifier}`);
@@ -525,7 +544,10 @@ async function recreateForNetworkHeal(identifier) {
     // softOnly: a hard install would REFORMAT the app's data volume (createAppVolume
     // fallocates + mke2fs). We removed a live container whose data was intact, so a
     // recreate that cannot verify the volume must fail and be retried - never wipe it.
-    await containerHealthMonitor.recreateMissingContainers(identifier, { softOnly: true });
+    // Capped like the vanished-path recreate: the container is already force-removed
+    // by this point, so a provision wedged on an unanswering daemon would otherwise
+    // hold this component's single-flight forever with no container and no way back.
+    await runCappedProvision(identifier, () => containerHealthMonitor.recreateMissingContainers(identifier, { softOnly: true }));
     appInspector.startAppMonitoring(identifier, globalState.appsMonitored);
     log.info(`appReconciler - recreated ${identifier} to clear a detached network endpoint`);
     fluxEventBus.publish('reconciler:actuated', { identifier, action: 'recreated', reason: 'networkDetached' });

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -485,7 +485,16 @@ async function recreateMissing(identifier) {
     // off, so a transient registry problem can never delete an established app and
     // its data across the fleet. Only a fresh install that vanished before it ever
     // ran is removed, which is the case this removal was written for.
-    const runtimeState = await appsRuntimeState.getState(identifier);
+    // The read is strict because the null branch here deletes the app: through
+    // getState a DB error reads as "never started". A failed read defers instead.
+    let runtimeState;
+    try {
+      runtimeState = await appsRuntimeState.getStateStrict(identifier);
+    } catch (stateReadError) {
+      log.warn(`appReconciler - cannot read runtime state for ${identifier} (${stateReadError.message}); keeping it and retrying in ${Math.round(MANAGED_RETRY_MS / 1000)}s`);
+      scheduleRetry(identifier, MANAGED_RETRY_MS);
+      return;
+    }
     if (err.provisionTimedOut || (runtimeState && runtimeState.hasEverStarted)) {
       await appsRuntimeState.recordRestart(identifier);
       const wait = Math.max(await appsRuntimeState.restartWaitMs(identifier), MANAGED_RETRY_MS);

--- a/ZelBack/src/services/appMonitoring/containerHealthMonitor.js
+++ b/ZelBack/src/services/appMonitoring/containerHealthMonitor.js
@@ -75,12 +75,12 @@ async function recreateMissingContainers(componentIdentifier, options = {}) {
       // volume not mounted
     }
     if (volumeMounted) {
-      await appInstaller.installApplicationSoft(componentSpec, mainAppName, true, null, appSpec);
+      await appInstaller.installApplicationSoft(componentSpec, mainAppName, true, null, appSpec, { allowLocalImageFallback: true });
     } else {
       if (softOnly) {
         throw new Error(`Cannot recreate ${componentIdentifier} without reformatting its volume: the data volume for ${mainAppName} could not be verified as mounted`);
       }
-      await appInstaller.installApplicationHard(componentSpec, mainAppName, true, null, appSpec);
+      await appInstaller.installApplicationHard(componentSpec, mainAppName, true, null, appSpec, false, { allowLocalImageFallback: true });
     }
   } else {
     for (const componentSpec of appSpec.compose) {
@@ -99,13 +99,13 @@ async function recreateMissingContainers(componentIdentifier, options = {}) {
       }
       if (volumeMounted) {
         // eslint-disable-next-line no-await-in-loop
-        await appInstaller.installApplicationSoft(componentSpec, mainAppName, true, null, appSpec);
+        await appInstaller.installApplicationSoft(componentSpec, mainAppName, true, null, appSpec, { allowLocalImageFallback: true });
       } else {
         if (softOnly) {
           throw new Error(`Cannot recreate ${componentIdentifier} without reformatting its volume: the data volume for ${mainAppName} could not be verified as mounted`);
         }
         // eslint-disable-next-line no-await-in-loop
-        await appInstaller.installApplicationHard(componentSpec, mainAppName, true, null, appSpec);
+        await appInstaller.installApplicationHard(componentSpec, mainAppName, true, null, appSpec, false, { allowLocalImageFallback: true });
       }
     }
   }

--- a/ZelBack/src/services/appMonitoring/syncthingFolderStateMachine.js
+++ b/ZelBack/src/services/appMonitoring/syncthingFolderStateMachine.js
@@ -160,6 +160,27 @@ async function checkDirectoryHasSyncScopedContent(dirPath) {
 }
 
 /**
+ * Counts sync-scoped regular FILES only (directories excluded from the count).
+ * The deletion-broadcast hazard is per-FILE: only a file the index still lists
+ * can be announced as locally deleted, so when the index claims files
+ * (globalFiles > 0) the disk must hold at least one — a surviving directory
+ * skeleton (e.g. a bare appdata/) protects nothing.
+ * @param {string} dirPath - Directory path to check
+ * @returns {Promise<{hasContent: boolean, fileCount: number}>} File status
+ */
+async function checkDirectoryHasSyncScopedFiles(dirPath) {
+  const fileCount = await countFilesUpTo(dirPath, 100, {
+    excludeNames: ['.stignore'],
+    excludeDirs: ['backup', '.stfolder'],
+    countDirs: false,
+  });
+  return {
+    hasContent: fileCount > 0,
+    fileCount,
+  };
+}
+
+/**
  * Verify that a Syncthing folder's mount is properly initialized
  * This is CRITICAL to prevent data loss when mounts are not ready after reboot
  * @param {string} appId - App ID (e.g., fluxwp_myapp)
@@ -248,7 +269,18 @@ async function verifySendReceiveFolderSafety(appId, folderPath) {
   const syncStatus = await getFolderSyncCompletion(appId);
   if (!syncStatus || syncStatus.globalBytes === 0) return result;
 
-  const dataCheck = await checkDirectoryHasSyncScopedContent(folderPath);
+  // The deletion-broadcast hazard is per-FILE, so the discriminator is
+  // files-aware: an index claiming files over a disk with none is phantom
+  // even when a directory skeleton survives (a bare appdata/ protects
+  // nothing), while a dirs-only payload (globalFiles 0, globalBytes > 0 from
+  // directory accounting — the 2026-07-04 false positive) stays healthy over
+  // its dirs-only disk. When the status carries no globalFiles field, fall
+  // back to the entry-level check (directories count).
+  const filesAware = syncStatus.globalFiles != null;
+  if (filesAware && syncStatus.globalFiles === 0) return result;
+  const dataCheck = filesAware
+    ? await checkDirectoryHasSyncScopedFiles(folderPath)
+    : await checkDirectoryHasSyncScopedContent(folderPath);
   if (!dataCheck.hasContent) {
     result.isSafe = false;
     result.reason = 'phantom_index_empty_disk';

--- a/ZelBack/src/services/appMonitoring/syncthingFolderStateMachine.js
+++ b/ZelBack/src/services/appMonitoring/syncthingFolderStateMachine.js
@@ -73,8 +73,11 @@ function noteSafetyObservation(appId, observation, logFn, message) {
  * @param {string} dirPath - Directory to scan
  * @param {number} limit - Stop counting once this many entries are found
  * @param {{excludeNames?: string[], excludeDirs?: string[], countDirs?: boolean}} options -
- *   Skips, and whether a (non-excluded) directory counts as content in its own
- *   right rather than only as a subtree to descend into.
+ *   Skips (applied at the ROOT level only, mirroring .stignore's anchored
+ *   '/backup' pattern - syncthing DOES sync a nested dir with an excluded
+ *   name, so the walk must count it), and whether a (non-excluded) directory
+ *   counts as content in its own right rather than only as a subtree to
+ *   descend into.
  * @returns {Promise<number>} Number of entries found (capped at limit)
  */
 async function countFilesUpTo(dirPath, limit, { excludeNames = [], excludeDirs = [], countDirs = false } = {}) {
@@ -82,6 +85,7 @@ async function countFilesUpTo(dirPath, limit, { excludeNames = [], excludeDirs =
   const pending = [dirPath];
   while (pending.length > 0 && count < limit) {
     const current = pending.pop();
+    const atRoot = current === dirPath;
     let entries;
     try {
       // eslint-disable-next-line no-await-in-loop
@@ -94,7 +98,7 @@ async function countFilesUpTo(dirPath, limit, { excludeNames = [], excludeDirs =
     // eslint-disable-next-line no-restricted-syntax
     for (const entry of entries) {
       if (entry.isDirectory()) {
-        if (excludeDirs.includes(entry.name)) {
+        if (atRoot && excludeDirs.includes(entry.name)) {
           // eslint-disable-next-line no-continue
           continue;
         }
@@ -108,7 +112,7 @@ async function countFilesUpTo(dirPath, limit, { excludeNames = [], excludeDirs =
           if (count >= limit) break;
         }
         pending.push(path.join(current, entry.name));
-      } else if (entry.isFile() && !excludeNames.includes(entry.name)) {
+      } else if (entry.isFile() && !(atRoot && excludeNames.includes(entry.name))) {
         count += 1;
         if (count >= limit) break;
       }

--- a/ZelBack/src/services/appMonitoring/syncthingFolderStateMachine.js
+++ b/ZelBack/src/services/appMonitoring/syncthingFolderStateMachine.js
@@ -328,6 +328,9 @@ async function getFolderSyncCompletion(folderId) {
     if (statusResponse && statusResponse.status === 'success') {
       const {
         globalBytes = 0, inSyncBytes = 0, state, receiveOnlyChangedFiles = 0,
+        // null (not 0) when absent, so the phantom guard can tell "no files
+        // claimed" apart from "field not reported" and fall back safely
+        globalFiles = null,
       } = statusResponse.data;
 
       const syncPercentage = globalBytes > 0 ? (inSyncBytes / globalBytes) * 100 : 100;
@@ -336,6 +339,7 @@ async function getFolderSyncCompletion(folderId) {
         syncPercentage,
         globalBytes,
         inSyncBytes,
+        globalFiles,
         state,
         // local additions/modifications in a receiveonly folder; invisible to the
         // completion metrics above (they only count cluster data)

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -327,6 +327,36 @@ async function dockerContainerChanges(idOrName) {
  * @param {object} res Response.
  * @param {function} callback Callback.
  */
+// Could the registry not be REACHED, as opposed to answering that the image is
+// bad? Only the former is safe to ride out on a local copy: an unreachable
+// registry is a condition of this node right now, while a rejected manifest is a
+// statement about the image. Anything unrecognised stays unclassified, so the
+// caller treats it as permanent - the conservative direction.
+const TRANSIENT_REGISTRY_CODES = ['ECONNREFUSED', 'ECONNRESET', 'ENOTFOUND', 'EAI_AGAIN', 'ETIMEDOUT', 'EHOSTUNREACH', 'ENETUNREACH', 'EPIPE'];
+
+function classifyRegistryError(error) {
+  if (!error) return error;
+  if (TRANSIENT_REGISTRY_CODES.includes(error.code)) error.registryErrorClass = 'transient';
+  return error;
+}
+
+/**
+ * Bytes of a locally-held image, or 0 when it is not present. Used to decide
+ * whether a recreate can proceed on the copy already on disk when the registry
+ * cannot be reached.
+ *
+ * @param {string} repoTag
+ * @returns {Promise<number>}
+ */
+async function appDockerImageSize(repoTag) {
+  try {
+    const image = await docker.getImage(repoTag).inspect();
+    return image?.Size ?? 0;
+  } catch (error) {
+    return 0;
+  }
+}
+
 function dockerPullStream(pullConfig, res, callback) {
   const { repoTag, provider, authToken } = pullConfig;
   let pullOptions;
@@ -368,7 +398,10 @@ function dockerPullStream(pullConfig, res, callback) {
   function armStall() {
     clearTimeout(stallTimer);
     stallTimer = setTimeout(() => {
-      done(new Error(`Pull of ${repoTag} stalled: no progress for ${Math.round(stallWindowMs / 1000)}s`));
+      const stallError = new Error(`Pull of ${repoTag} stalled: no progress for ${Math.round(stallWindowMs / 1000)}s`);
+      // the registry is not answering; the image itself may be perfectly fine
+      stallError.registryErrorClass = 'transient';
+      done(stallError);
       stallController.abort();
     }, stallWindowMs);
     if (stallTimer.unref) stallTimer.unref();
@@ -391,7 +424,7 @@ function dockerPullStream(pullConfig, res, callback) {
       log.info(event);
     }
     if (err) {
-      done(err);
+      done(classifyRegistryError(err));
     } else {
       armStall();
       docker.modem.followProgress(mystream, onFinished, onProgress);
@@ -1962,6 +1995,7 @@ module.exports = {
   dockerLogsFix,
   dockerNetworkInspect,
   dockerPullStream,
+  appDockerImageSize,
   dockerRemoveNetwork,
   dockerVersion,
   getAppDockerNameIdentifier,

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -242,8 +242,10 @@ async function getDockerContainerByIdOrName(idOrName) {
  * @returns {object}
  */
 async function dockerContainerInspect(idOrName, options = {}) {
-  // container ID or name
-  const dockerContainer = await getDockerContainerByIdOrName(idOrName);
+  // The name lookup is itself a docker call (listContainers), so it has to be
+  // bounded too - a ceiling that starts only after it would never fire against the
+  // wedged daemon it exists to defend against.
+  const dockerContainer = await withRuntimeOpTimeout(getDockerContainerByIdOrName(idOrName), `lookup ${idOrName}`);
   // A plain inspect reads local metadata and is bounded. `size: true` is a
   // different operation: docker walks the container's whole filesystem to compute
   // SizeRw/SizeRootFs, which on a large app volume legitimately takes minutes.
@@ -1210,7 +1212,7 @@ async function appDockerUpdateCpu(idOrName, nanoCpus) {
 async function appDockerStart(idOrName) {
   try {
     // container ID or name
-    const dockerContainer = await getDockerContainerByIdOrName(idOrName);
+    const dockerContainer = await withRuntimeOpTimeout(getDockerContainerByIdOrName(idOrName), `lookup ${idOrName}`);
 
     globalState.stoppingContainers.delete(getDockerName(idOrName));
     await withRuntimeOpTimeout(dockerContainer.start(), `start ${idOrName}`); // may throw
@@ -1221,7 +1223,7 @@ async function appDockerStart(idOrName) {
     // is reapplied on every start path (initial install, restart, recovery)
     // without each caller having to know about burst.
     try {
-      const containerInspect = await dockerContainer.inspect();
+      const containerInspect = await withRuntimeOpTimeout(dockerContainer.inspect(), `burst inspect ${idOrName}`);
       const dockerLabels = containerInspect.Config?.Labels || {};
       if (dockerLabels['flux.burst.eligible'] === 'true') {
         const cpuCores = parseFloat(dockerLabels['flux.burst.cores']);

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -25,6 +25,38 @@ const appsFolder = `${appsFolderPath}/`;
 const docker = new Docker();
 
 /**
+ * Bound a short docker control-plane call so a wedged daemon cannot hold a caller
+ * forever. Mirrors kubelet's --runtime-request-timeout: it covers the quick runtime
+ * operations and deliberately exempts the long-running ones (pull has its own
+ * progress-based stall detection; stop legitimately runs for hours under a graceful
+ * shutdown and declares its own grace via `t`).
+ *
+ * The race frees the CALLER; it cannot cancel the underlying HTTP request. That is
+ * sufficient here - the callers retry, and both bounded operations are safe to
+ * repeat (inspect is read-only, and starting an already-running container is a
+ * no-op to docker).
+ *
+ * @param {Promise} operation
+ * @param {string} label used in the timeout error
+ * @returns {Promise}
+ */
+async function withRuntimeOpTimeout(operation, label) {
+  const timeoutMs = config.fluxapps.dockerRuntimeOpTimeoutMs ?? 2 * 60 * 1000;
+  let timer = null;
+  try {
+    return await Promise.race([
+      operation,
+      new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`docker ${label} exceeded ${Math.round(timeoutMs / 1000)}s`)), timeoutMs);
+        if (timer.unref) timer.unref();
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
  * Creates a docker container object with a given ID.
  *
  * @param {string} id
@@ -212,7 +244,7 @@ async function getDockerContainerByIdOrName(idOrName) {
 async function dockerContainerInspect(idOrName, options = {}) {
   // container ID or name
   const dockerContainer = await getDockerContainerByIdOrName(idOrName);
-  const response = await dockerContainer.inspect(options);
+  const response = await withRuntimeOpTimeout(dockerContainer.inspect(options), `inspect ${idOrName}`);
   return response;
 }
 
@@ -1143,7 +1175,7 @@ async function appDockerStart(idOrName) {
     const dockerContainer = await getDockerContainerByIdOrName(idOrName);
 
     globalState.stoppingContainers.delete(getDockerName(idOrName));
-    await dockerContainer.start(); // may throw
+    await withRuntimeOpTimeout(dockerContainer.start(), `start ${idOrName}`); // may throw
 
     // Apply CFS burst after start — cgroup paths only exist once the container
     // is running. Eligibility was decided at appDockerCreate time and stamped

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -310,15 +310,43 @@ function dockerPullStream(pullConfig, res, callback) {
       throw new Error('Invalid login credentials for docker provided');
     }
   }
+  // A registry can black-hole rather than refuse (a dead IP behind a stale DNS
+  // cache), and an unbounded pull wedges whatever awaits it. A duration cap cannot
+  // tell a dead transfer from a large one - docker resumes completed layers but not
+  // partial ones, so any layer bigger than the cap's window could never finish.
+  // Silence is the signal, not elapsed time: every progress event re-arms the timer,
+  // so total pull time stays unbounded for as long as bytes are moving.
+  const stallWindowMs = config.fluxapps.pullStallMs ?? 90 * 1000;
+  const stallController = new AbortController();
+  let stallTimer = null;
+  let settled = false;
+
+  function done(error, output) {
+    if (settled) return;
+    settled = true;
+    clearTimeout(stallTimer);
+    callback(error, output);
+  }
+
+  function armStall() {
+    clearTimeout(stallTimer);
+    stallTimer = setTimeout(() => {
+      done(new Error(`Pull of ${repoTag} stalled: no progress for ${Math.round(stallWindowMs / 1000)}s`));
+      stallController.abort();
+    }, stallWindowMs);
+    if (stallTimer.unref) stallTimer.unref();
+  }
+
+  pullOptions = { ...(pullOptions ?? {}), abortSignal: stallController.signal };
+
   docker.pull(repoTag, pullOptions, (err, mystream) => {
     function onFinished(error, output) {
-      if (error) {
-        callback(err);
-      } else {
-        callback(null, output);
-      }
+      // report the followProgress error itself; this used to pass the outer `err`,
+      // which is always null here, so a failed pull was reported as a success
+      done(error ?? null, output);
     }
     function onProgress(event) {
+      armStall();
       if (res) {
         res.write(serviceHelper.ensureString(event));
         if (res.flush) res.flush();
@@ -326,8 +354,9 @@ function dockerPullStream(pullConfig, res, callback) {
       log.info(event);
     }
     if (err) {
-      callback(err);
+      done(err);
     } else {
+      armStall();
       docker.modem.followProgress(mystream, onFinished, onProgress);
     }
   });

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -161,7 +161,10 @@ async function dockerCreateNetwork(options) {
   // this (ensureAppDockerNetwork) advances on rejection - a second create for
   // the same name would then DUPLICATE it (dockerd accepts duplicate names),
   // leaving the app unstartable. A rejection from here must always mean the
-  // daemon answered. A wedged daemon is bounded by the provision ceiling.
+  // daemon answered. On the reconciler's recreate paths a wedge is bounded by
+  // the provision ceiling; on the install paths it is not bounded at all - a
+  // pre-existing gap (the global installationInProgress flag has no watchdog)
+  // owned by the operation-registry redesign, not fixable at this call.
   const network = await docker.createNetwork(options);
   return network;
 }
@@ -1204,7 +1207,9 @@ async function appDockerCreate(appSpecifications, appName, isComponent, fullAppS
   // ceiling ends a wedged pass with provisionTimedOut (a node condition, kept)
   // and tracks the still-running work in detachedProvisions; a lower bound here
   // settles early without either, which once turned a create-wedged daemon into
-  // a local uninstall of a never-started app.
+  // a local uninstall of a never-started app. The ceiling covers only the
+  // reconciler's recreate paths; on the install paths a wedge here is unbounded
+  // - a pre-existing gap owned by the operation-registry redesign.
   const app = await docker.createContainer(options).catch((error) => {
     log.error(error);
     throw error;

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -244,8 +244,13 @@ async function getDockerContainerByIdOrName(idOrName) {
 async function dockerContainerInspect(idOrName, options = {}) {
   // container ID or name
   const dockerContainer = await getDockerContainerByIdOrName(idOrName);
-  const response = await withRuntimeOpTimeout(dockerContainer.inspect(options), `inspect ${idOrName}`);
-  return response;
+  // A plain inspect reads local metadata and is bounded. `size: true` is a
+  // different operation: docker walks the container's whole filesystem to compute
+  // SizeRw/SizeRootFs, which on a large app volume legitimately takes minutes.
+  // Bounding that would report a storage figure of zero for exactly the apps whose
+  // usage matters most, so it keeps the daemon's own pace.
+  if (options.size) return dockerContainer.inspect(options);
+  return withRuntimeOpTimeout(dockerContainer.inspect(options), `inspect ${idOrName}`);
 }
 
 /**

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -193,7 +193,11 @@ async function dockerListContainers(all, limit, size, filter) {
     size,
     filter,
   };
-  const containers = await docker.listContainers(options);
+  // Bounded like the other short control-plane calls: the reconciler's own
+  // reachability probe lands here when an inspect times out, so an unbounded
+  // list would hand the wedged daemon back the single-flight the inspect
+  // ceiling just freed.
+  const containers = await withRuntimeOpTimeout(docker.listContainers(options), 'list containers');
   return containers;
 }
 
@@ -411,6 +415,10 @@ function dockerPullStream(pullConfig, res, callback) {
 
   pullOptions = { ...(pullOptions ?? {}), abortSignal: stallController.signal };
 
+  // Armed before the request, not from its callback: a dockerd that never answers
+  // the pull request at all is the same silence as a stalled transfer, and arming
+  // only on the answer would leave that phase unbounded.
+  armStall();
   docker.pull(repoTag, pullOptions, (err, mystream) => {
     function onFinished(error, output) {
       // report the followProgress error itself; this used to pass the outer `err`,

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -356,7 +356,10 @@ function classifyRegistryError(error) {
  */
 async function appDockerImageSize(repoTag) {
   try {
-    const image = await docker.getImage(repoTag).inspect();
+    // Bounded: this sits on the recreate path's local-image fallback decision, so
+    // a wedged daemon must produce an answer, not a hang. A timeout reads as 0 -
+    // "no usable local image" - which refuses the fallback, the conservative side.
+    const image = await withRuntimeOpTimeout(docker.getImage(repoTag).inspect(), `image inspect ${repoTag}`);
     return image?.Size ?? 0;
   } catch (error) {
     return 0;

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -414,8 +414,11 @@ function dockerPullStream(pullConfig, res, callback) {
   docker.pull(repoTag, pullOptions, (err, mystream) => {
     function onFinished(error, output) {
       // report the followProgress error itself; this used to pass the outer `err`,
-      // which is always null here, so a failed pull was reported as a success
-      done(error ?? null, output);
+      // which is always null here, so a failed pull was reported as a success. It
+      // needs the same reachability classification as the request-level error: a
+      // transfer that dies mid-stream is the registry going away, not a verdict on
+      // the image.
+      done(error ? classifyRegistryError(error) : null, output);
     }
     function onProgress(event) {
       armStall();

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -31,10 +31,14 @@ const docker = new Docker();
  * progress-based stall detection; stop legitimately runs for hours under a graceful
  * shutdown and declares its own grace via `t`).
  *
- * The race frees the CALLER; it cannot cancel the underlying HTTP request. That is
- * sufficient here - the callers retry, and both bounded operations are safe to
- * repeat (inspect is read-only, and starting an already-running container is a
- * no-op to docker).
+ * The race frees the CALLER; it cannot cancel the underlying HTTP request, which
+ * may still land later. The reads are safe to repeat; the creates are NOT - a
+ * create that lands after its timeout makes a blind retry collide (or worse,
+ * duplicate: dockerd accepts a second network with the same name). Callers on
+ * create paths must re-check for the thing by name before retrying, and every
+ * consumer of the rejection must read it as dockerRuntimeTimedOut says: the
+ * daemon did not ANSWER - a statement about this node right now, never a
+ * refusal and never a verdict on the app.
  *
  * @param {Promise} operation
  * @param {string} label used in the timeout error
@@ -47,7 +51,11 @@ async function withRuntimeOpTimeout(operation, label) {
     return await Promise.race([
       operation,
       new Promise((_, reject) => {
-        timer = setTimeout(() => reject(new Error(`docker ${label} exceeded ${Math.round(timeoutMs / 1000)}s`)), timeoutMs);
+        timer = setTimeout(() => {
+          const timeoutError = new Error(`docker ${label} exceeded ${Math.round(timeoutMs / 1000)}s`);
+          timeoutError.dockerRuntimeTimedOut = true;
+          reject(timeoutError);
+        }, timeoutMs);
         if (timer.unref) timer.unref();
       }),
     ]);
@@ -148,9 +156,13 @@ function getAppDockerNameIdentifier(appName) {
  * @returns {object} Network
  */
 async function dockerCreateNetwork(options) {
-  // Bounded like the other short control-plane calls: a daemon wedged on
-  // network create would otherwise hold its caller's provision open forever.
-  const network = await withRuntimeOpTimeout(docker.createNetwork(options), `create network ${options && options.Name}`);
+  // Deliberately NOT under the runtime-op timeout: a create that times out
+  // client-side can still land in the daemon, and the octet-retry loop above
+  // this (ensureAppDockerNetwork) advances on rejection - a second create for
+  // the same name would then DUPLICATE it (dockerd accepts duplicate names),
+  // leaving the app unstartable. A rejection from here must always mean the
+  // daemon answered. A wedged daemon is bounded by the provision ceiling.
+  const network = await docker.createNetwork(options);
   return network;
 }
 
@@ -1187,12 +1199,13 @@ async function appDockerCreate(appSpecifications, appName, isComponent, fullAppS
   }
   options.Env.push(`FLUX_APP_NAME=${appName}`);
 
-  // Bounded so a daemon wedged on POST /containers/create (while still
-  // answering inspects) cannot leave the provision promise pending forever -
-  // an unsettled provision pins its component's reconcile single-flight. The
-  // race only frees the caller; a create that lands late 409s the retry, which
-  // the reconciler already resolves via its "container now exists" re-check.
-  const app = await withRuntimeOpTimeout(docker.createContainer(options), `create ${identifier}`).catch((error) => {
+  // Deliberately NOT under the runtime-op timeout: settling the provision with
+  // a plain timeout would bypass the recreate ceiling's classification - the
+  // ceiling ends a wedged pass with provisionTimedOut (a node condition, kept)
+  // and tracks the still-running work in detachedProvisions; a lower bound here
+  // settles early without either, which once turned a create-wedged daemon into
+  // a local uninstall of a never-started app.
+  const app = await docker.createContainer(options).catch((error) => {
     log.error(error);
     throw error;
   });

--- a/ZelBack/src/services/dockerService.js
+++ b/ZelBack/src/services/dockerService.js
@@ -148,7 +148,9 @@ function getAppDockerNameIdentifier(appName) {
  * @returns {object} Network
  */
 async function dockerCreateNetwork(options) {
-  const network = await docker.createNetwork(options);
+  // Bounded like the other short control-plane calls: a daemon wedged on
+  // network create would otherwise hold its caller's provision open forever.
+  const network = await withRuntimeOpTimeout(docker.createNetwork(options), `create network ${options && options.Name}`);
   return network;
 }
 
@@ -1185,7 +1187,12 @@ async function appDockerCreate(appSpecifications, appName, isComponent, fullAppS
   }
   options.Env.push(`FLUX_APP_NAME=${appName}`);
 
-  const app = await docker.createContainer(options).catch((error) => {
+  // Bounded so a daemon wedged on POST /containers/create (while still
+  // answering inspects) cannot leave the provision promise pending forever -
+  // an unsettled provision pins its component's reconcile single-flight. The
+  // race only frees the caller; a create that lands late 409s the retry, which
+  // the reconciler already resolves via its "container now exists" re-check.
+  const app = await withRuntimeOpTimeout(docker.createContainer(options), `create ${identifier}`).catch((error) => {
     log.error(error);
     throw error;
   });

--- a/ZelBack/src/services/imageUpdateService.js
+++ b/ZelBack/src/services/imageUpdateService.js
@@ -321,10 +321,10 @@ async function checkAppForUpdates(appSpec) {
  * ask: the blocked-repositories compliance check, then per component the
  * registry manifest evaluation (size cap, architecture). The soft redeploy
  * verifies only after it has already stopped and removed the running
- * containers, and its failure path removes the app and its data - so a mutable
- * tag gone bad, a blocked repository, or a compliance list that cannot even be
- * fetched must all be refused HERE, where refusal costs nothing: the app keeps
- * running its current image and the refusal is logged each cycle. All
+ * containers - so a mutable tag gone bad, a blocked repository, or a
+ * compliance list that cannot even be fetched must all be refused HERE, where
+ * refusal costs nothing: the app keeps running its current image and the
+ * refusal is logged each cycle. All
  * components are checked, not just the changed one, because the redeploy will
  * re-verify all of them and dies on any. A lookup that cannot be completed
  * also refuses - an update that cannot be verified is not an update this

--- a/ZelBack/src/services/imageUpdateService.js
+++ b/ZelBack/src/services/imageUpdateService.js
@@ -317,7 +317,7 @@ async function checkAppForUpdates(appSpec) {
 }
 
 /**
- * Asks, BEFORE any teardown, the same questions the redeploy's install will
+ * Asks, BEFORE any teardown, the IMAGE questions the redeploy's install will
  * ask: the blocked-repositories compliance check, then per component the
  * registry manifest evaluation (size cap, architecture). The soft redeploy
  * verifies only after it has already stopped and removed the running
@@ -330,6 +330,13 @@ async function checkAppForUpdates(appSpec) {
  * also refuses - an update that cannot be verified is not an update this
  * cycle - and a registry rate-limit is surfaced as such so the caller can
  * abort the whole cycle instead of hammering on.
+ *
+ * NOT covered: the install's node-side gates (hardware resources, network
+ * requirements, port mapping) still run after the teardown - port mapping
+ * cannot be pre-asked at all, mapping IS the action. A failure there no longer
+ * removes the app (a failed soft redeploy keeps the app and its data for the
+ * reconciler); the cost of missing them here is a torn-down app waiting on the
+ * reconciler's retry ladder instead of an untouched running one.
  * @param {object} appSpec Application specification
  * @returns {Promise<{ok: boolean, reason: string|null, rateLimited: boolean}>}
  */
@@ -382,8 +389,14 @@ async function triggerAppUpdate(appSpec) {
 
     const preflight = await verifyAppImagesForUpdate(appSpec);
     if (!preflight.ok) {
-      log.warn(`Skipping image update for ${appSpec.name}: ${preflight.reason} - keeping the running image`);
-      fluxEventBus.publish('imageUpdate:updateRefused', { appName: appSpec.name, reason: preflight.reason });
+      // a rate limit is the registry refusing to ANSWER - not a verdict on the
+      // image, and not this app's refusal to record
+      if (preflight.rateLimited) {
+        log.warn(`Image update pre-flight for ${appSpec.name} rate-limited by the registry - deferring, keeping the running image`);
+      } else {
+        log.warn(`Skipping image update for ${appSpec.name}: ${preflight.reason} - keeping the running image`);
+        fluxEventBus.publish('imageUpdate:updateRefused', { appName: appSpec.name, reason: preflight.reason });
+      }
       return { triggered: false, rateLimited: preflight.rateLimited };
     }
 

--- a/ZelBack/src/services/imageUpdateService.js
+++ b/ZelBack/src/services/imageUpdateService.js
@@ -13,6 +13,7 @@ const appQueryService = require('./appQuery/appQueryService');
 const advancedWorkflows = require('./appLifecycle/advancedWorkflows');
 const registryCredentialHelper = require('./utils/registryCredentialHelper');
 const { ImageVerifier } = require('./utils/imageVerifier');
+const { systemArchitecture } = require('./appSystem/systemIntegration');
 const serviceHelper = require('./serviceHelper');
 const globalState = require('./utils/globalState');
 const fluxEventBus = require('./utils/fluxEventBus');
@@ -23,6 +24,10 @@ const DELAY_AFTER_REDEPLOY = config.fluxapps.imageUpdateDelayAfterRedeployMs || 
 const INITIAL_DELAY_MIN = config.fluxapps.imageUpdateInitialDelayMinMs || 10 * 60 * 1000;
 const INITIAL_DELAY_MAX = config.fluxapps.imageUpdateInitialDelayMaxMs || 30 * 60 * 1000;
 const DELAY_BETWEEN_COMPONENTS = config.fluxapps.imageUpdateDelayBetweenComponentsMs || 1000;
+
+// must match the installer's own set (appInstaller.js) - the pre-flight verify
+// below asks the same question the redeploy's install will ask
+const supportedArchitectures = ['amd64', 'arm64'];
 
 // Track the timers
 let checkIntervalTimer = null;
@@ -314,6 +319,43 @@ async function checkAppForUpdates(appSpec) {
 }
 
 /**
+ * Verifies EVERY component image of the app against the registry before any
+ * teardown. The soft redeploy verifies only after it has already stopped and
+ * removed the running containers, and its failure path removes the app and its
+ * data - so a mutable tag gone bad (over the size cap, wrong architecture,
+ * de-whitelisted) must be refused HERE, where refusal costs nothing: the app
+ * keeps running its current image and the refusal is logged each cycle. All
+ * components are checked, not just the changed one, because the redeploy will
+ * re-verify all of them and dies on any. A lookup that cannot be completed
+ * also refuses - an update that cannot be verified is not an update this cycle.
+ * @param {object} appSpec Application specification
+ * @returns {Promise<{ok: boolean, reason: string|null}>}
+ */
+async function verifyAppImagesForUpdate(appSpec) {
+  const architecture = await systemArchitecture();
+  const components = appSpec.version >= 4 && Array.isArray(appSpec.compose) ? appSpec.compose : [appSpec];
+  // eslint-disable-next-line no-restricted-syntax
+  for (const component of components) {
+    const verifierOptions = { maxImageSize: config.fluxapps.maxImageSize, architecture, architectureSet: supportedArchitectures };
+    if (component.repoauth && appSpec.version >= 7) {
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        const credentials = await registryCredentialHelper.getCredentials(component.repotag, component.repoauth, appSpec.version, appSpec.name);
+        if (credentials) verifierOptions.credentials = credentials;
+      } catch (credError) {
+        return { ok: false, reason: `credentials for ${component.repotag}: ${credError.message}` };
+      }
+    }
+    const verifier = new ImageVerifier(component.repotag, verifierOptions);
+    // eslint-disable-next-line no-await-in-loop
+    await verifier.verifyImage();
+    if (verifier.error) return { ok: false, reason: `${component.repotag}: ${verifier.errorDetail}` };
+    if (!verifier.supported) return { ok: false, reason: `${component.repotag}: architecture ${architecture} not supported` };
+  }
+  return { ok: true, reason: null };
+}
+
+/**
  * Triggers a soft redeploy for an app.
  * @param {object} appSpec Application specification
  * @returns {Promise<boolean>} True if redeploy was triggered, false otherwise
@@ -323,6 +365,13 @@ async function triggerAppUpdate(appSpec) {
     // Double-check globalState flags before triggering
     if (isOperationInProgress()) {
       log.warn(`Skipping redeploy for ${appSpec.name}: another operation in progress`);
+      return false;
+    }
+
+    const preflight = await verifyAppImagesForUpdate(appSpec);
+    if (!preflight.ok) {
+      log.warn(`Skipping image update for ${appSpec.name}: ${preflight.reason} - keeping the running image`);
+      fluxEventBus.publish('imageUpdate:updateRefused', { appName: appSpec.name, reason: preflight.reason });
       return false;
     }
 

--- a/ZelBack/src/services/imageUpdateService.js
+++ b/ZelBack/src/services/imageUpdateService.js
@@ -190,7 +190,7 @@ async function getRemoteManifestDigest(repotag, repoauth, specVersion, appName) 
     const digest = await verifier.fetchManifestDigestOnly();
 
     if (verifier.error) {
-      const errorMeta = verifier.errorMeta;
+      const { errorMeta } = verifier;
       if (errorMeta && errorMeta.errorType === 'rate_limit') {
         log.warn(`Rate limited while checking ${repotag}`);
         return { error: 'rate_limited', digest: null };

--- a/ZelBack/src/services/imageUpdateService.js
+++ b/ZelBack/src/services/imageUpdateService.js
@@ -14,6 +14,8 @@ const advancedWorkflows = require('./appLifecycle/advancedWorkflows');
 const registryCredentialHelper = require('./utils/registryCredentialHelper');
 const { ImageVerifier } = require('./utils/imageVerifier');
 const { systemArchitecture } = require('./appSystem/systemIntegration');
+const { checkApplicationImagesCompliance } = require('./appSecurity/imageManager');
+const { supportedArchitectures } = require('./utils/appConstants');
 const serviceHelper = require('./serviceHelper');
 const globalState = require('./utils/globalState');
 const fluxEventBus = require('./utils/fluxEventBus');
@@ -24,10 +26,6 @@ const DELAY_AFTER_REDEPLOY = config.fluxapps.imageUpdateDelayAfterRedeployMs || 
 const INITIAL_DELAY_MIN = config.fluxapps.imageUpdateInitialDelayMinMs || 10 * 60 * 1000;
 const INITIAL_DELAY_MAX = config.fluxapps.imageUpdateInitialDelayMaxMs || 30 * 60 * 1000;
 const DELAY_BETWEEN_COMPONENTS = config.fluxapps.imageUpdateDelayBetweenComponentsMs || 1000;
-
-// must match the installer's own set (appInstaller.js) - the pre-flight verify
-// below asks the same question the redeploy's install will ask
-const supportedArchitectures = ['amd64', 'arm64'];
 
 // Track the timers
 let checkIntervalTimer = null;
@@ -319,19 +317,28 @@ async function checkAppForUpdates(appSpec) {
 }
 
 /**
- * Verifies EVERY component image of the app against the registry before any
- * teardown. The soft redeploy verifies only after it has already stopped and
- * removed the running containers, and its failure path removes the app and its
- * data - so a mutable tag gone bad (over the size cap, wrong architecture,
- * de-whitelisted) must be refused HERE, where refusal costs nothing: the app
- * keeps running its current image and the refusal is logged each cycle. All
+ * Asks, BEFORE any teardown, the same questions the redeploy's install will
+ * ask: the blocked-repositories compliance check, then per component the
+ * registry manifest evaluation (size cap, architecture). The soft redeploy
+ * verifies only after it has already stopped and removed the running
+ * containers, and its failure path removes the app and its data - so a mutable
+ * tag gone bad, a blocked repository, or a compliance list that cannot even be
+ * fetched must all be refused HERE, where refusal costs nothing: the app keeps
+ * running its current image and the refusal is logged each cycle. All
  * components are checked, not just the changed one, because the redeploy will
  * re-verify all of them and dies on any. A lookup that cannot be completed
- * also refuses - an update that cannot be verified is not an update this cycle.
+ * also refuses - an update that cannot be verified is not an update this
+ * cycle - and a registry rate-limit is surfaced as such so the caller can
+ * abort the whole cycle instead of hammering on.
  * @param {object} appSpec Application specification
- * @returns {Promise<{ok: boolean, reason: string|null}>}
+ * @returns {Promise<{ok: boolean, reason: string|null, rateLimited: boolean}>}
  */
 async function verifyAppImagesForUpdate(appSpec) {
+  try {
+    await checkApplicationImagesCompliance(appSpec);
+  } catch (complianceError) {
+    return { ok: false, reason: `compliance: ${complianceError.message}`, rateLimited: false };
+  }
   const architecture = await systemArchitecture();
   const components = appSpec.version >= 4 && Array.isArray(appSpec.compose) ? appSpec.compose : [appSpec];
   // eslint-disable-next-line no-restricted-syntax
@@ -343,36 +350,49 @@ async function verifyAppImagesForUpdate(appSpec) {
         const credentials = await registryCredentialHelper.getCredentials(component.repotag, component.repoauth, appSpec.version, appSpec.name);
         if (credentials) verifierOptions.credentials = credentials;
       } catch (credError) {
-        return { ok: false, reason: `credentials for ${component.repotag}: ${credError.message}` };
+        return { ok: false, reason: `credentials for ${component.repotag}: ${credError.message}`, rateLimited: false };
       }
     }
     const verifier = new ImageVerifier(component.repotag, verifierOptions);
     // eslint-disable-next-line no-await-in-loop
     await verifier.verifyImage();
-    if (verifier.error) return { ok: false, reason: `${component.repotag}: ${verifier.errorDetail}` };
-    if (!verifier.supported) return { ok: false, reason: `${component.repotag}: architecture ${architecture} not supported` };
+    if (verifier.error) {
+      const rateLimited = !!(verifier.errorMeta && verifier.errorMeta.errorType === 'rate_limit');
+      return { ok: false, reason: `${component.repotag}: ${verifier.errorDetail}`, rateLimited };
+    }
+    if (!verifier.supported) return { ok: false, reason: `${component.repotag}: architecture ${architecture} not supported`, rateLimited: false };
   }
-  return { ok: true, reason: null };
+  return { ok: true, reason: null, rateLimited: false };
 }
 
 /**
- * Triggers a soft redeploy for an app.
+ * Triggers a soft redeploy for an app, gated by the pre-flight verify.
  * @param {object} appSpec Application specification
- * @returns {Promise<boolean>} True if redeploy was triggered, false otherwise
+ * @returns {Promise<{triggered: boolean, rateLimited: boolean}>} whether the
+ *          redeploy ran, and whether the registry rate-limited the pre-flight
+ *          (the cycle should abort rather than walk on into more lookups)
  */
 async function triggerAppUpdate(appSpec) {
   try {
     // Double-check globalState flags before triggering
     if (isOperationInProgress()) {
       log.warn(`Skipping redeploy for ${appSpec.name}: another operation in progress`);
-      return false;
+      return { triggered: false, rateLimited: false };
     }
 
     const preflight = await verifyAppImagesForUpdate(appSpec);
     if (!preflight.ok) {
       log.warn(`Skipping image update for ${appSpec.name}: ${preflight.reason} - keeping the running image`);
       fluxEventBus.publish('imageUpdate:updateRefused', { appName: appSpec.name, reason: preflight.reason });
-      return false;
+      return { triggered: false, rateLimited: preflight.rateLimited };
+    }
+
+    // the pre-flight is a real network walk (seconds to tens of seconds), so
+    // an install/removal may have started under it - softRedeploy would bail
+    // on its own flags and this must not read as a completed update
+    if (isOperationInProgress()) {
+      log.warn(`Skipping redeploy for ${appSpec.name}: another operation started during the pre-flight`);
+      return { triggered: false, rateLimited: false };
     }
 
     log.info(`Triggering soft redeploy for ${appSpec.name}`);
@@ -383,10 +403,10 @@ async function triggerAppUpdate(appSpec) {
 
     fluxEventBus.publish('imageUpdate:redeployComplete', { appName: appSpec.name });
 
-    return true;
+    return { triggered: true, rateLimited: false };
   } catch (error) {
     log.error(`Error triggering redeploy for ${appSpec.name}: ${error.message}`);
-    return false;
+    return { triggered: false, rateLimited: false };
   }
 }
 
@@ -440,8 +460,12 @@ async function checkForImageUpdates() {
 
         if (updateStatus.needsUpdate) {
           // eslint-disable-next-line no-await-in-loop
-          const redeployTriggered = await triggerAppUpdate(appSpec);
-          if (redeployTriggered) {
+          const trigger = await triggerAppUpdate(appSpec);
+          if (trigger.rateLimited) {
+            log.warn('Rate limited by registry during pre-flight verify, aborting remaining checks this cycle');
+            break;
+          }
+          if (trigger.triggered) {
             updatesTriggered += 1;
             // Wait longer after triggering a redeploy
             // eslint-disable-next-line no-await-in-loop

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -510,7 +510,7 @@ async function startFluxFunctions() {
       // masterSlave self-gates on syncthingAppsFirstRun (the syncthing monitor's
       // first-run mount-safety must complete before any g: election), so it starts
       // concurrently rather than after a timed offset.
-      advancedWorkflows.masterSlaveApps(
+      advancedWorkflows.startMasterSlaveApps(
         globalState,
         appQueryService.installedApps,
         appQueryService.listRunningApps,
@@ -518,7 +518,7 @@ async function startFluxFunctions() {
         globalState.backupInProgress,
         globalState.restoreInProgress,
         https,
-      ); // stops and starts g: syncthing apps when a new master is required or changed.
+      ); // interval-scheduled: stops and starts g: syncthing apps when a new master is required or changed.
       setTimeout(() => {
         appInspector.monitorSharedDBApps(appQueryService.installedApps, appUninstaller.removeAppLocally, globalState); // Monitor SharedDB Apps.
       }, 60 * 1000);

--- a/ZelBack/src/services/utils/fluxEventBus.js
+++ b/ZelBack/src/services/utils/fluxEventBus.js
@@ -23,7 +23,12 @@ class FluxEventBus extends EventEmitter {
     super();
     this.#buffer = new Array(RING_BUFFER_SIZE);
     this.#writeIndex = 0;
-    this.#nextId = 1;
+    // Seeded from the monotonic clock (microseconds since boot) so event ids
+    // stay monotonic ACROSS a FluxOS restart: a fresh process mints ids larger
+    // than anything the previous one served. A consumer filtering on
+    // last-seen-id (the harness's afterId) would otherwise silently discard
+    // every post-restart event.
+    this.#nextId = Number(process.hrtime.bigint() / 1000n);
     this.#enabled = enabled ?? (config.has('testEventStream') && config.get('testEventStream') === true);
   }
 

--- a/ZelBack/src/services/utils/fluxEventBus.js
+++ b/ZelBack/src/services/utils/fluxEventBus.js
@@ -24,10 +24,11 @@ class FluxEventBus extends EventEmitter {
     this.#buffer = new Array(RING_BUFFER_SIZE);
     this.#writeIndex = 0;
     // Seeded from the monotonic clock (microseconds since boot) so event ids
-    // stay monotonic ACROSS a FluxOS restart: a fresh process mints ids larger
-    // than anything the previous one served. A consumer filtering on
-    // last-seen-id (the harness's afterId) would otherwise silently discard
-    // every post-restart event.
+    // stay monotonic across a FluxOS restart on a running host: a fresh
+    // process mints ids larger than anything the previous one served, so a
+    // consumer filtering on last-seen-id (the harness's afterId) does not
+    // silently discard every post-restart event. Not monotonic across a HOST
+    // reboot (the clock restarts near zero) - consumers do not survive one.
     this.#nextId = Number(process.hrtime.bigint() / 1000n);
     this.#enabled = enabled ?? (config.has('testEventStream') && config.get('testEventStream') === true);
   }

--- a/ZelBack/src/services/utils/imageVerifier.js
+++ b/ZelBack/src/services/utils/imageVerifier.js
@@ -127,6 +127,23 @@ class ImageVerifier {
     return this.#lookupErrorMeta;
   }
 
+  /**
+   * The transient/permanent split consumers route verdicts on: 'transient' is a
+   * could-not-ask answer (network path, rate limit, registry 5xx) - retryable and
+   * never the image's fault; 'permanent' is the registry's verdict on the image,
+   * or a malformed tag/manifest. Anything unrecognized reads 'permanent', so an
+   * unknown failure shape degrades to the strict behavior, never to endless retry.
+   * @returns {'transient'|'permanent'|null} null when there is no error
+   */
+  get errorClass() {
+    if (!this.error) return null;
+    const transientTypes = ['network', 'rate_limit', 'server_error'];
+    if (this.#lookupErrorMeta && transientTypes.includes(this.#lookupErrorMeta.errorType)) {
+      return 'transient';
+    }
+    return 'permanent';
+  }
+
   get parts() {
     const parts = [this.provider, this.namespace, this.repository, this.tag];
     return parts.filter((x) => x);
@@ -620,15 +637,17 @@ class ImageVerifier {
   throwIfError() {
     if (!this.error) return;
 
-    try {
-      throw new Error(
-        this.#parseErrorDetail
-        || this.#lookupErrorDetail
-        || this.#evaluationErrorDetail,
-      );
-    } finally {
-      this.resetErrors();
-    }
+    const error = new Error(
+      this.#parseErrorDetail
+      || this.#lookupErrorDetail
+      || this.#evaluationErrorDetail,
+    );
+    // Carry the transient/permanent split on the throw - provisioning consumers
+    // route their verdicts on it (absence reads permanent). Captured before
+    // resetErrors wipes the meta it derives from.
+    error.registryErrorClass = this.errorClass;
+    this.resetErrors();
+    throw error;
   }
 
   /**

--- a/ZelBack/src/services/utils/imageVerifier.js
+++ b/ZelBack/src/services/utils/imageVerifier.js
@@ -380,9 +380,17 @@ class ImageVerifier {
       'ECONNABORTED',
       'ERR_CANCELED',
       'ENETUNREACH',
+      'ETIMEDOUT',
+      'ECONNRESET',
+      'ENOTFOUND',
+      'EAI_AGAIN',
+      'EHOSTUNREACH',
     ];
 
-    if (connectionErrors.includes(error.code)) {
+    // A request that got no HTTP response at all is a connectivity answer, not a
+    // registry verdict - route it with the coded connection errors rather than
+    // letting an undefined status read as an HTTP rejection below.
+    if (connectionErrors.includes(error.code) || (error.request && !error.response)) {
       this.#lookupErrorDetail = `Connection Error ${error.code}: ${this.rawImageTag} not available`;
       this.#lookupErrorMeta = {
         httpStatus: null,

--- a/test-infra/config/shared.js
+++ b/test-infra/config/shared.js
@@ -127,6 +127,10 @@ module.exports = {
     imageUpdateDelayAfterRedeployMs: 1000,
     imageUpdateDelayBetweenComponentsMs: 100,
     masterSlaveIntervalMs: 3000, // compressed g: FDM election cycle (prod 30s)
+    masterSlaveMaxPassMs: 12000, // compressed wedged-pass watchdog (prod 120s)
+    masterSlaveStaggerMs: 9000, // compressed per-index standby stagger (prod 180s)
+    masterSlaveProbeTimeoutMs: 5000, // compressed previous-primary probe (prod 10s)
+    masterSlaveFdmTimeoutMs: 5000, // compressed FDM lookup (prod 10s)
     installation: { probability: 100, delay: 5 },
     removal: { probability: 25, delay: 5 },
     redeploy: { probability: 2, delay: 1, composedDelay: 1 },

--- a/test-infra/fdm-stub/index.js
+++ b/test-infra/fdm-stub/index.js
@@ -13,6 +13,11 @@ const CONTROL_PORT = parseInt(process.env.CONTROL_PORT || '16131', 10);
 // which mirrors the real FDM returning an empty ips array (the node waits).
 const elected = new Map();
 
+// Per-request response delay (ms), driven by the control API. Sub-timeout values
+// model a degraded-but-answering FDM (each region lookup pays the delay), which
+// is how a suite makes an election pass SLOW without making it fail.
+let responseDelayMs = 0;
+
 // --- FDM API (what the FluxOS node polls) ---
 
 const app = express();
@@ -23,7 +28,9 @@ app.use(express.json());
 // An empty ips array is the "no primary set" path: the node keeps waiting.
 app.get('/appips/:app', (req, res) => {
   const ip = elected.get(req.params.app);
-  res.json({ status: 'success', data: { ips: ip ? [ip] : [] } });
+  const reply = () => res.json({ status: 'success', data: { ips: ip ? [ip] : [] } });
+  if (responseDelayMs > 0) setTimeout(reply, responseDelayMs);
+  else reply();
 });
 
 app.all('*', (req, res) => {
@@ -60,8 +67,15 @@ control.post('/clear/:app', (req, res) => {
   res.json({ ok: true });
 });
 
+// slow every /appips answer by ms (0 restores immediate answers)
+control.post('/delay', (req, res) => {
+  responseDelayMs = Number(req.body && req.body.ms) || 0;
+  res.json({ ok: true, ms: responseDelayMs });
+});
+
 control.post('/reset', (req, res) => {
   elected.clear();
+  responseDelayMs = 0;
   res.json({ ok: true });
 });
 

--- a/test-infra/runner/framework/fdm-control.js
+++ b/test-infra/runner/framework/fdm-control.js
@@ -33,6 +33,13 @@ export async function resetFdm() {
   return post('/reset');
 }
 
+// Slow every FDM /appips answer by ms (0 restores immediate answers). Each of a
+// pass's three region lookups pays the delay, so this is the knob for making an
+// election pass slow-but-healthy rather than failed.
+export async function setFdmDelay(ms) {
+  return post('/delay', { ms });
+}
+
 export async function getFdmState() {
   return get('/state');
 }

--- a/test-infra/runner/framework/registry-helper.js
+++ b/test-infra/runner/framework/registry-helper.js
@@ -78,7 +78,7 @@ async function uploadBlob(repo, data) {
     validateStatus: (s) => s === 202,
   });
 
-  const location = initRes.headers.location;
+  const { location } = initRes.headers;
   const separator = location.includes('?') ? '&' : '?';
   const putUrl = `${location}${separator}digest=${digest}`;
 

--- a/test-infra/runner/framework/registry-helper.js
+++ b/test-infra/runner/framework/registry-helper.js
@@ -93,7 +93,12 @@ async function uploadBlob(repo, data) {
   return digest;
 }
 
-export async function pushImage(repo, tag, markerContent = 'v1') {
+// opts.layerSizeOverride inflates the manifest's CLAIMED layer size without
+// changing the blobs: the registry does not validate the claim, and the node's
+// image verifier trusts it - which is exactly how a mutable tag can grow past
+// the network's size cap. Lets a suite turn a healthy installed tag into one
+// the registry definitively rejects (size_limit), with no new bytes.
+export async function pushImage(repo, tag, markerContent = 'v1', opts = {}) {
   const gzippedLayer = buildLayerTar(markerContent);
   const layerDigest = await uploadBlob(repo, gzippedLayer);
 
@@ -119,7 +124,7 @@ export async function pushImage(repo, tag, markerContent = 'v1') {
     },
     layers: [{
       mediaType: 'application/vnd.docker.image.rootfs.diff.tar.gzip',
-      size: gzippedLayer.length,
+      size: opts.layerSizeOverride ?? gzippedLayer.length,
       digest: layerDigest,
     }],
   };

--- a/test-infra/runner/framework/syncthing-control.js
+++ b/test-infra/runner/framework/syncthing-control.js
@@ -27,12 +27,14 @@ export async function getSyncthingState() {
   return get('/state');
 }
 
-// Raw setter for /rest/db/status.
+// Raw setter for /rest/db/status. globalFiles is optional: omitted, the stub
+// derives it from globalBytes (bytes imply at least one file); a dirs-only
+// payload pins globalFiles: 0 explicitly.
 export async function setSyncState({
-  ip = '*', folder, state = 'idle', globalBytes = 0, inSyncBytes = 0, receiveOnlyChangedFiles = 0,
+  ip = '*', folder, state = 'idle', globalBytes = 0, inSyncBytes = 0, receiveOnlyChangedFiles = 0, globalFiles,
 }) {
   return post('/sync-state', {
-    ip, folder, state, globalBytes, inSyncBytes, receiveOnlyChangedFiles,
+    ip, folder, state, globalBytes, inSyncBytes, receiveOnlyChangedFiles, globalFiles,
   });
 }
 

--- a/test-infra/runner/package.json
+++ b/test-infra/runner/package.json
@@ -15,6 +15,7 @@
     "eventsource": "^4.1.0",
     "mocha": "^11.7.5",
     "mongodb": "^7.2.0",
+    "socket.io-client": "~4.8.1",
     "testcontainers": "^11.14.0"
   }
 }

--- a/test-infra/runner/tests/33-reconciler-missing-recreate.js
+++ b/test-infra/runner/tests/33-reconciler-missing-recreate.js
@@ -1,5 +1,7 @@
 import { describe, it, before, after } from 'mocha';
+import { expect } from 'chai';
 import { createTestEnv } from '../framework/test-env.js';
+import { pushImage } from '../framework/registry-helper.js';
 import { getAppContainerStatus, killAppContainer } from '../framework/container.js';
 import { waitFor, waitForReconcileActuated } from '../framework/wait.js';
 import { bootAndPeer, seedSimpleApp } from '../framework/reconciler-suite.js';
@@ -47,6 +49,37 @@ describe('reconciler recreates a missing container', function () {
     // docker is reachable, so exists:false is a genuine miss -> recreate
     await waitForReconcileActuated(client, identifier, 'recreated', 90000, { afterId });
     await waitForUp(client, appName, 'recreated and running again');
+  });
+
+  it('keeps the app down - not deleted, not run stale - when the registry answers with a verdict', async function () {
+    this.timeout(300000);
+    const client = env.clients[idx];
+    await waitForUp(client, appName, 'running before the tag is re-pushed');
+
+    // The mutable tag is re-pushed claiming layers over the network's size cap -
+    // the same bytes, an inflated manifest. The registry is UP and answering:
+    // this is a verdict ABOUT THE IMAGE, not a reachability problem, so the
+    // rebuild must neither ride it out on the local copy (that would run a
+    // spec-violating image the network just rejected) nor delete the app and
+    // its data (the image was legal when it installed; the owner can fix the
+    // tag). Down-with-backoff is the only correct state.
+    await pushImage(appName, 'v1', 'v1', { layerSizeOverride: 6 * 1024 * 1024 * 1024 });
+
+    const afterId = client.getLastEventId();
+    await killAppContainer(client.container, appName);
+
+    await waitForReconcileActuated(client, identifier, 'recreateFailedKept', 120000, { afterId });
+    const status = await getAppContainerStatus(client.container, appName, { all: true });
+    expect(
+      !status || !status.status.startsWith('Up'),
+      'ran the stale local image despite a definitive registry verdict',
+    ).to.equal(true);
+
+    // restore the honest tag: the keep path retries on the backoff ladder, so
+    // the app must come back with no operator action at all
+    await pushImage(appName, 'v1', 'v1');
+    await waitForReconcileActuated(client, identifier, 'recreated', 180000, { afterId: client.getLastEventId() });
+    await waitForUp(client, appName, 'recovered once the tag was honest again');
   });
 
   it('recreates from the LOCAL image when the registry is unreachable', async function () {

--- a/test-infra/runner/tests/33-reconciler-missing-recreate.js
+++ b/test-infra/runner/tests/33-reconciler-missing-recreate.js
@@ -1,16 +1,14 @@
 import { describe, it, before, after } from 'mocha';
 import { createTestEnv } from '../framework/test-env.js';
 import { getAppContainerStatus, killAppContainer } from '../framework/container.js';
-import {
-  waitFor, waitForReconcileActuated, waitForAppRemoved,
-} from '../framework/wait.js';
+import { waitFor, waitForReconcileActuated } from '../framework/wait.js';
 import { bootAndPeer, seedSimpleApp } from '../framework/reconciler-suite.js';
 import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
 
 // A vanished container (no Docker event fires for absence) is recreated by the
-// reconciler when Docker is reachable. If recreation itself fails — e.g. the
-// image can no longer be pulled — the reconciler records the tampering signal
-// and removes the app locally, exactly as the old containerHealthMonitor did.
+// reconciler when Docker is reachable. A registry that cannot be reached does not
+// stop that: the layers are already on disk, so the rebuild rides the outage out on
+// the local image rather than leaving the customer down or destroying the app.
 
 async function waitForUp(client, appName, label) {
   await waitFor(async () => {
@@ -51,21 +49,23 @@ describe('reconciler recreates a missing container', function () {
     await waitForUp(client, appName, 'recreated and running again');
   });
 
-  it('uninstalls locally when recreation fails (image unpullable)', async function () {
+  it('recreates from the LOCAL image when the registry is unreachable', async function () {
     this.timeout(180000);
     const client = env.clients[idx];
-    await waitForUp(client, appName, 'running before forced recreate failure');
+    await waitForUp(client, appName, 'running before the registry goes away');
 
-    // make the recreate genuinely fail: stop the registry so the recreate's pull
-    // (verifyAndPullImage -> dockerPullStreamPromise) errors for real. No spec
-    // mutation — the image is simply unavailable, like a deleted/tampered image.
+    // This assertion used to be "uninstalls locally when recreation fails". A
+    // registry outage is a condition of this node right now, not a verdict on the
+    // app: the layers are already on disk from the install, so the rebuild rides the
+    // outage out on them. Deleting the app - and its appdata, fleet-wide - because a
+    // registry blinked is the behaviour this replaces.
     await env.containers.registry.stop();
 
     const afterId = client.getLastEventId();
     await killAppContainer(client.container, appName);
 
-    // recreate fails -> the reconciler reports it and removes the app locally
-    await waitForReconcileActuated(client, identifier, 'recreateFailed', 120000, { afterId });
-    await waitForAppRemoved(client, appName, 60000, { afterId });
+    await waitForReconcileActuated(client, identifier, 'recreated', 120000, { afterId });
+    // reaching Up at all proves it was neither removed nor left down
+    await waitForUp(client, appName, 'recreated from the local image during the outage');
   });
 });

--- a/test-infra/runner/tests/53-terminal-exec-crash-safety.js
+++ b/test-infra/runner/tests/53-terminal-exec-crash-safety.js
@@ -142,14 +142,19 @@ describe('docker terminal fails cleanly and never crashes the node', function ()
         socket.on('connect', () => socket.emit('exec', zelidauth, identifier, '/bin/pause', '', ''));
       });
 
-      // Keystrokes racing the teardown: the hijacked docker socket dies with the
-      // exec, and a write landing in that window fails ASYNCHRONOUSLY on the
-      // stream ('error', EPIPE). With no stream error listener that is an
-      // uncaught exception -> exit(1) - invisible from outside once the
-      // watchdog respawns, which is why the assertion is the pid.
+      // A write in flight when the hijacked docker socket dies fails
+      // ASYNCHRONOUSLY on the stream ('error', EPIPE). With no stream error
+      // listener that is an uncaught exception -> exit(1) - invisible from
+      // outside once the watchdog respawns, which is why the assertion is the
+      // pid. Writes AFTER the socket is destroyed return false silently, so a
+      // trickle of keystrokes almost never lands in the window - instead flood
+      // the pty, which the exec'd pause process never drains: the backpressured
+      // bytes queued in the socket when the kill lands are the EPIPE, made
+      // deterministic.
       const typer = setInterval(() => socket.emit('cmd', 'x'), 20);
       try {
         await opened;
+        for (let i = 0; i < 8; i += 1) socket.emit('cmd', 'x'.repeat(131072));
         await execInContainer(client.container, `docker kill flux${identifier}`);
         await new Promise((res) => { setTimeout(res, 2000); });
       } finally {

--- a/test-infra/runner/tests/53-terminal-exec-crash-safety.js
+++ b/test-infra/runner/tests/53-terminal-exec-crash-safety.js
@@ -121,15 +121,25 @@ describe('docker terminal fails cleanly and never crashes the node', function ()
     const pidBefore = await fluxosPid(client.container);
     expect(pidBefore).to.not.equal('');
 
-    // a real session: exec created, hijacked stream up, shell answering
+    // A real session against the harness stub image, which has no shell and no
+    // passwd: exec the one binary it carries (/bin/pause) as the image-default
+    // user. The pty echoes our keystrokes back regardless of the process reading
+    // them, so the first 'show' proves the hijacked stream is live.
     const socket = io(`${client.url}/terminal`, { transports: ['websocket'], reconnection: false, timeout: TERMINAL_TIMEOUT_MS });
     try {
-      await new Promise((resolve, reject) => {
+      let live = false;
+      const opened = new Promise((resolve, reject) => {
         const timer = setTimeout(() => reject(new Error('terminal never opened')), TERMINAL_TIMEOUT_MS);
-        socket.on('show', () => { clearTimeout(timer); resolve(); });
-        socket.on('error', (m) => { clearTimeout(timer); reject(new Error(`terminal error before kill: ${m}`)); });
+        socket.on('show', () => {
+          if (!live) { live = true; clearTimeout(timer); resolve(); }
+        });
+        // after the session is live, later socket errors are the handler
+        // REPORTING the killed stream - expected, and not a test failure
+        socket.on('error', (m) => {
+          if (!live) { clearTimeout(timer); reject(new Error(`terminal error before kill: ${m}`)); }
+        });
         socket.on('connect_error', (err) => { clearTimeout(timer); reject(new Error(`connect_error ${err.message}`)); });
-        socket.on('connect', () => socket.emit('exec', zelidauth, identifier, 'sh', '', 'root'));
+        socket.on('connect', () => socket.emit('exec', zelidauth, identifier, '/bin/pause', '', ''));
       });
 
       // Keystrokes racing the teardown: the hijacked docker socket dies with the
@@ -137,8 +147,9 @@ describe('docker terminal fails cleanly and never crashes the node', function ()
       // stream ('error', EPIPE). With no stream error listener that is an
       // uncaught exception -> exit(1) - invisible from outside once the
       // watchdog respawns, which is why the assertion is the pid.
-      const typer = setInterval(() => socket.emit('cmd', 'echo alive\n'), 20);
+      const typer = setInterval(() => socket.emit('cmd', 'x'), 20);
       try {
+        await opened;
         await execInContainer(client.container, `docker kill flux${identifier}`);
         await new Promise((res) => { setTimeout(res, 2000); });
       } finally {

--- a/test-infra/runner/tests/53-terminal-exec-crash-safety.js
+++ b/test-infra/runner/tests/53-terminal-exec-crash-safety.js
@@ -1,0 +1,150 @@
+import { describe, it, before, after } from 'mocha';
+import { expect } from 'chai';
+import { io } from 'socket.io-client';
+import { createTestEnv } from '../framework/test-env.js';
+import { authenticate } from '../auth.js';
+import { appOwnerKey } from '../framework/keys.js';
+import { execInContainer, getAppContainerStatus } from '../framework/container.js';
+import { waitFor } from '../framework/wait.js';
+import { bootAndPeer, seedSimpleApp } from '../framework/reconciler-suite.js';
+import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
+
+// MUST-PASS gate. Opening the web terminal must never take the node down.
+//
+// The /terminal socket.io handler runs its work inside an async socket listener,
+// so anything that throws there is an unhandled rejection -> the FluxOS process
+// exits(1). Production hit this twice on one node in 90 minutes: a customer opened
+// the console on a container that was not running, dockerode handed back a null
+// exec, and `exec.start` on null killed FluxOS. Each restart also re-armed the
+// syncthing first-run gate that blocks g: primary election, so a UI click became
+// an app outage.
+//
+// Two distinct ways in, both asserted here:
+//   1. container present but NOT running -> daemon rejects exec create (409),
+//      dockerode yields a null exec.
+//   2. container absent -> dockerService.getDockerContainerByIdOrName reads .Id
+//      off an undefined lookup result and rejects before the handler's own
+//      `if (!container)` guard can run.
+//
+// The assertion that matters in both cases is the same: a socket error reaches the
+// client AND the FluxOS process is the same one it was before (an exit(1) is
+// invisible from outside once the watchdog respawns it, so we compare the pid).
+
+const TERMINAL_TIMEOUT_MS = 20000;
+
+// The node app.js child pid, written by the image entrypoint watchdog. It changes
+// if and only if FluxOS died and was respawned.
+async function fluxosPid(container) {
+  const { stdout } = await execInContainer(container, 'cat /tmp/fluxos.pid 2>/dev/null || echo ""');
+  return stdout.trim();
+}
+
+async function apiAlive(client) {
+  const res = await client.get('/flux/version').catch(() => null);
+  return !!res;
+}
+
+// Open the /terminal namespace, ask for an exec, and resolve with whatever the
+// handler reports: { error } on a clean failure, { opened: true } if it streamed,
+// { timedOut: true } if nothing came back at all. Silence is deliberately NOT a
+// rejection - a node that died mid-request answers nothing, so we let the caller's
+// pid assertion report "the handler crashed the process" rather than masking it as
+// a generic timeout.
+function openTerminal(client, zelidauth, nameOrId) {
+  return new Promise((resolve, reject) => {
+    const socket = io(`${client.url}/terminal`, {
+      transports: ['websocket'],
+      reconnection: false,
+      timeout: TERMINAL_TIMEOUT_MS,
+    });
+
+    const done = (result) => {
+      socket.close();
+      resolve(result);
+    };
+
+    const timer = setTimeout(() => done({ timedOut: true }), TERMINAL_TIMEOUT_MS);
+    timer.unref?.();
+
+    socket.on('error', (message) => {
+      clearTimeout(timer);
+      done({ error: String(message) });
+    });
+    socket.on('show', () => {
+      clearTimeout(timer);
+      done({ opened: true });
+    });
+    socket.on('connect_error', (err) => {
+      clearTimeout(timer);
+      socket.close();
+      reject(new Error(`terminal: connect_error ${err.message}`));
+    });
+
+    socket.on('connect', () => {
+      socket.emit('exec', zelidauth, nameOrId, 'sh', '', 'root');
+    });
+  });
+}
+
+describe('docker terminal fails cleanly and never crashes the node', function () {
+  let env;
+  dumpLogsOnFailure(() => env);
+  let client;
+  let zelidauth;
+  const appName = `e2eterm${Date.now()}`;
+  const identifier = `${appName}_${appName}`;
+
+  before(async function () {
+    this.timeout(300000);
+    env = await createTestEnv({ hookCtx: this, nodes: 10, tickerAutostart: false });
+    await bootAndPeer(env);
+    const { index } = await seedSimpleApp(env, appName);
+    client = env.clients[index];
+    ({ zelidauth } = await authenticate(client.url, appOwnerKey()));
+
+    await waitFor(async () => {
+      const status = await getAppContainerStatus(client.container, appName);
+      return !!(status && status.status.startsWith('Up'));
+    }, { timeout: 90000, interval: 3000, label: 'app container running before terminal tests' });
+  });
+
+  after(async function () {
+    this.timeout(30000);
+    await env?.teardown();
+  });
+
+  it('reports an error instead of crashing when the container is not running', async function () {
+    this.timeout(180000);
+
+    // operator stop, so the reconciler leaves it down for the duration of the test
+    await client.getAuthed(`/apps/appstop/${appName}`, zelidauth);
+    await waitFor(async () => {
+      const status = await getAppContainerStatus(client.container, appName, { all: true });
+      return !!(status && !status.status.startsWith('Up'));
+    }, { timeout: 60000, interval: 2000, label: 'app container stopped' });
+
+    const pidBefore = await fluxosPid(client.container);
+    expect(pidBefore).to.not.equal('');
+
+    const result = await openTerminal(client, zelidauth, identifier);
+
+    // node survival first: it is the invariant, and a crash explains any other failure
+    expect(await fluxosPid(client.container), 'FluxOS restarted - the handler crashed the process').to.equal(pidBefore);
+    expect(await apiAlive(client)).to.equal(true);
+    expect(result.error, 'expected a socket error, not a live terminal').to.be.a('string');
+  });
+
+  it('reports an error instead of crashing when the container does not exist', async function () {
+    this.timeout(120000);
+
+    // the app half of the identifier still resolves for the ownership check, so
+    // this gets past auth and dies in the container lookup - the shape you get
+    // when a component was renamed or removed underneath an open management UI
+    const pidBefore = await fluxosPid(client.container);
+    const result = await openTerminal(client, zelidauth, `nosuch_${appName}`);
+
+    expect(await fluxosPid(client.container), 'FluxOS restarted - the handler crashed the process').to.equal(pidBefore);
+    expect(await apiAlive(client)).to.equal(true);
+    expect(result.error, 'expected a socket error, not a live terminal').to.be.a('string');
+  });
+});

--- a/test-infra/runner/tests/53-terminal-exec-crash-safety.js
+++ b/test-infra/runner/tests/53-terminal-exec-crash-safety.js
@@ -113,6 +113,45 @@ describe('docker terminal fails cleanly and never crashes the node', function ()
     await env?.teardown();
   });
 
+  // Ordered first: it needs the live container the before-hook waited for; the
+  // stopped-container case below deliberately leaves the app down.
+  it('survives a container killed under a live terminal session', async function () {
+    this.timeout(180000);
+
+    const pidBefore = await fluxosPid(client.container);
+    expect(pidBefore).to.not.equal('');
+
+    // a real session: exec created, hijacked stream up, shell answering
+    const socket = io(`${client.url}/terminal`, { transports: ['websocket'], reconnection: false, timeout: TERMINAL_TIMEOUT_MS });
+    try {
+      await new Promise((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('terminal never opened')), TERMINAL_TIMEOUT_MS);
+        socket.on('show', () => { clearTimeout(timer); resolve(); });
+        socket.on('error', (m) => { clearTimeout(timer); reject(new Error(`terminal error before kill: ${m}`)); });
+        socket.on('connect_error', (err) => { clearTimeout(timer); reject(new Error(`connect_error ${err.message}`)); });
+        socket.on('connect', () => socket.emit('exec', zelidauth, identifier, 'sh', '', 'root'));
+      });
+
+      // Keystrokes racing the teardown: the hijacked docker socket dies with the
+      // exec, and a write landing in that window fails ASYNCHRONOUSLY on the
+      // stream ('error', EPIPE). With no stream error listener that is an
+      // uncaught exception -> exit(1) - invisible from outside once the
+      // watchdog respawns, which is why the assertion is the pid.
+      const typer = setInterval(() => socket.emit('cmd', 'echo alive\n'), 20);
+      try {
+        await execInContainer(client.container, `docker kill flux${identifier}`);
+        await new Promise((res) => { setTimeout(res, 2000); });
+      } finally {
+        clearInterval(typer);
+      }
+    } finally {
+      socket.close();
+    }
+
+    expect(await fluxosPid(client.container), 'FluxOS restarted - the stream error crashed the process').to.equal(pidBefore);
+    expect(await apiAlive(client)).to.equal(true);
+  });
+
   it('reports an error instead of crashing when the container is not running', async function () {
     this.timeout(180000);
 

--- a/test-infra/runner/tests/54-masterslave-no-fdm-primary.js
+++ b/test-infra/runner/tests/54-masterslave-no-fdm-primary.js
@@ -139,38 +139,50 @@ describe('masterSlave election when FDM names no primary', function () {
   });
 
   it('still elects every app when FDM is slow - a pass over budget but advancing is not abandoned', async function () {
-    this.timeout(480000);
+    this.timeout(600000);
     // A degraded-but-answering FDM makes every pass SLOW: each g: app pays a
-    // full 3-region walk at the stub's delay. With two apps the pass runs well
-    // past the watchdog budget - and the watchdog must judge silence, not total
-    // elapsed time. A wall-clock budget abandons every pass mid-list, so the
-    // app later in the list is never elected, every cycle, for as long as the
-    // degradation lasts: exactly the failover conditions elections exist for.
-    const appName2 = `e2eslowfdm${Date.now()}`;
-    const identifier2 = `${appName2}_${appName2}`;
+    // full 3-region walk at the stub's delay (24s at 8s/region). The watchdog
+    // must judge silence, not total elapsed time: a wall-clock budget abandons
+    // every pass at the same point mid-list, so the app past that point is
+    // never elected, every cycle, for as long as the degradation lasts -
+    // exactly the failover conditions elections exist for. TWO new apps make
+    // the discriminator honest on every holder: the first app's dispatch lands
+    // inside any budget (~24s), the second's can only land at ~48s+ - past the
+    // 30s budget - so only a silence-judging watchdog lets it be elected.
+    // (The suite's original app cannot serve as the prefix: it is
+    // operator-stopped on one holder, whose passes skip it before the walk.)
+    const stamp = Date.now();
+    const names = [`e2eslowa${stamp}`, `e2eslowb${stamp}`];
 
     await setFdmDelay(8000);
     try {
-      await pushImage(appName2, 'v1');
-      const app2 = await buildSeedableSyncthingApp({ name: appName2, mode: 'g' });
-      const installAfters = holders.map((i) => env.clients[i].getLastEventId());
-      await installOnNodes(env, app2, holders);
+      // eslint-disable-next-line no-restricted-syntax
+      for (const name of names) {
+        const id = `${name}_${name}`;
+        // eslint-disable-next-line no-await-in-loop
+        await pushImage(name, 'v1');
+        // eslint-disable-next-line no-await-in-loop
+        const app = await buildSeedableSyncthingApp({ name, mode: 'g' });
+        const installAfters = holders.map((i) => env.clients[i].getLastEventId());
+        // eslint-disable-next-line no-await-in-loop
+        await installOnNodes(env, app, holders);
+        // eslint-disable-next-line no-await-in-loop
+        await Promise.all(holders.map(async (i, k) => {
+          await waitForReconcileActuated(env.clients[i], id, 'dataCleared', 120000, { afterId: installAfters[k] });
+          await seedSyncScopedData(env, name, i);
+        }));
+        // eslint-disable-next-line no-await-in-loop
+        await Promise.all(holders.map((i) => setSynced({ ip: subnet.nodeIp(i + 1), folder: `flux${id}` })));
+      }
 
-      const folder2 = `flux${appName2}_${appName2}`;
-      await Promise.all(holders.map(async (i, k) => {
-        await waitForReconcileActuated(env.clients[i], identifier2, 'dataCleared', 120000, { afterId: installAfters[k] });
-        await seedSyncScopedData(env, appName2, i);
-      }));
-      await Promise.all(holders.map((i) => setSynced({ ip: subnet.nodeIp(i + 1), folder: folder2 })));
-
-      // the first app (still installed, still polled) makes every pass carry
-      // its slow FDM walk before this app's election is even reached
       const clients = holders.map((i) => env.clients[i]);
-      const runningCount = async () => (await Promise.all(clients.map((c) => isUp(c, appName2)))).filter(Boolean).length;
-      await waitFor(async () => await runningCount() === 1, {
-        timeout: 300000, interval: 5000, label: 'second app elected under a slow FDM',
+      const runningCount = async (name) => (await Promise.all(clients.map((c) => isUp(c, name)))).filter(Boolean).length;
+      // the LAST app in the list is the one a wall-clock watchdog starves
+      await waitFor(async () => await runningCount(names[1]) === 1, {
+        timeout: 300000, interval: 5000, label: 'tail app elected under a slow FDM',
       });
-      expect(await runningCount(), 'split brain under a slow FDM').to.equal(1);
+      expect(await runningCount(names[1]), 'split brain under a slow FDM').to.equal(1);
+      expect(await runningCount(names[0]), 'head app lost its election under a slow FDM').to.equal(1);
     } finally {
       await setFdmDelay(0).catch(() => {});
     }

--- a/test-infra/runner/tests/54-masterslave-no-fdm-primary.js
+++ b/test-infra/runner/tests/54-masterslave-no-fdm-primary.js
@@ -6,7 +6,7 @@ import { authenticate } from '../auth.js';
 import { appOwnerKey } from '../framework/keys.js';
 import { buildSeedableSyncthingApp } from '../framework/seed-helper.js';
 import { getAppContainerStatus } from '../framework/container.js';
-import { clearMaster, electMaster, resetFdm } from '../framework/fdm-control.js';
+import { clearMaster, electMaster, resetFdm, setFdmDelay } from '../framework/fdm-control.js';
 import { setSynced, resetSyncState } from '../framework/syncthing-control.js';
 import { getSubnetConfig } from '../framework/subnet-config.js';
 import { waitFor, waitForReconcileActuated, assertNoEvent } from '../framework/wait.js';
@@ -54,7 +54,17 @@ describe('masterSlave election when FDM names no primary', function () {
 
   before(async function () {
     this.timeout(360000);
-    env = await createTestEnv({ hookCtx: this, nodes: 10, tickerAutostart: false });
+    // masterSlaveMaxPassMs compressed so the slow-FDM case can outrun the
+    // watchdog budget with two apps: one 3-region FDM walk at the stub's 8s
+    // delay is 24s of silence (under budget - the pass keeps beating between
+    // apps), while a two-app pass totals ~50s (over budget). Harmless to the
+    // other cases: their passes finish in milliseconds.
+    env = await createTestEnv({
+      hookCtx: this,
+      nodes: 10,
+      tickerAutostart: false,
+      configOverrides: { fluxapps: { masterSlaveMaxPassMs: 30000 } },
+    });
     await bootAndPeer(env);
     await resetFdm();
     await resetSyncState();
@@ -126,5 +136,43 @@ describe('masterSlave election when FDM names no primary', function () {
     await waitForDown(a, appName, 'primary stopped');
 
     await waitForUp(b, appName, 'standby promoted with no FDM row', 180000);
+  });
+
+  it('still elects every app when FDM is slow - a pass over budget but advancing is not abandoned', async function () {
+    this.timeout(480000);
+    // A degraded-but-answering FDM makes every pass SLOW: each g: app pays a
+    // full 3-region walk at the stub's delay. With two apps the pass runs well
+    // past the watchdog budget - and the watchdog must judge silence, not total
+    // elapsed time. A wall-clock budget abandons every pass mid-list, so the
+    // app later in the list is never elected, every cycle, for as long as the
+    // degradation lasts: exactly the failover conditions elections exist for.
+    const appName2 = `e2eslowfdm${Date.now()}`;
+    const identifier2 = `${appName2}_${appName2}`;
+
+    await setFdmDelay(8000);
+    try {
+      await pushImage(appName2, 'v1');
+      const app2 = await buildSeedableSyncthingApp({ name: appName2, mode: 'g' });
+      const installAfters = holders.map((i) => env.clients[i].getLastEventId());
+      await installOnNodes(env, app2, holders);
+
+      const folder2 = `flux${appName2}_${appName2}`;
+      await Promise.all(holders.map(async (i, k) => {
+        await waitForReconcileActuated(env.clients[i], identifier2, 'dataCleared', 120000, { afterId: installAfters[k] });
+        await seedSyncScopedData(env, appName2, i);
+      }));
+      await Promise.all(holders.map((i) => setSynced({ ip: subnet.nodeIp(i + 1), folder: folder2 })));
+
+      // the first app (still installed, still polled) makes every pass carry
+      // its slow FDM walk before this app's election is even reached
+      const clients = holders.map((i) => env.clients[i]);
+      const runningCount = async () => (await Promise.all(clients.map((c) => isUp(c, appName2)))).filter(Boolean).length;
+      await waitFor(async () => await runningCount() === 1, {
+        timeout: 300000, interval: 5000, label: 'second app elected under a slow FDM',
+      });
+      expect(await runningCount(), 'split brain under a slow FDM').to.equal(1);
+    } finally {
+      await setFdmDelay(0).catch(() => {});
+    }
   });
 });

--- a/test-infra/runner/tests/54-masterslave-no-fdm-primary.js
+++ b/test-infra/runner/tests/54-masterslave-no-fdm-primary.js
@@ -1,0 +1,124 @@
+import { describe, it, before, after } from 'mocha';
+import { expect } from 'chai';
+import { createTestEnv } from '../framework/test-env.js';
+import { pushImage } from '../framework/registry-helper.js';
+import { authenticate } from '../auth.js';
+import { appOwnerKey } from '../framework/keys.js';
+import { buildSeedableSyncthingApp } from '../framework/seed-helper.js';
+import { getAppContainerStatus } from '../framework/container.js';
+import { clearMaster, electMaster, resetFdm } from '../framework/fdm-control.js';
+import { setSynced, resetSyncState } from '../framework/syncthing-control.js';
+import { getSubnetConfig } from '../framework/subnet-config.js';
+import { waitFor, waitForReconcileActuated, assertNoEvent } from '../framework/wait.js';
+import { bootAndPeer, installOnNodes, seedSyncScopedData } from '../framework/reconciler-suite.js';
+import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
+
+const subnet = getSubnetConfig();
+
+// MUST-PASS gate. Suite 35 covers g: election while FDM names a primary. Every
+// branch that runs when FDM names NOBODY was untested - `clearMaster` existed in
+// the framework and no suite had ever called it - which is the branch family the
+// production incident lived in: an app whose FDM row had gone, on nodes that then
+// had to work out between themselves who runs it.
+//
+// Three invariants, in the order a real app meets them:
+//   1. bootstrap - no row has ever existed, someone must still start
+//   2. no split-brain - the row vanishing under a live primary must not start a second
+//   3. promotion - the primary genuinely gone, with no row, must promote a standby
+//
+// (2) is the one that matters most: FDM going quiet is indistinguishable from FDM
+// being down, and "start it here too" is the answer that corrupts the save.
+
+async function isUp(client, appName) {
+  const status = await getAppContainerStatus(client.container, appName);
+  return !!(status && status.status.startsWith('Up'));
+}
+
+async function waitForUp(client, appName, label, timeout = 90000) {
+  await waitFor(() => isUp(client, appName), { timeout, interval: 2000, label });
+}
+
+async function waitForDown(client, appName, label, timeout = 60000) {
+  await waitFor(async () => {
+    const status = await getAppContainerStatus(client.container, appName, { all: true });
+    return status ? !status.status.startsWith('Up') : true;
+  }, { timeout, interval: 2000, label });
+}
+
+describe('masterSlave election when FDM names no primary', function () {
+  let env;
+  dumpLogsOnFailure(() => env);
+  let holders;
+  const appName = `e2enofdm${Date.now()}`;
+  const identifier = `${appName}_${appName}`;
+
+  before(async function () {
+    this.timeout(360000);
+    env = await createTestEnv({ hookCtx: this, nodes: 10, tickerAutostart: false });
+    await bootAndPeer(env);
+    await resetFdm();
+    await resetSyncState();
+    await pushImage(appName, 'v1');
+    const app = await buildSeedableSyncthingApp({ name: appName, mode: 'g' });
+
+    const installAfters = [0, 1].map((i) => env.clients[i].getLastEventId());
+    holders = await installOnNodes(env, app, [0, 1]);
+
+    // both holders need a genuinely synced folder to be election-eligible (same
+    // requirement as suite 35 - an empty global is not treated as synced)
+    const folder = `flux${appName}_${appName}`;
+    await Promise.all(holders.map(async (i, k) => {
+      await waitForReconcileActuated(env.clients[i], identifier, 'dataCleared', 60000, { afterId: installAfters[k] });
+      await seedSyncScopedData(env, appName, i);
+    }));
+    await Promise.all(holders.map((i) => setSynced({ ip: subnet.nodeIp(i + 1), folder })));
+  });
+
+  after(async function () {
+    this.timeout(30000);
+    await resetFdm().catch(() => {});
+    await env?.teardown();
+  });
+
+  it('starts exactly one instance when FDM has never named a primary', async function () {
+    this.timeout(180000);
+    const [a, b] = holders.map((i) => env.clients[i]);
+
+    // FDM is empty from resetFdm: index 0 takes it immediately, and the higher
+    // index must hold off rather than race it
+    await waitForUp(a, appName, 'index-0 holder elected with no FDM row');
+    expect(await isUp(b, appName), 'both holders running - split brain on cold start').to.equal(false);
+  });
+
+  it('does not start a second instance when the FDM row disappears', async function () {
+    this.timeout(180000);
+    const [a, b] = holders.map((i) => env.clients[i]);
+
+    // hand FDM a primary, let it settle, then take the row away entirely - the
+    // shape of an FDM outage, or of a row ageing out while the app is healthy
+    await electMaster(appName, a.ip);
+    await waitForUp(a, appName, 'primary running before the row is cleared');
+
+    await clearMaster(appName);
+
+    // the standby must stay put: no row is not permission to start
+    await assertNoEvent(b, 'reconciler:actuated', (d) => d.identifier === identifier && d.action === 'started', 30000);
+    expect(await isUp(b, appName), 'standby started while the primary was still running').to.equal(false);
+    expect(await isUp(a, appName), 'primary stopped itself when the FDM row vanished').to.equal(true);
+  });
+
+  it('promotes a standby when the primary is gone and FDM still has no row', async function () {
+    this.timeout(240000);
+    const [a, b] = holders.map((i) => env.clients[i]);
+
+    // operator-stop the primary so it stays down (the reconciler will not
+    // resurrect it, and the election correctly ignores an operator-stopped
+    // component) - the standby is now the only candidate, with no FDM row to
+    // tell it so. It has to reach that conclusion by probing the old primary.
+    const auth = await authenticate(a.url, appOwnerKey());
+    await a.getAuthed(`/apps/appstop/${appName}`, auth.zelidauth);
+    await waitForDown(a, appName, 'primary stopped');
+
+    await waitForUp(b, appName, 'standby promoted with no FDM row', 180000);
+  });
+});

--- a/test-infra/runner/tests/54-masterslave-no-fdm-primary.js
+++ b/test-infra/runner/tests/54-masterslave-no-fdm-primary.js
@@ -82,12 +82,18 @@ describe('masterSlave election when FDM names no primary', function () {
 
   it('starts exactly one instance when FDM has never named a primary', async function () {
     this.timeout(180000);
-    const [a, b] = holders.map((i) => env.clients[i]);
+    const clients = holders.map((i) => env.clients[i]);
+    const runningCount = async () => (await Promise.all(clients.map((c) => isUp(c, appName)))).filter(Boolean).length;
 
-    // FDM is empty from resetFdm: index 0 takes it immediately, and the higher
-    // index must hold off rather than race it
-    await waitForUp(a, appName, 'index-0 holder elected with no FDM row');
-    expect(await isUp(b, appName), 'both holders running - split brain on cold start').to.equal(false);
+    // FDM is empty from resetFdm, so the holders settle this between themselves.
+    // Which one wins is not ours to predict: the election ranks candidates by their
+    // position in the app's location list, not by harness node order. The invariant
+    // is the count - one of them takes it, and the other holds off rather than
+    // racing it onto the same shared volume.
+    await waitFor(async () => await runningCount() === 1, {
+      timeout: 90000, interval: 2000, label: 'exactly one holder elected with no FDM row',
+    });
+    expect(await runningCount(), 'both holders running - split brain on cold start').to.equal(1);
   });
 
   it('does not start a second instance when the FDM row disappears', async function () {

--- a/test-infra/syncthing-stub/index.js
+++ b/test-infra/syncthing-stub/index.js
@@ -444,13 +444,17 @@ app.get('/rest/db/status', (req, res) => {
   const inSyncBytes = ov?.inSyncBytes ?? 0;
   const state = ov?.state ?? 'idle';
   const receiveOnlyChangedFiles = ov?.receiveOnlyChangedFiles ?? 0;
+  // Real syncthing reports the file count alongside the byte total; the
+  // phantom guard keys on it. Default: bytes imply at least one file (a
+  // dirs-only payload pins globalFiles: 0 explicitly).
+  const globalFiles = ov?.globalFiles ?? (globalBytes > 0 ? 1 : 0);
   const needBytes = Math.max(0, globalBytes - inSyncBytes);
   res.json({
     errors: 0,
     globalBytes,
     globalDeleted: 0,
     globalDirectories: 0,
-    globalFiles: 0,
+    globalFiles,
     globalSymlinks: 0,
     globalTotalItems: 0,
     ignorePatterns: false,
@@ -628,10 +632,11 @@ control.get('/state', (req, res) => {
 control.post('/sync-state', (req, res) => {
   const {
     ip = '*', folder, state = 'idle', globalBytes = 0, inSyncBytes = 0, receiveOnlyChangedFiles = 0, statusUnreadable = false,
+    globalFiles, // optional pin; omitted -> derived from globalBytes (dirs-only payloads pin 0)
   } = req.body;
   if (!folder) return res.status(400).json({ error: 'folder required' });
   syncOverrides.set(`${ip}|${folder}`, {
-    state, globalBytes, inSyncBytes, receiveOnlyChangedFiles, statusUnreadable,
+    state, globalBytes, inSyncBytes, receiveOnlyChangedFiles, statusUnreadable, globalFiles,
   });
   return res.json({ ok: true });
 });
@@ -652,7 +657,7 @@ control.post('/peer-completion', (req, res) => {
 // Device pause/resume calls observed for a node ip - how suites assert that the
 // stall ladder NUDGED (and did not restart syncthing or stop the container).
 control.get('/nudges', (req, res) => {
-  const ip = req.query.ip;
+  const { ip } = req.query;
   if (ip) return res.json({ nudges: nudgeLogs.get(ip) || [] });
   return res.json({ nudges: Object.fromEntries(Array.from(nudgeLogs.entries())) });
 });

--- a/tests/unit/advancedWorkflows.test.js
+++ b/tests/unit/advancedWorkflows.test.js
@@ -1275,6 +1275,56 @@ describe('advancedWorkflows tests', () => {
       sinon.restore();
     });
 
+    it('keeps the app and its data when the soft install fails - a failed soft redeploy never removes', async () => {
+      // The data volume was deliberately preserved (that is what makes the
+      // redeploy soft), so the rollback removal destroyed established data
+      // over what is usually a node-local failure. The spec and volume must
+      // stay; the reconciler retries with the current spec on its ladder.
+      const installedApp = {
+        name: 'TestApp',
+        version: 8,
+        compose: [{ name: 'frontend', repotag: 'repo/frontend:1.0', containerData: 'g:/data' }],
+      };
+      const newAppSpecs = {
+        name: 'TestApp',
+        version: 8,
+        compose: [{ name: 'frontend', repotag: 'repo/frontend:1.1', containerData: 'g:/data' }],
+      };
+      findInDatabaseStub = sinon.stub(dbHelper, 'findInDatabase').resolves([installedApp]);
+      sinon.stub(dbHelper, 'findOneInDatabase').resolves(installedApp);
+      sinon.stub(dbHelper, 'insertOneToDatabase').resolves();
+      sinon.stub(dbHelper, 'updateOneInDatabase').resolves();
+      sinon.stub(dbHelper, 'removeDocumentsFromCollection').resolves();
+
+      // eslint-disable-next-line global-require
+      const appUninstaller = require('../../ZelBack/src/services/appLifecycle/appUninstaller');
+      const removeSpy = sinon.stub(appUninstaller, 'removeAppLocally').resolves();
+      sinon.stub(appUninstaller, 'softUninstallComponent').resolves();
+
+      // eslint-disable-next-line global-require
+      const appInstaller = require('../../ZelBack/src/services/appLifecycle/appInstaller');
+      sinon.stub(appInstaller, 'checkAppRequirements').resolves(true);
+      sinon.stub(appInstaller, 'installApplicationSoft').rejects(new Error('Error: Port 31111 FAILed to open.'));
+
+      // eslint-disable-next-line global-require
+      const serviceHelper = require('../../ZelBack/src/services/serviceHelper');
+      sinon.stub(serviceHelper, 'delay').resolves();
+
+      // eslint-disable-next-line global-require
+      const globalState = require('../../ZelBack/src/services/utils/globalState');
+      globalState.receiveOnlySyncthingAppsCache = new Map();
+
+      const res = { write: sinon.stub(), flush: sinon.stub(), end: sinon.stub() };
+
+      await advancedWorkflows.softRedeploy(newAppSpecs, res);
+
+      expect(removeSpy.called, 'a failed soft redeploy removed the app and its data').to.equal(false);
+      expect(
+        globalState.receiveOnlySyncthingAppsCache.size,
+        'the kept g: component was not re-marked synced - the sync layer would clear its data',
+      ).to.be.greaterThan(0);
+    });
+
     it('should escalate to hard redeploy when component count changes for v8+ app', async () => {
       const installedApp = {
         name: 'TestApp',

--- a/tests/unit/advancedWorkflows.test.js
+++ b/tests/unit/advancedWorkflows.test.js
@@ -458,17 +458,12 @@ describe('advancedWorkflows tests', () => {
   describe('masterSlaveApps tests', () => {
     let globalState;
     let serviceHelperStub;
-    let serviceHelperDelayStub;
     let fluxNetworkHelperStub;
     let registryManagerStub;
     let dockerServiceStub;
     let syncthingServiceStub;
-    let syncthingServiceHealthStub;
-    let decryptEnterpriseAppsStub;
-    let recursionCounter;
 
     beforeEach(() => {
-      recursionCounter = 0;
       globalState = require('../../ZelBack/src/services/utils/globalState');
       globalState.masterSlaveAppsRunning = false;
       globalState.installationInProgress = false;
@@ -483,16 +478,6 @@ describe('advancedWorkflows tests', () => {
       const serviceHelper = require('../../ZelBack/src/services/serviceHelper');
       serviceHelperStub = sinon.stub(serviceHelper, 'axiosGet');
 
-      // Stub delay to prevent recursive calls - after first call, block recursion
-      serviceHelperDelayStub = sinon.stub(serviceHelper, 'delay').callsFake(async () => {
-        recursionCounter += 1;
-        if (recursionCounter > 1) {
-          // Prevent recursion by returning a promise that never resolves
-          return new Promise(() => {});
-        }
-        return Promise.resolve();
-      });
-
       const fluxNetworkHelper = require('../../ZelBack/src/services/fluxNetworkHelper');
       fluxNetworkHelperStub = sinon.stub(fluxNetworkHelper, 'getLocalSocketAddress');
 
@@ -504,14 +489,14 @@ describe('advancedWorkflows tests', () => {
 
       const syncthingService = require('../../ZelBack/src/services/syncthingService');
       syncthingServiceStub = sinon.stub(syncthingService, 'getConfigFolders');
-      syncthingServiceHealthStub = sinon.stub(syncthingService, 'getHealth').resolves({
+      sinon.stub(syncthingService, 'getHealth').resolves({
         status: 'success',
         data: { status: 'OK' },
       });
 
       // Stub decryptEnterpriseApps to return apps as-is
       const appQueryService = require('../../ZelBack/src/services/appQuery/appQueryService');
-      decryptEnterpriseAppsStub = sinon.stub(appQueryService, 'decryptEnterpriseApps').callsFake((apps) => Promise.resolve(apps));
+      sinon.stub(appQueryService, 'decryptEnterpriseApps').callsFake((apps) => Promise.resolve(apps));
 
       // Stub database connection to prevent actual DB access
       sinon.stub(dbHelper, 'databaseConnection').returns({
@@ -1263,7 +1248,6 @@ describe('advancedWorkflows tests', () => {
 
   describe('softRedeploy component structure change handling tests', () => {
     let findInDatabaseStub;
-    let databaseConnectionStub;
 
     beforeEach(() => {
       // Reset global state
@@ -1275,7 +1259,7 @@ describe('advancedWorkflows tests', () => {
       globalState.hardRedeployInProgress = false;
 
       // Setup database connection stub
-      databaseConnectionStub = sinon.stub(dbHelper, 'databaseConnection').returns({
+      sinon.stub(dbHelper, 'databaseConnection').returns({
         db: () => ({}),
       });
     });
@@ -1559,6 +1543,7 @@ describe('advancedWorkflows tests', () => {
     let installedAppsStub;
     let listRunningAppsStub;
     let intervalMs;
+    let maxPassMs;
     // eslint-disable-next-line global-require
     const https = require('https');
 
@@ -1566,6 +1551,7 @@ describe('advancedWorkflows tests', () => {
       // eslint-disable-next-line global-require
       const config = require('config');
       intervalMs = config.fluxapps.masterSlaveIntervalMs ?? 30 * 1000;
+      maxPassMs = config.fluxapps.masterSlaveMaxPassMs ?? Math.max(intervalMs * 4, 2 * 60 * 1000);
 
       globalStateMock = {
         installationInProgress: false,
@@ -1630,6 +1616,82 @@ describe('advancedWorkflows tests', () => {
       expect(installedAppsStub.callCount).to.be.at.least(2);
       await clock.tickAsync(intervalMs); // and again
       expect(installedAppsStub.callCount).to.be.at.least(3);
+      control.stop();
+    });
+
+    // The watchdog is the whole reason the scheduler exists. Production died with a
+    // pass wedged on an un-timed-out await (installedApps/listRunningApps have no
+    // timeout), so the `finally` that held the only reschedule never ran and
+    // elections stopped for 18h on a node that never restarted. These three cover
+    // the contract: hold the guard while in flight, release it on timeout, run a
+    // fresh pass after.
+    const wedgedPass = () => new Promise(() => {});
+
+    it('skips a tick while the previous pass is still in flight', async () => {
+      const hanging = sinon.stub().callsFake(wedgedPass);
+      const control = advancedWorkflows.startMasterSlaveApps(
+        globalStateMock, hanging, listRunningAppsStub, new Map(), [], [], https,
+      );
+      await clock.tickAsync(50); // immediate pass, wedges on installedApps
+      expect(hanging.callCount).to.equal(1);
+
+      // ticks land while the pass is still running - single-flight must not
+      // stack a second concurrent pass on top of it
+      await clock.tickAsync(intervalMs * 2);
+      expect(hanging.callCount).to.equal(1);
+      control.stop();
+    });
+
+    it('runs a fresh pass after the watchdog abandons a wedged one', async () => {
+      let calls = 0;
+      // first pass never settles; later passes complete normally
+      const installedApps = sinon.stub().callsFake(() => {
+        calls += 1;
+        return calls === 1 ? wedgedPass() : Promise.resolve({ status: 'success', data: [] });
+      });
+
+      const control = advancedWorkflows.startMasterSlaveApps(
+        globalStateMock, installedApps, listRunningAppsStub, new Map(), [], [], https,
+      );
+      await clock.tickAsync(50);
+      expect(installedApps.callCount).to.equal(1);
+
+      // nothing runs while the pass is wedged
+      await clock.tickAsync(intervalMs * 2);
+      expect(installedApps.callCount).to.equal(1);
+
+      // past the watchdog: the guard is released and the next tick runs again
+      await clock.tickAsync(maxPassMs + intervalMs + 50);
+      expect(installedApps.callCount, 'watchdog never released the single-flight guard').to.be.at.least(2);
+      control.stop();
+    });
+
+    it('releases the global masterSlaveAppsRunning lock when it abandons a pass', async () => {
+      // masterSlaveApps sets this true on entry and false in its own `finally` -
+      // which a wedged pass never reaches. appInstaller reads it to gate
+      // performDockerCleanup, so if the scheduler does not clear it alongside its
+      // own guard it stays set for the life of the process.
+      const writes = [];
+      let running = false;
+      Object.defineProperty(globalStateMock, 'masterSlaveAppsRunning', {
+        configurable: true,
+        get: () => running,
+        set: (value) => { running = value; writes.push(value); },
+      });
+
+      // every pass wedges, so masterSlaveApps itself can never write false -
+      // any false here came from the scheduler releasing the lock
+      const control = advancedWorkflows.startMasterSlaveApps(
+        globalStateMock, sinon.stub().callsFake(wedgedPass), listRunningAppsStub, new Map(), [], [], https,
+      );
+      await clock.tickAsync(50);
+      expect(writes).to.deep.equal([true]);
+
+      await clock.tickAsync(maxPassMs + 50);
+      expect(
+        writes.includes(false),
+        'a wedged pass leaves globalState.masterSlaveAppsRunning set forever',
+      ).to.equal(true);
       control.stop();
     });
   });

--- a/tests/unit/advancedWorkflows.test.js
+++ b/tests/unit/advancedWorkflows.test.js
@@ -1468,6 +1468,46 @@ describe('advancedWorkflows tests', () => {
         globalState.receiveOnlySyncthingAppsCache.size,
         'the kept g: component was not re-marked synced',
       ).to.be.greaterThan(0);
+      expect(res.end.called, 'the API response was left open - the client hangs to a gateway timeout').to.equal(true);
+    });
+
+    it('keeps the app - without stomping the other operation - when an install races into the redeploy window', async () => {
+      // The spawner has no softRedeployInProgress gate, so during the redeploy
+      // delay it can start installing an unrelated app and take
+      // installationInProgress. The register's busy guard used to bare-return:
+      // the redeploy then logged success with no row, no containers and an
+      // orphaned volume. The guard must surface as a failure (restore + keep),
+      // and the OTHER operation's flag must remain untouched - it is not ours
+      // to clear.
+      const { installedApp, newAppSpecs } = rowlessWindowFixture();
+      const rowState = stubRowLifecycle(installedApp);
+
+      const removeSpy = sinon.stub(appUninstaller, 'removeAppLocally').resolves();
+      sinon.stub(appUninstaller, 'softUninstallComponent').resolves();
+
+      sinon.stub(appInstaller, 'checkAppRequirements').resolves(true);
+      const installSoft = sinon.stub(appInstaller, 'installApplicationSoft').resolves();
+      sinon.stub(generalService, 'nodeTier').resolves('basic');
+      // the racing install lands while this redeploy sits in its delay
+      sinon.stub(serviceHelper, 'delay').callsFake(async () => { globalState.installationInProgress = true; });
+
+      globalState.receiveOnlySyncthingAppsCache.clear();
+
+      const res = { write: sinon.stub(), flush: sinon.stub(), end: sinon.stub() };
+
+      await advancedWorkflows.softRedeploy(newAppSpecs, res);
+
+      expect(removeSpy.called, 'the busy collision removed the app and its data').to.equal(false);
+      expect(installSoft.called, 'the install ran despite another operation holding the flag').to.equal(false);
+      expect(rowState.localRow, 'the local record deleted by the teardown was not restored').to.not.equal(null);
+      expect(
+        globalState.installationInProgress,
+        'the racing operation\'s installationInProgress flag was cleared by a flow that does not own it',
+      ).to.equal(true);
+      expect(
+        globalState.receiveOnlySyncthingAppsCache.size,
+        'the kept g: component was not re-marked synced',
+      ).to.be.greaterThan(0);
     });
 
     it('restores the local record and keeps the app when the register fails before its re-insert', async () => {

--- a/tests/unit/advancedWorkflows.test.js
+++ b/tests/unit/advancedWorkflows.test.js
@@ -1552,4 +1552,85 @@ describe('advancedWorkflows tests', () => {
   // These should be tested in integration tests rather than unit tests.
   // masterSlaveApps is included above with basic tests, but full integration testing
   // is recommended for comprehensive coverage of the master-slave coordination logic.
+
+  describe('startMasterSlaveApps scheduler', () => {
+    let clock;
+    let globalStateMock;
+    let installedAppsStub;
+    let listRunningAppsStub;
+    let intervalMs;
+    // eslint-disable-next-line global-require
+    const https = require('https');
+
+    beforeEach(() => {
+      // eslint-disable-next-line global-require
+      const config = require('config');
+      intervalMs = config.fluxapps.masterSlaveIntervalMs ?? 30 * 1000;
+
+      globalStateMock = {
+        installationInProgress: false,
+        removalInProgress: false,
+        softRedeployInProgress: false,
+        hardRedeployInProgress: false,
+        syncthingAppsFirstRun: false,
+        masterSlaveAppsRunning: false,
+      };
+
+      // Empty app list => masterSlaveApps completes a fast no-op pass each tick.
+      installedAppsStub = sinon.stub().resolves({ status: 'success', data: [] });
+      listRunningAppsStub = sinon.stub().resolves({ status: 'success', data: [] });
+
+      // eslint-disable-next-line global-require
+      const syncthingService = require('../../ZelBack/src/services/syncthingService');
+      sinon.stub(syncthingService, 'getHealth').resolves({ status: 'success', data: { status: 'OK' } });
+      // eslint-disable-next-line global-require
+      const appQueryService = require('../../ZelBack/src/services/appQuery/appQueryService');
+      sinon.stub(appQueryService, 'decryptEnterpriseApps').callsFake((apps) => Promise.resolve(apps));
+
+      clock = sinon.useFakeTimers();
+    });
+
+    afterEach(() => {
+      if (clock) clock.restore();
+      sinon.restore();
+    });
+
+    it('returns a control object and is active after start', () => {
+      const control = advancedWorkflows.startMasterSlaveApps(
+        globalStateMock, installedAppsStub, listRunningAppsStub, new Map(), [], [], https,
+      );
+      expect(control).to.have.property('stop').that.is.a('function');
+      expect(control).to.have.property('isActive').that.is.a('function');
+      expect(control.isActive()).to.be.true;
+      control.stop();
+    });
+
+    it('stops ticking after stop() is called', async () => {
+      const control = advancedWorkflows.startMasterSlaveApps(
+        globalStateMock, installedAppsStub, listRunningAppsStub, new Map(), [], [], https,
+      );
+      await clock.tickAsync(50); // let the immediate pass run
+      const callsBeforeStop = installedAppsStub.callCount;
+      control.stop();
+      expect(control.isActive()).to.be.false;
+      await clock.tickAsync(intervalMs * 3);
+      // no further passes after stop
+      expect(installedAppsStub.callCount).to.equal(callsBeforeStop);
+    });
+
+    it('keeps running across intervals - the scheduler does not die after one pass', async () => {
+      // This is the core guarantee of the fix: the previous recursive-finally
+      // reschedule could stop after a single pass, leaving g: apps unelected.
+      const control = advancedWorkflows.startMasterSlaveApps(
+        globalStateMock, installedAppsStub, listRunningAppsStub, new Map(), [], [], https,
+      );
+      await clock.tickAsync(50); // immediate pass
+      expect(installedAppsStub.callCount).to.equal(1);
+      await clock.tickAsync(intervalMs); // next interval tick
+      expect(installedAppsStub.callCount).to.be.at.least(2);
+      await clock.tickAsync(intervalMs); // and again
+      expect(installedAppsStub.callCount).to.be.at.least(3);
+      control.stop();
+    });
+  });
 });

--- a/tests/unit/advancedWorkflows.test.js
+++ b/tests/unit/advancedWorkflows.test.js
@@ -134,6 +134,7 @@ describe('advancedWorkflows tests', () => {
         json: sinon.stub(),
         write: sinon.stub(),
         flush: sinon.stub(),
+        end: sinon.stub(),
         setHeader: sinon.stub(),
       };
     });
@@ -237,6 +238,7 @@ describe('advancedWorkflows tests', () => {
       res = {
         write: sinon.stub(),
         flush: sinon.stub(),
+        end: sinon.stub(),
       };
     });
 
@@ -351,6 +353,7 @@ describe('advancedWorkflows tests', () => {
       res = {
         write: sinon.stub(),
         flush: sinon.stub(),
+        end: sinon.stub(),
       };
     });
 
@@ -1508,6 +1511,93 @@ describe('advancedWorkflows tests', () => {
         globalState.receiveOnlySyncthingAppsCache.size,
         'the kept g: component was not re-marked synced',
       ).to.be.greaterThan(0);
+      globalState.installationInProgress = false;
+    });
+
+    it('defers to an in-progress removal - no restore, no mark, no removal - when one races into the redeploy window', async () => {
+      // A removal racing into the redeploy delay may be THIS app's own
+      // deliberate removal (removeAppLocally deletes the row last, and is not
+      // gated on softRedeployInProgress). Restoring the row here could
+      // resurrect an app the operator just removed; removing would race the
+      // remover. The catch must leave the state to the removal entirely: no
+      // restore, no synced-mark, no removal of its own - and it must not
+      // touch the remover's flag.
+      const { installedApp, newAppSpecs } = rowlessWindowFixture();
+      const rowState = stubRowLifecycle(installedApp);
+
+      const removeSpy = sinon.stub(appUninstaller, 'removeAppLocally').resolves();
+      sinon.stub(appUninstaller, 'softUninstallComponent').resolves();
+
+      sinon.stub(appInstaller, 'checkAppRequirements').resolves(true);
+      const installSoft = sinon.stub(appInstaller, 'installApplicationSoft').resolves();
+      sinon.stub(generalService, 'nodeTier').resolves('basic');
+      // the racing removal lands while this redeploy sits in its delay
+      sinon.stub(serviceHelper, 'delay').callsFake(async () => { globalState.removalInProgress = true; });
+
+      globalState.receiveOnlySyncthingAppsCache.clear();
+
+      const res = { write: sinon.stub(), flush: sinon.stub(), end: sinon.stub() };
+
+      await advancedWorkflows.softRedeploy(newAppSpecs, res);
+
+      expect(removeSpy.called, 'the redeploy raced the remover with a removal of its own').to.equal(false);
+      expect(installSoft.called).to.equal(false);
+      expect(rowState.localRow, 'restored the row of an app a removal may be deliberately deleting').to.equal(null);
+      expect(
+        globalState.receiveOnlySyncthingAppsCache.size,
+        'marked synced during a removal - a rowless mark makes an empty later install eligible for g: primary',
+      ).to.equal(0);
+      expect(
+        globalState.removalInProgress,
+        'the remover\'s removalInProgress flag was cleared by a flow that does not own it',
+      ).to.equal(true);
+      expect(res.end.called, 'the API response was left open').to.equal(true);
+      globalState.removalInProgress = false;
+    });
+
+    it('stamps busy-guard throws so callers can tell a collision from a real failure', async () => {
+      // reinstallOldApplications' composed catch force-removes the whole app
+      // on any registration error; a transient flag collision must be
+      // distinguishable or a benign busy skip becomes data destruction.
+      const { newAppSpecs } = rowlessWindowFixture();
+
+      globalState.installationInProgress = true;
+      let installErr = null;
+      try {
+        await advancedWorkflows.softRegisterAppLocally(newAppSpecs, undefined, null);
+      } catch (error) { installErr = error; }
+      globalState.installationInProgress = false;
+      expect(installErr, 'the installation busy guard did not throw').to.not.equal(null);
+      expect(installErr.busyCollision).to.equal('installation');
+
+      globalState.removalInProgress = true;
+      let removalErr = null;
+      try {
+        await advancedWorkflows.softRegisterAppLocally(newAppSpecs, undefined, null);
+      } catch (error) { removalErr = error; }
+      globalState.removalInProgress = false;
+      expect(removalErr, 'the removal busy guard did not throw').to.not.equal(null);
+      expect(removalErr.busyCollision).to.equal('removal');
+    });
+
+    it('ends the response when the redeploy is refused by a busy guard', async () => {
+      // the top-of-function guards write a warning and return; without an end
+      // the API client hangs to a gateway timeout
+      const { newAppSpecs } = rowlessWindowFixture();
+
+      globalState.installationInProgress = true;
+      const res = { write: sinon.stub(), flush: sinon.stub(), end: sinon.stub() };
+      await advancedWorkflows.softRedeploy(newAppSpecs, res);
+      globalState.installationInProgress = false;
+      expect(res.write.called, 'no busy warning was written').to.equal(true);
+      expect(res.end.called, 'softRedeploy busy guard left the response open').to.equal(true);
+
+      globalState.removalInProgress = true;
+      const res2 = { write: sinon.stub(), flush: sinon.stub(), end: sinon.stub() };
+      await advancedWorkflows.hardRedeploy(newAppSpecs, res2);
+      globalState.removalInProgress = false;
+      expect(res2.write.called, 'no busy warning was written').to.equal(true);
+      expect(res2.end.called, 'hardRedeploy busy guard left the response open').to.equal(true);
     });
 
     it('restores the local record and keeps the app when the register fails before its re-insert', async () => {

--- a/tests/unit/advancedWorkflows.test.js
+++ b/tests/unit/advancedWorkflows.test.js
@@ -5,6 +5,13 @@ const { expect } = require('chai');
 const sinon = require('sinon');
 const advancedWorkflows = require('../../ZelBack/src/services/appLifecycle/advancedWorkflows');
 const dbHelper = require('../../ZelBack/src/services/dbHelper');
+const https = require('https');
+const config = require('config');
+const serviceHelper = require('../../ZelBack/src/services/serviceHelper');
+const fluxNetworkHelper = require('../../ZelBack/src/services/fluxNetworkHelper');
+const appReconciler = require('../../ZelBack/src/services/appMonitoring/appReconciler');
+const syncthingService = require('../../ZelBack/src/services/syncthingService');
+const appQueryService = require('../../ZelBack/src/services/appQuery/appQueryService');
 
 describe('advancedWorkflows tests', () => {
   afterEach(() => {
@@ -1544,12 +1551,8 @@ describe('advancedWorkflows tests', () => {
     let listRunningAppsStub;
     let intervalMs;
     let maxPassMs;
-    // eslint-disable-next-line global-require
-    const https = require('https');
 
     beforeEach(() => {
-      // eslint-disable-next-line global-require
-      const config = require('config');
       intervalMs = config.fluxapps.masterSlaveIntervalMs ?? 30 * 1000;
       maxPassMs = config.fluxapps.masterSlaveMaxPassMs ?? Math.max(intervalMs * 4, 2 * 60 * 1000);
 
@@ -1566,11 +1569,7 @@ describe('advancedWorkflows tests', () => {
       installedAppsStub = sinon.stub().resolves({ status: 'success', data: [] });
       listRunningAppsStub = sinon.stub().resolves({ status: 'success', data: [] });
 
-      // eslint-disable-next-line global-require
-      const syncthingService = require('../../ZelBack/src/services/syncthingService');
       sinon.stub(syncthingService, 'getHealth').resolves({ status: 'success', data: { status: 'OK' } });
-      // eslint-disable-next-line global-require
-      const appQueryService = require('../../ZelBack/src/services/appQuery/appQueryService');
       sinon.stub(appQueryService, 'decryptEnterpriseApps').callsFake((apps) => Promise.resolve(apps));
 
       clock = sinon.useFakeTimers();
@@ -1664,6 +1663,59 @@ describe('advancedWorkflows tests', () => {
       await clock.tickAsync(maxPassMs + intervalMs + 50);
       expect(installedApps.callCount, 'watchdog never released the single-flight guard').to.be.at.least(2);
       control.stop();
+    });
+
+    it('a pass abandoned by the watchdog cannot act when it later unwedges', async () => {
+      // The watchdog frees the guard but cannot cancel the pass, and production
+      // passes stalled 810s and 1050s and then RESUMED. A pass waking up that stale
+      // must not flip a live primary's syncthing folder or write controller state
+      // on a view of the world that has since been replaced.
+      const appName = 'gapp';
+      const identifier = `gcomp_${appName}`;
+      const setControllerDesired = sinon.stub(appReconciler, 'setControllerDesired');
+      sinon.stub(serviceHelper, 'axiosGet').resolves({ data: { status: 'success', data: { ips: ['192.168.1.99'] } } });
+
+      // this node is a standby (FDM names another primary) with the g: component
+      // running, which is the branch that writes desired-stopped
+      let releaseLocalAddr;
+      sinon.stub(fluxNetworkHelper, 'getLocalSocketAddress').returns(new Promise((resolve) => {
+        releaseLocalAddr = () => resolve('192.168.1.5:16127');
+      }));
+
+      const installedApps = sinon.stub().resolves({
+        status: 'success',
+        data: [{ name: appName, version: 8, compose: [{ name: 'gcomp', containerData: 'g:/data' }] }],
+      });
+      const listRunningApps = sinon.stub().resolves({
+        status: 'success',
+        data: [{ Names: [`/flux${identifier}`] }],
+      });
+
+      const control = advancedWorkflows.startMasterSlaveApps(
+        globalStateMock, installedApps, listRunningApps, new Map(), [], [], https,
+      );
+
+      // pass 1 reaches the FDM lookup then wedges before it can decide
+      await clock.tickAsync(50);
+      expect(setControllerDesired.called, 'acted before it had this node address').to.equal(false);
+
+      // watchdog abandons it - generation moves on, and the next tick starts a fresh
+      // pass which legitimately decides this node is a standby
+      await clock.tickAsync(maxPassMs + 50);
+      control.stop();
+
+      // ...and only now does the abandoned pass's wedged call return. Both passes
+      // are now resolving against the same stubs, so without the generation check
+      // the decision is written twice - once by a pass whose view of FDM is
+      // maxPassMs stale. Exactly one write is the contract.
+      releaseLocalAddr();
+      await clock.tickAsync(50);
+
+      expect(
+        setControllerDesired.callCount,
+        'the abandoned pass wrote controller state on top of the pass that replaced it',
+      ).to.equal(1);
+      expect(setControllerDesired.calledWith(identifier, 'stopped', 'masterSlave standby')).to.equal(true);
     });
 
     it('releases the global masterSlaveAppsRunning lock when it abandons a pass', async () => {

--- a/tests/unit/advancedWorkflows.test.js
+++ b/tests/unit/advancedWorkflows.test.js
@@ -1789,6 +1789,61 @@ describe('advancedWorkflows tests', () => {
       expect(setControllerDesired.callCount).to.equal(1);
     });
 
+    it('does not stack a second permissions-fix chain while one is still running', async () => {
+      // The scheduler dispatches the chain without await every 30s, and the
+      // recursive chmod legitimately runs for minutes - unguarded, every tick
+      // stacks another full-tree walk over the inodes the previous one is
+      // still fixing, with no self-termination.
+      const appName = 'gstack';
+      const identifier = `gcomp_${appName}`;
+      // eslint-disable-next-line global-require
+      const dockerService = require('../../ZelBack/src/services/dockerService');
+      // eslint-disable-next-line global-require
+      const { appsFolder } = require('../../ZelBack/src/services/utils/appConstants');
+      // eslint-disable-next-line global-require
+      const registryManager = require('../../ZelBack/src/services/appDatabase/registryManager');
+      const appId = dockerService.getAppIdentifier(identifier);
+      const setControllerDesired = sinon.stub(appReconciler, 'setControllerDesired');
+
+      sinon.stub(serviceHelper, 'axiosGet').resolves({ data: { status: 'success', data: { ips: [] } } });
+      sinon.stub(serviceHelper, 'runCommand').resolves({ error: null, stdout: '', stderr: '' });
+      sinon.stub(fluxNetworkHelper, 'getLocalSocketAddress').resolves('192.168.1.5:16127');
+      sinon.stub(registryManager, 'appLocation').resolves([{ ip: '192.168.1.5:16127' }]);
+
+      // the first chain parks on its first folder flip; later passes keep
+      // electing and re-dispatching the whole time
+      let releaseChain;
+      const folders = (type) => ({ status: 'success', data: [{ id: 'f1', path: `${appsFolder}${appId}`, type }] });
+      const getConfigFolders = sinon.stub(syncthingService, 'getConfigFolders');
+      getConfigFolders.onFirstCall().returns(new Promise((resolve) => {
+        releaseChain = () => resolve(folders('receiveonly'));
+      }));
+      getConfigFolders.resolves(folders('sendreceive'));
+
+      const installedApps = sinon.stub().resolves({
+        status: 'success',
+        data: [{ name: appName, version: 8, compose: [{ name: 'gcomp', containerData: 'g:/data' }] }],
+      });
+      const listRunningApps = sinon.stub().resolves({ status: 'success', data: [] });
+      const cache = new Map();
+      cache.set(appId, { restarted: true });
+
+      const control = advancedWorkflows.startMasterSlaveApps(
+        globalStateMock, installedApps, listRunningApps, cache, [], [], https,
+      );
+      await clock.tickAsync(3 * intervalMs + 50); // pass 1 dispatches; passes 2-4 re-decide
+      expect(installedApps.callCount).to.be.at.least(3);
+      expect(
+        getConfigFolders.callCount,
+        'a second chain was dispatched while the first was still running',
+      ).to.equal(1);
+      control.stop();
+
+      releaseChain();
+      await clock.tickAsync(50);
+      expect(setControllerDesired.calledOnceWith(identifier, 'running', 'masterSlave primary (synced)')).to.equal(true);
+    });
+
     it('does not request a start when the permissions fix fails', async () => {
       // runCommand reports failure via result.error, never a rejection. The chain
       // must read that result - discarding it deadened the guard, and a node got

--- a/tests/unit/advancedWorkflows.test.js
+++ b/tests/unit/advancedWorkflows.test.js
@@ -1718,6 +1718,77 @@ describe('advancedWorkflows tests', () => {
       expect(setControllerDesired.calledWith(identifier, 'stopped', 'masterSlave standby')).to.equal(true);
     });
 
+    it('a start chain from a completed pass survives a later pass being abandoned', async () => {
+      // The start chain (two folder flips + a recursive permissions fix) legitimately
+      // outlives the 30s pass cadence, so it is dispatched without await. Abandonment
+      // must therefore be per-pass: when a LATER pass wedges and the watchdog gives up
+      // on it, a completed pass's still-running chain must go on to issue its start.
+      // Dropping it strands the g: app primaryless for another full cycle - every
+      // cycle, on a node whose passes routinely run past the watchdog.
+      const appName = 'gsurvive';
+      const identifier = `gcomp_${appName}`;
+      // eslint-disable-next-line global-require
+      const dockerService = require('../../ZelBack/src/services/dockerService');
+      // eslint-disable-next-line global-require
+      const { appsFolder } = require('../../ZelBack/src/services/utils/appConstants');
+      // eslint-disable-next-line global-require
+      const registryManager = require('../../ZelBack/src/services/appDatabase/registryManager');
+      const appId = dockerService.getAppIdentifier(identifier);
+      const setControllerDesired = sinon.stub(appReconciler, 'setControllerDesired');
+
+      // FDM answers on every pass: no primary anywhere
+      sinon.stub(serviceHelper, 'axiosGet').resolves({ data: { status: 'success', data: { ips: [] } } });
+      sinon.stub(serviceHelper, 'runCommand').resolves(); // the chain's chmod
+      // pass 1 gets this node's address; pass 2 wedges here and gets abandoned
+      const localAddr = sinon.stub(fluxNetworkHelper, 'getLocalSocketAddress');
+      localAddr.onFirstCall().resolves('192.168.1.5:16127');
+      localAddr.returns(new Promise(() => {}));
+      // this node is the app's only location -> index 0, start immediately
+      sinon.stub(registryManager, 'appLocation').resolves([{ ip: '192.168.1.5:16127' }]);
+
+      // the chain parks on its first folder flip until the test releases it
+      let releaseChain;
+      const folders = (type) => ({ status: 'success', data: [{ id: 'f1', path: `${appsFolder}${appId}`, type }] });
+      const getConfigFolders = sinon.stub(syncthingService, 'getConfigFolders');
+      getConfigFolders.onFirstCall().returns(new Promise((resolve) => {
+        releaseChain = () => resolve(folders('receiveonly'));
+      }));
+      getConfigFolders.resolves(folders('sendreceive'));
+
+      const installedApps = sinon.stub().resolves({
+        status: 'success',
+        data: [{ name: appName, version: 8, compose: [{ name: 'gcomp', containerData: 'g:/data' }] }],
+      });
+      const listRunningApps = sinon.stub().resolves({ status: 'success', data: [] });
+      const cache = new Map();
+      cache.set(appId, { restarted: true }); // synced: eligible to become primary
+
+      const control = advancedWorkflows.startMasterSlaveApps(
+        globalStateMock, installedApps, listRunningApps, cache, [], [], https,
+      );
+
+      // pass 1 completes and dispatches the chain, which parks on the folder flip
+      await clock.tickAsync(50);
+      expect(installedApps.callCount).to.equal(1);
+      expect(setControllerDesired.called, 'the chain acted before it was released').to.equal(false);
+
+      // pass 2 wedges on the local-address lookup; the watchdog abandons it
+      await clock.tickAsync(intervalMs + 50);
+      expect(installedApps.callCount).to.equal(2);
+      await clock.tickAsync(maxPassMs + 50);
+      control.stop();
+
+      // the completed pass's chain now finishes: its start must land
+      releaseChain();
+      await clock.tickAsync(50);
+
+      expect(
+        setControllerDesired.calledWith(identifier, 'running', 'masterSlave primary (synced)'),
+        "another pass's abandonment dropped a completed pass's start",
+      ).to.equal(true);
+      expect(setControllerDesired.callCount).to.equal(1);
+    });
+
     it('releases the global masterSlaveAppsRunning lock when it abandons a pass', async () => {
       // masterSlaveApps sets this true on entry and false in its own `finally` -
       // which a wedged pass never reaches. appInstaller reads it to gate

--- a/tests/unit/advancedWorkflows.test.js
+++ b/tests/unit/advancedWorkflows.test.js
@@ -16,6 +16,8 @@ const generalService = require('../../ZelBack/src/services/generalService');
 const globalState = require('../../ZelBack/src/services/utils/globalState');
 const appInstaller = require('../../ZelBack/src/services/appLifecycle/appInstaller');
 const appUninstaller = require('../../ZelBack/src/services/appLifecycle/appUninstaller');
+const appsRuntimeState = require('../../ZelBack/src/services/appManagement/appsRuntimeState');
+const log = require('../../ZelBack/src/lib/log');
 
 describe('advancedWorkflows tests', () => {
   afterEach(() => {
@@ -620,6 +622,81 @@ describe('advancedWorkflows tests', () => {
       expect(installedApps.called).to.be.true;
       // But FDM should not be queried since app is skipped
       expect(serviceHelperStub.called).to.be.false;
+    });
+
+    it('announces the exclusion once when a g: component is operator-stopped, not every cycle', async () => {
+      const appName = 'operatorstoppedapp';
+      dockerServiceStub.returns('zel_operatorstoppedapp');
+      sinon.stub(appsRuntimeState, 'isOperatorStopped').resolves(true);
+      const logInfo = sinon.stub(log, 'info');
+
+      const installedApps = sinon.stub().resolves({
+        status: 'success',
+        data: [{ name: appName, version: 3, containerData: 'g:/syncdata' }],
+      });
+      const listRunningApps = sinon.stub().resolves({ status: 'success', data: [] });
+
+      const runPass = () => advancedWorkflows.masterSlaveApps(
+        globalState, installedApps, listRunningApps, new Map(), [], [], https,
+      );
+      const announcements = () => logInfo.getCalls()
+        .map((call) => String(call.args[0]))
+        .filter((msg) => msg.includes('operator-stopped'));
+
+      await runPass();
+
+      // positive proof the skip branch is what ran: election never reached FDM
+      expect(serviceHelperStub.called).to.be.false;
+      expect(announcements()).to.have.lengthOf(1);
+      expect(announcements()[0]).to.include(appName);
+
+      // a second 30s cycle must NOT repeat it - the latch is what makes the line
+      // affordable at election cadence
+      await runPass();
+      expect(announcements()).to.have.lengthOf(1);
+    });
+
+    it('announces again after the operator lock is lifted and re-applied', async () => {
+      const appName = 'relockapp';
+      dockerServiceStub.returns('zel_relockapp');
+      const operatorStopped = sinon.stub(appsRuntimeState, 'isOperatorStopped');
+      const logInfo = sinon.stub(log, 'info');
+
+      const installedApps = sinon.stub().resolves({
+        status: 'success',
+        data: [{ name: appName, version: 3, containerData: 'g:/syncdata' }],
+      });
+      const listRunningApps = sinon.stub().resolves({ status: 'success', data: [] });
+
+      // the un-stopped pass runs the real election, so give it what it reads
+      serviceHelperStub.resolves({ data: [] });
+      fluxNetworkHelperStub.resolves('192.168.1.5:16127');
+      registryManagerStub.resolves([{ name: appName, ip: '192.168.1.5:16127', runningSince: null }]);
+      syncthingServiceStub.resolves({ status: 'success', data: [] });
+
+      const runPass = () => advancedWorkflows.masterSlaveApps(
+        globalState, installedApps, listRunningApps, new Map(), [], [], https,
+      );
+      const announcements = () => logInfo.getCalls()
+        .map((call) => String(call.args[0]))
+        .filter((msg) => msg.includes('operator-stopped'));
+
+      operatorStopped.resetBehavior();
+      operatorStopped.resolves(true);
+      await runPass();
+      expect(announcements()).to.have.lengthOf(1);
+
+      // operator starts it again - the latch must clear
+      operatorStopped.resetBehavior();
+      operatorStopped.resolves(false);
+      await runPass();
+      expect(announcements()).to.have.lengthOf(1);
+
+      // and a fresh stop must be announced rather than swallowed by a stale latch
+      operatorStopped.resetBehavior();
+      operatorStopped.resolves(true);
+      await runPass();
+      expect(announcements()).to.have.lengthOf(2);
     });
 
     it('should handle apps with g: containerData (master-slave mode)', async () => {

--- a/tests/unit/advancedWorkflows.test.js
+++ b/tests/unit/advancedWorkflows.test.js
@@ -1585,7 +1585,7 @@ describe('advancedWorkflows tests', () => {
       // mirror the real removal's row delete so the record assertion below
       // can actually fail if the catch takes the removal path
       const removeSpy = sinon.stub(appUninstaller, 'removeAppLocally').callsFake(async () => { localRow = null; });
-      sinon.stub(appUninstaller, 'softUninstallComponent').resolves();
+      const softUninstall = sinon.stub(appUninstaller, 'softUninstallComponent').resolves();
 
       sinon.stub(appInstaller, 'checkAppRequirements').resolves(true);
       const registerHard = sinon.stub(appInstaller, 'registerAppLocally').resolves(true);
@@ -1598,6 +1598,13 @@ describe('advancedWorkflows tests', () => {
       sinon.stub(serviceHelper, 'delay').callsFake(async () => { globalState.installationInProgress = true; });
 
       await advancedWorkflows.reinstallOldApplications();
+
+      // positive proof the collision path actually ran: the composed soft
+      // teardown must have happened, and the delay stub's flag must still be
+      // set - without these, a regression that skips the redeploy entirely
+      // (probability gate, hash comparison) would leave this test green
+      expect(softUninstall.called, 'the composed soft redeploy was never attempted').to.equal(true);
+      expect(globalState.installationInProgress, 'the collision was never armed').to.equal(true);
       globalState.installationInProgress = false;
 
       expect(removeSpy.called, 'a busy collision force-removed the app and its data').to.equal(false);
@@ -1606,11 +1613,12 @@ describe('advancedWorkflows tests', () => {
       expect(localRow, 'the app must keep its local record for the reconciler').to.not.equal(null);
     });
 
-    it('createAppVolume drops a stale synced-mark - a fresh volume is by definition not synced', async () => {
-      // a cache entry surviving from a previous incarnation (e.g. a redeploy
-      // keep-mark re-planted while a same-app removal raced it) would let the
-      // next fresh install skip the new-install receiveonly protection and
-      // read as instantly ready for g: primary
+    it('createAppVolume preserves the synced-mark when pre-flight aborts before any volume is touched', async () => {
+      // a hard recreate whose pre-flight fails (a resources query blip, out
+      // of space - the LIKELY population for failed recreates) leaves the
+      // existing volume and its data untouched. Stripping the mark there
+      // hands the intact data to the not-in-cache skip/second-encounter
+      // chain, which clears it.
       const { newAppSpecs } = rowlessWindowFixture();
       const component = newAppSpecs.compose[0];
       globalState.receiveOnlySyncthingAppsCache.set('fluxfrontend_TestApp', {
@@ -1619,11 +1627,9 @@ describe('advancedWorkflows tests', () => {
 
       // eslint-disable-next-line global-require
       const hwRequirements = require('../../ZelBack/src/services/appRequirements/hwRequirements');
-      sinon.stub(hwRequirements, 'getNodeSpecs').resolves({ ssdStorage: 100 });
+      sinon.stub(hwRequirements, 'getNodeSpecs').resolves({ ssdStorage: 10000 });
       // eslint-disable-next-line global-require
       const resourceQueryService = require('../../ZelBack/src/services/appQuery/resourceQueryService');
-      // abort the creation right after the stale-mark drop - the volume
-      // machinery itself is not under test
       sinon.stub(resourceQueryService, 'appsResources').resolves({ status: 'error' });
 
       let thrown = null;
@@ -1631,11 +1637,48 @@ describe('advancedWorkflows tests', () => {
         await advancedWorkflows.createAppVolume(component, 'TestApp', true, null);
       } catch (error) { thrown = error; }
 
-      expect(thrown, 'the aborting stub did not fire').to.not.equal(null);
+      expect(thrown, 'the pre-flight abort did not fire').to.not.equal(null);
+      expect(thrown.message).to.include('Unable to obtain locked system resources');
       expect(
         globalState.receiveOnlySyncthingAppsCache.has('fluxfrontend_TestApp'),
-        'a fresh volume creation left a stale synced-mark in place',
+        'an aborted pre-flight stripped the synced-mark of an app whose data is intact',
+      ).to.equal(true);
+      globalState.receiveOnlySyncthingAppsCache.clear();
+    });
+
+    it('createAppVolume drops a stale synced-mark at the point of no return', async () => {
+      // once fallocate runs the old volume state is gone: a cache entry
+      // surviving from the previous incarnation would let this fresh install
+      // skip the new-install receiveonly protection and read as instantly
+      // ready for g: primary
+      const { newAppSpecs } = rowlessWindowFixture();
+      const component = newAppSpecs.compose[0];
+      globalState.receiveOnlySyncthingAppsCache.set('fluxfrontend_TestApp', {
+        restarted: true, numberOfExecutionsRequired: 4, numberOfExecutions: 10,
+      });
+
+      // eslint-disable-next-line global-require
+      const hwRequirements = require('../../ZelBack/src/services/appRequirements/hwRequirements');
+      sinon.stub(hwRequirements, 'getNodeSpecs').resolves({ ssdStorage: 10000 });
+      // eslint-disable-next-line global-require
+      const resourceQueryService = require('../../ZelBack/src/services/appQuery/resourceQueryService');
+      sinon.stub(resourceQueryService, 'appsResources').resolves({ status: 'success', data: { appsHddLocked: 0 } });
+      // let the flow reach the point of no return, then block the actual
+      // allocation - the drop must have happened by then
+      sinon.stub(serviceHelper, 'runCommand').callsFake(async (cmd) => (
+        cmd === 'fallocate' ? { error: new Error('fallocate blocked by test') } : {}));
+
+      let thrown = null;
+      try {
+        await advancedWorkflows.createAppVolume(component, 'TestApp', true, null);
+      } catch (error) { thrown = error; }
+
+      expect(thrown, 'the flow never reached the allocation').to.not.equal(null);
+      expect(
+        globalState.receiveOnlySyncthingAppsCache.has('fluxfrontend_TestApp'),
+        'the point of no return left a stale synced-mark in place',
       ).to.equal(false);
+      globalState.receiveOnlySyncthingAppsCache.clear();
     });
 
     it('stamps busy-guard throws so callers can tell a collision from a real failure', async () => {

--- a/tests/unit/advancedWorkflows.test.js
+++ b/tests/unit/advancedWorkflows.test.js
@@ -1673,7 +1673,12 @@ describe('advancedWorkflows tests', () => {
         await advancedWorkflows.createAppVolume(component, 'TestApp', true, null);
       } catch (error) { thrown = error; }
 
+      // assert WHICH error aborted before judging the cache: this test rides
+      // the host's real df output through the space pre-flight, and on a
+      // low-disk host the pre-flight throws first - that must read as "never
+      // reached the allocation", not as a phantom production regression
       expect(thrown, 'the flow never reached the allocation').to.not.equal(null);
+      expect(thrown.message, 'the flow aborted before the allocation').to.equal('fallocate blocked by test');
       expect(
         globalState.receiveOnlySyncthingAppsCache.has('fluxfrontend_TestApp'),
         'the point of no return left a stale synced-mark in place',

--- a/tests/unit/advancedWorkflows.test.js
+++ b/tests/unit/advancedWorkflows.test.js
@@ -12,6 +12,10 @@ const fluxNetworkHelper = require('../../ZelBack/src/services/fluxNetworkHelper'
 const appReconciler = require('../../ZelBack/src/services/appMonitoring/appReconciler');
 const syncthingService = require('../../ZelBack/src/services/syncthingService');
 const appQueryService = require('../../ZelBack/src/services/appQuery/appQueryService');
+const generalService = require('../../ZelBack/src/services/generalService');
+const globalState = require('../../ZelBack/src/services/utils/globalState');
+const appInstaller = require('../../ZelBack/src/services/appLifecycle/appInstaller');
+const appUninstaller = require('../../ZelBack/src/services/appLifecycle/appUninstaller');
 
 describe('advancedWorkflows tests', () => {
   afterEach(() => {
@@ -1258,8 +1262,6 @@ describe('advancedWorkflows tests', () => {
 
     beforeEach(() => {
       // Reset global state
-      // eslint-disable-next-line global-require
-      const globalState = require('../../ZelBack/src/services/utils/globalState');
       globalState.removalInProgress = false;
       globalState.installationInProgress = false;
       globalState.softRedeployInProgress = false;
@@ -1278,51 +1280,109 @@ describe('advancedWorkflows tests', () => {
     it('keeps the app and its data when the soft install fails - a failed soft redeploy never removes', async () => {
       // The data volume was deliberately preserved (that is what makes the
       // redeploy soft), so the rollback removal destroyed established data
-      // over what is usually a node-local failure. The spec and volume must
-      // stay; the reconciler retries with the current spec on its ladder.
-      const installedApp = {
+      // over what is usually a node-local failure. With the local row present
+      // the spec and volume must stay; the reconciler retries with the
+      // current spec on its ladder.
+      const composed = (repotag) => ({
+        name: 'frontend',
+        repotag,
+        containerData: 'g:/data',
+        ports: [31111],
+        domains: [''],
+        environmentParameters: [],
+        commands: [],
+        containerPorts: [80],
+        cpu: 0.1,
+        ram: 100,
+        hdd: 1,
+        tiered: false,
+      });
+      const base = {
         name: 'TestApp',
+        description: 'test app',
+        owner: '1TESTOWNERADDRESS',
         version: 8,
-        compose: [{ name: 'frontend', repotag: 'repo/frontend:1.0', containerData: 'g:/data' }],
+        instances: 3,
+        contacts: [],
+        geolocation: [],
+        expire: 22000,
+        nodes: [],
+        staticip: false,
+        hash: 'testhash',
+        height: 1000,
       };
-      const newAppSpecs = {
-        name: 'TestApp',
-        version: 8,
-        compose: [{ name: 'frontend', repotag: 'repo/frontend:1.1', containerData: 'g:/data' }],
-      };
-      findInDatabaseStub = sinon.stub(dbHelper, 'findInDatabase').resolves([installedApp]);
-      sinon.stub(dbHelper, 'findOneInDatabase').resolves(installedApp);
-      sinon.stub(dbHelper, 'insertOneToDatabase').resolves();
+      const installedApp = { ...base, compose: [composed('repo/frontend:1.0')] };
+      const newAppSpecs = { ...base, compose: [composed('repo/frontend:1.1')] };
+      // The stubs mirror the real local-row lifecycle: the soft remove
+      // deletes the row (so the register's already-installed check passes),
+      // the register's insert restores it (so the catch's row-exists gate
+      // sees it). A blanket always-returns-row stub aborts the register
+      // with 'already installed' and never reaches the install.
+      let localRow = installedApp;
+      findInDatabaseStub = sinon.stub(dbHelper, 'findInDatabase').callsFake(async () => (localRow ? [localRow] : []));
+      sinon.stub(dbHelper, 'findOneInDatabase').callsFake(async () => localRow);
+      sinon.stub(dbHelper, 'insertOneToDatabase').callsFake(async (db, col, doc) => { localRow = doc; return doc; });
       sinon.stub(dbHelper, 'updateOneInDatabase').resolves();
       sinon.stub(dbHelper, 'removeDocumentsFromCollection').resolves();
+      sinon.stub(dbHelper, 'findOneAndDeleteInDatabase').callsFake(async () => { const row = localRow; localRow = null; return row; });
 
-      // eslint-disable-next-line global-require
-      const appUninstaller = require('../../ZelBack/src/services/appLifecycle/appUninstaller');
       const removeSpy = sinon.stub(appUninstaller, 'removeAppLocally').resolves();
       sinon.stub(appUninstaller, 'softUninstallComponent').resolves();
 
-      // eslint-disable-next-line global-require
-      const appInstaller = require('../../ZelBack/src/services/appLifecycle/appInstaller');
       sinon.stub(appInstaller, 'checkAppRequirements').resolves(true);
-      sinon.stub(appInstaller, 'installApplicationSoft').rejects(new Error('Error: Port 31111 FAILed to open.'));
+      sinon.stub(appInstaller, 'ensureAppDockerNetwork').resolves();
+      const installSoft = sinon.stub(appInstaller, 'installApplicationSoft').rejects(new Error('Error: Port 31111 FAILed to open.'));
+      sinon.stub(generalService, 'nodeTier').resolves('basic');
 
-      // eslint-disable-next-line global-require
-      const serviceHelper = require('../../ZelBack/src/services/serviceHelper');
       sinon.stub(serviceHelper, 'delay').resolves();
 
-      // eslint-disable-next-line global-require
-      const globalState = require('../../ZelBack/src/services/utils/globalState');
-      globalState.receiveOnlySyncthingAppsCache = new Map();
+      // the property is getter-only: clear the real shared map, never reassign
+      globalState.receiveOnlySyncthingAppsCache.clear();
 
       const res = { write: sinon.stub(), flush: sinon.stub(), end: sinon.stub() };
 
       await advancedWorkflows.softRedeploy(newAppSpecs, res);
 
+      expect(installSoft.called, 'the flow never reached the soft install - the test is not exercising the register-site keep').to.equal(true);
       expect(removeSpy.called, 'a failed soft redeploy removed the app and its data').to.equal(false);
       expect(
         globalState.receiveOnlySyncthingAppsCache.size,
         'the kept g: component was not re-marked synced - the sync layer would clear its data',
       ).to.be.greaterThan(0);
+    });
+
+    it('falls back to full removal - and does not mark synced - when the app has no local record', async () => {
+      // 'Flux App not found' (redeploy called on a node without the app, or a
+      // failure after the soft uninstall deleted the row and before the
+      // register restored it): keeping is incoherent - nothing converges an
+      // app the reconciler cannot see, and a stale synced-mark would make an
+      // empty later install eligible for g: primary. The catch must take the
+      // removal path and must NOT touch the cache.
+      const newAppSpecs = {
+        name: 'TestAppGone',
+        description: 'test app',
+        owner: '1TESTOWNERADDRESS',
+        version: 8,
+        compose: [{ name: 'frontend', repotag: 'repo/frontend:1.1', containerData: 'g:/data' }],
+      };
+      findInDatabaseStub = sinon.stub(dbHelper, 'findInDatabase').resolves([]);
+      sinon.stub(dbHelper, 'findOneInDatabase').resolves(null);
+
+      const removeSpy = sinon.stub(appUninstaller, 'removeAppLocally').resolves();
+
+      sinon.stub(serviceHelper, 'delay').resolves();
+
+      globalState.receiveOnlySyncthingAppsCache.clear();
+
+      const res = { write: sinon.stub(), flush: sinon.stub(), end: sinon.stub() };
+
+      await advancedWorkflows.softRedeploy(newAppSpecs, res);
+
+      expect(removeSpy.called, 'the rowless failure did not fall back to removal').to.equal(true);
+      expect(
+        globalState.receiveOnlySyncthingAppsCache.size,
+        'marked synced for an app this node does not even have',
+      ).to.equal(0);
     });
 
     it('should escalate to hard redeploy when component count changes for v8+ app', async () => {

--- a/tests/unit/advancedWorkflows.test.js
+++ b/tests/unit/advancedWorkflows.test.js
@@ -1565,8 +1565,9 @@ describe('advancedWorkflows tests', () => {
       // whole app (containers, volumes, data, row, broadcast) on a real
       // registration failure - it must NOT do that when the register merely
       // collided with another operation's flag. The components stay
-      // soft-uninstalled with the row and data volumes intact; the next
-      // reinstall pass completes the update.
+      // soft-uninstalled with the row (already carrying the new spec) and
+      // data volumes intact; the reconciler recreates the missing
+      // components over the preserved volumes.
       const { installedApp, newAppSpecs } = rowlessWindowFixture();
       const localRowStart = { ...installedApp, hash: 'oldhash' };
       const globalSpec = { ...newAppSpecs, hash: 'newhash' };
@@ -1581,7 +1582,9 @@ describe('advancedWorkflows tests', () => {
       sinon.stub(dbHelper, 'removeDocumentsFromCollection').callsFake(async () => { localRow = null; });
       sinon.stub(dbHelper, 'findOneAndDeleteInDatabase').callsFake(async () => { const row = localRow; localRow = null; return row; });
 
-      const removeSpy = sinon.stub(appUninstaller, 'removeAppLocally').resolves();
+      // mirror the real removal's row delete so the record assertion below
+      // can actually fail if the catch takes the removal path
+      const removeSpy = sinon.stub(appUninstaller, 'removeAppLocally').callsFake(async () => { localRow = null; });
       sinon.stub(appUninstaller, 'softUninstallComponent').resolves();
 
       sinon.stub(appInstaller, 'checkAppRequirements').resolves(true);
@@ -1600,10 +1603,38 @@ describe('advancedWorkflows tests', () => {
       expect(removeSpy.called, 'a busy collision force-removed the app and its data').to.equal(false);
       expect(registerHard.called, 'the equal-hdd component took the hard path').to.equal(false);
       expect(installSoft.called).to.equal(false);
-      expect(localRow, 'the app must keep its local record for the next pass').to.not.equal(null);
+      expect(localRow, 'the app must keep its local record for the reconciler').to.not.equal(null);
+    });
+
+    it('createAppVolume drops a stale synced-mark - a fresh volume is by definition not synced', async () => {
+      // a cache entry surviving from a previous incarnation (e.g. a redeploy
+      // keep-mark re-planted while a same-app removal raced it) would let the
+      // next fresh install skip the new-install receiveonly protection and
+      // read as instantly ready for g: primary
+      const { newAppSpecs } = rowlessWindowFixture();
+      const component = newAppSpecs.compose[0];
+      globalState.receiveOnlySyncthingAppsCache.set('fluxfrontend_TestApp', {
+        restarted: true, numberOfExecutionsRequired: 4, numberOfExecutions: 10,
+      });
+
+      // eslint-disable-next-line global-require
+      const hwRequirements = require('../../ZelBack/src/services/appRequirements/hwRequirements');
+      sinon.stub(hwRequirements, 'getNodeSpecs').resolves({ ssdStorage: 100 });
+      // eslint-disable-next-line global-require
+      const resourceQueryService = require('../../ZelBack/src/services/appQuery/resourceQueryService');
+      // abort the creation right after the stale-mark drop - the volume
+      // machinery itself is not under test
+      sinon.stub(resourceQueryService, 'appsResources').resolves({ status: 'error' });
+
+      let thrown = null;
+      try {
+        await advancedWorkflows.createAppVolume(component, 'TestApp', true, null);
+      } catch (error) { thrown = error; }
+
+      expect(thrown, 'the aborting stub did not fire').to.not.equal(null);
       expect(
-        globalState.reinstallationOfOldAppsInProgress,
-        'the reinstall pass flag leaked',
+        globalState.receiveOnlySyncthingAppsCache.has('fluxfrontend_TestApp'),
+        'a fresh volume creation left a stale synced-mark in place',
       ).to.equal(false);
     });
 

--- a/tests/unit/advancedWorkflows.test.js
+++ b/tests/unit/advancedWorkflows.test.js
@@ -1738,7 +1738,7 @@ describe('advancedWorkflows tests', () => {
 
       // FDM answers on every pass: no primary anywhere
       sinon.stub(serviceHelper, 'axiosGet').resolves({ data: { status: 'success', data: { ips: [] } } });
-      sinon.stub(serviceHelper, 'runCommand').resolves(); // the chain's chmod
+      sinon.stub(serviceHelper, 'runCommand').resolves({ error: null, stdout: '', stderr: '' }); // the chain's chmod
       // pass 1 gets this node's address; pass 2 wedges here and gets abandoned
       const localAddr = sinon.stub(fluxNetworkHelper, 'getLocalSocketAddress');
       localAddr.onFirstCall().resolves('192.168.1.5:16127');
@@ -1787,6 +1787,146 @@ describe('advancedWorkflows tests', () => {
         "another pass's abandonment dropped a completed pass's start",
       ).to.equal(true);
       expect(setControllerDesired.callCount).to.equal(1);
+    });
+
+    it('does not request a start when the permissions fix fails', async () => {
+      // runCommand reports failure via result.error, never a rejection. The chain
+      // must read that result - discarding it deadened the guard, and a node got
+      // elected write-side primary over data whose ownership it could not fix.
+      const appName = 'gpermfail';
+      const identifier = `gcomp_${appName}`;
+      // eslint-disable-next-line global-require
+      const dockerService = require('../../ZelBack/src/services/dockerService');
+      // eslint-disable-next-line global-require
+      const { appsFolder } = require('../../ZelBack/src/services/utils/appConstants');
+      // eslint-disable-next-line global-require
+      const registryManager = require('../../ZelBack/src/services/appDatabase/registryManager');
+      const appId = dockerService.getAppIdentifier(identifier);
+      const setControllerDesired = sinon.stub(appReconciler, 'setControllerDesired');
+
+      sinon.stub(serviceHelper, 'axiosGet').resolves({ data: { status: 'success', data: { ips: [] } } });
+      sinon.stub(serviceHelper, 'runCommand').resolves({ error: new Error('chmod: cannot access'), stdout: '', stderr: '' });
+      sinon.stub(fluxNetworkHelper, 'getLocalSocketAddress').resolves('192.168.1.5:16127');
+      sinon.stub(registryManager, 'appLocation').resolves([{ ip: '192.168.1.5:16127' }]);
+      const getConfigFolders = sinon.stub(syncthingService, 'getConfigFolders')
+        .resolves({ status: 'success', data: [{ id: 'f1', path: `${appsFolder}${appId}`, type: 'receiveonly' }] });
+
+      const installedApps = sinon.stub().resolves({
+        status: 'success',
+        data: [{ name: appName, version: 8, compose: [{ name: 'gcomp', containerData: 'g:/data' }] }],
+      });
+      const listRunningApps = sinon.stub().resolves({ status: 'success', data: [] });
+      const cache = new Map();
+      cache.set(appId, { restarted: true });
+
+      const control = advancedWorkflows.startMasterSlaveApps(
+        globalStateMock, installedApps, listRunningApps, cache, [], [], https,
+      );
+      await clock.tickAsync(50);
+      control.stop();
+
+      expect(
+        setControllerDesired.called,
+        'started a primary over data whose permissions fix failed',
+      ).to.equal(false);
+      expect(
+        getConfigFolders.callCount,
+        'flipped the folder to sendreceive after a failed permissions fix',
+      ).to.equal(1);
+    });
+
+    it('does not abandon a pass that is slow but still making progress', async () => {
+      // The watchdog judges silence, not total elapsed time: a pass with several
+      // g: apps against a degraded FDM legitimately outruns any fixed budget
+      // while advancing, and abandoning it drops the standby stops / primary
+      // starts for every app later in the list - on stable timings, the same
+      // tail every cycle.
+      const appNames = ['gslowa', 'gslowb'];
+      const identifiers = appNames.map((n) => `gcomp_${n}`);
+      const setControllerDesired = sinon.stub(appReconciler, 'setControllerDesired');
+
+      // FDM answers with another node as primary - after 3/4 of the watchdog
+      // budget, so two apps together far exceed the budget but each answer is
+      // fresh progress
+      const fdmDelayMs = Math.round(maxPassMs * 0.75);
+      sinon.stub(serviceHelper, 'axiosGet').callsFake(() => new Promise((resolve) => {
+        setTimeout(() => resolve({ data: { status: 'success', data: { ips: ['192.168.1.99'] } } }), fdmDelayMs);
+      }));
+      sinon.stub(fluxNetworkHelper, 'getLocalSocketAddress').resolves('192.168.1.5:16127');
+
+      const installedApps = sinon.stub().resolves({
+        status: 'success',
+        data: appNames.map((name) => ({ name, version: 8, compose: [{ name: 'gcomp', containerData: 'g:/data' }] })),
+      });
+      // both components run here, and FDM names another primary -> standby stops
+      const listRunningApps = sinon.stub().resolves({
+        status: 'success',
+        data: identifiers.map((id) => ({ Names: [`/flux${id}`] })),
+      });
+
+      const control = advancedWorkflows.startMasterSlaveApps(
+        globalStateMock, installedApps, listRunningApps, new Map(), [], [], https,
+      );
+      await clock.tickAsync(2 * fdmDelayMs + 1000);
+      control.stop();
+
+      identifiers.forEach((id) => {
+        expect(
+          setControllerDesired.calledWith(id, 'stopped', 'masterSlave standby'),
+          `the slow-but-advancing pass was abandoned before it reached ${id}`,
+        ).to.equal(true);
+      });
+    });
+
+    it("an abandoned pass's late finally does not release the lock its replacement holds", async () => {
+      // The finally only clears masterSlaveAppsRunning when its pass is still
+      // current: an abandoned pass that unwedges minutes later must not clobber
+      // the lock the live pass set for itself.
+      const writes = [];
+      let running = false;
+      Object.defineProperty(globalStateMock, 'masterSlaveAppsRunning', {
+        configurable: true,
+        get: () => running,
+        set: (value) => { running = value; writes.push(value); },
+      });
+      // eslint-disable-next-line global-require
+      const registryManager = require('../../ZelBack/src/services/appDatabase/registryManager');
+      sinon.stub(registryManager, 'appLocation').resolves([]);
+      sinon.stub(serviceHelper, 'axiosGet').resolves({ data: { status: 'success', data: { ips: [] } } });
+      sinon.stub(syncthingService, 'getConfigFolders').resolves({ status: 'error' });
+
+      // pass 1 wedges on the address lookup and is abandoned; pass 2 wedges the
+      // same way and is still in flight when pass 1 is released
+      let releaseFirst;
+      const localAddr = sinon.stub(fluxNetworkHelper, 'getLocalSocketAddress');
+      localAddr.onFirstCall().returns(new Promise((resolve) => {
+        releaseFirst = () => resolve('192.168.1.5:16127');
+      }));
+      localAddr.returns(new Promise(() => {}));
+
+      const installedApps = sinon.stub().resolves({
+        status: 'success',
+        data: [{ name: 'glateclear', version: 8, compose: [{ name: 'gcomp', containerData: 'g:/data' }] }],
+      });
+
+      const control = advancedWorkflows.startMasterSlaveApps(
+        globalStateMock, installedApps, listRunningAppsStub, new Map(), [], [], https,
+      );
+      await clock.tickAsync(50);
+      expect(writes).to.deep.equal([true]);
+
+      // the watchdog abandons pass 1 (writes false), and the next interval tick -
+      // possibly in the same timer batch - starts pass 2, which wedges too
+      await clock.tickAsync(maxPassMs + intervalMs);
+      expect(writes).to.deep.equal([true, false, true]);
+      control.stop();
+
+      releaseFirst(); // pass 1 unwedges and runs its finally
+      await clock.tickAsync(50);
+      expect(
+        writes,
+        "the abandoned pass's finally released the replacement's lock",
+      ).to.deep.equal([true, false, true]);
     });
 
     it('releases the global masterSlaveAppsRunning lock when it abandons a pass', async () => {

--- a/tests/unit/advancedWorkflows.test.js
+++ b/tests/unit/advancedWorkflows.test.js
@@ -1514,14 +1514,19 @@ describe('advancedWorkflows tests', () => {
       globalState.installationInProgress = false;
     });
 
-    it('defers to an in-progress removal - no restore, no mark, no removal - when one races into the redeploy window', async () => {
-      // A removal racing into the redeploy delay may be THIS app's own
-      // deliberate removal (removeAppLocally deletes the row last, and is not
-      // gated on softRedeployInProgress). Restoring the row here could
-      // resurrect an app the operator just removed; removing would race the
-      // remover. The catch must leave the state to the removal entirely: no
-      // restore, no synced-mark, no removal of its own - and it must not
-      // touch the remover's flag.
+    it('restores and keeps - without touching the remover\'s flag - when a removal races into the redeploy window', async () => {
+      // A removal racing into the redeploy delay is almost always for an
+      // UNRELATED app (removeAppLocally is not gated on
+      // softRedeployInProgress). Hands-off here would orphan THIS app
+      // permanently: its row is already deleted by its own teardown, nothing
+      // enumerates a rowless app, its volume vanishes from the resource
+      // accounting, and a later spawner re-selection reformats it. Restore
+      // and keep, like any other mid-flight failure. The same-app
+      // interleaving this could theoretically resurrect is self-correcting
+      // in all but a milliseconds window (the remover deletes the row LAST,
+      // so its own final delete undoes this restore) - and a removal that
+      // FINISHES before the register runs resurrects on the success path
+      // regardless, so hands-off bought nothing there either.
       const { installedApp, newAppSpecs } = rowlessWindowFixture();
       const rowState = stubRowLifecycle(installedApp);
 
@@ -1542,17 +1547,64 @@ describe('advancedWorkflows tests', () => {
 
       expect(removeSpy.called, 'the redeploy raced the remover with a removal of its own').to.equal(false);
       expect(installSoft.called).to.equal(false);
-      expect(rowState.localRow, 'restored the row of an app a removal may be deliberately deleting').to.equal(null);
+      expect(rowState.localRow, 'the local record deleted by the teardown was not restored').to.not.equal(null);
       expect(
         globalState.receiveOnlySyncthingAppsCache.size,
-        'marked synced during a removal - a rowless mark makes an empty later install eligible for g: primary',
-      ).to.equal(0);
+        'the kept g: component was not re-marked synced',
+      ).to.be.greaterThan(0);
       expect(
         globalState.removalInProgress,
         'the remover\'s removalInProgress flag was cleared by a flow that does not own it',
       ).to.equal(true);
       expect(res.end.called, 'the API response was left open').to.equal(true);
       globalState.removalInProgress = false;
+    });
+
+    it('reinstallOldApplications defers on a busy collision instead of force-removing the app', async () => {
+      // the headline contract: the composed-update catch force-removes the
+      // whole app (containers, volumes, data, row, broadcast) on a real
+      // registration failure - it must NOT do that when the register merely
+      // collided with another operation's flag. The components stay
+      // soft-uninstalled with the row and data volumes intact; the next
+      // reinstall pass completes the update.
+      const { installedApp, newAppSpecs } = rowlessWindowFixture();
+      const localRowStart = { ...installedApp, hash: 'oldhash' };
+      const globalSpec = { ...newAppSpecs, hash: 'newhash' };
+      const globalCollection = config.database.appsglobal.collections.appsInformation;
+
+      let localRow = localRowStart;
+      sinon.stub(dbHelper, 'findInDatabase').callsFake(async () => (localRow ? [localRow] : []));
+      sinon.stub(dbHelper, 'findOneInDatabase').callsFake(async (db, collection) => (
+        collection === globalCollection ? globalSpec : localRow));
+      sinon.stub(dbHelper, 'insertOneToDatabase').callsFake(async (db, col, doc) => { localRow = doc; return doc; });
+      sinon.stub(dbHelper, 'updateOneInDatabase').resolves();
+      sinon.stub(dbHelper, 'removeDocumentsFromCollection').callsFake(async () => { localRow = null; });
+      sinon.stub(dbHelper, 'findOneAndDeleteInDatabase').callsFake(async () => { const row = localRow; localRow = null; return row; });
+
+      const removeSpy = sinon.stub(appUninstaller, 'removeAppLocally').resolves();
+      sinon.stub(appUninstaller, 'softUninstallComponent').resolves();
+
+      sinon.stub(appInstaller, 'checkAppRequirements').resolves(true);
+      const registerHard = sinon.stub(appInstaller, 'registerAppLocally').resolves(true);
+      const installSoft = sinon.stub(appInstaller, 'installApplicationSoft').resolves();
+      sinon.stub(generalService, 'nodeTier').resolves('basic');
+      sinon.stub(generalService, 'checkSynced').resolves(true);
+      // deterministic 'redeploy this cycle' outcome for the probability roll
+      sinon.stub(Math, 'random').returns(0);
+      // the collision lands during the composed delay before the register
+      sinon.stub(serviceHelper, 'delay').callsFake(async () => { globalState.installationInProgress = true; });
+
+      await advancedWorkflows.reinstallOldApplications();
+      globalState.installationInProgress = false;
+
+      expect(removeSpy.called, 'a busy collision force-removed the app and its data').to.equal(false);
+      expect(registerHard.called, 'the equal-hdd component took the hard path').to.equal(false);
+      expect(installSoft.called).to.equal(false);
+      expect(localRow, 'the app must keep its local record for the next pass').to.not.equal(null);
+      expect(
+        globalState.reinstallationOfOldAppsInProgress,
+        'the reinstall pass flag leaked',
+      ).to.equal(false);
     });
 
     it('stamps busy-guard throws so callers can tell a collision from a real failure', async () => {

--- a/tests/unit/advancedWorkflows.test.js
+++ b/tests/unit/advancedWorkflows.test.js
@@ -1351,13 +1351,13 @@ describe('advancedWorkflows tests', () => {
       ).to.be.greaterThan(0);
     });
 
-    it('falls back to full removal - and does not mark synced - when the app has no local record', async () => {
-      // 'Flux App not found' (redeploy called on a node without the app, or a
-      // failure after the soft uninstall deleted the row and before the
-      // register restored it): keeping is incoherent - nothing converges an
-      // app the reconciler cannot see, and a stale synced-mark would make an
-      // empty later install eligible for g: primary. The catch must take the
-      // removal path and must NOT touch the cache.
+    it('falls back to full removal - and does not mark synced - when the app was never locally installed', async () => {
+      // 'Flux App not found': a redeploy called on a node without the app.
+      // Nothing of value exists here to keep - the removal fallback cleans up
+      // local remnants - and a stale synced-mark would make an empty later
+      // install eligible for g: primary, so the cache must stay untouched.
+      // (A failure after this redeploy's OWN teardown deleted the row is the
+      // opposite case: data on disk, row restored - pinned separately below.)
       const newAppSpecs = {
         name: 'TestAppGone',
         description: 'test app',
@@ -1383,6 +1383,155 @@ describe('advancedWorkflows tests', () => {
         globalState.receiveOnlySyncthingAppsCache.size,
         'marked synced for an app this node does not even have',
       ).to.equal(0);
+    });
+
+    // Shared fixture for the rowless-window tests: an installed v8 app with a
+    // g: component whose redeploy is mid-flight when the failure lands.
+    const rowlessWindowFixture = () => {
+      const composed = (repotag) => ({
+        name: 'frontend',
+        repotag,
+        containerData: 'g:/data',
+        ports: [31111],
+        domains: [''],
+        environmentParameters: [],
+        commands: [],
+        containerPorts: [80],
+        cpu: 0.1,
+        ram: 100,
+        hdd: 1,
+        tiered: false,
+      });
+      const base = {
+        name: 'TestApp',
+        description: 'test app',
+        owner: '1TESTOWNERADDRESS',
+        version: 8,
+        instances: 3,
+        contacts: [],
+        geolocation: [],
+        expire: 22000,
+        nodes: [],
+        staticip: false,
+        hash: 'testhash',
+        height: 1000,
+      };
+      return {
+        installedApp: { ...base, compose: [composed('repo/frontend:1.0')] },
+        newAppSpecs: { ...base, compose: [composed('repo/frontend:1.1')] },
+      };
+    };
+
+    // Mutable-row db stubs mirroring the real local-row lifecycle (soft remove
+    // deletes the row, the register's insert restores it). Returns accessors
+    // so tests can observe and preset the row.
+    const stubRowLifecycle = (initialRow) => {
+      const state = { localRow: initialRow };
+      sinon.stub(dbHelper, 'findInDatabase').callsFake(async () => (state.localRow ? [state.localRow] : []));
+      sinon.stub(dbHelper, 'findOneInDatabase').callsFake(async () => state.localRow);
+      sinon.stub(dbHelper, 'insertOneToDatabase').callsFake(async (db, col, doc) => { state.localRow = doc; return doc; });
+      sinon.stub(dbHelper, 'updateOneInDatabase').resolves();
+      sinon.stub(dbHelper, 'removeDocumentsFromCollection').resolves();
+      sinon.stub(dbHelper, 'findOneAndDeleteInDatabase').callsFake(async () => { const row = state.localRow; state.localRow = null; return row; });
+      return state;
+    };
+
+    it('restores the local record and keeps the app when the requirements check fails after teardown', async () => {
+      // The rowless window: this redeploy's own teardown deleted the row, and
+      // checkAppRequirements throws before the register restored it (a blipped
+      // geolocation/resource query - node-local, transient, and correlated
+      // across nodes during an image-update wave). The volume is still mounted
+      // with established data: the catch must put the row back and keep, never
+      // hand the app to removeAppLocally.
+      const { installedApp, newAppSpecs } = rowlessWindowFixture();
+      const rowState = stubRowLifecycle(installedApp);
+
+      const removeSpy = sinon.stub(appUninstaller, 'removeAppLocally').resolves();
+      sinon.stub(appUninstaller, 'softUninstallComponent').resolves();
+
+      sinon.stub(appInstaller, 'checkAppRequirements').rejects(new Error('Node Geolocation not set. Aborting.'));
+      const installSoft = sinon.stub(appInstaller, 'installApplicationSoft').resolves();
+      sinon.stub(generalService, 'nodeTier').resolves('basic');
+      sinon.stub(serviceHelper, 'delay').resolves();
+
+      globalState.receiveOnlySyncthingAppsCache.clear();
+
+      const res = { write: sinon.stub(), flush: sinon.stub(), end: sinon.stub() };
+
+      await advancedWorkflows.softRedeploy(newAppSpecs, res);
+
+      expect(removeSpy.called, 'a mid-flight failure removed the app and its data').to.equal(false);
+      expect(installSoft.called, 'the install must not run after the requirements check failed').to.equal(false);
+      expect(rowState.localRow, 'the local record deleted by the teardown was not restored').to.not.equal(null);
+      expect(rowState.localRow.name).to.equal('TestApp');
+      expect(
+        globalState.receiveOnlySyncthingAppsCache.size,
+        'the kept g: component was not re-marked synced',
+      ).to.be.greaterThan(0);
+    });
+
+    it('restores the local record and keeps the app when the register fails before its re-insert', async () => {
+      // Same window, register side: the caller's teardown already deleted the
+      // row, and ensureAppDockerNetwork throws before insertOneToDatabase ran.
+      // A soft register only ever runs over an app installed here, so the
+      // catch restores the row and keeps rather than removing.
+      const { newAppSpecs } = rowlessWindowFixture();
+      const rowState = stubRowLifecycle(null);
+
+      const removeSpy = sinon.stub(appUninstaller, 'removeAppLocally').resolves();
+      sinon.stub(appInstaller, 'checkAppRequirements').resolves(true);
+      sinon.stub(appInstaller, 'ensureAppDockerNetwork').rejects(new Error('docker daemon not responding'));
+      const installSoft = sinon.stub(appInstaller, 'installApplicationSoft').resolves();
+      sinon.stub(generalService, 'nodeTier').resolves('basic');
+      sinon.stub(serviceHelper, 'delay').resolves();
+
+      globalState.receiveOnlySyncthingAppsCache.clear();
+
+      const res = { write: sinon.stub(), flush: sinon.stub(), end: sinon.stub() };
+
+      await advancedWorkflows.softRegisterAppLocally(newAppSpecs, undefined, res);
+
+      expect(removeSpy.called, 'a pre-insert register failure removed the app and its data').to.equal(false);
+      expect(installSoft.called).to.equal(false);
+      expect(rowState.localRow, 'the local record was not restored').to.not.equal(null);
+      expect(rowState.localRow.name).to.equal('TestApp');
+      expect(globalState.installationInProgress, 'the installation flag leaked').to.equal(false);
+      expect(
+        globalState.receiveOnlySyncthingAppsCache.size,
+        'the kept g: component was not re-marked synced',
+      ).to.be.greaterThan(0);
+    });
+
+    it('restores the local record and keeps the app when the node tier read fails mid-redeploy', async () => {
+      // nodeTier failing (a wedged/restarting daemon) used to early-return out
+      // of the register inside the rowless window: row deleted, containers
+      // gone, volume mounted, nothing keeping or removing or converging the
+      // app. It must route through the keep path like any other failure.
+      const { installedApp, newAppSpecs } = rowlessWindowFixture();
+      const rowState = stubRowLifecycle(installedApp);
+
+      const removeSpy = sinon.stub(appUninstaller, 'removeAppLocally').resolves();
+      sinon.stub(appUninstaller, 'softUninstallComponent').resolves();
+
+      sinon.stub(appInstaller, 'checkAppRequirements').resolves(true);
+      const installSoft = sinon.stub(appInstaller, 'installApplicationSoft').resolves();
+      sinon.stub(generalService, 'nodeTier').rejects(new Error('daemon wedged'));
+      sinon.stub(serviceHelper, 'delay').resolves();
+
+      globalState.receiveOnlySyncthingAppsCache.clear();
+
+      const res = { write: sinon.stub(), flush: sinon.stub(), end: sinon.stub() };
+
+      await advancedWorkflows.softRedeploy(newAppSpecs, res);
+
+      expect(removeSpy.called, 'the tier failure removed the app and its data').to.equal(false);
+      expect(installSoft.called).to.equal(false);
+      expect(rowState.localRow, 'the local record was not restored').to.not.equal(null);
+      expect(globalState.installationInProgress, 'the installation flag leaked').to.equal(false);
+      expect(
+        globalState.receiveOnlySyncthingAppsCache.size,
+        'the kept g: component was not re-marked synced',
+      ).to.be.greaterThan(0);
     });
 
     it('should escalate to hard redeploy when component count changes for v8+ app', async () => {

--- a/tests/unit/appInstaller.test.js
+++ b/tests/unit/appInstaller.test.js
@@ -1380,4 +1380,36 @@ describe('appInstaller tests', () => {
       expect(writes.some((w) => w && w.status && w.status.includes('already exists'))).to.be.true;
     });
   });
+
+  describe('isRegistryUnreachable', () => {
+    // The shapes here are ImageVerifier's own, read from its errorMeta getter. The
+    // integration suite caught this predicate silently reading `undefined` because
+    // the accessor was named for the private field; these pin both the mapping and
+    // the accessor's existence, which is cheaper than a six-minute suite.
+    const { ImageVerifier } = require('../../ZelBack/src/services/utils/imageVerifier');
+
+    it('reads an accessor ImageVerifier actually exposes', () => {
+      const descriptor = Object.getOwnPropertyDescriptor(ImageVerifier.prototype, 'errorMeta');
+      expect(descriptor && typeof descriptor.get, 'ImageVerifier.errorMeta is not a getter').to.equal('function');
+    });
+
+    it('treats a request nothing answered as unreachable', () => {
+      // what a stopped registry produces: no response, so no status
+      expect(appInstaller.isRegistryUnreachable({ httpStatus: undefined, errorCode: null, errorType: 'http_error' })).to.equal(true);
+      expect(appInstaller.isRegistryUnreachable({ httpStatus: null, errorCode: 'ECONNREFUSED', errorType: 'network' })).to.equal(true);
+    });
+
+    it('treats rate limiting and server faults as unreachable', () => {
+      expect(appInstaller.isRegistryUnreachable({ httpStatus: 429, errorType: 'rate_limit' })).to.equal(true);
+      expect(appInstaller.isRegistryUnreachable({ httpStatus: 503, errorType: 'server_error' })).to.equal(true);
+    });
+
+    it('treats an answer about the image as permanent', () => {
+      // the registry replied - the image is genuinely absent or forbidden, and
+      // riding that out on a stale local copy would hide a real problem
+      expect(appInstaller.isRegistryUnreachable({ httpStatus: 404, errorType: 'http_error' })).to.equal(false);
+      expect(appInstaller.isRegistryUnreachable({ httpStatus: 403, errorType: 'http_error' })).to.equal(false);
+      expect(appInstaller.isRegistryUnreachable(null)).to.equal(false);
+    });
+  });
 });

--- a/tests/unit/appInstaller.test.js
+++ b/tests/unit/appInstaller.test.js
@@ -1,7 +1,6 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
-const fs = require('fs');
 
 // The full-install dockerService stub, shared by every proxyquire setup that
 // drives registerAppLocally. Pass overrides for the few tests that need a
@@ -1382,55 +1381,37 @@ describe('appInstaller tests', () => {
     });
   });
 
-  describe('isRegistryUnreachable', () => {
-    // The shapes here are ImageVerifier's own, read from its errorMeta getter. The
-    // integration suite caught this predicate silently reading `undefined` because
-    // the accessor was named for the private field; these pin both the mapping and
-    // the accessor's existence, which is cheaper than a six-minute suite.
+  describe('image verify failure classification', () => {
+    // The transient/permanent split rides ON the error throwIfError throws
+    // (ImageVerifier.errorClass, stamped as registryErrorClass), so a definitive
+    // answer about the image - bad arch, over size, not whitelisted - can never
+    // read as "registry unreachable" and be ridden out on the local copy.
     const { ImageVerifier } = require('../../ZelBack/src/services/utils/imageVerifier');
 
-    it('errorMeta is destroyed by throwIfError, so it must be read first', () => {
-      // throwIfError() calls resetErrors() in its own finally. Reading errorMeta from
-      // the catch block therefore always yields null, and every failure classifies as
-      // permanent - which is exactly how the local-image fallback silently never fired.
-      const source = fs.readFileSync(
-        require.resolve('../../ZelBack/src/services/utils/imageVerifier'), 'utf8',
-      );
-      const throwIfErrorBody = source.slice(source.indexOf('throwIfError()'), source.indexOf('throwIfError()') + 400);
-      expect(throwIfErrorBody, 'throwIfError no longer resets - the capture-first dance may be removable')
-        .to.include('resetErrors()');
-
-      const installerSource = fs.readFileSync(
-        require.resolve('../../ZelBack/src/services/appLifecycle/appInstaller'), 'utf8',
-      );
-      const capture = installerSource.indexOf('const verifyErrorMeta = imgVerifier.errorMeta;');
-      const throwCall = installerSource.indexOf('imgVerifier.throwIfError();');
-      expect(capture, 'the failure metadata is never captured').to.be.greaterThan(-1);
-      expect(capture, 'metadata is captured after throwIfError has already wiped it').to.be.lessThan(throwCall);
+    it('exposes errorClass and errorMeta as getters', () => {
+      // Structural: cheaper than a six-minute integration cycle at catching a
+      // renamed accessor. errorMeta is still read by imageManager and
+      // imageUpdateService; errorClass is what throwIfError stamps.
+      ['errorClass', 'errorMeta'].forEach((name) => {
+        const descriptor = Object.getOwnPropertyDescriptor(ImageVerifier.prototype, name);
+        expect(descriptor && typeof descriptor.get, `ImageVerifier.${name} is not a getter`).to.equal('function');
+      });
     });
 
-    it('reads an accessor ImageVerifier actually exposes', () => {
-      const descriptor = Object.getOwnPropertyDescriptor(ImageVerifier.prototype, 'errorMeta');
-      expect(descriptor && typeof descriptor.get, 'ImageVerifier.errorMeta is not a getter').to.equal('function');
-    });
-
-    it('treats a request nothing answered as unreachable', () => {
-      // what a stopped registry produces: no response, so no status
-      expect(appInstaller.isRegistryUnreachable({ httpStatus: undefined, errorCode: null, errorType: 'http_error' })).to.equal(true);
-      expect(appInstaller.isRegistryUnreachable({ httpStatus: null, errorCode: 'ECONNREFUSED', errorType: 'network' })).to.equal(true);
-    });
-
-    it('treats rate limiting and server faults as unreachable', () => {
-      expect(appInstaller.isRegistryUnreachable({ httpStatus: 429, errorType: 'rate_limit' })).to.equal(true);
-      expect(appInstaller.isRegistryUnreachable({ httpStatus: 503, errorType: 'server_error' })).to.equal(true);
-    });
-
-    it('treats an answer about the image as permanent', () => {
-      // the registry replied - the image is genuinely absent or forbidden, and
-      // riding that out on a stale local copy would hide a real problem
-      expect(appInstaller.isRegistryUnreachable({ httpStatus: 404, errorType: 'http_error' })).to.equal(false);
-      expect(appInstaller.isRegistryUnreachable({ httpStatus: 403, errorType: 'http_error' })).to.equal(false);
-      expect(appInstaller.isRegistryUnreachable(null)).to.equal(false);
+    it('stamps the classification on the throw, before resetErrors wipes the meta it derives from', () => {
+      // A verdict that is not a could-not-ask answer must read permanent - the
+      // conservative direction: an unknown failure shape degrades to the strict
+      // behavior (no local-image fallback), never to riding out a real verdict.
+      const verifier = new ImageVerifier('not a parseable repotag');
+      expect(verifier.error, 'an unparseable tag should be an error').to.equal(true);
+      let thrown;
+      try {
+        verifier.throwIfError();
+      } catch (error) {
+        thrown = error;
+      }
+      expect(thrown, 'throwIfError did not throw for a bad tag').to.not.equal(undefined);
+      expect(thrown.registryErrorClass).to.equal('permanent');
     });
   });
 });

--- a/tests/unit/appInstaller.test.js
+++ b/tests/unit/appInstaller.test.js
@@ -1398,6 +1398,19 @@ describe('appInstaller tests', () => {
       });
     });
 
+    it('classifies a connection nothing answered as transient', async () => {
+      // What a stopped or unreachable registry produces: a connection-level
+      // failure with NO HTTP response. That is an answer about connectivity,
+      // never about the image - it must read transient, or a registry outage
+      // reads as an image verdict and the recreate's local-image fallback is
+      // refused during the exact condition it exists for.
+      const verifier = new ImageVerifier('127.0.0.1:1/someorg/someimage:v1');
+      await verifier.verifyImage();
+      expect(verifier.error, 'a refused connection should be an error').to.equal(true);
+      expect(verifier.errorMeta && verifier.errorMeta.errorType).to.equal('network');
+      expect(verifier.errorClass).to.equal('transient');
+    });
+
     it('stamps the classification on the throw, before resetErrors wipes the meta it derives from', () => {
       // A verdict that is not a could-not-ask answer must read permanent - the
       // conservative direction: an unknown failure shape degrades to the strict

--- a/tests/unit/appInstaller.test.js
+++ b/tests/unit/appInstaller.test.js
@@ -1,6 +1,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
+const fs = require('fs');
 
 // The full-install dockerService stub, shared by every proxyquire setup that
 // drives registerAppLocally. Pass overrides for the few tests that need a
@@ -1387,6 +1388,26 @@ describe('appInstaller tests', () => {
     // the accessor was named for the private field; these pin both the mapping and
     // the accessor's existence, which is cheaper than a six-minute suite.
     const { ImageVerifier } = require('../../ZelBack/src/services/utils/imageVerifier');
+
+    it('errorMeta is destroyed by throwIfError, so it must be read first', () => {
+      // throwIfError() calls resetErrors() in its own finally. Reading errorMeta from
+      // the catch block therefore always yields null, and every failure classifies as
+      // permanent - which is exactly how the local-image fallback silently never fired.
+      const source = fs.readFileSync(
+        require.resolve('../../ZelBack/src/services/utils/imageVerifier'), 'utf8',
+      );
+      const throwIfErrorBody = source.slice(source.indexOf('throwIfError()'), source.indexOf('throwIfError()') + 400);
+      expect(throwIfErrorBody, 'throwIfError no longer resets - the capture-first dance may be removable')
+        .to.include('resetErrors()');
+
+      const installerSource = fs.readFileSync(
+        require.resolve('../../ZelBack/src/services/appLifecycle/appInstaller'), 'utf8',
+      );
+      const capture = installerSource.indexOf('const verifyErrorMeta = imgVerifier.errorMeta;');
+      const throwCall = installerSource.indexOf('imgVerifier.throwIfError();');
+      expect(capture, 'the failure metadata is never captured').to.be.greaterThan(-1);
+      expect(capture, 'metadata is captured after throwIfError has already wiped it').to.be.lessThan(throwCall);
+    });
 
     it('reads an accessor ImageVerifier actually exposes', () => {
       const descriptor = Object.getOwnPropertyDescriptor(ImageVerifier.prototype, 'errorMeta');

--- a/tests/unit/appReconciler.test.js
+++ b/tests/unit/appReconciler.test.js
@@ -333,6 +333,24 @@ describe('appReconciler tests', () => {
       expect(stubs.appsRuntimeState.recordRestart.called, 'kept it but did not back off').to.be.true;
     });
 
+    it('keeps the app when a bounded docker call timed out inside the provision', async () => {
+      // A runtime-op timeout is the daemon not ANSWERING - the same statement
+      // about the node as the provision ceiling, arriving through a different
+      // throw. Reading it as a recreate failure would let a wedged daemon
+      // delete a never-started app and its data.
+      stubs.dockerService.dockerContainerInspect.rejects(new TypeError("Cannot read properties of undefined (reading 'Id')"));
+      stubs.dockerService.dockerListContainers.resolves([]);
+      stubs.containerHealthMonitor.recreateMissingContainers = sinon.stub()
+        .rejects(Object.assign(new Error('docker start www_App exceeded 120s'), { dockerRuntimeTimedOut: true }));
+
+      await appReconciler.reconcile('www_App');
+
+      expect(
+        stubs.appUninstaller.removeAppLocally.called,
+        'uninstalled the app over a node condition',
+      ).to.be.false;
+    });
+
     it('retries the established-mark when the durable write fails, instead of memoising the failure', async () => {
       // Memoising a write that never landed would leave the component deletable
       // by a failed rebuild for the life of the process - the next observation

--- a/tests/unit/appReconciler.test.js
+++ b/tests/unit/appReconciler.test.js
@@ -60,6 +60,10 @@ describe('appReconciler tests', () => {
         restartWaitMs: sinon.stub().resolves(0),
         recordRestart: sinon.stub().resolves(),
         recordExit: sinon.stub().resolves(),
+        // durable "docker has started this component here before". Default null keeps
+        // the never-ran path, which is what the existing removal tests assert.
+        getState: sinon.stub().resolves(null),
+        setEverStarted: sinon.stub().resolves(),
         // durable "I removed this container for a network heal" flag + its own ladder
         isNetworkHealRemoval: sinon.stub().resolves(false),
         setNetworkHealRemoval: sinon.stub().resolves(),
@@ -286,6 +290,38 @@ describe('appReconciler tests', () => {
       await appReconciler.reconcile('www_App');
       expect(stubs.appTamperingDetectionService.recordEvent.calledWithMatch('App', 'recreation_failed')).to.be.true;
       expect(stubs.appUninstaller.removeAppLocally.calledOnceWith('App', null, false, true, true)).to.be.true;
+    });
+
+    it('keeps a component docker has started here before, instead of deleting it and its data', async () => {
+      // The removal above is for a fresh install that vanished before it ever ran.
+      // An established component must survive the same failure: an image that has
+      // become unpullable, a bad update, or a registry that is merely unreachable
+      // right now would otherwise delete the app AND its data on every node that
+      // tries to recreate it.
+      stubs.appsRuntimeState.getState.resolves({ hasEverStarted: true });
+      stubs.dockerService.dockerContainerInspect.rejects(new TypeError("Cannot read properties of undefined (reading 'Id')"));
+      stubs.dockerService.dockerListContainers.resolves([]); // probe: docker is up
+      stubs.containerHealthMonitor.recreateMissingContainers.rejects(new Error('registry unreachable'));
+
+      await appReconciler.reconcile('www_App');
+
+      expect(
+        stubs.appUninstaller.removeAppLocally.called,
+        'deleted an established app over a failed rebuild',
+      ).to.be.false;
+      expect(stubs.appsRuntimeState.recordRestart.called, 'kept it but did not back off').to.be.true;
+    });
+
+    it('records that docker started a component, so a later failed rebuild cannot delete it', async () => {
+      stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: false, Status: 'exited', ExitCode: 0 } });
+
+      await appReconciler.reconcile('www_App');
+
+      expect(stubs.dockerService.appDockerStart.called).to.be.true;
+      expect(
+        stubs.appsRuntimeState.setEverStarted.calledWith('www_App'),
+        'a started component was never marked established, so it stays deletable',
+      ).to.be.true;
     });
 
     // "Vanished" requires docker to CONFIRM absence: the reachability probe

--- a/tests/unit/appReconciler.test.js
+++ b/tests/unit/appReconciler.test.js
@@ -63,7 +63,9 @@ describe('appReconciler tests', () => {
         // durable "docker has started this component here before". Default null keeps
         // the never-ran path, which is what the existing removal tests assert.
         getStateStrict: sinon.stub().resolves(null),
-        setEverStarted: sinon.stub().resolves(),
+        // resolves the real contract: true = the durable write landed (the
+        // reconciler only memoises a landed write)
+        setEverStarted: sinon.stub().resolves(true),
         // durable "I removed this container for a network heal" flag + its own ladder
         isNetworkHealRemoval: sinon.stub().resolves(false),
         setNetworkHealRemoval: sinon.stub().resolves(),
@@ -329,6 +331,29 @@ describe('appReconciler tests', () => {
         'deleted an established app over a failed rebuild',
       ).to.be.false;
       expect(stubs.appsRuntimeState.recordRestart.called, 'kept it but did not back off').to.be.true;
+    });
+
+    it('retries the established-mark when the durable write fails, instead of memoising the failure', async () => {
+      // Memoising a write that never landed would leave the component deletable
+      // by a failed rebuild for the life of the process - the next observation
+      // pass must retry, and only a landed write is memoised.
+      stubs.appsRuntimeState.setEverStarted.onFirstCall().resolves(false);
+      stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: true, Status: 'running', ExitCode: 0 } });
+
+      await appReconciler.reconcile('www_App');
+      expect(stubs.appsRuntimeState.setEverStarted.callCount).to.equal(1);
+
+      await appReconciler.reconcile('www_App');
+      expect(
+        stubs.appsRuntimeState.setEverStarted.callCount,
+        'a failed mark write was never retried',
+      ).to.equal(2);
+
+      await appReconciler.reconcile('www_App');
+      expect(
+        stubs.appsRuntimeState.setEverStarted.callCount,
+        'a landed write should be memoised, not re-written every pass',
+      ).to.equal(2);
     });
 
     it('keeps the app when the runtime-state read fails, instead of reading the failure as "never started"', async () => {
@@ -1465,6 +1490,23 @@ describe('appReconciler tests', () => {
         stubs.appUninstaller.removeAppLocally.called,
         'a provision that hit the time ceiling deleted the app and its data',
       ).to.equal(false);
+    });
+
+    it('caps a network-heal recreate whose provisioning never returns, instead of wedging on it', async () => {
+      // The heal already force-removed the container, so a provision wedged on an
+      // unanswering daemon would otherwise pin a container-less component's
+      // single-flight for the process lifetime, with no way back to a container.
+      stubs.appsRuntimeState.isNetworkHealRemoval.resolves(true);
+      stubs.dockerService.dockerContainerInspect.rejects(Object.assign(new Error('no such container'), { statusCode: 404 }));
+      stubs.dockerService.dockerListContainers.resolves([]);
+      stubs.containerHealthMonitor.recreateMissingContainers = sinon.stub().returns(new Promise(() => {}));
+
+      await appReconciler.reconcile('www_App');
+
+      const healGaveUp = stubs.log.error.getCalls()
+        .some((c) => String(c.args[0]).includes('after network detach'));
+      expect(healGaveUp, 'the heal pass never gave up on the provision').to.equal(true);
+      expect(stubs.appUninstaller.removeAppLocally.called, 'the heal must never uninstall the app').to.equal(false);
     });
   });
 });

--- a/tests/unit/appReconciler.test.js
+++ b/tests/unit/appReconciler.test.js
@@ -351,7 +351,12 @@ describe('appReconciler tests', () => {
     });
 
     it('records that docker started a component, so a later failed rebuild cannot delete it', async () => {
-      stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: false, Status: 'exited', ExitCode: 0 } });
+      // Status 'created' is the one state dockerActual will NOT mark as ever-run
+      // (the container has never started), so the only thing that can satisfy this
+      // assertion is the reconciler marking after its own successful start - the
+      // path the test exists to pin. An 'exited' stub here would pass via
+      // dockerActual's observation mark even with the post-start marking deleted.
+      stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: false, Status: 'created', ExitCode: 0 } });
 
       await appReconciler.reconcile('www_App');
 
@@ -359,6 +364,10 @@ describe('appReconciler tests', () => {
       expect(
         stubs.appsRuntimeState.setEverStarted.calledWith('www_App'),
         'a started component was never marked established, so it stays deletable',
+      ).to.be.true;
+      expect(
+        stubs.appsRuntimeState.setEverStarted.calledAfter(stubs.dockerService.appDockerStart),
+        'marked before the start was even attempted',
       ).to.be.true;
     });
 
@@ -698,6 +707,28 @@ describe('appReconciler tests', () => {
       await appReconciler.reconcile('db_App');
       expect(stubs.dockerService.appDockerStop.calledWith('db_App')).to.be.true;
       sinon.assert.callOrder(stubs.dockerService.appDockerStop, stubs.dockerOperations.appDeleteDataInMountPoint);
+    });
+
+    it('aborts the wipe when docker cannot confirm the container stopped', async () => {
+      localSpec = { name: 'App', version: 4, compose: [{ name: 'db', containerData: 'g:/data' }] };
+      // Running at entry; the stop lands, but by the pre-wipe re-read docker has
+      // become unreachable. "Cannot tell" reads as running:false from dockerActual,
+      // and an rm -rf needs a positive answer that nothing is running - containers
+      // outlive a crashed dockerd, so proceeding would wipe under a live one.
+      stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: true, Status: 'running', ExitCode: 0 } });
+      stubs.dockerService.appDockerStop.callsFake(async () => {
+        const connErr = new Error('connect ENOENT /var/run/docker.sock');
+        stubs.dockerService.dockerContainerInspect.rejects(connErr);
+        stubs.dockerService.dockerListContainers.rejects(connErr);
+      });
+      stubs.globalState.bootContainerStateSettled = false;
+      appReconciler.requestStopAndClearData('fluxdb_App', 'syncthing reset');
+      stubs.globalState.bootContainerStateSettled = true;
+      await appReconciler.reconcile('db_App');
+      expect(
+        stubs.dockerOperations.appDeleteDataInMountPoint.called,
+        'wiped appdata on an indeterminate docker read',
+      ).to.be.false;
     });
 
     it('is one-shot: wipes first, then the next reconcile starts once the verdict is running', async () => {

--- a/tests/unit/appReconciler.test.js
+++ b/tests/unit/appReconciler.test.js
@@ -647,7 +647,13 @@ describe('appReconciler tests', () => {
 
     it('stops a running container before wiping (no rm -rf under a live container)', async () => {
       localSpec = { name: 'App', version: 4, compose: [{ name: 'db', containerData: 'g:/data' }] };
+      // docker reports it running until the stop lands, then stopped - the reconciler
+      // re-reads immediately before the wipe, so a stub frozen at "running" would be
+      // asserting that it deletes under a live container
       stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: true, Status: 'running', ExitCode: 0 } });
+      stubs.dockerService.appDockerStop.callsFake(async () => {
+        stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: false, Status: 'exited', ExitCode: 0 } });
+      });
       stubs.globalState.bootContainerStateSettled = false;
       appReconciler.requestStopAndClearData('fluxdb_App', 'syncthing reset');
       stubs.globalState.bootContainerStateSettled = true;

--- a/tests/unit/appReconciler.test.js
+++ b/tests/unit/appReconciler.test.js
@@ -62,7 +62,7 @@ describe('appReconciler tests', () => {
         recordExit: sinon.stub().resolves(),
         // durable "docker has started this component here before". Default null keeps
         // the never-ran path, which is what the existing removal tests assert.
-        getState: sinon.stub().resolves(null),
+        getStateStrict: sinon.stub().resolves(null),
         setEverStarted: sinon.stub().resolves(),
         // durable "I removed this container for a network heal" flag + its own ladder
         isNetworkHealRemoval: sinon.stub().resolves(false),
@@ -317,7 +317,7 @@ describe('appReconciler tests', () => {
       // become unpullable, a bad update, or a registry that is merely unreachable
       // right now would otherwise delete the app AND its data on every node that
       // tries to recreate it.
-      stubs.appsRuntimeState.getState.resolves({ hasEverStarted: true });
+      stubs.appsRuntimeState.getStateStrict.resolves({ hasEverStarted: true });
       stubs.dockerService.dockerContainerInspect.rejects(new TypeError("Cannot read properties of undefined (reading 'Id')"));
       stubs.dockerService.dockerListContainers.resolves([]); // probe: docker is up
       stubs.containerHealthMonitor.recreateMissingContainers.rejects(new Error('registry unreachable'));
@@ -329,6 +329,25 @@ describe('appReconciler tests', () => {
         'deleted an established app over a failed rebuild',
       ).to.be.false;
       expect(stubs.appsRuntimeState.recordRestart.called, 'kept it but did not back off').to.be.true;
+    });
+
+    it('keeps the app when the runtime-state read fails, instead of reading the failure as "never started"', async () => {
+      // The gate reads via getStateStrict precisely so it can tell "never
+      // started" from "cannot tell". Deleting on "cannot tell" would let a
+      // transient DB blip destroy the app and its data.
+      stubs.appsRuntimeState.getStateStrict.rejects(new Error('mongo not available'));
+      stubs.dockerService.dockerContainerInspect.rejects(new TypeError("Cannot read properties of undefined (reading 'Id')"));
+      stubs.dockerService.dockerListContainers.resolves([]); // probe: docker is up
+      stubs.containerHealthMonitor.recreateMissingContainers.rejects(new Error('boom'));
+
+      await appReconciler.reconcile('www_App');
+
+      expect(
+        stubs.appUninstaller.removeAppLocally.called,
+        'deleted the app on an indeterminate runtime-state read',
+      ).to.be.false;
+      const deferred = stubs.log.warn.getCalls().some((c) => /cannot read runtime state/.test(c.args[0]));
+      expect(deferred, 'should say why it kept the app').to.equal(true);
     });
 
     it('records that docker started a component, so a later failed rebuild cannot delete it', async () => {

--- a/tests/unit/appReconciler.test.js
+++ b/tests/unit/appReconciler.test.js
@@ -292,6 +292,25 @@ describe('appReconciler tests', () => {
       expect(stubs.appUninstaller.removeAppLocally.calledOnceWith('App', null, false, true, true)).to.be.true;
     });
 
+    it('re-marks a reinstalled component, instead of trusting a memo the uninstall invalidated', async () => {
+      // markEverStarted memoises per process to avoid writing on every steady-state
+      // pass. An uninstall deletes the durable flag that memo stands in for, so if the
+      // memo outlives it the reinstalled component is never re-marked - and spends the
+      // rest of the process eligible for deletion by a failed rebuild.
+      stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: true, Status: 'running', ExitCode: 0 } });
+      await appReconciler.reconcile('www_App');
+      expect(stubs.appsRuntimeState.setEverStarted.callCount, 'never marked on first run').to.equal(1);
+
+      // the uninstall seam appUninstaller drives via onComponentRemoved
+      appReconciler.clearControllerDesired('www_App');
+
+      await appReconciler.reconcile('www_App');
+      expect(
+        stubs.appsRuntimeState.setEverStarted.callCount,
+        'a reinstalled component was never re-marked, so a failed rebuild would delete it',
+      ).to.equal(2);
+    });
+
     it('keeps a component docker has started here before, instead of deleting it and its data', async () => {
       // The removal above is for a fresh install that vanished before it ever ran.
       // An established component must survive the same failure: an image that has

--- a/tests/unit/appReconciler.test.js
+++ b/tests/unit/appReconciler.test.js
@@ -1296,4 +1296,53 @@ describe('appReconciler tests', () => {
       }
     });
   });
+
+  describe('wedge guards', () => {
+    // inFlight is released only in runReconcile's finally, so a pass that never
+    // settles keeps its key forever and every later enqueue for that component is
+    // dropped without a word. Production lost a component that way for 18.5 hours.
+    it('reports an in-flight pass that has outlived any legitimate one', async () => {
+      const stuck = deferred();
+      stubs.dbHelper.findOneInDatabase = sinon.stub().returns(stuck.promise);
+
+      appReconciler.enqueue('www_App'); // pass wedges reading the spec
+      await new Promise((res) => { setTimeout(res, 80); }); // past reconcileStuckWarnMs
+
+      appReconciler.enqueue('www_App'); // coalesces - and must not do so silently
+
+      const warned = stubs.log.error.getCalls()
+        .some((c) => String(c.args[0]).includes('has been reconciling for'));
+      expect(warned, 'a component whose reconciles are being dropped said nothing').to.equal(true);
+
+      stuck.resolve(localSpec);
+    });
+
+    it('says nothing about a pass that is merely in progress', async () => {
+      const inProgress = deferred();
+      stubs.dbHelper.findOneInDatabase = sinon.stub().returns(inProgress.promise);
+
+      appReconciler.enqueue('www_App');
+      appReconciler.enqueue('www_App'); // coalesces immediately - normal, not stuck
+
+      const warned = stubs.log.error.getCalls()
+        .some((c) => String(c.args[0]).includes('has been reconciling for'));
+      expect(warned, 'warned about a healthy in-flight pass').to.equal(false);
+
+      inProgress.resolve(localSpec);
+    });
+
+    it('fails a recreate whose provisioning never returns, instead of wedging on it', async () => {
+      // a registry can black-hole rather than refuse; unbounded, the hung provision
+      // holds this component's single-flight for the life of the process
+      stubs.dockerService.dockerContainerInspect.rejects(Object.assign(new Error('no such container'), { statusCode: 404 }));
+      stubs.dockerService.dockerListContainers.resolves([]);
+      stubs.containerHealthMonitor.recreateMissingContainers = sinon.stub().returns(new Promise(() => {}));
+
+      await appReconciler.reconcile('www_App');
+
+      const capped = stubs.log.error.getCalls()
+        .some((c) => String(c.args[0]).includes('exceeded') || String(c.args[0]).includes('aborted'));
+      expect(capped, 'the pass never gave up on the provision').to.equal(true);
+    });
+  });
 });

--- a/tests/unit/appReconciler.test.js
+++ b/tests/unit/appReconciler.test.js
@@ -1379,6 +1379,17 @@ describe('appReconciler tests', () => {
       const capped = stubs.log.error.getCalls()
         .some((c) => String(c.args[0]).includes('exceeded') || String(c.args[0]).includes('aborted'));
       expect(capped, 'the pass never gave up on the provision').to.equal(true);
+
+      // The ceiling wraps the whole provision, image pull included, so it fires on a
+      // large image that is downloading perfectly well - the stall detector, which is
+      // what tells a dead transfer from a slow one, never trips because bytes keep
+      // moving. Escalating that to removal destroys a healthy app and its appdata for
+      // the sole offence of downloading slowly. Note this app has NEVER started here,
+      // so the established-component gate is not what is protecting it.
+      expect(
+        stubs.appUninstaller.removeAppLocally.called,
+        'a provision that hit the time ceiling deleted the app and its data',
+      ).to.equal(false);
     });
   });
 });

--- a/tests/unit/dockerService.test.js
+++ b/tests/unit/dockerService.test.js
@@ -1346,6 +1346,27 @@ describe('dockerService tests', () => {
       expect(await size).to.equal(0);
     });
 
+    it('bounds the container create itself', () => {
+      // A daemon wedged on POST /containers/create while still answering
+      // inspects leaves the provision promise pending forever - which pins the
+      // component's reconcile single-flight. appDockerCreate's pre-create path
+      // (networks, IP allocation) talks to the real daemon and cannot run under
+      // fake timers, so pin the bound structurally; the network-create test
+      // below proves the same wrapper behaviorally.
+      // eslint-disable-next-line global-require
+      const fs = require('fs');
+      const source = fs.readFileSync(require.resolve('../../ZelBack/src/services/dockerService'), 'utf8');
+      expect(source, 'docker.createContainer is no longer bounded').to.match(/withRuntimeOpTimeout\(docker\.createContainer\(/);
+    });
+
+    it('gives up on a network create that the daemon never answers', async () => {
+      sinon.stub(Dockerode.prototype, 'createNetwork').returns(new Promise(() => {}));
+      const netted = dockerService.dockerCreateNetwork({ Name: 'fluxDockerNetwork_test' });
+      const assertion = expect(netted).to.eventually.be.rejectedWith(/exceeded/);
+      await clock.tickAsync(timeoutMs + 1000);
+      await assertion;
+    });
+
     it('gives up on a container list that the daemon never answers', async () => {
       // The reconciler's reachability probe lands here when an inspect times out,
       // so an unbounded list would hand the wedged daemon back the single-flight

--- a/tests/unit/dockerService.test.js
+++ b/tests/unit/dockerService.test.js
@@ -1336,6 +1336,16 @@ describe('dockerService tests', () => {
       await assertion;
     });
 
+    it('answers 0 for an image size the daemon never reports', async () => {
+      // appDockerImageSize decides the local-image fallback on the recreate path;
+      // a hang here would pin the detached provision. A timeout must degrade to
+      // "no usable local image", which refuses the fallback.
+      sinon.stub(Dockerode.prototype, 'getImage').returns({ inspect: () => new Promise(() => {}) });
+      const size = dockerService.appDockerImageSize('some/image:v1');
+      await clock.tickAsync(timeoutMs + 1000);
+      expect(await size).to.equal(0);
+    });
+
     it('gives up on a container list that the daemon never answers', async () => {
       // The reconciler's reachability probe lands here when an inspect times out,
       // so an unbounded list would hand the wedged daemon back the single-flight

--- a/tests/unit/dockerService.test.js
+++ b/tests/unit/dockerService.test.js
@@ -4,10 +4,16 @@ process.env.NODE_CONFIG_DIR = `${process.cwd()}/tests/unit/globalconfig`;
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 const Dockerode = require('dockerode');
+const config = require('config');
 const sinon = require('sinon');
 const path = require('path');
 const dockerService = require('../../ZelBack/src/services/dockerService');
 const globalState = require('../../ZelBack/src/services/utils/globalState');
+
+// docker-modem is a transitive dependency of dockerode, so reach its prototype
+// through an instance rather than importing it directly. dockerService's own docker
+// instance shares this prototype, which is what makes stubbing it effective.
+const modemPrototype = Object.getPrototypeOf(new Dockerode().modem);
 
 chai.use(chaiAsPromised);
 const { expect } = chai;
@@ -1207,6 +1213,114 @@ describe('dockerService tests', () => {
       };
 
       await expect(dockerService.appDockerCreate(nodeApp, appName, true)).to.eventually.be.rejectedWith('Cannot read properties of undefined (reading \'forEach\')');
+    });
+  });
+
+  describe('dockerPullStream stall detection', () => {
+    // A pull is judged by silence, not elapsed time: a large image on a slow link is
+    // healthy, a black-holed registry is not, and only the progress stream can tell
+    // them apart. These pin that contract plus the error-reporting fix.
+    let clock;
+    let stallMs;
+
+    beforeEach(() => {
+      stallMs = config.fluxapps.pullStallMs ?? 90 * 1000;
+      clock = sinon.useFakeTimers();
+    });
+
+    afterEach(() => {
+      if (clock) clock.restore();
+      sinon.restore();
+    });
+
+    // drives docker.pull + followProgress so the test controls when progress arrives
+    function stubPull() {
+      const harness = {};
+      sinon.stub(Dockerode.prototype, 'pull').callsFake((repoTag, opts, cb) => {
+        harness.pullOptions = opts;
+        cb(null, {});
+      });
+      // modem is an instance property, so the stub goes on docker-modem's prototype
+      sinon.stub(modemPrototype, 'followProgress').callsFake((stream, onFinished, onProgress) => {
+        harness.onFinished = onFinished;
+        harness.onProgress = onProgress;
+      });
+      return harness;
+    }
+
+    it('aborts a pull whose progress stream goes silent', async () => {
+      const harness = stubPull();
+      let result;
+      dockerService.dockerPullStream({ repoTag: 'some/image:v1' }, null, (err) => { result = err; });
+
+      await clock.tickAsync(stallMs - 1000);
+      expect(result, 'gave up while still inside the stall window').to.equal(undefined);
+
+      await clock.tickAsync(2000);
+      expect(result).to.be.an('error');
+      expect(result.message).to.include('stalled');
+      expect(harness.pullOptions.abortSignal.aborted, 'transfer was not aborted').to.equal(true);
+    });
+
+    it('lets a slow pull run indefinitely while progress keeps arriving', async () => {
+      const harness = stubPull();
+      let result;
+      let finished = false;
+      dockerService.dockerPullStream({ repoTag: 'some/image:v1' }, null, (err) => { result = err; finished = true; });
+
+      // ten stall windows of steady progress - far longer than any fixed cap would
+      // allow, and correct: bytes are moving
+      for (let i = 0; i < 10; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await clock.tickAsync(stallMs - 1000);
+        harness.onProgress({ status: 'Downloading' });
+      }
+      expect(finished, 'a healthy long pull was aborted').to.equal(false);
+
+      harness.onFinished(null, 'done');
+      expect(result).to.equal(null);
+    });
+
+    it('reports a followProgress failure as an error, not a success', async () => {
+      const harness = stubPull();
+      let result;
+      let called = false;
+      dockerService.dockerPullStream({ repoTag: 'some/image:v1' }, null, (err) => { result = err; called = true; });
+
+      harness.onFinished(new Error('manifest unknown'));
+
+      expect(called).to.equal(true);
+      // used to pass the outer `err` (always null here), so a failed pull looked fine
+      expect(result).to.be.an('error');
+      expect(result.message).to.equal('manifest unknown');
+    });
+  });
+
+  describe('short docker calls are bounded', () => {
+    let clock;
+    let timeoutMs;
+
+    beforeEach(() => {
+      timeoutMs = config.fluxapps.dockerRuntimeOpTimeoutMs ?? 2 * 60 * 1000;
+      clock = sinon.useFakeTimers();
+    });
+
+    afterEach(() => {
+      if (clock) clock.restore();
+      sinon.restore();
+    });
+
+    it('gives up on a start that the daemon never answers', async () => {
+      sinon.stub(Dockerode.prototype, 'listContainers').resolves([{ Id: 'abc', Names: ['/fluxwedged_wedged'] }]);
+      sinon.stub(Dockerode.prototype, 'getContainer').returns({
+        start: () => new Promise(() => {}), // daemon never replies
+        inspect: sinon.stub().resolves({}),
+      });
+
+      const started = dockerService.appDockerStart('wedged_wedged');
+      const assertion = expect(started).to.eventually.be.rejectedWith(/exceeded/);
+      await clock.tickAsync(timeoutMs + 1000);
+      await assertion;
     });
   });
 });

--- a/tests/unit/dockerService.test.js
+++ b/tests/unit/dockerService.test.js
@@ -1281,6 +1281,19 @@ describe('dockerService tests', () => {
       expect(result).to.equal(null);
     });
 
+    it('gives up on a pull request dockerd never answers', async () => {
+      // No stream, no progress events, nothing to re-arm the timer: the request
+      // phase itself is the silence. The timer is armed before the request, so a
+      // dockerd that never calls back is caught by the same detector.
+      sinon.stub(Dockerode.prototype, 'pull').callsFake(() => {});
+      let result;
+      dockerService.dockerPullStream({ repoTag: 'some/image:v1' }, null, (err) => { result = err; });
+
+      await clock.tickAsync(stallMs + 1000);
+      expect(result).to.be.an('error');
+      expect(result.message).to.include('stalled');
+    });
+
     it('reports a followProgress failure as an error, not a success', async () => {
       const harness = stubPull();
       let result;
@@ -1319,6 +1332,17 @@ describe('dockerService tests', () => {
 
       const started = dockerService.appDockerStart('wedged_wedged');
       const assertion = expect(started).to.eventually.be.rejectedWith(/exceeded/);
+      await clock.tickAsync(timeoutMs + 1000);
+      await assertion;
+    });
+
+    it('gives up on a container list that the daemon never answers', async () => {
+      // The reconciler's reachability probe lands here when an inspect times out,
+      // so an unbounded list would hand the wedged daemon back the single-flight
+      // the inspect ceiling just freed.
+      sinon.stub(Dockerode.prototype, 'listContainers').returns(new Promise(() => {}));
+      const listed = dockerService.dockerListContainers(true);
+      const assertion = expect(listed).to.eventually.be.rejectedWith(/exceeded/);
       await clock.tickAsync(timeoutMs + 1000);
       await assertion;
     });

--- a/tests/unit/dockerService.test.js
+++ b/tests/unit/dockerService.test.js
@@ -1346,25 +1346,17 @@ describe('dockerService tests', () => {
       expect(await size).to.equal(0);
     });
 
-    it('bounds the container create itself', () => {
-      // A daemon wedged on POST /containers/create while still answering
-      // inspects leaves the provision promise pending forever - which pins the
-      // component's reconcile single-flight. appDockerCreate's pre-create path
-      // (networks, IP allocation) talks to the real daemon and cannot run under
-      // fake timers, so pin the bound structurally; the network-create test
-      // below proves the same wrapper behaviorally.
+    it('does NOT bound the creates - a create rejection must always mean the daemon answered', () => {
+      // A create that times out client-side can still land in the daemon: the
+      // octet-retry loop advances on rejection (a second same-name create
+      // DUPLICATES the network), and a provision settled by a plain timeout
+      // bypasses the recreate ceiling's kept-not-deleted classification. The
+      // creates are bounded one level up, by the provision ceiling.
       // eslint-disable-next-line global-require
       const fs = require('fs');
       const source = fs.readFileSync(require.resolve('../../ZelBack/src/services/dockerService'), 'utf8');
-      expect(source, 'docker.createContainer is no longer bounded').to.match(/withRuntimeOpTimeout\(docker\.createContainer\(/);
-    });
-
-    it('gives up on a network create that the daemon never answers', async () => {
-      sinon.stub(Dockerode.prototype, 'createNetwork').returns(new Promise(() => {}));
-      const netted = dockerService.dockerCreateNetwork({ Name: 'fluxDockerNetwork_test' });
-      const assertion = expect(netted).to.eventually.be.rejectedWith(/exceeded/);
-      await clock.tickAsync(timeoutMs + 1000);
-      await assertion;
+      expect(source, 'docker.createContainer must not run under the runtime-op timeout').to.not.match(/withRuntimeOpTimeout\(docker\.createContainer\(/);
+      expect(source, 'docker.createNetwork must not run under the runtime-op timeout').to.not.match(/withRuntimeOpTimeout\(docker\.createNetwork\(/);
     });
 
     it('gives up on a container list that the daemon never answers', async () => {

--- a/tests/unit/globalconfig/default.js
+++ b/tests/unit/globalconfig/default.js
@@ -115,6 +115,9 @@ module.exports = {
   fluxapps: {
     crashBackoffDelaysMs: [0, 30000, 300000, 900000, 1800000],
     crashBackoffStableRunMs: 600000,
+    // compressed so the wedge guards are reachable within a unit test's lifetime
+    recreateProvisionCapMs: 200,
+    reconcileStuckWarnMs: 50,
     // in flux main chain per month (blocksLasting)
     price: [
       { // any price fork can be done by adjusting object similarily.

--- a/tests/unit/imageUpdateService.test.js
+++ b/tests/unit/imageUpdateService.test.js
@@ -27,6 +27,10 @@ const registryCredentialHelperStub = {
   getCredentials: sinon.stub(),
 };
 
+const imageManagerStub = {
+  checkApplicationImagesCompliance: sinon.stub().resolves(),
+};
+
 const serviceHelperStub = {
   delay: sinon.stub().resolves(),
 };
@@ -54,27 +58,39 @@ let mockDigestToReturn = null;
 let mockVerifierSupported = true;
 
 class MockImageVerifier {
+  // Mirrors the real class's recording semantics: the constructor knows only
+  // the parse verdict; lookup/evaluation state (error, errorDetail, errorMeta,
+  // supported) is recorded by the CALLS - so a caller that skips verifyImage()
+  // has no verdict and `supported` stays false, exactly like the real class.
   constructor(repotag, options) {
     this.repotag = repotag;
     this.options = options;
     this.parseError = mockVerifierParseError;
-    this.error = mockVerifierError;
+    this.error = mockVerifierParseError;
+    this.errorDetail = '';
+    this.errorMeta = null;
+    this.verified = false;
+  }
+
+  #recordLookup() {
+    this.error = this.parseError || mockVerifierError;
     this.errorDetail = mockVerifierErrorDetail;
     this.errorMeta = mockVerifierErrorMeta;
   }
 
   async fetchManifestDigestOnly() {
+    this.#recordLookup();
     if (this.parseError || this.error) return null;
     return mockDigestToReturn;
   }
 
-  // the pre-flight verify reads error/errorDetail (set from the mock flags in
-  // the constructor, mirroring the real class's lookup-error recording) and
-  // the supported verdict after verifyImage()
-  async verifyImage() {}
+  async verifyImage() {
+    this.#recordLookup();
+    this.verified = !this.error;
+  }
 
   get supported() {
-    return !this.error && mockVerifierSupported;
+    return this.verified && mockVerifierSupported;
   }
 }
 
@@ -87,6 +103,8 @@ const imageUpdateService = proxyquire('../../ZelBack/src/services/imageUpdateSer
   './utils/registryCredentialHelper': registryCredentialHelperStub,
   './utils/imageVerifier': { ImageVerifier: MockImageVerifier },
   './appSystem/systemIntegration': { systemArchitecture: async () => 'amd64' },
+  './appSecurity/imageManager': imageManagerStub,
+  './utils/appConstants': { supportedArchitectures: ['amd64', 'arm64'] },
   './serviceHelper': serviceHelperStub,
   './utils/globalState': globalStateStub,
 });
@@ -127,6 +145,9 @@ describe('imageUpdateService tests', () => {
     mockVerifierError = false;
     mockVerifierErrorDetail = '';
     mockVerifierSupported = true;
+
+    imageManagerStub.checkApplicationImagesCompliance.reset();
+    imageManagerStub.checkApplicationImagesCompliance.resolves();
     mockVerifierErrorMeta = null;
     mockDigestToReturn = null;
   });
@@ -462,7 +483,7 @@ describe('imageUpdateService tests', () => {
 
       const result = await imageUpdateService.triggerAppUpdate(appSpec);
 
-      expect(result).to.equal(true);
+      expect(result.triggered).to.equal(true);
       sinon.assert.calledOnce(advancedWorkflowsStub.softRedeploy);
       sinon.assert.calledWith(advancedWorkflowsStub.softRedeploy, appSpec, null);
     });
@@ -478,7 +499,7 @@ describe('imageUpdateService tests', () => {
 
       const result = await imageUpdateService.triggerAppUpdate(appSpec);
 
-      expect(result).to.equal(false);
+      expect(result.triggered).to.equal(false);
       sinon.assert.notCalled(advancedWorkflowsStub.softRedeploy);
       const refused = logStub.warn.getCalls().some((c) => String(c.args[0]).includes('keeping the running image'));
       expect(refused, 'the refusal must say why the update was skipped').to.equal(true);
@@ -490,7 +511,34 @@ describe('imageUpdateService tests', () => {
 
       const result = await imageUpdateService.triggerAppUpdate(appSpec);
 
-      expect(result).to.equal(false);
+      expect(result.triggered).to.equal(false);
+      sinon.assert.notCalled(advancedWorkflowsStub.softRedeploy);
+    });
+
+    it('refuses the update when the compliance check fails - including a list that cannot be fetched', async () => {
+      // The install runs checkApplicationImagesCompliance BEFORE its verifier,
+      // and throws both on a blocked repository and when the blocked list
+      // cannot be fetched at all. Either way the redeploy would tear down and
+      // then die into the removal path - so both must be refused up front.
+      imageManagerStub.checkApplicationImagesCompliance.rejects(new Error('Unable to communicate with Flux Services! Try again later.'));
+      const appSpec = { name: 'TestApp', version: 3, repotag: 'someorg/someimage:v1' };
+
+      const result = await imageUpdateService.triggerAppUpdate(appSpec);
+
+      expect(result.triggered).to.equal(false);
+      sinon.assert.notCalled(advancedWorkflowsStub.softRedeploy);
+    });
+
+    it('surfaces a registry rate-limit so the cycle can abort, instead of reading it as an image verdict', async () => {
+      mockVerifierError = true;
+      mockVerifierErrorDetail = 'Bad HTTP Status 429: someorg/someimage:v1 not available';
+      mockVerifierErrorMeta = { httpStatus: 429, errorCode: null, errorType: 'rate_limit' };
+      const appSpec = { name: 'TestApp', version: 3, repotag: 'someorg/someimage:v1' };
+
+      const result = await imageUpdateService.triggerAppUpdate(appSpec);
+
+      expect(result.triggered).to.equal(false);
+      expect(result.rateLimited, 'a 429 must abort the cycle, not walk on to more lookups').to.equal(true);
       sinon.assert.notCalled(advancedWorkflowsStub.softRedeploy);
     });
 
@@ -500,7 +548,7 @@ describe('imageUpdateService tests', () => {
 
       const result = await imageUpdateService.triggerAppUpdate(appSpec);
 
-      expect(result).to.equal(false);
+      expect(result.triggered).to.equal(false);
       sinon.assert.notCalled(advancedWorkflowsStub.softRedeploy);
     });
 
@@ -510,7 +558,7 @@ describe('imageUpdateService tests', () => {
 
       const result = await imageUpdateService.triggerAppUpdate(appSpec);
 
-      expect(result).to.equal(false);
+      expect(result.triggered).to.equal(false);
       sinon.assert.notCalled(advancedWorkflowsStub.softRedeploy);
     });
 
@@ -520,7 +568,7 @@ describe('imageUpdateService tests', () => {
 
       const result = await imageUpdateService.triggerAppUpdate(appSpec);
 
-      expect(result).to.equal(false);
+      expect(result.triggered).to.equal(false);
       sinon.assert.notCalled(advancedWorkflowsStub.softRedeploy);
     });
 
@@ -530,7 +578,7 @@ describe('imageUpdateService tests', () => {
 
       const result = await imageUpdateService.triggerAppUpdate(appSpec);
 
-      expect(result).to.equal(false);
+      expect(result.triggered).to.equal(false);
       sinon.assert.notCalled(advancedWorkflowsStub.softRedeploy);
     });
 
@@ -540,7 +588,7 @@ describe('imageUpdateService tests', () => {
 
       const result = await imageUpdateService.triggerAppUpdate(appSpec);
 
-      expect(result).to.equal(false);
+      expect(result.triggered).to.equal(false);
       sinon.assert.calledOnce(logStub.error);
     });
   });

--- a/tests/unit/imageUpdateService.test.js
+++ b/tests/unit/imageUpdateService.test.js
@@ -67,7 +67,9 @@ class MockImageVerifier {
     this.options = options;
     this.parseError = mockVerifierParseError;
     this.error = mockVerifierParseError;
-    this.errorDetail = '';
+    // the real class's errorDetail getter serves the parse detail with no
+    // lookup call - only lookup/evaluation detail is recorded by the calls
+    this.errorDetail = mockVerifierParseError ? mockVerifierErrorDetail : '';
     this.errorMeta = null;
     this.verified = false;
   }
@@ -521,6 +523,21 @@ describe('imageUpdateService tests', () => {
       // cannot be fetched at all. Either way the redeploy would tear down and
       // then die into the removal path - so both must be refused up front.
       imageManagerStub.checkApplicationImagesCompliance.rejects(new Error('Unable to communicate with Flux Services! Try again later.'));
+      const appSpec = { name: 'TestApp', version: 3, repotag: 'someorg/someimage:v1' };
+
+      const result = await imageUpdateService.triggerAppUpdate(appSpec);
+
+      expect(result.triggered).to.equal(false);
+      sinon.assert.notCalled(advancedWorkflowsStub.softRedeploy);
+    });
+
+    it('does not report a redeploy when another operation started during the pre-flight', async () => {
+      // The pre-flight is a real network walk; an install/removal can start
+      // under it. softRedeploy would bail on its own flags, and that must not
+      // be counted - and slept on - as a completed update.
+      imageManagerStub.checkApplicationImagesCompliance.callsFake(async () => {
+        globalStateStub.installationInProgress = true;
+      });
       const appSpec = { name: 'TestApp', version: 3, repotag: 'someorg/someimage:v1' };
 
       const result = await imageUpdateService.triggerAppUpdate(appSpec);

--- a/tests/unit/imageUpdateService.test.js
+++ b/tests/unit/imageUpdateService.test.js
@@ -51,6 +51,7 @@ let mockVerifierError = false;
 let mockVerifierErrorDetail = '';
 let mockVerifierErrorMeta = null;
 let mockDigestToReturn = null;
+let mockVerifierSupported = true;
 
 class MockImageVerifier {
   constructor(repotag, options) {
@@ -66,6 +67,15 @@ class MockImageVerifier {
     if (this.parseError || this.error) return null;
     return mockDigestToReturn;
   }
+
+  // the pre-flight verify reads error/errorDetail (set from the mock flags in
+  // the constructor, mirroring the real class's lookup-error recording) and
+  // the supported verdict after verifyImage()
+  async verifyImage() {}
+
+  get supported() {
+    return !this.error && mockVerifierSupported;
+  }
 }
 
 // Load module with stubs using noCallThru
@@ -76,6 +86,7 @@ const imageUpdateService = proxyquire('../../ZelBack/src/services/imageUpdateSer
   './appLifecycle/advancedWorkflows': advancedWorkflowsStub,
   './utils/registryCredentialHelper': registryCredentialHelperStub,
   './utils/imageVerifier': { ImageVerifier: MockImageVerifier },
+  './appSystem/systemIntegration': { systemArchitecture: async () => 'amd64' },
   './serviceHelper': serviceHelperStub,
   './utils/globalState': globalStateStub,
 });
@@ -115,6 +126,7 @@ describe('imageUpdateService tests', () => {
     mockVerifierParseError = false;
     mockVerifierError = false;
     mockVerifierErrorDetail = '';
+    mockVerifierSupported = true;
     mockVerifierErrorMeta = null;
     mockDigestToReturn = null;
   });
@@ -453,6 +465,33 @@ describe('imageUpdateService tests', () => {
       expect(result).to.equal(true);
       sinon.assert.calledOnce(advancedWorkflowsStub.softRedeploy);
       sinon.assert.calledWith(advancedWorkflowsStub.softRedeploy, appSpec, null);
+    });
+
+    it('refuses the update when the new image fails verification, keeping the running image', async () => {
+      // The soft redeploy verifies only AFTER tearing the running container
+      // down, and its failure path removes the app and its data - so a mutable
+      // tag gone bad (over the size cap, de-whitelisted) must be refused before
+      // anything is touched. Refusal costs nothing: the app keeps running.
+      mockVerifierError = true;
+      mockVerifierErrorDetail = 'Docker image: someorg/someimage:v1 size is over Flux limit';
+      const appSpec = { name: 'TestApp', version: 3, repotag: 'someorg/someimage:v1' };
+
+      const result = await imageUpdateService.triggerAppUpdate(appSpec);
+
+      expect(result).to.equal(false);
+      sinon.assert.notCalled(advancedWorkflowsStub.softRedeploy);
+      const refused = logStub.warn.getCalls().some((c) => String(c.args[0]).includes('keeping the running image'));
+      expect(refused, 'the refusal must say why the update was skipped').to.equal(true);
+    });
+
+    it('refuses the update when the new image does not support this architecture', async () => {
+      mockVerifierSupported = false;
+      const appSpec = { name: 'TestApp', version: 3, repotag: 'someorg/someimage:v1' };
+
+      const result = await imageUpdateService.triggerAppUpdate(appSpec);
+
+      expect(result).to.equal(false);
+      sinon.assert.notCalled(advancedWorkflowsStub.softRedeploy);
     });
 
     it('should return false when removal is in progress', async () => {

--- a/tests/unit/syncthingFolderStateMachine.test.js
+++ b/tests/unit/syncthingFolderStateMachine.test.js
@@ -1327,6 +1327,57 @@ describe('syncthingFolderStateMachine tests', () => {
       expect(result.isSafe).to.be.true;
     });
 
+    it('counts files under a NESTED backup directory as synced payload (root-anchored exclusion)', async () => {
+      // .stignore pins '/backup' - root-anchored - so syncthing DOES index a
+      // nested backup/ dir and its files. The disk walk must count them too,
+      // or an app whose only files live under a nested dir named backup (a
+      // database dump app) reads as a phantom index and is held down healthy.
+      fsMock.promises.readdir.resolves([]);
+      fsMock.promises.readdir.withArgs('/apps/test-app').resolves([
+        dirent('.stignore'), dirent('.stfolder', false), dirent('appdata', false),
+      ]);
+      fsMock.promises.readdir.withArgs('/apps/test-app/appdata').resolves([
+        dirent('backup', false),
+      ]);
+      fsMock.promises.readdir.withArgs('/apps/test-app/appdata/backup').resolves([
+        dirent('dump.sql'),
+      ]);
+      syncthingServiceMock.getDbStatus.resolves({
+        status: 'success',
+        data: {
+          globalBytes: 100000, inSyncBytes: 100000, globalFiles: 1, state: 'idle',
+        },
+      });
+
+      const result = await stateMachine.verifySendReceiveFolderSafety('test-app', '/apps/test-app');
+
+      expect(result.isSafe).to.be.true;
+    });
+
+    it('still ignores the ROOT backup directory - its files are outside the sync scope', async () => {
+      // root /backup is what .stignore excludes: files there are invisible to
+      // the index, so a disk holding ONLY root-backup files under an index
+      // that claims synced files is still a phantom.
+      fsMock.promises.readdir.resolves([]);
+      fsMock.promises.readdir.withArgs('/apps/test-app').resolves([
+        dirent('.stignore'), dirent('.stfolder', false), dirent('backup', false),
+      ]);
+      fsMock.promises.readdir.withArgs('/apps/test-app/backup').resolves([
+        dirent('dump.sql'),
+      ]);
+      syncthingServiceMock.getDbStatus.resolves({
+        status: 'success',
+        data: {
+          globalBytes: 100000, inSyncBytes: 100000, globalFiles: 3, state: 'idle',
+        },
+      });
+
+      const result = await stateMachine.verifySendReceiveFolderSafety('test-app', '/apps/test-app');
+
+      expect(result.isSafe).to.be.false;
+      expect(result.reason).to.equal('phantom_index_empty_disk');
+    });
+
     it('falls back to the mount-level verdict when the sync status is unreadable', async () => {
       syncthingServiceMock.getDbStatus.rejects(new Error('syncthing down'));
 

--- a/tests/unit/syncthingFolderStateMachine.test.js
+++ b/tests/unit/syncthingFolderStateMachine.test.js
@@ -1268,6 +1268,65 @@ describe('syncthingFolderStateMachine tests', () => {
       expect(result.isSafe).to.be.true;
     });
 
+    it('is unsafe when the index claims FILES over a surviving directory skeleton (files-aware)', async () => {
+      // the wiped-files case a directory skeleton must NOT mask: the index
+      // still lists real files (globalFiles > 0) while the disk holds only an
+      // empty appdata/ dir - syncthing would broadcast every missing FILE as a
+      // deletion; the bare dir protects nothing.
+      fsMock.promises.readdir.resolves([]); // appdata/ is empty
+      fsMock.promises.readdir.withArgs('/apps/test-app').resolves([
+        dirent('.stignore'), dirent('.stfolder', false), dirent('appdata', false),
+      ]);
+      syncthingServiceMock.getDbStatus.resolves({
+        status: 'success',
+        data: {
+          globalBytes: 100000, inSyncBytes: 100000, globalFiles: 3, state: 'idle',
+        },
+      });
+
+      const result = await stateMachine.verifySendReceiveFolderSafety('test-app', '/apps/test-app');
+
+      expect(result.isSafe).to.be.false;
+      expect(result.reason).to.equal('phantom_index_empty_disk');
+    });
+
+    it('is safe for a dirs-only payload when the index reports globalFiles 0 (files-aware)', async () => {
+      // the 2026-07-04 contract under the files-aware discriminator: dirs-only
+      // payload (globalBytes from directory accounting, zero files claimed)
+      // over a dirs-only disk is healthy - no file exists to be broadcast.
+      fsMock.promises.readdir.resolves([]);
+      fsMock.promises.readdir.withArgs('/apps/test-app').resolves([
+        dirent('.stignore'), dirent('.stfolder', false), dirent('data', false),
+      ]);
+      syncthingServiceMock.getDbStatus.resolves({
+        status: 'success',
+        data: {
+          globalBytes: 256, inSyncBytes: 256, globalFiles: 0, state: 'idle',
+        },
+      });
+
+      const result = await stateMachine.verifySendReceiveFolderSafety('test-app', '/apps/test-app');
+
+      expect(result.isSafe).to.be.true;
+    });
+
+    it('is safe when the index claims files and the disk holds a sync-scoped file (files-aware)', async () => {
+      fsMock.promises.readdir.resolves([]);
+      fsMock.promises.readdir.withArgs('/apps/test-app').resolves([
+        dirent('.stignore'), dirent('appdata', false), dirent('config.json'),
+      ]);
+      syncthingServiceMock.getDbStatus.resolves({
+        status: 'success',
+        data: {
+          globalBytes: 100000, inSyncBytes: 100000, globalFiles: 1, state: 'idle',
+        },
+      });
+
+      const result = await stateMachine.verifySendReceiveFolderSafety('test-app', '/apps/test-app');
+
+      expect(result.isSafe).to.be.true;
+    });
+
     it('falls back to the mount-level verdict when the sync status is unreadable', async () => {
       syncthingServiceMock.getDbStatus.rejects(new Error('syncthing down'));
 


### PR DESCRIPTION
## What happened in production

On 2026-07-25 a customer's g:-synced app was down for ~8 hours across two nodes. The root cause was the container reconciler wedging: a recreate whose docker pull never settled held the per-app single-flight guard forever, silently — no retry, no log, no recovery. Two other real defects rode along (a terminal-exec crash and a masterSlave election loop that died on its first throw), but the wedge was the outage.

While fixing the wedge we found that the failure paths *around* it were worse than the wedge itself: four separate code paths could **delete an established app and its data** in response to what is usually a transient, node-local failure. This PR closes all of them.

## The core contract this PR establishes

**A failure never destroys an established app's data.** A failed recreate, redeploy, or update converges to *kept-down-with-data*: the app stays in the local DB with its volume intact, and the reconciler retries it on a backoff ladder. A down instance stops broadcasting `apprunning`, so the network replaces it elsewhere through the normal spawner machinery — removal is never needed for availability. Only an app that never ran on a node (nothing to preserve) may be cleaned up.

## Changes by area

### Container reconciler
- A recreate's provision runs under a hard ceiling, so a hung pull can no longer wedge the per-app single-flight forever; a superseded pass can never write state over its replacement.
- Docker pulls are judged by **silence, not elapsed time** — a slow-but-progressing pull of a large image is healthy; only a stalled stream trips the ceiling.
- The deletion gate **fails closed**: a runtime-state read error, a provision timeout, or a docker-runtime timeout is never grounds for removal. An app that has ever started on this node is kept on failure, always.
- The appdata wipe requires a positive answer that nothing is running (unreachable/indeterminate container state aborts the wipe), and a detached provision can no longer race it.
- Short docker calls (lookup, inspect, list, image-size) are bounded so a wedged daemon fails a pass quickly instead of hanging it. Container/network creates are deliberately **not** bounded — a timeout there is not a refusal, and acting as if it were caused duplicate-resource bugs; the comments carry the reasoning.

### Image verification and the update path
- `ImageVerifier` classifies its own failures (transient network/rate-limit/server errors vs. permanent refusals), and a request that received no response at all is a *connectivity* answer, not a verdict. A recreate rides out a registry outage on the locally present image instead of failing the app.
- The mutable-tag image updater now **verifies the new image before anything is torn down** (compliance plus per-component size/arch checks). Previously a digest change triggered the teardown first and verified after — a bad push or a registry error at the wrong moment removed the app and its data. A registry rate-limit aborts the whole cycle rather than burning the budget across apps.

### Soft redeploy — the keep contract
- A failed soft redeploy **never removes the app**. All three failure sites (the redeploy driver, the registration step, the block-driven spec-update path) keep the app and its data for the reconciler.
- The redeploy's own teardown deletes the app's local DB row and the registration step re-inserts it minutes later; a failure inside that window used to hit "no row → remove with force". The row is now **restored** in that window (the spec being applied is re-inserted), because a rowless app is invisible to every recovery sweep. Only an app that was never locally installed falls back to cleanup.
- Concurrency collisions (another install or removal holding the operation flag when the registration runs) are **typed** and treated as deferrals, not failures: the spec-update path no longer force-removes an app over a timing collision, and a collision can never clear another operation's flag.
- The kept app's synced components are re-marked so the sync layer's first-encounter handling cannot clear their data; a mark is never written for an app the node doesn't hold.
- Every busy-guard early return across the four redeploy entry points now closes its streamed API response (previously the client hung to a gateway timeout).

### Syncthing data-safety guards
- The phantom-index discriminator (which demotes a sendreceive folder whose index claims data over an empty disk — the guard that stops a wiped node broadcasting deletions to healthy replicas) is now **files-aware**: an index claiming files over a disk holding only a directory skeleton is correctly caught, while a dirs-only payload (the 2026-07-04 false positive) stays healthy. The sync-status plumbing carries `globalFiles` through so the discriminator actually sees it.
- The disk walk's exclusions are **root-anchored**, matching the `.stignore` FluxOS writes (`/backup` is anchored): files under a *nested* directory named `backup` are synced payload and now count, so such an app is no longer falsely held down as a phantom.
- Creating a fresh volume **invalidates any surviving synced-mark** for that component — at the point of no return, not at entry, so an aborted pre-flight (e.g. out of space) preserves the mark protecting the intact existing data.

### masterSlave scheduler
- Election passes are abandoned per-pass: a stuck pass can no longer kill the scheduler loop or have its stale writes land over a newer pass.
- A heartbeat watchdog judges passes by **silence**, on monotonic time; a legitimately long pass that keeps making progress is left alone.
- The permissions-fix chain is single-flight per app with a hard time budget, and its result is actually read.

### Terminal (socket.io exec)
All four crash paths closed: EPIPE on a flooded pty stream, the hijacked stream's `error` event, a client disconnecting before exec setup completes, and deferred callbacks firing after teardown.

### Test-event stream
Event ids are seeded from the monotonic clock, so a FluxOS restart mints ids above anything previously served and last-event-id consumers don't silently discard every post-restart event.

## Verification

- **441 unit tests** across the touched suites, every behavioral fix proven to fail with the fix reverted (both directions where a placement was in question). Tests that route through catches carry explicit reached-the-path assertions so they cannot pass vacuously.
- **Full 54-suite integration gate: 54/54 pass, clean run**, including new system-level cases pinning the registry-verdict keep, the slow-registry election budget, the live-session terminal crash, the phantom-index guard, and volume-mount ownership across reboots.
- The branch went through repeated independent adversarial reviews to convergence; each round's findings were verified against the code before being fixed, and each fix landed with its own pinning test.

## Notes for reviewers

- **v9 relationship:** `feat/fluxos-v9` rebases on top of this branch after merge. Most of this PR's redeploy hardening maps onto structure v9 already has (per-app operation leases, no rowless window, native keep-on-failure); the two genuine carry-overs (the fresh-volume mark invalidation and the root-anchored walk) are flagged in their commit messages.
- **Documented, deliberately not built here:** the image-update pre-flight cannot cover the install's node-side gates (hardware, network requirements, port mapping — the mapping *is* the action). With keep-on-failure, missing them costs a torn-down app waiting on the reconciler's ladder, never data. The unbounded create under the fresh-install path (`registerAppLocally`) pins the installation flag until process restart and predates this branch; it is owned by the operation-registry redesign.

*Description written against `01a7dec89`.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
