### PR TITLE
Reconciler: the only actuator for every operator command, and a ladder that paces faults not operators

### DIFF
--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -144,6 +144,8 @@ module.exports = {
     // count. A container that fails to START never ran, so it is never a fault
     // and never walks the ladder directly - it reaches it only by filling this
     // window, and a window narrower than that retries forever.
+    // Counted as restarts ALREADY RECORDED, so at 5 the sixth restart is the one
+    // that earns a rung and the seventh is the first one held back.
     restartBurstCount: 5,
     restartBurstWindowMs: 300000,
     // How long a finished operation stays readable at /apps/operations/:jobId,

--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -132,11 +132,20 @@ module.exports = {
     // and the run length that counts as stable (resets the ladder)
     crashBackoffDelaysMs: [0, 30000, 300000, 900000, 1800000],
     crashBackoffStableRunMs: 600000,
-    // cause-blind backstop for images whose entrypoint discards the payload's
-    // exit status: this many automatic restarts inside the window is treated as
-    // a crash and enters the ladder above
+    // Backstop for images whose entrypoint discards the payload's exit status.
+    // A clean exit proves nothing, so for those images restart RATE is the only
+    // fault evidence left and this is the only thing that ever paces them.
+    // This many automatic restarts inside the window is treated as a crash and
+    // enters the ladder above, which reaches anything restarting closer together
+    // than window/count - 60s apart at these values. Slower is deliberately left
+    // alone: Palworld's segfault-restart cycle is ~77s at its worst, and coming
+    // straight back is better for the customer than being paced.
+    // Keep the window wider than the reconciler's retry interval times this
+    // count. A container that fails to START never ran, so it is never a fault
+    // and never walks the ladder directly - it reaches it only by filling this
+    // window, and a window narrower than that retries forever.
     restartBurstCount: 5,
-    restartBurstWindowMs: 60000,
+    restartBurstWindowMs: 300000,
     // How long a finished operation stays readable at /apps/operations/:jobId,
     // and how long a client is told to wait between polls while one runs. A
     // RUNNING job never expires - only terminal ones are retained on a clock.

--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -132,6 +132,11 @@ module.exports = {
     // and the run length that counts as stable (resets the ladder)
     crashBackoffDelaysMs: [0, 30000, 300000, 900000, 1800000],
     crashBackoffStableRunMs: 600000,
+    // cause-blind backstop for images whose entrypoint discards the payload's
+    // exit status: this many automatic restarts inside the window is treated as
+    // a crash and enters the ladder above
+    restartBurstCount: 5,
+    restartBurstWindowMs: 60000,
     // How long a finished operation stays readable at /apps/operations/:jobId,
     // and how long a client is told to wait between polls while one runs. A
     // RUNNING job never expires - only terminal ones are retained on a clock.

--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -410,7 +410,7 @@ module.exports = {
     daemonPONFork: 2020000, // block height where PON (Proof of Node) fork activates - chain works 4x faster after this block
     blocksAllowanceInterval: 1000, // ap differences can be in 1000s - more than 1 day
     removeBlocksAllowanceIntervalBlock: 1625000, // after this block we can start having app updates without extending subscription - block expected in April 19th 2024
-    ownerAppAllowance: 1000, // in case of node owner installing some app, the app will run for this amount of blocks
+    ownerAppAllowance: 1000, // a by-name local install (fluxteam only) runs for this amount of blocks before the expiry sweep removes it
     temporaryAppAllowance: 200, // in case of any user installing some temporary app message for testing purposes, the app will run for this many blocks
     expireFluxAppsPeriod: 100, // every 100 blocks we run a check that deletes apps specifications and stops/removes the application from existence if it has been lastly updated more than 22k blocks ago
     updateFluxAppsPeriod: 9, // every 9 blocks we check for reinstalling of old application versions

--- a/ZelBack/src/routes.js
+++ b/ZelBack/src/routes.js
@@ -1229,6 +1229,12 @@ module.exports = (app) => {
   app.get('/apps/apprestart/:appname?/:global?', alwaysRespond, requireBootSettled, (req, res) => {
     appController.appRestart(req, res);
   });
+  // No :global - a kill is deliberately per-node. Its privilege is narrower than
+  // its siblings' too: appKill checks appownerorfluxteam, so the node operator
+  // cannot order a hard kill of an app they only host.
+  app.get('/apps/appkill/:appname?', alwaysRespond, requireBootSettled, (req, res) => {
+    appController.appKill(req, res);
+  });
   app.get('/apps/apppause/:appname?/:global?', alwaysRespond, requireBootSettled, (req, res) => {
     appController.appPause(req, res);
   });

--- a/ZelBack/src/services/appLifecycle/appInstaller.js
+++ b/ZelBack/src/services/appLifecycle/appInstaller.js
@@ -970,8 +970,19 @@ async function installAppLocally(req, res) {
         blockAllowance = config.fluxapps.temporaryAppAllowance;
       }
       if (!appSpecifications) {
-        // only owner can deploy permanent message or existing app
-        const ownerAuthorized = await verificationHelper.verifyPrivilege('adminandfluxteam', req);
+        // Placing a registered app on a node is not the node operator's call, for
+        // the same reason removing one is not: hosting an app is not owning it.
+        // This branch resolves an app BY NAME from the marketplace, the global
+        // registry or a permanent message, so an operator reaching it is choosing
+        // which customer's app runs on hardware they control - and for a g:/r: app
+        // the new instance syncs that customer's data down to it. The spawner
+        // decides placement; the owner decides everything else.
+        //
+        // The temporary-message branch above is untouched and stays open to any
+        // logged-in user: that is how an app is tested before it is registered,
+        // it is addressed by hash rather than by name, and it expires on its own
+        // (temporaryAppAllowance).
+        const ownerAuthorized = await verificationHelper.verifyPrivilege('fluxteam', req);
         if (!ownerAuthorized) {
           const errMessage = messageHelper.errUnauthorizedMessage();
           res.json(errMessage);
@@ -1134,8 +1145,19 @@ async function testAppInstall(req, res) {
       }
 
       if (!appSpecifications) {
-        // only owner can deploy permanent message or existing app
-        const ownerAuthorized = await verificationHelper.verifyPrivilege('adminandfluxteam', req);
+        // Placing a registered app on a node is not the node operator's call, for
+        // the same reason removing one is not: hosting an app is not owning it.
+        // This branch resolves an app BY NAME from the marketplace, the global
+        // registry or a permanent message, so an operator reaching it is choosing
+        // which customer's app runs on hardware they control - and for a g:/r: app
+        // the new instance syncs that customer's data down to it. The spawner
+        // decides placement; the owner decides everything else.
+        //
+        // The temporary-message branch above is untouched and stays open to any
+        // logged-in user: that is how an app is tested before it is registered,
+        // it is addressed by hash rather than by name, and it expires on its own
+        // (temporaryAppAllowance).
+        const ownerAuthorized = await verificationHelper.verifyPrivilege('fluxteam', req);
         if (!ownerAuthorized) {
           const errMessage = messageHelper.errUnauthorizedMessage();
           res.json(errMessage);

--- a/ZelBack/src/services/appLifecycle/appUninstaller.js
+++ b/ZelBack/src/services/appLifecycle/appUninstaller.js
@@ -21,7 +21,6 @@ const { specificationFormatter } = require('../utils/appSpecHelpers');
 const { stopAppMonitoring } = require('../appManagement/appInspector');
 const appsRuntimeState = require('../appManagement/appsRuntimeState');
 const volumeService = require('../utils/volumeService');
-const imageManager = require('../appSecurity/imageManager');
 const fluxEventBus = require('../utils/fluxEventBus');
 
 const fluxDirPath = process.env.FLUXOS_PATH || path.join(process.env.HOME, 'zelflux');
@@ -1202,37 +1201,20 @@ async function removeAppLocallyApi(req, res) {
       throw new Error('No Flux App specified');
     }
 
-    const authorized = await verificationHelper.verifyPrivilege('appownerabove', req, appname);
+    // The node operator is deliberately NOT here. Hosting an app is not owning it:
+    // an operator who can remove one can script the removal against every install
+    // and keep a customer's app off their node indefinitely, which the customer
+    // experiences as an app that will not stay deployed and cannot diagnose.
+    // Ending an app is the owner's call, or the team's on their behalf.
+    //
+    // One gate, and vetted status does not narrow it further: appownerorfluxteam
+    // admits exactly {owner, fluxTeam, fluxSupport}, which is who may uninstall a
+    // vetted app too. A second check against the same set can only ever agree, and
+    // asking it costs two database reads and a vetted lookup per uninstall.
+    const authorized = await verificationHelper.verifyPrivilege('appownerorfluxteam', req, appname);
     if (!authorized) {
       const errMessage = messageHelper.errUnauthorizedMessage();
       return res.json(errMessage);
-    }
-
-    // For vetted apps, only app owner or Flux Team can uninstall
-    // First, get app specifications to check if vetted
-    const dbopen = dbHelper.databaseConnection();
-    const appsDatabase = dbopen.db(config.database.appslocal.database);
-    const database = dbopen.db(config.database.appsglobal.database);
-    const appsQuery = { name: appname };
-    const appsProjection = {};
-
-    let appSpecsForVettedCheck = await dbHelper.findOneInDatabase(appsDatabase, localAppsInformation, appsQuery, appsProjection);
-    if (!appSpecsForVettedCheck) {
-      appSpecsForVettedCheck = await dbHelper.findOneInDatabase(database, globalAppsInformation, appsQuery, appsProjection);
-    }
-
-    if (appSpecsForVettedCheck) {
-      const appIsVetted = await imageManager.isAppVetted(appSpecsForVettedCheck);
-      if (appIsVetted) {
-        // Check if user is specifically the app owner or Flux Team
-        const isAppOwner = await verificationHelper.verifyPrivilege('appowner', req, appname);
-        const isFluxTeam = await verificationHelper.verifyPrivilege('fluxteam', req);
-
-        if (!isAppOwner && !isFluxTeam) {
-          const errMessage = messageHelper.createErrorMessage('This is a vetted application. Only the app owner or InFlux Support Team are allowed to uninstall it.');
-          return res.json(errMessage);
-        }
-      }
     }
 
     if (global) {

--- a/ZelBack/src/services/appManagement/appController.js
+++ b/ZelBack/src/services/appManagement/appController.js
@@ -164,10 +164,11 @@ async function executeAppGlobalCommand(appname, command, zelidauth, paramA, bypa
  * @param {object|null} appSpecs full app spec (null for a component command)
  * @param {boolean} stopped
  */
-async function setAppOperatorStopped(appname, appSpecs, stopped) {
+async function setAppOperatorStopped(appname, appSpecs, stopped, { awaitPass = false } = {}) {
   const ids = (!appname.includes('_') && appSpecs && appSpecs.version > 3)
     ? appSpecs.compose.map((c) => `${c.name}_${appSpecs.name}`)
     : [appname];
+  let allActuated = true;
   // eslint-disable-next-line no-restricted-syntax
   for (const id of ids) {
     // Written through the reconciler's per-key slot rather than straight to the
@@ -178,9 +179,10 @@ async function setAppOperatorStopped(appname, appSpecs, stopped) {
     // the write lands, and enqueues on release - so the two cannot interleave,
     // and the next pass reads what was just written.
     // eslint-disable-next-line no-await-in-loop
-    await appReconciler.applyIntent(id, async () => {
+    const actuated = await appReconciler.applyIntent(id, async () => {
       await appsRuntimeState.setOperatorStopped(id, stopped);
-    });
+    }, { awaitPass });
+    if (!actuated) allActuated = false;
     // A stop retracts the controller's desire as well as taking the lock. The
     // lock only suppresses the reconciler while it is held; a desire left
     // standing is reconciled against the stopped container the moment the lock
@@ -196,6 +198,29 @@ async function setAppOperatorStopped(appname, appSpecs, stopped) {
     // the sync layer marks a component processed before it asks.
     if (stopped) appReconciler.clearControllerDesired(id);
   }
+  return { ids, actuated: allActuated };
+}
+
+/**
+ * What the containers are actually doing, once the reconciler has had its pass.
+ *
+ * `actuated` says a pass ran, not that it achieved anything: a pass that finds
+ * docker unreachable completes by deferring. So the answer to "is it stopped"
+ * comes from probing, and dockerActual is the probe that can tell a container
+ * being gone from docker being unreachable - which is the difference between
+ * reporting done and reporting pending.
+ * @param {string[]} ids Component identifiers.
+ * @returns {Promise<{settled: boolean, reason: string|null}>}
+ */
+async function containersReachedStopped(ids) {
+  // eslint-disable-next-line no-restricted-syntax
+  for (const id of ids) {
+    // eslint-disable-next-line no-await-in-loop
+    const actual = await appReconciler.dockerActual(id);
+    if (!actual.reachable) return { settled: false, reason: 'docker is not reachable' };
+    if (actual.running) return { settled: false, reason: 'the reconciler has not stopped it yet' };
+  }
+  return { settled: true, reason: null };
 }
 
 async function appStart(req, res) {
@@ -366,43 +391,58 @@ async function appStop(req, res) {
       return res ? res.json(appResponse) : appResponse;
     }
 
+    // THE RECONCILER STOPS IT, NOT THIS HANDLER.
+    //
+    // Two things drove the container before this: the handler called
+    // appDockerStop directly while the reconciler actuated off its own per-key
+    // queue. Two writers to one container is what made an operator stop
+    // interleave with a pass - the pass read the lock, the stop landed, the pass
+    // started the container it had already decided to start. Writing the intent
+    // and letting the single actuator converge removes the second writer rather
+    // than narrowing the window between them.
+    //
+    // The contract is unchanged: awaitPass holds this handler until the pass has
+    // run, so a success still means the container is stopped, in the same
+    // wall-clock the direct call took.
     const isComponent = appname.includes('_'); // it is a component stop
-    let appRes;
+    let ids;
+    let actuated;
+    let stoppedName;
 
     if (isComponent) {
-      // lock BEFORE the docker op (matching the whole-app path): a crash between
-      // the stop and the lock write would leave a stopped container the
-      // reconciler restarts against the operator's intent
-      await setAppOperatorStopped(appname, null, true);
+      ({ ids, actuated } = await setAppOperatorStopped(appname, null, true, { awaitPass: true }));
       appInspector.stopAppMonitoring(appname, false);
-      appRes = await dockerService.appDockerStop(appname);
+      stoppedName = appname;
     } else {
       // Check if app exists before stopping
       const appSpecs = await registryManager.getApplicationSpecifications(mainAppName);
       if (!appSpecs) {
         throw new Error('Application not found');
       }
-      // operator stop persists so the reconciler does not restart it
-      await setAppOperatorStopped(appname, appSpecs, true);
-
+      ({ ids, actuated } = await setAppOperatorStopped(appname, appSpecs, true, { awaitPass: true }));
       // eslint-disable-next-line no-restricted-syntax
-      if (appSpecs.version <= 3) {
-        // eslint-disable-next-line no-await-in-loop
-        appInspector.stopAppMonitoring(appname, false);
-        appRes = await dockerService.appDockerStop(appname);
-      } else {
-        // For composed applications (version > 3), stop all components in reverse order
-        // eslint-disable-next-line no-restricted-syntax
-        for (const appComponent of appSpecs.compose.reverse()) {
-          appInspector.stopAppMonitoring(`${appComponent.name}_${appSpecs.name}`, false);
-          // eslint-disable-next-line no-await-in-loop
-          await dockerService.appDockerStop(`${appComponent.name}_${appSpecs.name}`);
-        }
-        appRes = `Application ${appSpecs.name} stopped`;
-      }
+      for (const id of ids) appInspector.stopAppMonitoring(id, false);
+      stoppedName = appSpecs.name;
     }
 
-    const appResponse = messageHelper.createDataMessage(appRes);
+    // A pass that completed is not a container that stopped - docker being
+    // unreachable completes by deferring. Probe rather than infer, so a stop
+    // that has not happened yet is never reported as one that has.
+    const outcome = actuated
+      ? await containersReachedStopped(ids)
+      : { settled: false, reason: 'no reconcile has run yet' };
+
+    if (!outcome.settled) {
+      // Accepted, not applied. The intent is durable and the reconciler will
+      // converge, so an error here would be false - the old direct call threw
+      // in exactly this case, after the lock had already been written.
+      const pending = messageHelper.createDataMessage(
+        `Application ${stoppedName} will be stopped: ${outcome.reason}`,
+      );
+      return res ? res.json(pending) : pending;
+    }
+
+    const appResponse = messageHelper.createDataMessage(`Application ${stoppedName} stopped`);
     return res ? res.json(appResponse) : appResponse;
   } catch (error) {
     log.error(error);

--- a/ZelBack/src/services/appManagement/appController.js
+++ b/ZelBack/src/services/appManagement/appController.js
@@ -721,32 +721,8 @@ async function appPause(req, res) {
 async function appUnpause(req, res) {
   return deprecatedPauseResponse(req, res);
 }
-/**
- * Docker restart app (internal function)
- * @param {string} appname - Application name
- * @returns {Promise<void>}
- */
-async function appDockerRestart(appname) {
-  try {
-    // mainAppName extracted for potential future use
-    // eslint-disable-next-line no-unused-vars
-    const mainAppName = appname.split('_')[1] || appname;
-    const isComponent = appname.includes('_'); // it is a component restart. Proceed with restarting just component
-    if (isComponent) {
-      await dockerService.appDockerRestart(appname);
-      // Note: startAppMonitoring would need to be injected or called separately
-      log.info(`Component ${appname} restarted successfully`);
-    } else {
-      // ask for restarting entire composed application
-      // This would need getApplicationSpecifications from registryManager
-      log.info(`Restarting entire application ${appname}`);
-      await dockerService.appDockerRestart(appname);
-    }
-  } catch (error) {
-    log.error(`Docker restart failed for ${appname}: ${error.message}`);
-    throw error;
-  }
-}
+// Nothing in this module drives a container. Every route here records the
+// operator's desired state and lets the reconciler actuate it.
 
 /**
  * To stop all non Flux running apps. Executes continuously at regular intervals.
@@ -799,6 +775,5 @@ module.exports = {
   appKill,
   appPause,
   appUnpause,
-  appDockerRestart,
   stopAllNonFluxRunningApps,
 };

--- a/ZelBack/src/services/appManagement/appController.js
+++ b/ZelBack/src/services/appManagement/appController.js
@@ -182,6 +182,16 @@ async function operatorTargetIds(appname) {
   }
   const appName = installedRes.data[0].name;
   const ids = await appReconciler.componentIdsOf(installedRes.data);
+  // An installed app with nothing to address is not an app that needs nothing
+  // done to it - it is one whose parts this node cannot work out: a spec that
+  // will not decrypt, falling back to a docker listing that is empty or that
+  // failed outright. Acting on the empty list wrote no intent, settled
+  // vacuously against nothing, and answered that the command had succeeded.
+  // Refused rather than reported, in the operator's terms: what they need to
+  // know is that nothing happened.
+  if (!ids.length) {
+    throw new Error(`Application ${appName} was not changed: this node cannot determine its components`);
+  }
   if (!appname.includes('_')) return { ids, appName };
   // A component is addressed by name, and a name that is not one of this app's
   // components addresses nothing. Taking it verbatim wrote a durable operator

--- a/ZelBack/src/services/appManagement/appController.js
+++ b/ZelBack/src/services/appManagement/appController.js
@@ -170,8 +170,17 @@ async function setAppOperatorStopped(appname, appSpecs, stopped) {
     : [appname];
   // eslint-disable-next-line no-restricted-syntax
   for (const id of ids) {
+    // Written through the reconciler's per-key slot rather than straight to the
+    // store. A pass reads the lock and acts on that answer once docker has
+    // replied, so a write landing in between is not seen: the pass starts a
+    // container the operator has just stopped and the next pass stops it again.
+    // applyIntent waits out any pass deciding for this id, holds the key while
+    // the write lands, and enqueues on release - so the two cannot interleave,
+    // and the next pass reads what was just written.
     // eslint-disable-next-line no-await-in-loop
-    await appsRuntimeState.setOperatorStopped(id, stopped);
+    await appReconciler.applyIntent(id, async () => {
+      await appsRuntimeState.setOperatorStopped(id, stopped);
+    });
     // A stop retracts the controller's desire as well as taking the lock. The
     // lock only suppresses the reconciler while it is held; a desire left
     // standing is reconciled against the stopped container the moment the lock

--- a/ZelBack/src/services/appManagement/appController.js
+++ b/ZelBack/src/services/appManagement/appController.js
@@ -4,7 +4,6 @@ const serviceHelper = require('../serviceHelper');
 // Removed verificationHelper to avoid circular dependency - will use dynamic require where needed
 const messageHelper = require('../messageHelper');
 const dockerService = require('../dockerService');
-const registryManager = require('../appDatabase/registryManager');
 const appsRuntimeState = require('./appsRuntimeState');
 const appReconciler = require('../appMonitoring/appReconciler');
 const fluxNetworkHelper = require('../fluxNetworkHelper');
@@ -162,16 +161,40 @@ async function executeAppGlobalCommand(appname, command, zelidauth, paramA, bypa
  *
  * @param {string} appname app or component identifier
  * @param {object|null} appSpecs full app spec (null for a component command)
+ * The components are resolved from what the app is actually made of, never from a
+ * stored spec's `compose`: an enterprise app keeps its component names inside an
+ * encrypted blob, so reading compose yields an empty list and a whole-app command
+ * addresses nothing while reporting success.
+ *
  * @param {boolean} stopped
  * @param {object} [options]
  * @param {boolean} [options.awaitPass] hold until the reconcile pass has run
  * @param {boolean} [options.force] a stop is a hard kill, not a graceful stop
  * @param {boolean} [options.alsoRestart] raise the restart generation with the lock
  */
-async function setAppOperatorStopped(appname, appSpecs, stopped, { awaitPass = false, force = false, alsoRestart = false } = {}) {
-  const ids = (!appname.includes('_') && appSpecs && appSpecs.version > 3)
-    ? appSpecs.compose.map((c) => `${c.name}_${appSpecs.name}`)
-    : [appname];
+async function operatorTargetIds(appname) {
+  const mainAppName = appname.split('_')[1] || appname;
+  // eslint-disable-next-line global-require
+  const appQueryService = require('../appQuery/appQueryService');
+  const installedRes = await appQueryService.installedApps(mainAppName);
+  if (!installedRes || installedRes.status !== 'success' || !installedRes.data.length) {
+    throw new Error(`Application ${mainAppName} is not installed on this node`);
+  }
+  const appName = installedRes.data[0].name;
+  const ids = await appReconciler.componentIdsOf(installedRes.data);
+  if (!appname.includes('_')) return { ids, appName };
+  // A component is addressed by name, and a name that is not one of this app's
+  // components addresses nothing. Taking it verbatim wrote a durable operator
+  // lock under a component that does not exist - nothing clears one, and it holds
+  // the real component down if one is ever created with that name.
+  if (!ids.includes(appname)) {
+    throw new Error(`Component ${appname} is not installed on this node`);
+  }
+  return { ids: [appname], appName: appname };
+}
+
+async function setAppOperatorStopped(appname, stopped, { awaitPass = false, force = false, alsoRestart = false } = {}) {
+  const { ids, appName } = await operatorTargetIds(appname);
   // Components come up in compose order and go down in the reverse of it, so a
   // dependency outlives what writes to it: the database stops after the server it
   // serves, not before it. awaitPass holds each component's pass open before the
@@ -224,7 +247,7 @@ async function setAppOperatorStopped(appname, appSpecs, stopped, { awaitPass = f
     // the sync layer marks a component processed before it asks.
     if (stopped) appReconciler.clearControllerDesired(id);
   }
-  return { ids, actuated: allActuated };
+  return { ids, actuated: allActuated, appName };
 }
 
 /**
@@ -244,6 +267,10 @@ async function containersReachedStopped(ids) {
     // eslint-disable-next-line no-await-in-loop
     const actual = await appReconciler.dockerActual(id);
     if (!actual.reachable) return { settled: false, reason: 'docker is not reachable' };
+    // Nothing there is not the same as stopped. dockerActual distinguishes the two
+    // and this read the pair as one, so a command against a container that does not
+    // exist settled - and answered "stopped" for something that was never running.
+    if (!actual.exists) return { settled: false, reason: 'it is not installed on this node' };
     if (actual.running) return { settled: false, reason: 'the reconciler has not stopped it yet' };
   }
   return { settled: true, reason: null };
@@ -337,23 +364,9 @@ async function appStart(req, res) {
     //
     // awaitPass holds this handler until the pass has run, so a success still
     // means the container is running in the same wall-clock the direct call took.
-    const isComponent = appname.includes('_'); // it is a component start
-    let ids;
-    let actuated;
-    let startedName;
-
-    if (isComponent) {
-      ({ ids, actuated } = await setAppOperatorStopped(appname, null, false, { awaitPass: true }));
-      startedName = appname;
-    } else {
-      // Check if app exists before starting
-      const appSpecs = await registryManager.getApplicationSpecifications(mainAppName);
-      if (!appSpecs) {
-        throw new Error('Application not found');
-      }
-      ({ ids, actuated } = await setAppOperatorStopped(appname, appSpecs, false, { awaitPass: true }));
-      startedName = appSpecs.name;
-    }
+    // Which components this addresses - and whether the app or component even
+    // exists here - is resolved from what the app is made of, in one place.
+    const { ids, actuated, appName: startedName } = await setAppOperatorStopped(appname, false, { awaitPass: true });
 
     // A pass that completed is not a container that started - docker being
     // unreachable completes by deferring, and a synced component the election
@@ -439,23 +452,9 @@ async function appStop(req, res) {
     // Monitoring goes with the container, so the reconciler turns it off when it
     // stops one. Doing it here stopped the sampler for a container the stop had
     // not reached - an unreachable docker left it running and unwatched.
-    const isComponent = appname.includes('_'); // it is a component stop
-    let ids;
-    let actuated;
-    let stoppedName;
-
-    if (isComponent) {
-      ({ ids, actuated } = await setAppOperatorStopped(appname, null, true, { awaitPass: true }));
-      stoppedName = appname;
-    } else {
-      // Check if app exists before stopping
-      const appSpecs = await registryManager.getApplicationSpecifications(mainAppName);
-      if (!appSpecs) {
-        throw new Error('Application not found');
-      }
-      ({ ids, actuated } = await setAppOperatorStopped(appname, appSpecs, true, { awaitPass: true }));
-      stoppedName = appSpecs.name;
-    }
+    // Which components this addresses - and whether the app or component even
+    // exists here - is resolved from what the app is made of, in one place.
+    const { ids, actuated, appName: stoppedName } = await setAppOperatorStopped(appname, true, { awaitPass: true });
 
     // A pass that completed is not a container that stopped - docker being
     // unreachable completes by deferring. Probe rather than infer, so a stop
@@ -530,23 +529,9 @@ async function appRestart(req, res) {
     // the same request satisfied. Expressing it as a level rather than an action
     // is what removes the race: there is no window between this handler deciding
     // and the reconciler deciding, because only one of them decides.
-    const isComponent = appname.includes('_'); // it is a component restart
-    let ids;
-    let actuated;
-    let restartedName;
-
-    if (isComponent) {
-      ({ ids, actuated } = await setAppOperatorStopped(appname, null, false, { awaitPass: true, alsoRestart: true }));
-      restartedName = appname;
-    } else {
-      // Check if app exists before restarting
-      const appSpecs = await registryManager.getApplicationSpecifications(mainAppName);
-      if (!appSpecs) {
-        throw new Error('Application not found');
-      }
-      ({ ids, actuated } = await setAppOperatorStopped(appname, appSpecs, false, { awaitPass: true, alsoRestart: true }));
-      restartedName = appSpecs.name;
-    }
+    // Which components this addresses - and whether the app or component even
+    // exists here - is resolved from what the app is made of, in one place.
+    const { ids, actuated, appName: restartedName } = await setAppOperatorStopped(appname, false, { awaitPass: true, alsoRestart: true });
 
     const outcome = actuated
       ? await containersReachedRunning(ids)
@@ -605,23 +590,9 @@ async function appKill(req, res) {
     // with a mode: the lock, plus force. The reconciler reads the mode where it
     // stops the container, which keeps the choice of signal beside the decision
     // to stop rather than in a handler racing it.
-    const isComponent = appname.includes('_'); // it is a component kill
-    let ids;
-    let actuated;
-    let killedName;
-
-    if (isComponent) {
-      ({ ids, actuated } = await setAppOperatorStopped(appname, null, true, { awaitPass: true, force: true }));
-      killedName = appname;
-    } else {
-      // Check if app exists before killing
-      const appSpecs = await registryManager.getApplicationSpecifications(mainAppName);
-      if (!appSpecs) {
-        throw new Error('Application not found');
-      }
-      ({ ids, actuated } = await setAppOperatorStopped(appname, appSpecs, true, { awaitPass: true, force: true }));
-      killedName = appSpecs.name;
-    }
+    // Which components this addresses - and whether the app or component even
+    // exists here - is resolved from what the app is made of, in one place.
+    const { ids, actuated, appName: killedName } = await setAppOperatorStopped(appname, true, { awaitPass: true, force: true });
 
     const outcome = actuated
       ? await containersReachedStopped(ids)

--- a/ZelBack/src/services/appManagement/appController.js
+++ b/ZelBack/src/services/appManagement/appController.js
@@ -5,11 +5,11 @@ const serviceHelper = require('../serviceHelper');
 const messageHelper = require('../messageHelper');
 const dockerService = require('../dockerService');
 const registryManager = require('../appDatabase/registryManager');
-const appInspector = require('./appInspector');
 const appsRuntimeState = require('./appsRuntimeState');
 const appReconciler = require('../appMonitoring/appReconciler');
 const fluxNetworkHelper = require('../fluxNetworkHelper');
 const { extractIp, extractPort } = require('../utils/socketAddressUtils');
+const fluxEventBus = require('../utils/fluxEventBus');
 const log = require('../../lib/log');
 
 const { globalCmdDelayMs } = config.fluxapps;
@@ -163,8 +163,12 @@ async function executeAppGlobalCommand(appname, command, zelidauth, paramA, bypa
  * @param {string} appname app or component identifier
  * @param {object|null} appSpecs full app spec (null for a component command)
  * @param {boolean} stopped
+ * @param {object} [options]
+ * @param {boolean} [options.awaitPass] hold until the reconcile pass has run
+ * @param {boolean} [options.force] a stop is a hard kill, not a graceful stop
+ * @param {boolean} [options.alsoRestart] raise the restart generation with the lock
  */
-async function setAppOperatorStopped(appname, appSpecs, stopped, { awaitPass = false } = {}) {
+async function setAppOperatorStopped(appname, appSpecs, stopped, { awaitPass = false, force = false, alsoRestart = false } = {}) {
   const ids = (!appname.includes('_') && appSpecs && appSpecs.version > 3)
     ? appSpecs.compose.map((c) => `${c.name}_${appSpecs.name}`)
     : [appname];
@@ -180,7 +184,22 @@ async function setAppOperatorStopped(appname, appSpecs, stopped, { awaitPass = f
     // and the next pass reads what was just written.
     // eslint-disable-next-line no-await-in-loop
     const actuated = await appReconciler.applyIntent(id, async () => {
-      await appsRuntimeState.setOperatorStopped(id, stopped);
+      await appsRuntimeState.setOperatorStopped(id, stopped, { force });
+      // Raised inside the same slot as the lock, so a pass cannot read one
+      // without the other and bounce a container the operator meant to keep down.
+      if (alsoRestart) await appsRuntimeState.requestRestart(id);
+      // The operator's intent is the one desired-state write in this flow that
+      // announced nothing, so nothing could be ordered against it - and the
+      // failure it hides is an actuation on the PREVIOUS intent arriving after
+      // this one landed. Published from inside the slot: after the write, so it
+      // can never claim an intent that did not persist, and before the pass,
+      // which is what makes it the ordering point.
+      fluxEventBus.publish('app:operatorIntent', {
+        // The bare component id the reconciler publishes its own actuations
+        // under. An event carrying a different spelling of the same component
+        // cannot be ordered against them, which is the only thing it is for.
+        identifier: dockerService.getBaseAppName(id), stopped, force, restartRequested: alsoRestart,
+      });
     }, { awaitPass });
     if (!actuated) allActuated = false;
     // A stop retracts the controller's desire as well as taking the lock. The
@@ -223,6 +242,53 @@ async function containersReachedStopped(ids) {
   return { settled: true, reason: null };
 }
 
+// Why the reconciler is not running a component, in the operator's terms. The
+// election cases are not failures: a synced component runs on the node the
+// election made the writer, so "not started" is the correct outcome elsewhere
+// and saying so is more use than a generic wait.
+const NOT_RUNNING_REASONS = {
+  awaitingController: 'waiting for the election',
+  controllerDesired: 'the election has not made this node the writer',
+  policy: 'its restart policy does not allow it to run',
+  invalidSpec: 'its specification cannot be actuated',
+  notInstalled: 'it is not installed on this node',
+};
+
+/**
+ * What the containers are actually doing, once the reconciler has had its pass.
+ *
+ * The mirror of containersReachedStopped, with one asymmetry: a container that
+ * is not running may be one the reconciler is right to leave alone, so the
+ * reason comes from the reconciler's own verdict rather than from the absence.
+ *
+ * @param {string[]} ids Component identifiers.
+ * @returns {Promise<{settled: boolean, reason: string|null}>}
+ */
+async function containersReachedRunning(ids) {
+  // eslint-disable-next-line no-restricted-syntax
+  for (const id of ids) {
+    // eslint-disable-next-line no-await-in-loop
+    const actual = await appReconciler.dockerActual(id);
+    if (!actual.reachable) return { settled: false, reason: 'docker is not reachable' };
+    if (actual.running) {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+    let verdict;
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      verdict = await appReconciler.desiredRunState(id);
+    } catch (err) {
+      return { settled: false, reason: `its state could not be read: ${err.message}` };
+    }
+    return {
+      settled: false,
+      reason: NOT_RUNNING_REASONS[verdict.reason] || 'the reconciler has not started it yet',
+    };
+  }
+  return { settled: true, reason: null };
+}
+
 async function appStart(req, res) {
   try {
     let { appname } = req.params;
@@ -237,7 +303,6 @@ async function appStart(req, res) {
 
     const mainAppName = appname.split('_')[1] || appname;
 
-    // eslint-disable-next-line global-require
     // Use dynamic require to avoid circular dependency
     // eslint-disable-next-line global-require
     const verificationHelper = require('../verificationHelper');
@@ -253,96 +318,55 @@ async function appStart(req, res) {
       return res ? res.json(appResponse) : appResponse;
     }
 
+    // THE RECONCILER STARTS IT, NOT THIS HANDLER.
+    //
+    // Clearing the lock is the whole of an operator start: whether the container
+    // may run is a decision the election already owns for a g:/r: component, and
+    // the reconciler consults it on every pass. A handler that also probed docker
+    // was asking a different question - "is this container running now" as a proxy
+    // for "should this node be running it" - and those diverge both ways: a
+    // primary whose container is stopped was refused a start, a standby whose
+    // container happened to be up was started.
+    //
+    // awaitPass holds this handler until the pass has run, so a success still
+    // means the container is running in the same wall-clock the direct call took.
     const isComponent = appname.includes('_'); // it is a component start
-    let appRes;
+    let ids;
+    let actuated;
+    let startedName;
 
     if (isComponent) {
-      // user-initiated start clears the operator stop lock so the reconciler keeps it running
-      await setAppOperatorStopped(appname, null, false);
-      // For component start, check if it uses g:syncthing mode
-      const componentMainApp = appname.split('_')[1];
-      const appSpecs = await registryManager.getApplicationSpecifications(componentMainApp);
-      if (appSpecs && appSpecs.version > 3) {
-        const componentSpec = appSpecs.compose.find((comp) => `${comp.name}_${appSpecs.name}` === appname);
-        if (componentSpec && componentSpec.containerData && componentSpec.containerData.includes('g:')) {
-          // Check if component is running
-          try {
-            const containers = await dockerService.dockerListContainers(false); // Get only running containers
-            const isRunning = containers.some((container) => container.Names[0] === dockerService.getAppDockerNameIdentifier(appname) || container.Id === appname);
-            if (!isRunning) {
-              log.info(`Skipping start for g:syncthing component ${appname} - not currently running`);
-              appRes = `Component ${appname} uses g:syncthing mode and is not running - skipped start`;
-              const appResponse = messageHelper.createDataMessage(appRes);
-              return res ? res.json(appResponse) : appResponse;
-            }
-          } catch (error) {
-            log.warn(`Could not check running status for ${appname}: ${error.message}`);
-          }
-        }
-      }
-      appRes = await dockerService.appDockerStart(appname);
-      appInspector.startAppMonitoring(appname);
+      ({ ids, actuated } = await setAppOperatorStopped(appname, null, false, { awaitPass: true }));
+      startedName = appname;
     } else {
       // Check if app exists before starting
       const appSpecs = await registryManager.getApplicationSpecifications(mainAppName);
       if (!appSpecs) {
         throw new Error('Application not found');
       }
-      // user-initiated start clears the operator stop lock so the reconciler keeps it running
-      await setAppOperatorStopped(appname, appSpecs, false);
-
-      if (appSpecs.version <= 3) {
-        // For non-composed apps, check if it uses g:syncthing mode
-        if (appSpecs.containerData && appSpecs.containerData.includes('g:')) {
-          try {
-            const containers = await dockerService.dockerListContainers(false);
-            const isRunning = containers.some((container) => container.Names[0] === dockerService.getAppDockerNameIdentifier(appname) || container.Id === appname);
-            if (!isRunning) {
-              log.info(`Skipping start for g:syncthing app ${appname} - not currently running`);
-              appRes = `Application ${appname} uses g:syncthing mode and is not running - skipped start`;
-              const appResponse = messageHelper.createDataMessage(appRes);
-              return res ? res.json(appResponse) : appResponse;
-            }
-          } catch (error) {
-            log.warn(`Could not check running status for ${appname}: ${error.message}`);
-          }
-        }
-        appRes = await dockerService.appDockerStart(appname);
-        appInspector.startAppMonitoring(appname);
-      } else {
-        // For composed applications (version > 3), start all components
-        log.info(`Starting composed app ${appSpecs.name} with ${appSpecs.compose.length} components`);
-        // eslint-disable-next-line no-restricted-syntax
-        for (const appComponent of appSpecs.compose) {
-          const componentName = `${appComponent.name}_${appSpecs.name}`;
-          // Check if component uses g:syncthing mode
-          if (appComponent.containerData && appComponent.containerData.includes('g:')) {
-            try {
-              // eslint-disable-next-line no-await-in-loop
-              const containers = await dockerService.dockerListContainers(false);
-              const isRunning = containers.some((container) => container.Names[0] === dockerService.getAppDockerNameIdentifier(componentName) || container.Id === componentName);
-              if (!isRunning) {
-                log.info(`Skipping start for g:syncthing component ${componentName} - not currently running`);
-                // eslint-disable-next-line no-continue
-                continue;
-              }
-            } catch (error) {
-              log.warn(`Could not check running status for ${componentName}: ${error.message}`);
-            }
-          }
-          log.info(`Starting component: ${componentName}`);
-          // eslint-disable-next-line no-await-in-loop
-          await dockerService.appDockerStart(componentName);
-          log.info(`Component ${componentName} started, starting monitoring`);
-          appInspector.startAppMonitoring(componentName);
-          log.info(`Monitoring started for ${componentName}`);
-        }
-        log.info(`All components started for ${appSpecs.name}`);
-        appRes = `Application ${appSpecs.name} started`;
-      }
+      ({ ids, actuated } = await setAppOperatorStopped(appname, appSpecs, false, { awaitPass: true }));
+      startedName = appSpecs.name;
     }
 
-    const appResponse = messageHelper.createDataMessage(appRes);
+    // A pass that completed is not a container that started - docker being
+    // unreachable completes by deferring, and a synced component the election
+    // holds elsewhere is a pass that correctly did nothing. Probe rather than
+    // infer, and name which of the two it was.
+    const outcome = actuated
+      ? await containersReachedRunning(ids)
+      : { settled: false, reason: 'no reconcile has run yet' };
+
+    if (!outcome.settled) {
+      // Accepted, not applied. The intent is durable and the reconciler converges
+      // on it; where the reason is the election, "not started here" is the correct
+      // outcome rather than a failure, and the operator is told which it is.
+      const pending = messageHelper.createDataMessage(
+        `Application ${startedName} will be started: ${outcome.reason}`,
+      );
+      return res ? res.json(pending) : pending;
+    }
+
+    const appResponse = messageHelper.createDataMessage(`Application ${startedName} started`);
     return res ? res.json(appResponse) : appResponse;
   } catch (error) {
     log.error(error);
@@ -404,6 +428,10 @@ async function appStop(req, res) {
     // The contract is unchanged: awaitPass holds this handler until the pass has
     // run, so a success still means the container is stopped, in the same
     // wall-clock the direct call took.
+    //
+    // Monitoring goes with the container, so the reconciler turns it off when it
+    // stops one. Doing it here stopped the sampler for a container the stop had
+    // not reached - an unreachable docker left it running and unwatched.
     const isComponent = appname.includes('_'); // it is a component stop
     let ids;
     let actuated;
@@ -411,7 +439,6 @@ async function appStop(req, res) {
 
     if (isComponent) {
       ({ ids, actuated } = await setAppOperatorStopped(appname, null, true, { awaitPass: true }));
-      appInspector.stopAppMonitoring(appname, false);
       stoppedName = appname;
     } else {
       // Check if app exists before stopping
@@ -420,8 +447,6 @@ async function appStop(req, res) {
         throw new Error('Application not found');
       }
       ({ ids, actuated } = await setAppOperatorStopped(appname, appSpecs, true, { awaitPass: true }));
-      // eslint-disable-next-line no-restricted-syntax
-      for (const id of ids) appInspector.stopAppMonitoring(id, false);
       stoppedName = appSpecs.name;
     }
 
@@ -469,7 +494,6 @@ async function appRestart(req, res) {
     global = global || req.query.global || false;
     global = serviceHelper.ensureBoolean(global);
 
-    // eslint-disable-next-line global-require
     if (!appname) {
       throw new Error('No Flux App specified');
     }
@@ -491,91 +515,44 @@ async function appRestart(req, res) {
       return res ? res.json(appResponse) : appResponse;
     }
 
+    // A RESTART IS DESIRED STATE, NOT A DOCKER CALL.
+    //
+    // "Make it run now" is the lock cleared and the restart generation raised.
+    // The reconciler bounces a running container once the generation passes the
+    // one it last actuated, and a stopped container is simply started - which is
+    // the same request satisfied. Expressing it as a level rather than an action
+    // is what removes the race: there is no window between this handler deciding
+    // and the reconciler deciding, because only one of them decides.
     const isComponent = appname.includes('_'); // it is a component restart
-    let appRes;
+    let ids;
+    let actuated;
+    let restartedName;
 
     if (isComponent) {
-      // user-initiated restart means "make it run": clear the operator stop lock
-      // (before the docker op) so the reconciler keeps it running afterwards
-      await setAppOperatorStopped(appname, null, false);
-      // For component restart, check if it uses g:syncthing mode
-      const componentMainApp = appname.split('_')[1];
-      const appSpecs = await registryManager.getApplicationSpecifications(componentMainApp);
-      if (appSpecs && appSpecs.version > 3) {
-        const componentSpec = appSpecs.compose.find((comp) => `${comp.name}_${appSpecs.name}` === appname);
-        if (componentSpec && componentSpec.containerData && componentSpec.containerData.includes('g:')) {
-          // Check if component is running
-          try {
-            const containers = await dockerService.dockerListContainers(false); // Get only running containers
-            const isRunning = containers.some((container) => container.Names[0] === dockerService.getAppDockerNameIdentifier(appname) || container.Id === appname);
-            if (!isRunning) {
-              log.info(`Skipping restart for g:syncthing component ${appname} - not currently running`);
-              appRes = `Component ${appname} uses g:syncthing mode and is not running - skipped restart`;
-              const appResponse = messageHelper.createDataMessage(appRes);
-              return res ? res.json(appResponse) : appResponse;
-            }
-          } catch (error) {
-            log.warn(`Could not check running status for ${appname}: ${error.message}`);
-          }
-        }
-      }
-      appRes = await dockerService.appDockerRestart(appname);
+      ({ ids, actuated } = await setAppOperatorStopped(appname, null, false, { awaitPass: true, alsoRestart: true }));
+      restartedName = appname;
     } else {
       // Check if app exists before restarting
       const appSpecs = await registryManager.getApplicationSpecifications(mainAppName);
-      // eslint-disable-next-line no-restricted-syntax
       if (!appSpecs) {
         throw new Error('Application not found');
       }
-      // user-initiated restart means "make it run": clear the operator stop lock
-      // for every component (before the docker ops), matching appStart
-      await setAppOperatorStopped(appname, appSpecs, false);
-
-      if (appSpecs.version <= 3) {
-        // For non-composed apps, check if it uses g:syncthing mode
-        if (appSpecs.containerData && appSpecs.containerData.includes('g:')) {
-          try {
-            const containers = await dockerService.dockerListContainers(false);
-            const isRunning = containers.some((container) => container.Names[0] === dockerService.getAppDockerNameIdentifier(appname) || container.Id === appname);
-            if (!isRunning) {
-              log.info(`Skipping restart for g:syncthing app ${appname} - not currently running`);
-              appRes = `Application ${appname} uses g:syncthing mode and is not running - skipped restart`;
-              const appResponse = messageHelper.createDataMessage(appRes);
-              return res ? res.json(appResponse) : appResponse;
-            }
-          } catch (error) {
-            log.warn(`Could not check running status for ${appname}: ${error.message}`);
-          }
-        }
-        appRes = await dockerService.appDockerRestart(appname);
-      } else {
-        // For composed applications (version > 3), restart all components
-        // eslint-disable-next-line no-restricted-syntax
-        for (const appComponent of appSpecs.compose) {
-          const componentName = `${appComponent.name}_${appSpecs.name}`;
-          // Check if component uses g:syncthing mode
-          if (appComponent.containerData && appComponent.containerData.includes('g:')) {
-            try {
-              // eslint-disable-next-line no-await-in-loop
-              const containers = await dockerService.dockerListContainers(false);
-              const isRunning = containers.some((container) => container.Names[0] === dockerService.getAppDockerNameIdentifier(componentName) || container.Id === componentName);
-              if (!isRunning) {
-                log.info(`Skipping restart for g:syncthing component ${componentName} - not currently running`);
-                // eslint-disable-next-line no-continue
-                continue;
-              }
-            } catch (error) {
-              log.warn(`Could not check running status for ${componentName}: ${error.message}`);
-            }
-          }
-          // eslint-disable-next-line no-await-in-loop
-          await dockerService.appDockerRestart(`${appComponent.name}_${appSpecs.name}`);
-        }
-        appRes = `Application ${appSpecs.name} restarted`;
-      }
+      ({ ids, actuated } = await setAppOperatorStopped(appname, appSpecs, false, { awaitPass: true, alsoRestart: true }));
+      restartedName = appSpecs.name;
     }
 
-    const appResponse = messageHelper.createDataMessage(appRes);
+    const outcome = actuated
+      ? await containersReachedRunning(ids)
+      : { settled: false, reason: 'no reconcile has run yet' };
+
+    if (!outcome.settled) {
+      const pending = messageHelper.createDataMessage(
+        `Application ${restartedName} will be restarted: ${outcome.reason}`,
+      );
+      return res ? res.json(pending) : pending;
+    }
+
+    const appResponse = messageHelper.createDataMessage(`Application ${restartedName} restarted`);
     return res ? res.json(appResponse) : appResponse;
   } catch (error) {
     log.error(error);
@@ -597,7 +574,6 @@ async function appRestart(req, res) {
 async function appKill(req, res) {
   try {
     let { appname } = req.params;
-    // eslint-disable-next-line global-require
     appname = appname || req.query.appname;
 
     if (!appname) {
@@ -609,43 +585,49 @@ async function appKill(req, res) {
     // Use dynamic require to avoid circular dependency
     // eslint-disable-next-line global-require
     const verificationHelper = require('../verificationHelper');
-    const authorized = await verificationHelper.verifyPrivilege('appownerabove', req, mainAppName);
+    // Not appownerabove: that admits the node operator, and a hard kill of
+    // someone else's app is not theirs to order. The owner and the flux team
+    // only - the operator keeps every other lifecycle control.
+    const authorized = await verificationHelper.verifyPrivilege('appownerorfluxteam', req, mainAppName);
     if (!authorized) {
       const errMessage = messageHelper.errUnauthorizedMessage();
       return res ? res.json(errMessage) : errMessage;
     }
 
-    const isComponent = appname.includes('_'); // it is a component kill. Proceed with killing just component
-    let appRes;
+    // A kill is a stop that carries a signal, so it is the same desired state
+    // with a mode: the lock, plus force. The reconciler reads the mode where it
+    // stops the container, which keeps the choice of signal beside the decision
+    // to stop rather than in a handler racing it.
+    const isComponent = appname.includes('_'); // it is a component kill
+    let ids;
+    let actuated;
+    let killedName;
 
     if (isComponent) {
-      // lock BEFORE the docker op (matching the whole-app path) - crash-safe direction
-      await setAppOperatorStopped(appname, null, true);
-      appRes = await dockerService.appDockerKill(appname);
+      ({ ids, actuated } = await setAppOperatorStopped(appname, null, true, { awaitPass: true, force: true }));
+      killedName = appname;
     } else {
-      // eslint-disable-next-line no-restricted-syntax
       // Check if app exists before killing
       const appSpecs = await registryManager.getApplicationSpecifications(mainAppName);
       if (!appSpecs) {
         throw new Error('Application not found');
       }
-      // operator kill persists so the reconciler does not restart it
-      await setAppOperatorStopped(appname, appSpecs, true);
-
-      if (appSpecs.version <= 3) {
-        appRes = await dockerService.appDockerKill(appname);
-      } else {
-        // For composed applications (version > 3), kill all components in reverse order
-        // eslint-disable-next-line no-restricted-syntax
-        for (const appComponent of appSpecs.compose.reverse()) {
-          // eslint-disable-next-line no-await-in-loop
-          await dockerService.appDockerKill(`${appComponent.name}_${appSpecs.name}`);
-        }
-        appRes = `Application ${appSpecs.name} killed`;
-      }
+      ({ ids, actuated } = await setAppOperatorStopped(appname, appSpecs, true, { awaitPass: true, force: true }));
+      killedName = appSpecs.name;
     }
 
-    const appResponse = messageHelper.createDataMessage(appRes);
+    const outcome = actuated
+      ? await containersReachedStopped(ids)
+      : { settled: false, reason: 'no reconcile has run yet' };
+
+    if (!outcome.settled) {
+      const pending = messageHelper.createDataMessage(
+        `Application ${killedName} will be killed: ${outcome.reason}`,
+      );
+      return res ? res.json(pending) : pending;
+    }
+
+    const appResponse = messageHelper.createDataMessage(`Application ${killedName} killed`);
     return res ? res.json(appResponse) : appResponse;
   } catch (error) {
     log.error(error);

--- a/ZelBack/src/services/appManagement/appController.js
+++ b/ZelBack/src/services/appManagement/appController.js
@@ -172,6 +172,13 @@ async function setAppOperatorStopped(appname, appSpecs, stopped, { awaitPass = f
   const ids = (!appname.includes('_') && appSpecs && appSpecs.version > 3)
     ? appSpecs.compose.map((c) => `${c.name}_${appSpecs.name}`)
     : [appname];
+  // Components come up in compose order and go down in the reverse of it, so a
+  // dependency outlives what writes to it: the database stops after the server it
+  // serves, not before it. awaitPass holds each component's pass open before the
+  // next id is touched, so this order is the order the containers move in.
+  // Reversed on the mapped ids, which is a fresh array - never on the spec, whose
+  // compose array is shared with whatever the caller fetched it from.
+  if (stopped) ids.reverse();
   let allActuated = true;
   // eslint-disable-next-line no-restricted-syntax
   for (const id of ids) {

--- a/ZelBack/src/services/appManagement/appInspector.js
+++ b/ZelBack/src/services/appManagement/appInspector.js
@@ -679,10 +679,30 @@ function stopAppMonitoring(appName, deleteData) {
 
   if (appsMonitored[appName]) {
     clearInterval(appsMonitored[appName].oneMinuteInterval);
+    // Dropped, not just cleared: a stale handle is indistinguishable from a live
+    // one, and ensureAppMonitoring has to be able to tell them apart.
+    appsMonitored[appName].oneMinuteInterval = null;
     if (deleteData) {
       delete appsMonitored[appName];
     }
   }
+}
+
+/**
+ * Starts monitoring only if it is not already running.
+ *
+ * startAppMonitoring resets statsStore, so calling it for a container that is
+ * already monitored discards the series the charts read. The reconciler reaches
+ * a running container on every pass, so it needs the question asked rather than
+ * the reset repeated.
+ *
+ * @param {string} appName - Application name
+ * @returns {void}
+ */
+function ensureAppMonitoring(appName) {
+  const { appsMonitored } = globalState;
+  if (appsMonitored[appName] && appsMonitored[appName].oneMinuteInterval) return;
+  startAppMonitoring(appName);
 }
 
 /**
@@ -1209,6 +1229,7 @@ module.exports = {
   appExec,
   appChanges,
   startAppMonitoring,
+  ensureAppMonitoring,
   stopAppMonitoring,
   listAppsImages,
   getAppsDOSState,

--- a/ZelBack/src/services/appManagement/appsRuntimeState.js
+++ b/ZelBack/src/services/appManagement/appsRuntimeState.js
@@ -142,15 +142,20 @@ async function requestRestart(identifier) {
  * Marks a restart generation as actuated, so the pass that follows the bounce
  * does not bounce it again.
  *
+ * Throws, unlike the recorders either side of it, because this write is not
+ * history - it is the only thing that stops the next pass bouncing the container
+ * again. Swallowed, a failure here read as "recorded" and the pass that followed
+ * found the request still outstanding: on a node whose reads work and whose
+ * writes do not, that restarted the app every POST_START_VERIFY_MS forever, on
+ * the one path deliberately exempt from the backoff ladder. Losing an exit code
+ * (recordExit) costs a log line; losing this one costs the app.
+ *
  * @param {string} identifier
  * @param {number} generation
+ * @throws when the write fails
  */
 async function recordRestartGeneration(identifier, generation) {
-  try {
-    await setFields(identifier, { actuatedRestartGeneration: generation });
-  } catch (err) {
-    log.error(`appsRuntimeState - failed to record restart generation for ${identifier}: ${err.message}`);
-  }
+  await setFields(identifier, { actuatedRestartGeneration: generation });
 }
 
 /**

--- a/ZelBack/src/services/appManagement/appsRuntimeState.js
+++ b/ZelBack/src/services/appManagement/appsRuntimeState.js
@@ -20,6 +20,15 @@ const STABLE_RUN_MS = config.fluxapps.crashBackoffStableRunMs ?? 10 * 60 * 1000;
 // only the count (capped by the ladder) and the last timestamp are ever read,
 // so the persisted history never needs to grow beyond the ladder length
 const MAX_HISTORY = BACKOFF_DELAYS_MS.length;
+// The exit code cannot prove a fault: an image whose entrypoint is a wrapper
+// script ending in `exit 0` reports a clean stop for a segfault, and no init we
+// wrap around it can recover a status the image already discarded. So pacing on
+// the code alone would leave such a container restarting without limit. This is
+// the cause-blind backstop - this many automatic restarts inside the window is
+// itself evidence of a fault, whatever Docker reported, and it disposes into the
+// same ladder rather than into a state a human has to clear.
+const RESTART_BURST_COUNT = config.fluxapps.restartBurstCount ?? 5;
+const RESTART_BURST_WINDOW_MS = config.fluxapps.restartBurstWindowMs ?? 60 * 1000;
 
 function collection() {
   const db = dbHelper.databaseConnection();
@@ -93,7 +102,10 @@ async function setOperatorStopped(identifier, stopped) {
   // app. Swallowing a write failure would let the API report success while the
   // lock never persisted - the caller must surface the failure instead.
   const fields = { operatorStopped: stopped };
-  if (!stopped) fields.restartHistory = [];
+  if (!stopped) {
+    fields.restartHistory = [];
+    fields.autoRestartWindow = [];
+  }
   await setFields(identifier, fields);
 }
 
@@ -139,20 +151,39 @@ async function operatorStoppedIdentifiers() {
 }
 
 /**
- * Appends a restart attempt (wall-clock) and trims the history to the ladder
- * length so a perpetually crashing container never grows the array unbounded.
+ * Whether the automatic restarts already recorded fill the burst window. Read
+ * BEFORE the current attempt is appended, so it answers "have there already
+ * been enough" and the caller's own restart is the one over the line.
+ *
+ * @param {object|null} state
+ * @returns {boolean}
+ */
+function burstExceeded(state) {
+  const recent = (state && state.autoRestartWindow) || [];
+  if (recent.length < RESTART_BURST_COUNT) return false;
+  return Date.now() - recent[0] <= RESTART_BURST_WINDOW_MS;
+}
+
+/**
+ * Appends a restart attempt (wall-clock). Every automatic restart lands in the
+ * burst window; only one with crash evidence - or one that fills the burst
+ * window, which is the same conclusion reached without the exit code - also
+ * walks the ladder. Both arrays are trimmed to their own bound so a
+ * perpetually restarting container never grows the document unbounded.
  *
  * @param {string} identifier
+ * @param {boolean} crashed - Docker reported a fault (non-zero exit or OOM kill)
  */
-async function recordRestart(identifier) {
+async function recordRestart(identifier, crashed = true) {
   try {
     const state = await getState(identifier);
-    const history = (state && state.restartHistory) || [];
-    history.push(Date.now());
-    if (history.length > MAX_HISTORY) {
-      history.splice(0, history.length - MAX_HISTORY);
+    const fields = {
+      autoRestartWindow: [...((state && state.autoRestartWindow) || []), Date.now()].slice(-RESTART_BURST_COUNT),
+    };
+    if (crashed || burstExceeded(state)) {
+      fields.restartHistory = [...((state && state.restartHistory) || []), Date.now()].slice(-MAX_HISTORY);
     }
-    await setFields(identifier, { restartHistory: history });
+    await setFields(identifier, fields);
   } catch (err) {
     log.error(`appsRuntimeState - failed to record restart for ${identifier}: ${err.message}`);
   }
@@ -179,10 +210,16 @@ async function recordRestart(identifier) {
  * @param {string} identifier
  * @param {number|null} lastFinishedAtMs - docker State.FinishedAt of the
  *        stopped container (ms epoch), when the caller has inspect data
+ * @param {boolean} crashed - Docker reported a fault (non-zero exit or OOM kill)
  * @returns {Promise<number>}
  */
-async function restartWaitMs(identifier, lastFinishedAtMs = null) {
+async function restartWaitMs(identifier, lastFinishedAtMs = null, crashed = true) {
   const state = await getState(identifier);
+  // A clean exit is the operator's own restart far more often than it is a
+  // fault, and pacing it makes a deliberate restart look like an outage. It
+  // goes back immediately - unless the restarts are arriving fast enough to
+  // fill the burst window, which is a fault however the exit code reads.
+  if (!crashed && !burstExceeded(state)) return 0;
   const history = (state && state.restartHistory) || [];
   if (history.length === 0) return 0;
 
@@ -360,6 +397,7 @@ async function prepareCollection() {
           networkHealRemoval: twins.some((t) => t.networkHealRemoval === true),
           networkHealHistory: [...new Set(twins.flatMap((t) => t.networkHealHistory || []))].sort((a, b) => a - b).slice(-MAX_HISTORY),
           restartHistory: [...new Set(twins.flatMap((t) => t.restartHistory || []))].sort((a, b) => a - b).slice(-MAX_HISTORY),
+          autoRestartWindow: [...new Set(twins.flatMap((t) => t.autoRestartWindow || []))].sort((a, b) => a - b).slice(-RESTART_BURST_COUNT),
           updatedAt: Math.max(...twins.map((t) => t.updatedAt || 0)),
         };
         const newestExit = twins.filter((t) => t.lastDiedAt !== undefined).sort((a, b) => b.lastDiedAt - a.lastDiedAt)[0];
@@ -398,4 +436,6 @@ module.exports = {
   BACKOFF_DELAYS_MS,
   STABLE_RUN_MS,
   MAX_HISTORY,
+  RESTART_BURST_COUNT,
+  RESTART_BURST_WINDOW_MS,
 };

--- a/ZelBack/src/services/appManagement/appsRuntimeState.js
+++ b/ZelBack/src/services/appManagement/appsRuntimeState.js
@@ -287,7 +287,6 @@ async function recordRestart(identifier, crashed = true) {
  * @param {string} identifier
  * @param {number|null} lastFinishedAtMs - docker State.FinishedAt of the
  *        stopped container (ms epoch), when the caller has inspect data
- * @param {boolean} crashed - Docker reported a fault (non-zero exit or OOM kill)
  * @returns {Promise<number>}
  */
 async function restartWaitMs(identifier, lastFinishedAtMs = null) {

--- a/ZelBack/src/services/appManagement/appsRuntimeState.js
+++ b/ZelBack/src/services/appManagement/appsRuntimeState.js
@@ -24,9 +24,13 @@ const MAX_HISTORY = BACKOFF_DELAYS_MS.length;
 // script ending in `exit 0` reports a clean stop for a segfault, and no init we
 // wrap around it can recover a status the image already discarded. So pacing on
 // the code alone would leave such a container restarting without limit. This is
-// the cause-blind backstop - this many automatic restarts inside the window is
-// itself evidence of a fault, whatever Docker reported, and it disposes into the
-// same ladder rather than into a state a human has to clear.
+// the cause-blind backstop - this many automatic restarts ALREADY RECORDED
+// inside the window is evidence of a fault whatever Docker reported, and it
+// disposes into the same ladder rather than into a state a human has to clear.
+//
+// The count is of restarts already behind it, so at 5 the SIXTH restart is the
+// one that earns a rung and the seventh is the first one held back. Six free
+// restarts from a knob that reads as five is worth knowing before tuning it.
 const RESTART_BURST_COUNT = config.fluxapps.restartBurstCount ?? 5;
 const RESTART_BURST_WINDOW_MS = config.fluxapps.restartBurstWindowMs ?? 5 * 60 * 1000;
 
@@ -191,9 +195,13 @@ async function operatorStoppedIdentifiers() {
 }
 
 /**
- * Whether the automatic restarts already recorded fill the burst window. Read
- * BEFORE the current attempt is appended, so it answers "have there already
- * been enough" and the caller's own restart is the one over the line.
+ * Whether the restarts already recorded fill the burst window, read before the
+ * current attempt is appended - so it answers "have there already been enough",
+ * and the restart asking is the one that carries the count over.
+ *
+ * That restart is counted, not held: restartWaitMs runs ahead of recordRestart
+ * and finds an empty ladder, so it goes back immediately and earns the first
+ * rung on its way past. The one after it is the first to be made to wait.
  *
  * @param {object|null} state
  * @returns {boolean}

--- a/ZelBack/src/services/appManagement/appsRuntimeState.js
+++ b/ZelBack/src/services/appManagement/appsRuntimeState.js
@@ -28,7 +28,7 @@ const MAX_HISTORY = BACKOFF_DELAYS_MS.length;
 // itself evidence of a fault, whatever Docker reported, and it disposes into the
 // same ladder rather than into a state a human has to clear.
 const RESTART_BURST_COUNT = config.fluxapps.restartBurstCount ?? 5;
-const RESTART_BURST_WINDOW_MS = config.fluxapps.restartBurstWindowMs ?? 60 * 1000;
+const RESTART_BURST_WINDOW_MS = config.fluxapps.restartBurstWindowMs ?? 5 * 60 * 1000;
 
 function collection() {
   const db = dbHelper.databaseConnection();
@@ -220,7 +220,10 @@ async function recordRestart(identifier, crashed = true) {
     const fields = {
       autoRestartWindow: [...((state && state.autoRestartWindow) || []), Date.now()].slice(-RESTART_BURST_COUNT),
     };
-    if (crashed || burstExceeded(state)) {
+    // A rung is earned by evidence of a fault - a non-zero exit, or restarts
+    // arriving fast enough to be one whatever the code said - and by a component
+    // that already holds rungs, which is that finding still standing.
+    if (crashed || burstExceeded(state) || ((state && state.restartHistory) || []).length > 0) {
       fields.restartHistory = [...((state && state.restartHistory) || []), Date.now()].slice(-MAX_HISTORY);
     }
     await setFields(identifier, fields);
@@ -253,16 +256,22 @@ async function recordRestart(identifier, crashed = true) {
  * @param {boolean} crashed - Docker reported a fault (non-zero exit or OOM kill)
  * @returns {Promise<number>}
  */
-async function restartWaitMs(identifier, lastFinishedAtMs = null, crashed = true) {
+async function restartWaitMs(identifier, lastFinishedAtMs = null) {
   const state = await getState(identifier);
-  // A clean exit is the operator's own restart far more often than it is a
-  // fault, and pacing it makes a deliberate restart look like an outage. It
-  // goes back immediately - unless the restarts are arriving fast enough to
-  // fill the burst window, which is a fault however the exit code reads.
-  if (!crashed && !burstExceeded(state)) return 0;
+  // An empty ladder is a component nothing has found fault with: a clean exit is
+  // the operator's own restart far more often than it is a fault, and pacing that
+  // makes a deliberate restart look like an outage. recordRestart decides what
+  // earns a rung; once a component holds one it is paced until it clears them,
+  // whatever its exit code reads. The burst window empties while a component
+  // sits out a wait, so the ladder is what has to carry the finding across one.
   const history = (state && state.restartHistory) || [];
   if (history.length === 0) return 0;
 
+  // The ladder's last rung IS the component's last start, because a component
+  // holding rungs earns one for every restart. That is what makes this a stable
+  // run and not a wait it just served: if a restart could go unrecorded while
+  // rungs stood, the gap measured here would be the wait itself, and any rung
+  // longer than STABLE_RUN_MS would clear the ladder every time it fired.
   const lastRestart = history[history.length - 1];
   const lastDeath = Math.max(state.lastDiedAt || 0, lastFinishedAtMs || 0);
   if (lastDeath > lastRestart && lastDeath - lastRestart > STABLE_RUN_MS) {

--- a/ZelBack/src/services/appManagement/appsRuntimeState.js
+++ b/ZelBack/src/services/appManagement/appsRuntimeState.js
@@ -171,6 +171,27 @@ async function isOperatorStopped(identifier) {
 }
 
 /**
+ * The operator's stop lock and the mode they asked for, from ONE read.
+ *
+ * They are two fields of one document, and a caller needing both must not ask
+ * twice: getState returns null for a read failure exactly as it does for "no
+ * record", so a second read that failed reported no force flag and turned the
+ * operator's "kill now" into a drain they did not ask for. Answering both from a
+ * single read is a window that cannot open - and one round-trip fewer on every
+ * stop the reconciler performs.
+ *
+ * @param {string} identifier
+ * @returns {Promise<{stopped: boolean, force: boolean}>}
+ */
+async function operatorStopState(identifier) {
+  const state = await getState(identifier);
+  return {
+    stopped: state?.operatorStopped === true,
+    force: state?.operatorStopForce === true,
+  };
+}
+
+/**
  * Every component identifier on this node the operator has deliberately stopped.
  *
  * One query rather than isOperatorStopped per component. The caller is the
@@ -492,6 +513,7 @@ module.exports = {
   getState,
   setOperatorStopped,
   isOperatorStopped,
+  operatorStopState,
   operatorStoppedIdentifiers,
   recordRestart,
   requestRestart,

--- a/ZelBack/src/services/appManagement/appsRuntimeState.js
+++ b/ZelBack/src/services/appManagement/appsRuntimeState.js
@@ -97,16 +97,56 @@ async function setFields(rawIdentifier, fields) {
  * @param {string} identifier
  * @param {boolean} stopped
  */
-async function setOperatorStopped(identifier, stopped) {
+async function setOperatorStopped(identifier, stopped, opts = {}) {
   // No catch: the lock is the contract that the reconciler will not restart the
   // app. Swallowing a write failure would let the API report success while the
   // lock never persisted - the caller must surface the failure instead.
   const fields = { operatorStopped: stopped };
-  if (!stopped) {
+  if (stopped) {
+    // A hard kill skips the graceful shutdown window. Durable, so a crash between
+    // the write and the stop cannot quietly downgrade "kill now" to a drain that
+    // waits for the app to finish what it is doing.
+    fields.operatorStopForce = opts.force === true;
+  } else {
+    fields.operatorStopForce = false;
     fields.restartHistory = [];
     fields.autoRestartWindow = [];
   }
   await setFields(identifier, fields);
+}
+
+/**
+ * Raises the component's restart generation, which is how an operator restart is
+ * expressed as desired state rather than as a docker call from the handler.
+ *
+ * The reconciler bounces the container when the generation exceeds the one it
+ * last actuated, so the request is level-based - replaying it changes nothing -
+ * and durable, so it survives a restart of FluxOS itself.
+ *
+ * No catch, for setOperatorStopped's reason: a request that did not persist must
+ * not be reported to the operator as one that did.
+ *
+ * @param {string} identifier
+ */
+async function requestRestart(identifier) {
+  const state = await getState(identifier);
+  const next = ((state && state.restartGeneration) || 0) + 1;
+  await setFields(identifier, { restartGeneration: next });
+}
+
+/**
+ * Marks a restart generation as actuated, so the pass that follows the bounce
+ * does not bounce it again.
+ *
+ * @param {string} identifier
+ * @param {number} generation
+ */
+async function recordRestartGeneration(identifier, generation) {
+  try {
+    await setFields(identifier, { actuatedRestartGeneration: generation });
+  } catch (err) {
+    log.error(`appsRuntimeState - failed to record restart generation for ${identifier}: ${err.message}`);
+  }
 }
 
 /**
@@ -392,6 +432,13 @@ async function prepareCollection() {
           identifier,
           // a lock anywhere is a lock: never auto-start a deliberately stopped app
           operatorStopped: twins.some((t) => t.operatorStopped === true),
+          // a force anywhere is a force: a kill must never be merged down into a
+          // graceful stop the operator did not ask for
+          operatorStopForce: twins.some((t) => t.operatorStopForce === true),
+          // the highest request wins and the lowest actuation does, so a restart
+          // asked for on either doc still bounces the container once
+          restartGeneration: Math.max(0, ...twins.map((t) => t.restartGeneration || 0)),
+          actuatedRestartGeneration: Math.min(...twins.map((t) => t.actuatedRestartGeneration || 0)),
           // likewise, a heal-removal anywhere means a heal may be mid-flight: keep
           // the reconciler on the recreate path rather than the uninstall path
           networkHealRemoval: twins.some((t) => t.networkHealRemoval === true),
@@ -425,6 +472,8 @@ module.exports = {
   isOperatorStopped,
   operatorStoppedIdentifiers,
   recordRestart,
+  requestRestart,
+  recordRestartGeneration,
   restartWaitMs,
   setNetworkHealRemoval,
   isNetworkHealRemoval,

--- a/ZelBack/src/services/appManagement/appsRuntimeState.js
+++ b/ZelBack/src/services/appManagement/appsRuntimeState.js
@@ -70,14 +70,13 @@ function isDuplicateKeyError(err) {
   return err && (err.code === 11000 || /E11000/.test(err.message || ''));
 }
 
-async function setFields(rawIdentifier, fields) {
-  const identifier = canonical(rawIdentifier);
+async function upsertState(identifier, update) {
   const database = collection();
   const write = () => dbHelper.updateOneInDatabase(
     database,
     appsRuntimeState,
     { identifier },
-    { $set: { identifier, ...fields, updatedAt: Date.now() } },
+    update,
     { upsert: true },
   );
   try {
@@ -86,10 +85,16 @@ async function setFields(rawIdentifier, fields) {
     // Under the unique index, the loser of a concurrent first upsert THROWS a
     // duplicate-key error instead of converting to an update. The document
     // exists at that point, so one retry takes the update path - without it the
-    // loser's write (possibly the operator stop lock) would be silently dropped.
+    // loser's write (possibly the operator stop lock, or a restart request)
+    // would be silently dropped.
     if (!isDuplicateKeyError(err)) throw err;
     await write();
   }
+}
+
+async function setFields(rawIdentifier, fields) {
+  const identifier = canonical(rawIdentifier);
+  await upsertState(identifier, { $set: { identifier, ...fields, updatedAt: Date.now() } });
 }
 
 /**
@@ -132,10 +137,21 @@ async function setOperatorStopped(identifier, stopped, opts = {}) {
  *
  * @param {string} identifier
  */
-async function requestRestart(identifier) {
-  const state = await getState(identifier);
-  const next = ((state && state.restartGeneration) || 0) + 1;
-  await setFields(identifier, { restartGeneration: next });
+async function requestRestart(rawIdentifier) {
+  // Incremented by the database, never read and rewritten here. Reading first
+  // asked getState for a number and got null for two different answers - "no
+  // record yet" and "the read failed" - and treating the second as zero wrote a
+  // generation BELOW the one already actuated, which reads as nothing pending: the
+  // restart is reported and never happens. $inc has no such answer to
+  // misread, and creates the field at 1 when there is no record, which is what
+  // the read was for. It also counts two concurrent requests as two, where
+  // read-then-write had both read the same number and one silently overwrite the
+  // other.
+  const identifier = canonical(rawIdentifier);
+  await upsertState(identifier, {
+    $inc: { restartGeneration: 1 },
+    $set: { identifier, updatedAt: Date.now() },
+  });
 }
 
 /**

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -1008,9 +1008,17 @@ async function reconcile(rawIdentifier) {
     const cause = crashed
       ? `exit ${actual.exitCode}${actual.oomKilled ? ' (OOM-killed)' : ''}`
       : 'restarting too fast to be healthy';
-    log.warn(`appReconciler - ${identifier} stopped, ${cause}; backing off ${Math.round(wait / 1000)}s before restart`);
+    // How far up the ladder this is. waitMs alone cannot say: it is what REMAINS
+    // of the rung, and the worker re-enqueues during a wait, so one rung reports
+    // several times, each smaller than the last. Two backoffs cannot be compared
+    // without it - which is how far a component has escalated, and whether it
+    // ever went backwards. Read on the backoff path only, which is a paced
+    // restart and therefore cold.
+    const backoffState = await appsRuntimeState.getState(identifier);
+    const rung = ((backoffState && backoffState.restartHistory) || []).length;
+    log.warn(`appReconciler - ${identifier} stopped, ${cause}; backing off ${Math.round(wait / 1000)}s before restart (rung ${rung})`);
     fluxEventBus.publish('reconciler:actuated', {
-      identifier, action: 'backoff', waitMs: wait, crashed,
+      identifier, action: 'backoff', waitMs: wait, rung, crashed,
     });
     scheduleRetry(identifier, wait);
     return;

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -54,7 +54,10 @@ const startingClaims = new Set();
 // its appdata mount before the wipe (mirrors the sync layer's prior 500ms delay).
 const DATA_CLEAR_SETTLE_MS = 500;
 
-const inFlight = new Set(); // ids currently reconciling (per-key single-flight)
+// id -> promise of the pass (or intent write) currently holding this key. A Map
+// rather than a Set so a caller can WAIT for the holder: applyIntent below needs
+// to know when a pass has finished, not merely that one is running.
+const inFlight = new Map(); // per-key single-flight
 const dirty = new Set(); // ids re-requested while in flight -> reconcile again
 const bootPending = new Set(); // ids enqueued before the boot gate opened
 const backoffTimers = new Map(); // id -> scheduled retry timeout
@@ -999,7 +1002,7 @@ function scheduleRetry(identifier, delayMs) {
 }
 
 function runReconcile(identifier) {
-  reconcile(identifier)
+  const pass = reconcile(identifier)
     .catch((err) => log.error(`appReconciler - reconcile ${identifier} failed: ${err.message}`))
     .finally(() => {
       inFlight.delete(identifier);
@@ -1012,6 +1015,9 @@ function runReconcile(identifier) {
         setImmediate(() => enqueue(identifier));
       }
     });
+  // Registered synchronously: promise callbacks are microtasks, so the finally
+  // above cannot run before this line and clear an entry that is not there yet.
+  inFlight.set(identifier, pass);
 }
 
 /**
@@ -1029,8 +1035,53 @@ function enqueue(rawIdentifier) {
     dirty.add(identifier);
     return;
   }
-  inFlight.add(identifier);
   runReconcile(identifier);
+}
+
+/**
+ * Change what a component is supposed to be doing, without racing a pass that is
+ * deciding what to do about it.
+ *
+ * A reconcile reads the desired state, then acts on that answer some
+ * milliseconds later once docker has answered. An intent written in that gap is
+ * not seen: the pass starts a container an operator has just stopped, and the
+ * next pass stops it again. The lock is written correctly and early - the
+ * problem is that the check and the action are not atomic against a concurrent
+ * writer, so narrowing the gap with a second check before acting would leave the
+ * same defect with a smaller window.
+ *
+ * Instead the write takes the same per-key slot a pass takes. It waits out a
+ * pass already deciding, holds the key while it writes so `enqueue` marks the
+ * key dirty rather than starting one, and enqueues on release so the next pass
+ * reads the intent it just wrote. The two can no longer interleave because they
+ * are mutually exclusive by construction.
+ *
+ * The wait is bounded by one pass of ONE component - a docker probe and at most
+ * one action - so an operator's command is never behind unrelated work.
+ * @param {string} rawIdentifier Component identifier.
+ * @param {Function} mutate Writes the new intent. Awaited while the key is held.
+ * @returns {Promise<void>} Resolves once the intent is durable and a pass is queued.
+ */
+async function applyIntent(rawIdentifier, mutate) {
+  const identifier = canonical(rawIdentifier);
+
+  // A loop, not a single await: releasing the key lets a queued pass start
+  // before this continues, and that pass would be reading the state we are
+  // about to replace.
+  // eslint-disable-next-line no-await-in-loop
+  while (inFlight.has(identifier)) await inFlight.get(identifier).catch(() => {});
+
+  let release;
+  const held = new Promise((resolve) => { release = resolve; });
+  inFlight.set(identifier, held);
+  try {
+    await mutate();
+  } finally {
+    inFlight.delete(identifier);
+    release();
+  }
+
+  enqueue(identifier);
 }
 
 /**
@@ -1216,6 +1267,7 @@ function stop() {
 
 module.exports = {
   enqueue,
+  applyIntent,
   enqueueAll,
   setControllerDesired,
   clearControllerDesired,

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -378,8 +378,21 @@ function isManagedElsewhere(identifier) {
   return false;
 }
 
+/**
+ * What this component should be doing, why, and - when the answer is an operator
+ * stop - whether that operator asked for a hard kill.
+ *
+ * The lock and the force flag are fields of one document, so they come from one
+ * read. The stop branch used to re-read the same document for the flag alone,
+ * and getState returns null for a read failure exactly as it does for "no
+ * record" - so a second read that failed turned "kill now" into a drain. One
+ * read is a window that cannot open, and one round-trip fewer on every stop.
+ *
+ * @returns {Promise<{desired: boolean|null, reason: string, force: boolean}>}
+ */
 async function effectiveDesiredRunning(identifier, spec, exitCode) {
-  if (await appsRuntimeState.isOperatorStopped(identifier)) return { desired: false, reason: 'operatorStopped' };
+  const operatorStop = await appsRuntimeState.operatorStopState(identifier);
+  if (operatorStop.stopped) return { desired: false, reason: 'operatorStopped', force: operatorStop.force };
   if (spec.isG || spec.isR) {
     const cd = controllerDesired.get(identifier) ?? null;
     // No controller opinion yet. controllerDesired is in-memory, so a FluxOS
@@ -387,11 +400,12 @@ async function effectiveDesiredRunning(identifier, spec, exitCode) {
     // the FluxOS process). Take no action - leave the container as-is until the
     // masterSlave/syncthing decider re-derives intent. Treating "unset" as "stop"
     // here would bounce every running syncthing app on every FluxOS restart.
-    if (cd === null) return { desired: null, reason: 'awaitingController' };
-    if (cd !== 'running') return { desired: false, reason: 'controllerDesired' };
+    if (cd === null) return { desired: null, reason: 'awaitingController', force: false };
+    if (cd !== 'running') return { desired: false, reason: 'controllerDesired', force: false };
   }
   const desired = policyAllowsRun(getRestartPolicy(spec), exitCode);
-  return { desired, reason: desired ? 'running' : 'policy' };
+  // Only an operator asks for a hard kill; every other stop reason is a drain.
+  return { desired, reason: desired ? 'running' : 'policy', force: false };
 }
 
 /**
@@ -407,13 +421,13 @@ async function effectiveDesiredRunning(identifier, spec, exitCode) {
  * is held when nothing has decided anything.
  *
  * @param {string} rawIdentifier
- * @returns {Promise<{desired: boolean|null, reason: string}>}
+ * @returns {Promise<{desired: boolean|null, reason: string, force: boolean}>}
  */
 async function desiredRunState(rawIdentifier) {
   const identifier = canonical(rawIdentifier);
   const spec = await getLocalComponentSpec(identifier);
-  if (!spec) return { desired: false, reason: 'notInstalled' };
-  if (spec.invalidSpec) return { desired: false, reason: 'invalidSpec' };
+  if (!spec) return { desired: false, reason: 'notInstalled', force: false };
+  if (spec.invalidSpec) return { desired: false, reason: 'invalidSpec', force: false };
   const actual = await dockerActual(identifier);
   return effectiveDesiredRunning(identifier, spec, actual.exitCode);
 }
@@ -891,7 +905,7 @@ async function reconcile(rawIdentifier) {
     return;
   }
 
-  const { desired, reason } = await effectiveDesiredRunning(identifier, spec, actual.exitCode);
+  const { desired, reason, force } = await effectiveDesiredRunning(identifier, spec, actual.exitCode);
 
   // null = no controller opinion yet for a g:/r: component: neither start nor stop,
   // leave the container in its current state until the decider speaks.
@@ -900,10 +914,10 @@ async function reconcile(rawIdentifier) {
   if (!desired) {
     if (actual.running) {
       // A hard kill skips the graceful shutdown window, and only an operator asks
-      // for one - every other stop reason is a graceful stop, so the durable flag
-      // is read only where one could have been set.
-      const stopState = reason === 'operatorStopped' ? await appsRuntimeState.getState(identifier) : null;
-      const forceKill = Boolean(stopState && stopState.operatorStopForce);
+      // for one - every other stop reason is a drain. The flag arrives with the
+      // decision that read it, from the same document and the same read as the
+      // lock itself, so there is no second read here to disagree with the first.
+      const forceKill = force === true;
       log.info(`appReconciler - ${identifier} desired stopped, ${forceKill ? 'killing' : 'stopping'}`);
       if (forceKill) {
         await dockerService.appDockerKill(identifier);

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -317,6 +317,9 @@ async function dockerActual(identifier) {
       running: !!(info.State && info.State.Running) && !info.State.Paused,
       paused: !!(info.State && info.State.Paused),
       exitCode: everRan ? (info.State.ExitCode ?? null) : null,
+      // the kernel's verdict, not the entrypoint's: an image that swallows its
+      // payload's status still cannot hide this one
+      oomKilled: !!(info.State && info.State.OOMKilled),
       finishedAt,
       // classified from THIS inspect so the running-branch network check needs no
       // second docker call (and no TOCTOU between two inspects).
@@ -916,12 +919,25 @@ async function reconcile(rawIdentifier) {
     return;
   }
 
-  // exists but stopped, should run -> backoff-paced restart (no sleeping; the
-  // worker re-enqueues when the backoff window elapses)
-  const wait = await appsRuntimeState.restartWaitMs(identifier, actual.finishedAt);
+  // exists but stopped, should run -> restart, paced by the ladder only when the
+  // stop carries evidence of a fault (no sleeping; the worker re-enqueues when
+  // the backoff window elapses). A clean exit goes back immediately: it is an
+  // operator restarting their own app far more often than it is a crash, and
+  // pacing that turns a deliberate restart into what looks like an outage.
+  // exitCode null is a container that has never run - an initial start, not a death.
+  const crashed = !!actual.oomKilled || (actual.exitCode !== null && actual.exitCode !== 0);
+  const wait = await appsRuntimeState.restartWaitMs(identifier, actual.finishedAt, crashed);
   if (wait > 0) {
-    log.warn(`appReconciler - ${identifier} stopped, backing off ${Math.round(wait / 1000)}s before restart`);
-    fluxEventBus.publish('reconciler:actuated', { identifier, action: 'backoff', waitMs: wait });
+    // name which of the two put it here: a reported fault, or restarts arriving
+    // fast enough to be one whatever the exit code said. Support cannot tell
+    // these apart from the outside, and the difference decides what they do next.
+    const cause = crashed
+      ? `exit ${actual.exitCode}${actual.oomKilled ? ' (OOM-killed)' : ''}`
+      : 'restarting too fast to be healthy';
+    log.warn(`appReconciler - ${identifier} stopped, ${cause}; backing off ${Math.round(wait / 1000)}s before restart`);
+    fluxEventBus.publish('reconciler:actuated', {
+      identifier, action: 'backoff', waitMs: wait, crashed,
+    });
     scheduleRetry(identifier, wait);
     return;
   }
@@ -942,7 +958,7 @@ async function reconcile(rawIdentifier) {
     return;
   }
 
-  await appsRuntimeState.recordRestart(identifier);
+  await appsRuntimeState.recordRestart(identifier, crashed);
   try {
     await dockerService.appDockerStart(identifier);
   } catch (err) {

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -1320,7 +1320,11 @@ async function componentIdsOf(installed) {
     const containers = await dockerService.dockerListContainers(true);
     dockerNames = containers.map((c) => (c.Names && c.Names[0] ? c.Names[0].slice(1) : ''));
   } catch (err) {
-    log.warn(`appReconciler - cannot list containers for undecryptable apps: ${err.message}`);
+    // The list is returned short rather than refused, so one app's failure
+    // cannot cost the readable apps their sweep. Named at error level because a
+    // short list is indistinguishable from a complete one at every call site:
+    // the app is simply absent from what the caller acts on.
+    log.error(`appReconciler - cannot list containers, dropping undecryptable apps [${unreadable.map((app) => app.name).join(', ')}]: ${err.message}`);
     return ids;
   }
   unreadable.forEach((app) => {

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -1000,7 +1000,7 @@ async function reconcile(rawIdentifier) {
   // pacing that turns a deliberate restart into what looks like an outage.
   // exitCode null is a container that has never run - an initial start, not a death.
   const crashed = !!actual.oomKilled || (actual.exitCode !== null && actual.exitCode !== 0);
-  const wait = await appsRuntimeState.restartWaitMs(identifier, actual.finishedAt, crashed);
+  const wait = await appsRuntimeState.restartWaitMs(identifier, actual.finishedAt);
   if (wait > 0) {
     // name which of the two put it here: a reported fault, or restarts arriving
     // fast enough to be one whatever the exit code said. Support cannot tell

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -772,14 +772,32 @@ async function reconcile(rawIdentifier) {
     // reached - skipping the stop here would leave a frozen container over the
     // missing volume with nothing left to release it. docker stop works on a
     // paused container.
-    if (controllerDesired.get(identifier) === 'stopped') {
+    // The operator's stop counts here for the same reason the controller's does,
+    // and is the more urgent of the two: a volume that will not mount is the state
+    // support reaches for a stop IN, so a stop that waits for the mount to come
+    // back is a stop that never arrives when it is wanted. It outranks the
+    // controller everywhere else in this pass (see effectiveDesiredRunning) and
+    // reading only the controller here was the one place it did not.
+    const operatorStop = await appsRuntimeState.operatorStopState(identifier);
+    if (operatorStop.stopped || controllerDesired.get(identifier) === 'stopped') {
       try {
         const actualNow = await dockerActual(identifier);
         if (actualNow.reachable && !actualNow.indeterminate && (actualNow.running || actualNow.paused)) {
-          log.info(`appReconciler - ${identifier} data volume unavailable but a stop is desired; stopping the container`);
-          await dockerService.appDockerStop(identifier);
+          // Only an operator asks for a hard kill; every other stop reason is a
+          // drain. Carried through here too, or an appkill against an unmounted
+          // volume quietly becomes a graceful stop.
+          const forceKill = operatorStop.stopped && operatorStop.force === true;
+          const reason = operatorStop.stopped ? 'operatorStopped' : 'controllerDesired';
+          log.info(`appReconciler - ${identifier} data volume unavailable but a stop is desired; ${forceKill ? 'killing' : 'stopping'} the container`);
+          if (forceKill) {
+            await dockerService.appDockerKill(identifier);
+          } else {
+            await dockerService.appDockerStop(identifier);
+          }
           appInspector.stopAppMonitoring(identifier, false);
-          fluxEventBus.publish('reconciler:actuated', { identifier, action: 'stopped', reason: 'controllerDesired' });
+          fluxEventBus.publish('reconciler:actuated', {
+            identifier, action: 'stopped', reason, forced: forceKill,
+          });
         }
       } catch (err) {
         log.error(`appReconciler - ${identifier} stop under unavailable volume failed: ${err.message}`);
@@ -1520,6 +1538,11 @@ module.exports = {
   // What the reconciler would do with this component now, for a caller that has
   // to report an operator command's outcome truthfully.
   desiredRunState,
+  // What an app is actually made of. Enterprise specs keep their component names
+  // inside an encrypted blob, so reading `compose` off a stored spec yields an
+  // empty list and silently addresses nothing - which is why every caller that
+  // needs an app's components asks here rather than working it out again.
+  componentIdsOf,
   // exposed for tests
   reconcile,
   policyAllowsRun,

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -950,11 +950,17 @@ async function reconcile(rawIdentifier) {
           scheduleRetry(identifier, MANAGED_RETRY_MS);
           return;
         }
-        await appsRuntimeState.recordRestartGeneration(identifier, desiredGeneration);
         fluxEventBus.publish('reconciler:actuated', { identifier, action: 'restarted', reason: 'operatorRequested' });
         notifyContainerStarted(identifier);
         // A restart is a start, so it can come up on a stale endpoint the same way.
         scheduleRetry(identifier, POST_START_VERIFY_MS);
+        // Last, because it throws. The bounce above already happened, so a write
+        // failure must not also cost the event, the peer notification and the
+        // attachment check a successful restart is owed - it is the record that
+        // failed, not the restart. The throw reaches the pass-level retry, which
+        // paces it and gives up, rather than the swallow that bounced the
+        // container every POST_START_VERIFY_MS for as long as writes failed.
+        await appsRuntimeState.recordRestartGeneration(identifier, desiredGeneration);
         return;
       }
       // The container is where it should be; monitoring may not be. A stop turns
@@ -1076,9 +1082,7 @@ async function reconcile(rawIdentifier) {
   // would bounce a container the operator has just watched come up.
   const startedState = await appsRuntimeState.getState(identifier);
   const pendingGeneration = (startedState && startedState.restartGeneration) || 0;
-  if (pendingGeneration > ((startedState && startedState.actuatedRestartGeneration) || 0)) {
-    await appsRuntimeState.recordRestartGeneration(identifier, pendingGeneration);
-  }
+  const satisfiesRestart = pendingGeneration > ((startedState && startedState.actuatedRestartGeneration) || 0);
   log.info(`appReconciler - ${identifier} restarted`);
   fluxEventBus.publish('reconciler:actuated', { identifier, action: 'started', exitCode: actual.exitCode });
   notifyContainerStarted(identifier);
@@ -1087,6 +1091,11 @@ async function reconcile(rawIdentifier) {
   // BEFORE this start, so verify the new one shortly - otherwise a detached-at-boot
   // container waits for the hourly sweep.
   scheduleRetry(identifier, POST_START_VERIFY_MS);
+  // Last, because it throws - the start above already happened, and the record
+  // failing must not cost the bookkeeping that start is owed.
+  if (satisfiesRestart) {
+    await appsRuntimeState.recordRestartGeneration(identifier, pendingGeneration);
+  }
 }
 
 // --- workqueue (per-key single-flight, boot-gated) -----------------------

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -971,9 +971,15 @@ async function reconcile(rawIdentifier) {
         // Last, because it throws. The bounce above already happened, so a write
         // failure must not also cost the event, the peer notification and the
         // attachment check a successful restart is owed - it is the record that
-        // failed, not the restart. The throw reaches the pass-level retry, which
-        // paces it and gives up, rather than the swallow that bounced the
-        // container every POST_START_VERIFY_MS for as long as writes failed.
+        // failed, not the restart.
+        //
+        // The throw reaches the pass-level retry, which PACES it - a rate, not a
+        // bound, and the difference matters. UNHANDLED_FAILURE_RETRIES clears only
+        // on a pass that succeeds, so a database that reads but cannot write never
+        // records the generation: four bounces over fifteen seconds, then one per
+        // hourly sweep for as long as the condition holds. Bounding it needs that
+        // condition to be something the node observes centrally rather than each
+        // write site discovering it alone, which is its own change.
         await appsRuntimeState.recordRestartGeneration(identifier, desiredGeneration);
         return;
       }
@@ -1204,8 +1210,21 @@ function enqueue(rawIdentifier) {
  * reads the intent it just wrote. The two can no longer interleave because they
  * are mutually exclusive by construction.
  *
- * The wait is bounded by one pass of ONE component - a docker probe and at most
- * one action - so an operator's command is never behind unrelated work.
+ * The wait is one pass of ONE component - a docker probe and at most one action -
+ * so an operator's command is never behind unrelated work. That is a BOUND only
+ * while passes terminate, and the docker calls a pass makes carry no timeout of
+ * their own: a daemon that HANGS rather than fails leaves the pass unfinished and
+ * this wait with nothing to wake it.
+ *
+ * What that costs is durability, not correctness: nothing wrong is recorded, and
+ * the caller's request hangs on a wedged daemon regardless. What is lost is a
+ * FluxOS restart during the hang - the write has not landed, so the intent does
+ * not survive one.
+ *
+ * Bounding THIS wait is not the repair - giving up on it and writing anyway
+ * restores the interleave described above, which is the defect this exists to
+ * fix. Bounding the docker calls is, and that is fleet-wide work rather than
+ * something this function can do alone.
  * @param {string} rawIdentifier Component identifier.
  * @param {Function} mutate Writes the new intent. Awaited while the key is held.
  * @param {object} [opts]
@@ -1245,50 +1264,97 @@ async function applyIntent(rawIdentifier, mutate, { awaitPass = false } = {}) {
 }
 
 /**
+ * The component identifiers of a set of installed apps.
+ *
+ * Enterprise specs are stored encrypted (compose: []) and the component names
+ * live INSIDE the blob, so the set is decrypted first - leniently: one app
+ * failing to decrypt must not cost the rest their components. An app that stays
+ * encrypted is enumerated from the containers docker is already holding for it,
+ * matched on the `_<appname>` suffix, so it is never silently skipped. That
+ * source can only see components that EXIST, which is the most that can be known
+ * about such an app anyway: a vanished component of one cannot be recreated
+ * either, because recreating it needs the spec.
+ *
+ * The listing is taken once for the whole set, and only if something failed to
+ * decrypt.
+ *
+ * @param {Array<object>} installed Records from appQueryService.installedApps().
+ * @returns {Promise<string[]>} Component identifiers across every app given.
+ */
+async function componentIdsOf(installed) {
+  const { readable, unreadable } = await appQueryService.decryptEnterpriseApps(installed, { formatSpecs: false });
+  const ids = [];
+
+  readable.forEach((app) => {
+    if (app.version >= 4 && Array.isArray(app.compose)) {
+      app.compose.forEach((c) => ids.push(`${c.name}_${app.name}`));
+    } else {
+      ids.push(app.name);
+    }
+  });
+
+  if (!unreadable.length) return ids;
+
+  let dockerNames;
+  try {
+    const containers = await dockerService.dockerListContainers(true);
+    dockerNames = containers.map((c) => (c.Names && c.Names[0] ? c.Names[0].slice(1) : ''));
+  } catch (err) {
+    log.warn(`appReconciler - cannot list containers for undecryptable apps: ${err.message}`);
+    return ids;
+  }
+  unreadable.forEach((app) => {
+    const suffix = `_${app.name}`;
+    dockerNames.filter((name) => name.endsWith(suffix)).forEach((name) => ids.push(name));
+  });
+  return ids;
+}
+
+/**
  * Enqueue every installed component (hourly tick / reconnect / boot drift).
- * Enterprise specs are stored encrypted (compose: []), so the sweep decrypts
- * to enumerate components — leniently: one app failing to decrypt must not
- * abort the sweep for the rest. An app that stays encrypted is still covered
- * via its existing docker containers (see below); never silently skipped.
  */
 async function enqueueAll(reason = 'resync') {
   const res = await appQueryService.installedApps();
   if (!res || res.status !== 'success') return;
-  const { readable: apps, unreadable } = await appQueryService.decryptEnterpriseApps(res.data, { formatSpecs: false });
-  let count = 0;
-  let dockerNames = null; // fetched once, only if some app failed to decrypt
-  // Decryption failed (already logged by decryptEnterpriseApps). The component
-  // names live inside the blob, so enumerate each app's EXISTING docker
-  // containers instead: their reconciles defer on the same decrypt failure
-  // and converge the moment fluxbenchd answers again. A vanished container of
-  // an undecryptable app cannot be recovered anyway (recreation needs the
-  // spec); the next sweep retries, so coverage resumes with decryption.
-  for (const app of unreadable) {
-    if (dockerNames === null) {
-      try {
-        // eslint-disable-next-line no-await-in-loop
-        const containers = await dockerService.dockerListContainers(true);
-        dockerNames = containers.map((c) => (c.Names && c.Names[0] ? c.Names[0].slice(1) : ''));
-      } catch (err) {
-        log.warn(`appReconciler - enqueueAll cannot list containers for undecryptable apps: ${err.message}`);
-        dockerNames = [];
-      }
-    }
-    const suffix = `_${app.name}`;
-    dockerNames.filter((name) => name.endsWith(suffix)).forEach((name) => {
-      enqueue(name); // canonicalised to the bare component identifier by enqueue
-      count += 1;
-    });
+  const ids = await componentIdsOf(res.data);
+  // canonicalised to the bare component identifier by enqueue
+  ids.forEach((id) => enqueue(id));
+  fluxEventBus.publish('reconciler:swept', { reason, count: ids.length });
+}
+
+/**
+ * Ask every component of these apps to restart, and let the normal machinery
+ * carry it out.
+ *
+ * For a caller that knows the node has changed underneath its apps - the address
+ * moved, so the containers have to come up on the new one - and knows nothing
+ * else about them. Everything an app is made of is worked out here rather than by
+ * the caller: which components it has, whether its specs can be read, and what a
+ * restart request even is.
+ *
+ * Durable and paced, deliberately. A generation survives a FluxOS restart part
+ * way through, where a docker call issued from the caller is simply lost, and it
+ * queues behind the same slot as every other intent instead of racing it. Each
+ * request is independent: one component that cannot be recorded must not cost the
+ * others theirs.
+ *
+ * @param {Array<object>} installed Records from appQueryService.installedApps().
+ * @param {string} reason Why, for the log.
+ * @returns {Promise<number>} How many components were asked.
+ */
+async function requestRestartOf(installed, reason) {
+  const ids = await componentIdsOf(installed);
+  let asked = 0;
+  // eslint-disable-next-line no-restricted-syntax
+  for (const id of ids) {
+    // eslint-disable-next-line no-await-in-loop
+    await applyIntent(id, async () => {
+      await appsRuntimeState.requestRestart(id);
+    }).then(() => { asked += 1; })
+      .catch((err) => log.error(`appReconciler - could not request restart of ${id} (${reason}): ${err.message}`));
   }
-  for (const app of apps) {
-    if (app.version >= 4 && Array.isArray(app.compose)) {
-      app.compose.forEach((c) => { enqueue(`${c.name}_${app.name}`); count += 1; });
-    } else {
-      enqueue(app.name);
-      count += 1;
-    }
-  }
-  fluxEventBus.publish('reconciler:swept', { reason, count });
+  log.info(`appReconciler - restart requested for ${asked}/${ids.length} components (${reason})`);
+  return asked;
 }
 
 // --- controllerDesired seam (written by masterSlave/syncthing deciders) ---
@@ -1434,6 +1500,7 @@ module.exports = {
   enqueue,
   applyIntent,
   enqueueAll,
+  requestRestartOf,
   setControllerDesired,
   clearControllerDesired,
   forgetDesiredState,

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -1297,7 +1297,9 @@ async function applyIntent(rawIdentifier, mutate, { awaitPass = false } = {}) {
  * decrypt.
  *
  * @param {Array<object>} installed Records from appQueryService.installedApps().
- * @returns {Promise<string[]>} Component identifiers across every app given.
+ * @returns {Promise<string[]>} Bare component identifiers (`<component>_<app>`,
+ *   or `<app>` for v1-3) across every app given - one spelling whichever source
+ *   they came from.
  */
 async function componentIdsOf(installed) {
   const { readable, unreadable } = await appQueryService.decryptEnterpriseApps(installed, { formatSpecs: false });
@@ -1323,7 +1325,13 @@ async function componentIdsOf(installed) {
   }
   unreadable.forEach((app) => {
     const suffix = `_${app.name}`;
-    dockerNames.filter((name) => name.endsWith(suffix)).forEach((name) => ids.push(name));
+    // Docker holds the namespaced name (`flux<component>_<app>`); the readable
+    // branch above produces the bare one. One list carries one spelling, so a
+    // consumer that compares it against a component name an operator typed
+    // matches it, rather than refusing every component of an app whose spec
+    // will not decrypt. The consumers that canonicalise on ingest cannot tell
+    // the two apart, which is why they coexisted unnoticed.
+    dockerNames.filter((name) => name.endsWith(suffix)).forEach((name) => ids.push(canonical(name)));
   });
   return ids;
 }

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -964,8 +964,12 @@ async function reconcile(rawIdentifier) {
   } catch (err) {
     // No die event fires for a failed start (the container never ran), so a
     // dropped throw here leaves the component down until the hourly sweep.
-    // Schedule our own retry; pacing is free - the attempt was recorded above,
-    // so a persistent failure walks the backoff ladder instead of hammering.
+    // Schedule our own retry. A start that never ran carries no exit code, so it
+    // is not a fault and does not walk the ladder directly - it reaches the
+    // ladder by filling the burst window, which these retries do comfortably
+    // (restartBurstCount x MANAGED_RETRY_MS against restartBurstWindowMs). That
+    // relationship is what bounds a permanently failing start, and the config
+    // comment on the window is where it is stated.
     log.error(`appReconciler - failed to start ${identifier}: ${err.message}; retrying`);
     fluxEventBus.publish('reconciler:actuated', { identifier, action: 'startFailed', reason: err.message });
     scheduleRetry(identifier, MANAGED_RETRY_MS);

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -1018,6 +1018,7 @@ function runReconcile(identifier) {
   // Registered synchronously: promise callbacks are microtasks, so the finally
   // above cannot run before this line and clear an entry that is not there yet.
   inFlight.set(identifier, pass);
+  return pass;
 }
 
 /**
@@ -1029,13 +1030,16 @@ function enqueue(rawIdentifier) {
   const identifier = canonical(rawIdentifier);
   if (!globalState.bootContainerStateSettled) {
     bootPending.add(identifier);
-    return;
+    return null;
   }
   if (inFlight.has(identifier)) {
     dirty.add(identifier);
-    return;
+    // The pass already running was started against state older than whatever
+    // just changed, so it is NOT the pass a caller wanting actuation should
+    // wait on. The re-run this marks dirty is, and it has no promise yet.
+    return null;
   }
-  runReconcile(identifier);
+  return runReconcile(identifier);
 }
 
 /**
@@ -1060,9 +1064,17 @@ function enqueue(rawIdentifier) {
  * one action - so an operator's command is never behind unrelated work.
  * @param {string} rawIdentifier Component identifier.
  * @param {Function} mutate Writes the new intent. Awaited while the key is held.
- * @returns {Promise<void>} Resolves once the intent is durable and a pass is queued.
+ * @param {object} [opts]
+ * @param {boolean} [opts.awaitPass] Wait for the reconcile that follows, so a
+ *   caller can report what was DONE rather than what was asked for. The pass is
+ *   awaited to completion, actuated or deferred - it never throws here, since
+ *   runReconcile absorbs its own failures.
+ * @returns {Promise<boolean>} True when a pass ran to completion. False when the
+ *   intent is durable but nothing has acted on it yet - the boot gate is shut,
+ *   or another pass is mid-flight and the re-run has not started. Callers that
+ *   report to a user must not present false as success.
  */
-async function applyIntent(rawIdentifier, mutate) {
+async function applyIntent(rawIdentifier, mutate, { awaitPass = false } = {}) {
   const identifier = canonical(rawIdentifier);
 
   // A loop, not a single await: releasing the key lets a queued pass start
@@ -1081,7 +1093,11 @@ async function applyIntent(rawIdentifier, mutate) {
     release();
   }
 
-  enqueue(identifier);
+  const pass = enqueue(identifier);
+  if (!awaitPass) return Boolean(pass);
+  if (!pass) return false;
+  await pass;
+  return true;
 }
 
 /**

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -382,6 +382,30 @@ async function effectiveDesiredRunning(identifier, spec, exitCode) {
 }
 
 /**
+ * The run state the reconciler would converge this component to right now, and
+ * why — the same spec read, docker probe and policy a reconcile pass uses, so a
+ * caller reporting on an operator command never re-derives the decision.
+ *
+ * `desired` is null for a g:/r: component whose decider has not spoken: the
+ * reconciler takes no action, which is neither running nor stopped.
+ *
+ * Throws what getLocalComponentSpec throws — a transient spec read is not an
+ * answer, and reporting one as "not running" would tell an operator their app
+ * is held when nothing has decided anything.
+ *
+ * @param {string} rawIdentifier
+ * @returns {Promise<{desired: boolean|null, reason: string}>}
+ */
+async function desiredRunState(rawIdentifier) {
+  const identifier = canonical(rawIdentifier);
+  const spec = await getLocalComponentSpec(identifier);
+  if (!spec) return { desired: false, reason: 'notInstalled' };
+  if (spec.invalidSpec) return { desired: false, reason: 'invalidSpec' };
+  const actual = await dockerActual(identifier);
+  return effectiveDesiredRunning(identifier, spec, actual.exitCode);
+}
+
+/**
  * Recreates a vanished container (no Docker event fires for absence), recording
  * the tampering signals and falling back to local removal on failure — the
  * behavior previously in containerHealthMonitor.monitorAndRecoverApps.
@@ -727,6 +751,7 @@ async function reconcile(rawIdentifier) {
         if (actualNow.reachable && !actualNow.indeterminate && (actualNow.running || actualNow.paused)) {
           log.info(`appReconciler - ${identifier} data volume unavailable but a stop is desired; stopping the container`);
           await dockerService.appDockerStop(identifier);
+          appInspector.stopAppMonitoring(identifier, false);
           fluxEventBus.publish('reconciler:actuated', { identifier, action: 'stopped', reason: 'controllerDesired' });
         }
       } catch (err) {
@@ -793,6 +818,7 @@ async function reconcile(rawIdentifier) {
     log.warn(`appReconciler - ${identifier} is paused, which nothing can act on; stopping it so it can be reconciled normally`);
     try {
       await dockerService.appDockerStop(identifier);
+      appInspector.stopAppMonitoring(identifier, false);
       fluxEventBus.publish('reconciler:actuated', { identifier, action: 'unpaused' });
     } catch (err) {
       log.error(`appReconciler - failed to stop the paused ${identifier}: ${err.message}; retrying. No FluxOS primitive releases a paused container - manual remedy on the node: docker unpause ${dockerService.getAppIdentifier(identifier)}`);
@@ -827,6 +853,7 @@ async function reconcile(rawIdentifier) {
       if (actual.running) {
         log.info(`appReconciler - ${identifier} stopping before local appdata clear`);
         await dockerService.appDockerStop(identifier);
+        appInspector.stopAppMonitoring(identifier, false);
         fluxEventBus.publish('reconciler:actuated', { identifier, action: 'stopped', reason: 'dataClear' });
       }
       await serviceHelper.delay(DATA_CLEAR_SETTLE_MS);
@@ -859,9 +886,24 @@ async function reconcile(rawIdentifier) {
 
   if (!desired) {
     if (actual.running) {
-      log.info(`appReconciler - ${identifier} desired stopped, stopping`);
-      await dockerService.appDockerStop(identifier);
-      fluxEventBus.publish('reconciler:actuated', { identifier, action: 'stopped', reason });
+      // A hard kill skips the graceful shutdown window, and only an operator asks
+      // for one - every other stop reason is a graceful stop, so the durable flag
+      // is read only where one could have been set.
+      const stopState = reason === 'operatorStopped' ? await appsRuntimeState.getState(identifier) : null;
+      const forceKill = Boolean(stopState && stopState.operatorStopForce);
+      log.info(`appReconciler - ${identifier} desired stopped, ${forceKill ? 'killing' : 'stopping'}`);
+      if (forceKill) {
+        await dockerService.appDockerKill(identifier);
+      } else {
+        await dockerService.appDockerStop(identifier);
+      }
+      // Monitoring follows the container. The per-minute sampler otherwise runs
+      // against a stopped container, logging an error a minute until something
+      // else happens to stop it.
+      appInspector.stopAppMonitoring(identifier, false);
+      fluxEventBus.publish('reconciler:actuated', {
+        identifier, action: 'stopped', reason, forced: forceKill,
+      });
     }
     return;
   }
@@ -877,6 +919,35 @@ async function reconcile(rawIdentifier) {
     // Verify the attachment (from the inspect dockerActual already did) before
     // trusting "running"; heal by recreating, confirmed in-pass and paced.
     if (!dockerService.isContainerDetachedFromNetwork(actual.attachment)) {
+      // An operator restart is a level, not an action: it raises a generation and
+      // this bounces the container once the generation passes the one already
+      // actuated. Not paced by the backoff ladder - a deliberate bounce is not
+      // crash recovery, and pacing it is what made six restarts look like an app
+      // that could not stay up.
+      const restartState = await appsRuntimeState.getState(identifier);
+      const desiredGeneration = (restartState && restartState.restartGeneration) || 0;
+      const actuatedGeneration = (restartState && restartState.actuatedRestartGeneration) || 0;
+      if (desiredGeneration > actuatedGeneration) {
+        log.info(`appReconciler - ${identifier} restart requested (generation ${desiredGeneration}); restarting`);
+        try {
+          await dockerService.appDockerRestart(identifier);
+        } catch (err) {
+          log.error(`appReconciler - failed to restart ${identifier} on request: ${err.message}; retrying`);
+          fluxEventBus.publish('reconciler:actuated', { identifier, action: 'restartRequestFailed', reason: err.message });
+          scheduleRetry(identifier, MANAGED_RETRY_MS);
+          return;
+        }
+        await appsRuntimeState.recordRestartGeneration(identifier, desiredGeneration);
+        fluxEventBus.publish('reconciler:actuated', { identifier, action: 'restarted', reason: 'operatorRequested' });
+        notifyContainerStarted(identifier);
+        // A restart is a start, so it can come up on a stale endpoint the same way.
+        scheduleRetry(identifier, POST_START_VERIFY_MS);
+        return;
+      }
+      // The container is where it should be; monitoring may not be. A stop turns
+      // it off, and a stop docker never carried out leaves a running container
+      // unmonitored with no later pass to notice.
+      appInspector.ensureAppMonitoring(identifier);
       return; // running and properly attached (heal state was cleared above)
     }
     await healDetachedNetwork(identifier, mainAppName, spec);
@@ -979,6 +1050,14 @@ async function reconcile(rawIdentifier) {
     return;
   }
   appInspector.startAppMonitoring(identifier);
+  // A restart of a container that was already stopped IS this start, so the
+  // request is satisfied here. Left pending, the pass that next finds it running
+  // would bounce a container the operator has just watched come up.
+  const startedState = await appsRuntimeState.getState(identifier);
+  const pendingGeneration = (startedState && startedState.restartGeneration) || 0;
+  if (pendingGeneration > ((startedState && startedState.actuatedRestartGeneration) || 0)) {
+    await appsRuntimeState.recordRestartGeneration(identifier, pendingGeneration);
+  }
   log.info(`appReconciler - ${identifier} restarted`);
   fluxEventBus.publish('reconciler:actuated', { identifier, action: 'started', exitCode: actual.exitCode });
   notifyContainerStarted(identifier);
@@ -1301,6 +1380,9 @@ module.exports = {
   // being unreachable from the container being gone. Anything that acts on a
   // container's run state needs that distinction, not just the reconciler.
   dockerActual,
+  // What the reconciler would do with this component now, for a caller that has
+  // to report an operator command's outcome truthfully.
+  desiredRunState,
   // exposed for tests
   reconcile,
   policyAllowsRun,

--- a/ZelBack/src/services/appMonitoring/appReconciler.js
+++ b/ZelBack/src/services/appMonitoring/appReconciler.js
@@ -61,6 +61,7 @@ const inFlight = new Map(); // per-key single-flight
 const dirty = new Set(); // ids re-requested while in flight -> reconcile again
 const bootPending = new Set(); // ids enqueued before the boot gate opened
 const backoffTimers = new Map(); // id -> scheduled retry timeout
+const unhandledFailures = new Map(); // id -> consecutive passes that threw
 
 // The boot-drain gate: opens once every boot-held component has completed ONE
 // reconcile pass (started, backoff-deferred, awaiting-controller, or failed
@@ -108,6 +109,18 @@ function notifyContainerStarted(identifier) {
 // container, defer and re-check shortly (the operation also re-enqueues on
 // completion, so this is just a backstop)
 const MANAGED_RETRY_MS = 5000;
+
+// How many consecutive passes may throw before the component is left to the
+// hourly sweep. A pass that throws is by definition one whose failure nobody
+// anticipated: every failure this file expects returns after deciding either to
+// pace a retry (a transient fault) or deliberately not to (an invalid spec, which
+// no retry can fix). An unhandled throw made neither decision, so it reached the
+// sweep - and with the operator's stop now actuated here rather than inline, a
+// container could keep running for an hour after a stop reported success.
+// Retrying is safe because a pass is level-based: it re-derives desired against
+// actual rather than resuming half-finished work. The bound is what keeps a
+// permanent fault from becoming a five-second log loop forever.
+const UNHANDLED_FAILURE_RETRIES = 3;
 
 // an unmountable volume usually means its host filesystem is still coming up
 // (e.g. the encrypted data partition after a reboot) - retry on a pace that
@@ -1090,7 +1103,28 @@ function scheduleRetry(identifier, delayMs) {
 
 function runReconcile(identifier) {
   const pass = reconcile(identifier)
-    .catch((err) => log.error(`appReconciler - reconcile ${identifier} failed: ${err.message}`))
+    .then(() => {
+      // A pass that got through is the only evidence the fault has cleared.
+      unhandledFailures.delete(identifier);
+    })
+    .catch((err) => {
+      const attempt = (unhandledFailures.get(identifier) || 0) + 1;
+      unhandledFailures.set(identifier, attempt);
+      const retrying = attempt <= UNHANDLED_FAILURE_RETRIES;
+      log.error(
+        `appReconciler - reconcile ${identifier} failed: ${err.message}`
+        + (retrying
+          ? `; retrying (${attempt}/${UNHANDLED_FAILURE_RETRIES})`
+          : `; ${attempt} consecutive failures, leaving it to the hourly sweep`),
+      );
+      // Published for every unhandled failure rather than at each throw site: the
+      // sites that can throw are the ones nobody thought to guard, so an event
+      // added per site would miss exactly the same ones the retry did.
+      fluxEventBus.publish('reconciler:actuated', {
+        identifier, action: 'reconcileFailed', reason: err.message, attempt, retrying,
+      });
+      if (retrying) scheduleRetry(identifier, MANAGED_RETRY_MS);
+    })
     .finally(() => {
       inFlight.delete(identifier);
       // one completed pass (actuated or deferred) is all the boot drain needs
@@ -1294,6 +1328,10 @@ function forgetDesiredState(rawIdentifier) {
   const identifier = canonical(rawIdentifier);
   controllerDesired.delete(identifier);
   dataDesired.delete(identifier);
+  // A removed component keeps no failure history: the map is keyed by identifier
+  // and a reinstall under the same name would otherwise start part-way up the
+  // count and reach the sweep sooner than a first failure should.
+  unhandledFailures.delete(identifier);
 }
 
 /**
@@ -1358,6 +1396,7 @@ function stop() {
   started = false;
   backoffTimers.forEach((t) => clearTimeout(t));
   backoffTimers.clear();
+  unhandledFailures.clear();
   if (bootDrainCapTimer) {
     clearTimeout(bootDrainCapTimer);
     bootDrainCapTimer = null;

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -25,7 +25,7 @@ const cacheManager = require('./utils/cacheManager').default;
 const networkStateService = require('./networkStateService');
 const fluxEventBus = require('./utils/fluxEventBus');
 const {
-  normalizeSocketAddress, extractIp, extractPort, socketAddressesMatch, parseSocketAddress,
+  normalizeSocketAddress, extractIp, extractPort, socketAddressesMatch, parseSocketAddress, ipsMatch,
 } = require('./utils/socketAddressUtils');
 
 const isArcane = Boolean(process.env.FLUXOS_PATH);
@@ -1208,7 +1208,21 @@ async function adjustExternalIP(ip) {
 
           // eslint-disable-next-line no-await-in-loop
           const runningAppList = await registryManager.appLocation(app.name);
-          const duplicateInstance = runningAppList.find((instance) => extractIp(instance.ip) === ip);
+          // An instance at this address means the ports are taken and this node
+          // cannot run the app: one instance per IP is enforced by the host port
+          // mapping, so a UPnP sibling on another port holds them just as surely
+          // as a node that owns the address alone. That is why the address is
+          // compared at IP granularity.
+          //
+          // The node's OWN registration is not that. It stores its own running-app
+          // row locally, at the address benchmark reports, so the row sitting at
+          // this address is most often itself - and removing on that is a node
+          // deleting an app that is exactly where it belongs, then telling the
+          // network it is gone. Own-ness is the full socket address, which is what
+          // separates it from the sibling that shares only the IP.
+          const duplicateInstance = runningAppList.find(
+            (instance) => ipsMatch(instance.ip, ip) && !socketAddressesMatch(instance.ip, localSocketAddress),
+          );
           if (duplicateInstance) {
             log.info(`Aplication: ${app.name}, was found on the network already running under the same ip, uninstalling app`);
             log.warn(`REMOVAL REASON: Duplicate IP detected - ${app.name} already running on network with IP ${ip} (after IP change)`);

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -1130,6 +1130,23 @@ async function adjustExternalIP(ip) {
     if (ip === userconfig.initial.ipaddress) {
       return;
     }
+    // Everything below needs to know which node this is: whose registration among
+    // the ones found at the new address is our own, which apps are ours to hand
+    // over, and what address the fluxipchanged broadcast is moving FROM.
+    // localSocketAddress is cleared whenever benchmark hiccups, and a comparison
+    // against nothing matches nothing - so acting here would read our own rows as
+    // strangers' and uninstall the apps they belong to.
+    //
+    // Return BEFORE the userconfig write, which is what makes this a deferral
+    // rather than a silent drop: the write is what marks the change handled, so
+    // leaving it unwritten leaves the change pending. checkMyFluxAvailability
+    // already refuses to run while the address is unknown, so nothing reaches here
+    // again until benchmark answers - and then this runs with the node knowing
+    // itself, exactly once, as designed.
+    if (!localSocketAddress) {
+      log.warn(`adjustExternalIP - own address unknown, deferring the change to ${ip} until benchmark answers`);
+      return;
+    }
     const oldUserConfigIp = userconfig.initial.ipaddress;
     log.info(`Adjusting External IP from ${userconfig.initial.ipaddress} to ${ip}`);
     const dataToWrite = `module.exports = {

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -30,6 +30,20 @@ const {
 
 const isArcane = Boolean(process.env.FLUXOS_PATH);
 
+// Fired once, with the apps that survived an address change, after the node's
+// public IP has moved. serviceManager wires it to appReconciler.requestRestartOf
+// (mirrors appUninstaller.setOnComponentRemoved).
+//
+// A seam rather than a require, and not for tidiness: appUninstaller requires
+// THIS module and appReconciler requires appUninstaller, so reaching upward from
+// here for either closes a cycle. Twenty-odd app-layer modules import this one -
+// it sits underneath them and stays there. What it knows is that the address
+// moved and which apps it kept; what restarting one involves is not its business.
+let onAddressChanged = null;
+function setOnAddressChanged(callback) {
+  onAddressChanged = callback;
+}
+
 let dosState = 0; // we can start at bigger number later
 let dosMessage = null;
 
@@ -1155,13 +1169,15 @@ async function adjustExternalIP(ip) {
       // eslint-disable-next-line global-require
       const appUninstaller = require('./appLifecycle/appUninstaller');
       // eslint-disable-next-line global-require
-      const appController = require('./appManagement/appController');
-      // eslint-disable-next-line global-require
       const enterpriseHelper = require('./utils/enterpriseHelper');
       let apps = await appQueryService.installedApps();
       if (apps.status === 'success' && apps.data.length > 0) {
         apps = apps.data;
         let appsRemoved = 0;
+        // The apps still installed once the loop has removed the ones that cannot
+        // stay. Handed to whoever registered for an address change; nothing here
+        // knows what bringing them back involves.
+        const staying = [];
         // eslint-disable-next-line no-restricted-syntax
         for (const app of apps) {
           // Check if app requires static IP - if so, uninstall it since IP changed
@@ -1200,10 +1216,19 @@ async function adjustExternalIP(ip) {
             await appUninstaller.removeAppLocally(app.name, null, true, null, true).catch((error) => log.error(error));
             appsRemoved += 1;
           } else {
-            // once app specs v8 is done we check if app have specs that is using fluxnode service.
-            // eslint-disable-next-line no-await-in-loop
-            await appController.appDockerRestart(app.name);
+            staying.push(app);
           }
+        }
+        // One handover for the whole set, not a call per app: what an app is made
+        // of - a composed one's containers are `<component>_<app>`, and an
+        // enterprise one's names are inside a blob this layer cannot read - is
+        // knowledge the reconciler already holds. Failures stay inside it too, so
+        // one app that cannot be asked costs the others nothing and leaves the
+        // broadcast, the confirmation transaction and the geolocation update below
+        // reachable.
+        if (staying.length && onAddressChanged) {
+          await onAddressChanged(staying, `node ip changed to ${ip}`)
+            .catch((error) => log.error(`adjustExternalIP - restart request failed: ${error.message}`));
         }
         if (apps.length > appsRemoved) {
           const broadcastedAt = Date.now();
@@ -2259,6 +2284,7 @@ module.exports = {
   checkFluxbenchVersionAllowed,
   checkMyFluxAvailability,
   adjustExternalIP,
+  setOnAddressChanged,
   allowPort,
   allowOutPort,
   isFirewallActive,

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -440,6 +440,10 @@ async function startFluxFunctions() {
     // a removed component's in-memory controller verdict dies with it - a
     // reinstalled g:/r: app must await a fresh election, not inherit a stale one
     appUninstaller.setOnComponentRemoved((id) => appReconciler.forgetDesiredState(id));
+    // the node's address moved, so every app that survived it has to come up on
+    // the new one - asked for durably here rather than driven from the network
+    // layer, which sits underneath the reconciler and cannot require it
+    fluxNetworkHelper.setOnAddressChanged((apps, reason) => appReconciler.requestRestartOf(apps, reason));
     log.info('App Spawner initialized');
 
     fluxNetworkHelper.adjustFirewall();

--- a/ZelBack/src/services/verificationHelper.js
+++ b/ZelBack/src/services/verificationHelper.js
@@ -8,7 +8,7 @@ const verificationHelperUtils = require('./verificationHelperUtils');
 
 /**
  * Verifies a specific privilege based on request headers.
- * @param {string} privilege - 'admin, 'fluxteam', 'adminandfluxteam', 'appownerabove', 'appowner', 'user'
+ * @param {string} privilege - 'admin, 'fluxteam', 'adminandfluxteam', 'appownerabove', 'appownerorfluxteam', 'appowner', 'user'
  * @param {object} req
  * @param {string} appName
  *
@@ -29,6 +29,9 @@ async function verifyPrivilege(privilege, req, appName) {
         break;
       case 'appownerabove':
         authorized = await verificationHelperUtils.verifyAppOwnerOrHigherSession(req.headers, appName);
+        break;
+      case 'appownerorfluxteam':
+        authorized = await verificationHelperUtils.verifyAppOwnerOrFluxTeamSession(req.headers, appName);
         break;
       case 'appowner':
         authorized = await verificationHelperUtils.verifyAppOwnerSession(req.headers, appName);

--- a/ZelBack/src/services/verificationHelperUtils.js
+++ b/ZelBack/src/services/verificationHelperUtils.js
@@ -268,10 +268,65 @@ async function verifyAppOwnerOrHigherSession(headers, appName) {
   return false;
 }
 
+/**
+ * Verifies an app-owner or flux-team session: the app's owner and the flux team,
+ * but NOT the node operator.
+ *
+ * verifyAppOwnerOrHigherSession also admits the node's own admin, which is right
+ * for reading and for the ordinary lifecycle controls - the operator hosts the
+ * container and needs them. It is wrong for a control whose whole purpose is to
+ * end an app abruptly: the node operator is not the party entitled to decide
+ * that someone else's app takes a hard kill rather than a graceful stop.
+ *
+ * @param {object} headers
+ * @param {string} appName
+ * @returns {Promise<boolean>} authorized
+ */
+async function verifyAppOwnerOrFluxTeamSession(headers, appName) {
+  if (!headers || !headers.zelidauth || !appName) return false;
+  const auth = serviceHelper.ensureObject(headers.zelidauth);
+  if (!auth.zelid || !auth.signature || !auth.loginPhrase) return false;
+  // Use dynamic require to avoid circular dependency
+  // eslint-disable-next-line global-require
+  const registryManager = require('./appDatabase/registryManager');
+  const ownerFluxID = await registryManager.getApplicationOwner(appName);
+  if (auth.zelid !== ownerFluxID && auth.zelid !== config.fluxTeamFluxID && auth.zelid !== config.fluxSupportTeamFluxID) return false;
+
+  const db = dbHelper.databaseConnection();
+  const database = db.db(config.database.local.database);
+  const collection = config.database.local.collections.loggedUsers;
+  const query = { $and: [{ loginPhrase: auth.loginPhrase }, { zelid: auth.zelid }] };
+  const projection = {};
+  const loggedUser = await dbHelper.findOneInDatabase(database, collection, query, projection);
+  // if not logged, check if not older than 2 hours
+  if (!loggedUser) {
+    const timestamp = Date.now();
+    const message = auth.loginPhrase;
+    const maxHours = 2 * 60 * 60 * 1000;
+    if (Number(message.substring(0, 13)) < (timestamp - maxHours) || Number(message.substring(0, 13)) > timestamp || message.length > 70 || message.length < 40) {
+      return false;
+    }
+  }
+
+  // check if signature corresponds to message with that zelid
+  let valid = false;
+  try {
+    valid = signatureVerifier.verifySignature(auth.loginPhrase, auth.zelid, auth.signature);
+  } catch (error) {
+    return false;
+  }
+  if (valid) {
+    // now we know this is indeed a logged application owner
+    return true;
+  }
+  return false;
+}
+
 module.exports = {
   nodeAdminZelid,
   verifyAdminAndFluxTeamSession,
   verifyAdminSession,
+  verifyAppOwnerOrFluxTeamSession,
   verifyAppOwnerOrHigherSession,
   verifyAppOwnerSession,
   verifyFluxTeamSession,

--- a/test-infra/daemon-stub/index.js
+++ b/test-infra/daemon-stub/index.js
@@ -67,7 +67,21 @@ try {
 
 function nodeBySourceIp(sourceIp) {
   const clean = sourceIp.replace('::ffff:', '');
-  return deterministicNodeList.find((n) => n.ip.split(':')[0] === clean) || null;
+  const listed = deterministicNodeList.find((n) => n.ip.split(':')[0] === clean);
+  if (listed) return listed;
+  // A node that has really moved arrives from its NEW address while its list entry
+  // still says where it was - which is exactly the state an address change puts it
+  // in, before the chain catches up. It is the same node, and failing to recognise
+  // it here costs it its own identity: every answer about it falls back to the
+  // not-found defaults, so it reads its own address as 127.0.0.1, decides it is not
+  // in the confirmed list, and skips the availability check that would have told it
+  // what happened.
+  for (const [realIp, override] of reportedAddresses) {
+    if (String(override.reported).split(':')[0] === clean) {
+      return deterministicNodeList.find((n) => n.ip.split(':')[0] === realIp) || null;
+    }
+  }
+  return null;
 }
 
 // Where a node really is, versus where the network is told it is.
@@ -114,12 +128,37 @@ function publicIpAnswerFor(node) {
   return (o ? o.reported : node.ip).split(':')[0];
 }
 
-// The list as the network sees it: every entry at its reported address. A node
-// that has not moved is returned untouched, so a run with no override in play
-// serves the very same objects it always did.
-function publishedNodeList() {
-  if (!reportedAddresses.size) return deterministicNodeList;
-  return deterministicNodeList.map((n) => {
+// Nodes hidden from their PEERS' view of the network, but never from their own.
+//
+// This is what makes a node unreachable to the fleet deterministically. Asked
+// whether it can reach a node, a peer consults its node list FIRST and answers
+// "not available" outright when the address is not in it - no probe, no timeout,
+// no dependence on how fast anything answers. Blocking packets instead only makes
+// the probe slow, and a slow probe is a different answer from an absent one: the
+// asker times out on the PEER and never learns it is unreachable.
+//
+// The node still sees ITSELF, because it has its own confirmed-list gate to pass
+// before it will run the availability check at all. Hiding it from everyone,
+// itself included, stops the check ever running.
+const hiddenFromPeers = new Set(); // real ip -> hidden from other nodes' lists
+
+// The list as a given requester sees it: every entry at its reported address,
+// minus any node hidden from that requester. A run with nothing hidden and nothing
+// moved serves the very same objects it always did.
+function publishedNodeList(sourceIp) {
+  const asker = sourceIp ? sourceIp.replace('::ffff:', '') : null;
+  const visible = hiddenFromPeers.size
+    ? deterministicNodeList.filter((n) => {
+      const ip = n.ip.split(':')[0];
+      return !hiddenFromPeers.has(ip) || ip === asker;
+    })
+    : deterministicNodeList;
+  return publishReported(visible);
+}
+
+function publishReported(list) {
+  if (!reportedAddresses.size) return list;
+  return list.map((n) => {
     const o = reportedAddresses.get(n.ip.split(':')[0]);
     return o && o.scope === 'all' ? { ...n, ip: o.reported } : n;
   });
@@ -223,8 +262,8 @@ const rpcHandlers = {
   getmempoolinfo: () => ({ size: 0, bytes: 0, usage: 0 }),
   getrawmempool: () => [],
 
-  viewdeterministiczelnodelist: () => publishedNodeList(),
-  viewdeterministicfluxnodelist: () => publishedNodeList(),
+  viewdeterministiczelnodelist: (params, sourceIp) => publishedNodeList(sourceIp),
+  viewdeterministicfluxnodelist: (params, sourceIp) => publishedNodeList(sourceIp),
 
   getzelnodestatus: (params, sourceIp) => {
     const node = nodeBySourceIp(sourceIp);
@@ -268,8 +307,8 @@ const rpcHandlers = {
   getdoslist: () => [],
   getstartlist: () => [],
 
-  listfluxnodes: () => publishedNodeList(),
-  listzelnodes: () => publishedNodeList(),
+  listfluxnodes: (params, sourceIp) => publishedNodeList(sourceIp),
+  listzelnodes: (params, sourceIp) => publishedNodeList(sourceIp),
 
   getrawtransaction: (params) => {
     const txid = params[0];
@@ -607,6 +646,20 @@ control.post('/set-node-list', (req, res) => {
 // address moves and before the chain has caught up - and it is the only state in
 // which a node can DETECT the move, because detection is precisely those two
 // answers disagreeing.
+// Hide a node from its PEERS' view of the network, or put it back. The node keeps
+// seeing itself, which is what lets it still run the availability check that then
+// comes back "unreachable" - deterministically, because a peer answers from its
+// list rather than from a probe.
+control.post('/node-visibility/:ip', (req, res) => {
+  const key = String(req.params.ip).split(':')[0];
+  const node = deterministicNodeList.find((n) => n.ip.split(':')[0] === key);
+  if (!node) return res.status(404).json({ error: `no node in the list at ${key}` });
+  const hidden = (req.body || {}).hidden !== false;
+  if (hidden) hiddenFromPeers.add(key);
+  else hiddenFromPeers.delete(key);
+  return res.json({ node: key, hiddenFromPeers: hidden });
+});
+
 control.post('/node-address/:ip', (req, res) => {
   const key = String(req.params.ip).split(':')[0];
   const node = deterministicNodeList.find((n) => n.ip.split(':')[0] === key);
@@ -776,6 +829,7 @@ control.delete('/seed-data', (req, res) => {
 control.post('/reset', (req, res) => {
   nodeStatusOverrides.clear();
   reportedAddresses.clear();
+  hiddenFromPeers.clear();
   rpcFailures.clear();
   deterministicNodeList = [...originalNodeList];
   pendingBlocks = [];

--- a/test-infra/daemon-stub/index.js
+++ b/test-infra/daemon-stub/index.js
@@ -70,6 +70,13 @@ function nodeBySourceIp(sourceIp) {
   return deterministicNodeList.find((n) => n.ip.split(':')[0] === clean) || null;
 }
 
+// What benchmark reports as a node's public address, when the harness wants it to
+// differ from where the node actually is. Keyed by the address a request ARRIVES
+// from, so the container keeps its real address and only the ANSWER moves - a node
+// detects that its address changed with nothing renumbered underneath it, which is
+// the only way to reach that path without rebuilding the fleet's network.
+const publicIpOverrides = new Map(); // real source ip -> reported ip
+
 const rpcHandlers = {
   getblockchaininfo: () => ({
     chain: 'main',
@@ -319,6 +326,8 @@ const benchHandlers = {
   }),
 
   getpublicip: (params, sourceIp) => {
+    const override = publicIpOverrides.get(sourceIp.replace('::ffff:', ''));
+    if (override) return override;
     const node = nodeBySourceIp(sourceIp);
     return node ? node.ip.split(':')[0] : '127.0.0.1';
   },
@@ -539,6 +548,18 @@ control.post('/set-node-list', (req, res) => {
   res.json({ nodeCount: deterministicNodeList.length });
 });
 
+// Move a node's public address as benchmark reports it. `node` is where the node
+// really is (what its requests arrive from), `reported` is what getpublicip will
+// answer it. Sending no `reported` puts it back to the truth.
+control.post('/public-ip', (req, res) => {
+  const { node, reported } = req.body;
+  if (!node) return res.status(400).json({ error: 'node required' });
+  const key = String(node).split(':')[0];
+  if (reported) publicIpOverrides.set(key, String(reported).split(':')[0]);
+  else publicIpOverrides.delete(key);
+  return res.json({ node: key, reported: publicIpOverrides.get(key) ?? null });
+});
+
 control.post('/queue-app-tx', (req, res) => {
   const { appHash } = req.body;
   if (!appHash) return res.status(400).json({ error: 'appHash required' });
@@ -684,6 +705,7 @@ control.delete('/seed-data', (req, res) => {
 
 control.post('/reset', (req, res) => {
   nodeStatusOverrides.clear();
+  publicIpOverrides.clear();
   rpcFailures.clear();
   deterministicNodeList = [...originalNodeList];
   pendingBlocks = [];

--- a/test-infra/daemon-stub/index.js
+++ b/test-infra/daemon-stub/index.js
@@ -70,12 +70,60 @@ function nodeBySourceIp(sourceIp) {
   return deterministicNodeList.find((n) => n.ip.split(':')[0] === clean) || null;
 }
 
-// What benchmark reports as a node's public address, when the harness wants it to
-// differ from where the node actually is. Keyed by the address a request ARRIVES
-// from, so the container keeps its real address and only the ANSWER moves - a node
-// detects that its address changed with nothing renumbered underneath it, which is
-// the only way to reach that path without rebuilding the fleet's network.
-const publicIpOverrides = new Map(); // real source ip -> reported ip
+// Where a node really is, versus where the network is told it is.
+//
+// A node's list entry carries ONE address and the stub uses it for two different
+// jobs: matching the address a request ARRIVES from, to work out whose request it
+// is, and answering every chain-facing question about where that node lives.
+// Moving the second by editing the entry breaks the first - the node stops being
+// findable by its own requests - so the override sits beside the list, keyed by
+// where the node really is, and only the ANSWERS move. The container keeps its
+// address and nothing is renumbered underneath it.
+//
+// Every answer that names a node's address reads through here: getbenchmarks
+// (which is what a node's own getLocalSocketAddress reads, and so what it believes
+// about itself), getpublicip, its status, and the deterministic list the network is
+// served. One dial rather than one per RPC - a suite that moves an address means
+// all of them, and a per-RPC dial is how a suite comes to move an answer the
+// product never reads.
+const reportedAddresses = new Map(); // real ip -> { reported, scope }
+
+// Two facts, and a real address change separates them for as long as it takes the
+// chain to catch up: where the network says the node lives, and what benchmark's
+// public-IP probe reads right now. `all` moves both. `publicip` moves only the
+// probe - benchmark still reports the old address as the node's own, the node is
+// still listed there, and only getpublicip has noticed. That is the state a node
+// is actually in when its address moves, and it is what lets it detect the move at
+// all: the two answers disagreeing IS the detection.
+function overrideFor(node) {
+  if (!node) return null;
+  return reportedAddresses.get(node.ip.split(':')[0]) || null;
+}
+
+// The address the network believes this node has. Unmoved under `publicip`.
+function reportedAddressOf(node) {
+  if (!node) return null;
+  const o = overrideFor(node);
+  return o && o.scope === 'all' ? o.reported : node.ip;
+}
+
+// What benchmark's public-IP probe answers, which moves under either scope.
+function publicIpAnswerFor(node) {
+  if (!node) return null;
+  const o = overrideFor(node);
+  return (o ? o.reported : node.ip).split(':')[0];
+}
+
+// The list as the network sees it: every entry at its reported address. A node
+// that has not moved is returned untouched, so a run with no override in play
+// serves the very same objects it always did.
+function publishedNodeList() {
+  if (!reportedAddresses.size) return deterministicNodeList;
+  return deterministicNodeList.map((n) => {
+    const o = reportedAddresses.get(n.ip.split(':')[0]);
+    return o && o.scope === 'all' ? { ...n, ip: o.reported } : n;
+  });
+}
 
 const rpcHandlers = {
   getblockchaininfo: () => ({
@@ -175,8 +223,8 @@ const rpcHandlers = {
   getmempoolinfo: () => ({ size: 0, bytes: 0, usage: 0 }),
   getrawmempool: () => [],
 
-  viewdeterministiczelnodelist: () => deterministicNodeList,
-  viewdeterministicfluxnodelist: () => deterministicNodeList,
+  viewdeterministiczelnodelist: () => publishedNodeList(),
+  viewdeterministicfluxnodelist: () => publishedNodeList(),
 
   getzelnodestatus: (params, sourceIp) => {
     const node = nodeBySourceIp(sourceIp);
@@ -187,7 +235,7 @@ const rpcHandlers = {
       collateral: node ? node.collateral : 'COutPoint(0000000000000000000000000000000000000000000000000000000000000000, 0)',
       txhash: node ? node.txhash : '0000000000000000000000000000000000000000000000000000000000000000',
       outidx: node ? node.outidx : '0',
-      ip: node ? node.ip : '127.0.0.1',
+      ip: node ? reportedAddressOf(node) : '127.0.0.1',
       network: '',
       added_height: node ? node.added_height : currentHeight - 1000,
       confirmed_height: node ? node.confirmed_height : currentHeight - 500,
@@ -220,8 +268,8 @@ const rpcHandlers = {
   getdoslist: () => [],
   getstartlist: () => [],
 
-  listfluxnodes: () => deterministicNodeList,
-  listzelnodes: () => deterministicNodeList,
+  listfluxnodes: () => publishedNodeList(),
+  listzelnodes: () => publishedNodeList(),
 
   getrawtransaction: (params) => {
     const txid = params[0];
@@ -298,7 +346,7 @@ const benchHandlers = {
     };
     const s = specs[tier] || specs.cumulus;
     return {
-      ipaddress: node ? node.ip : '127.0.0.1',
+      ipaddress: node ? reportedAddressOf(node) : '127.0.0.1',
       cores: s.cores,
       ram: s.ram,
       ssd: s.ssd,
@@ -326,10 +374,8 @@ const benchHandlers = {
   }),
 
   getpublicip: (params, sourceIp) => {
-    const override = publicIpOverrides.get(sourceIp.replace('::ffff:', ''));
-    if (override) return override;
     const node = nodeBySourceIp(sourceIp);
-    return node ? node.ip.split(':')[0] : '127.0.0.1';
+    return node ? publicIpAnswerFor(node) : '127.0.0.1';
   },
 
   getpublickey: (params, sourceIp) => {
@@ -548,16 +594,40 @@ control.post('/set-node-list', (req, res) => {
   res.json({ nodeCount: deterministicNodeList.length });
 });
 
-// Move a node's public address as benchmark reports it. `node` is where the node
-// really is (what its requests arrive from), `reported` is what getpublicip will
-// answer it. Sending no `reported` puts it back to the truth.
-control.post('/public-ip', (req, res) => {
-  const { node, reported } = req.body;
-  if (!node) return res.status(400).json({ error: 'node required' });
-  const key = String(node).split(':')[0];
-  if (reported) publicIpOverrides.set(key, String(reported).split(':')[0]);
-  else publicIpOverrides.delete(key);
-  return res.json({ node: key, reported: publicIpOverrides.get(key) ?? null });
+// Move where a node is said to be. `:ip` is where it really is - the address its
+// requests arrive from, which never changes - and `reported` is the address that
+// then answers for it. Sending no `reported` puts it back to the truth.
+//
+// `scope: 'all'` (default) moves every chain-facing answer together: benchmark's
+// reply about the node itself, getpublicip, its status, and its list entry. That is
+// an address change already settled everywhere.
+//
+// `scope: 'publicip'` moves only benchmark's public-IP probe. Everything else still
+// says the node is where it was. That is the state a node is in the moment its
+// address moves and before the chain has caught up - and it is the only state in
+// which a node can DETECT the move, because detection is precisely those two
+// answers disagreeing.
+control.post('/node-address/:ip', (req, res) => {
+  const key = String(req.params.ip).split(':')[0];
+  const node = deterministicNodeList.find((n) => n.ip.split(':')[0] === key);
+  if (!node) return res.status(404).json({ error: `no node in the list at ${key}` });
+
+  const { reported, scope = 'all' } = req.body || {};
+  if (!reported) {
+    reportedAddresses.delete(key);
+    return res.json({ node: key, reported: node.ip, scope: null });
+  }
+  if (scope !== 'all' && scope !== 'publicip') {
+    return res.status(400).json({ error: `scope must be 'all' or 'publicip', got '${scope}'` });
+  }
+
+  // A bare address keeps the node's own port. The api port is what its peers reach
+  // it on, and moving that is a different change from moving the address.
+  const value = String(reported);
+  const realPort = node.ip.split(':')[1];
+  const full = value.includes(':') || !realPort ? value : `${value}:${realPort}`;
+  reportedAddresses.set(key, { reported: full, scope });
+  return res.json({ node: key, reported: full, scope });
 });
 
 control.post('/queue-app-tx', (req, res) => {
@@ -705,7 +775,7 @@ control.delete('/seed-data', (req, res) => {
 
 control.post('/reset', (req, res) => {
   nodeStatusOverrides.clear();
-  publicIpOverrides.clear();
+  reportedAddresses.clear();
   rpcFailures.clear();
   deterministicNodeList = [...originalNodeList];
   pendingBlocks = [];

--- a/test-infra/runner/framework/boot-lock.js
+++ b/test-infra/runner/framework/boot-lock.js
@@ -72,6 +72,15 @@ export function bootQueue() {
 }
 
 let heldTicket = null;
+let heldSince = null;
+
+// Queued-vs-held is the number the lock's WIDTH turns on, and nothing recorded it:
+// a suite's wall time is boot plus however long it sat behind five siblings, and the
+// two are indistinguishable from the outside. Emitted as TAP comments because
+// run-all.sh pipes mocha's `2>&1` straight into the .tap it later tallies with
+// `grep -c '^ok '` - a leading `#` is a comment to any TAP reader and can never be
+// counted as a result.
+const report = (fields) => { console.log(`# boot-lock ${fields}`); };
 
 export async function acquireBootLock() {
   mkdirSync(BOOT_LOCK_DIR, { recursive: true });
@@ -79,10 +88,16 @@ export async function acquireBootLock() {
   writeFileSync(join(BOOT_LOCK_DIR, ticket), '');
   heldTicket = ticket;
   const startedAt = process.hrtime.bigint();
+  let aheadOnArrival = null;
   for (;;) {
     const queue = bootQueue();
-    if (queue[0] === ticket) return;
+    if (aheadOnArrival === null) aheadOnArrival = Math.max(0, queue.indexOf(ticket));
     const waitedMs = Number((process.hrtime.bigint() - startedAt) / 1000000n);
+    if (queue[0] === ticket) {
+      heldSince = process.hrtime.bigint();
+      report(`acquired waited_ms=${waitedMs} ahead_on_arrival=${aheadOnArrival} pid=${process.pid}`);
+      return;
+    }
     if (waitedMs > BOOT_LOCK_MAX_WAIT_MS) {
       const ahead = queue.indexOf(ticket);
       const holder = queue[0] ? ticketOrder(queue[0])[1] : 'none';
@@ -99,6 +114,12 @@ export async function acquireBootLock() {
 
 export function releaseBootLock() {
   if (!heldTicket) return;
+  // Null when the wait timed out rather than succeeded, which is a queue that never
+  // held the lock and must not report a boot duration.
+  if (heldSince !== null) {
+    report(`released held_ms=${Number((process.hrtime.bigint() - heldSince) / 1000000n)} pid=${process.pid}`);
+    heldSince = null;
+  }
   try {
     rmSync(join(BOOT_LOCK_DIR, heldTicket), { force: true });
   } catch {

--- a/test-infra/runner/framework/boot-lock.js
+++ b/test-infra/runner/framework/boot-lock.js
@@ -115,8 +115,16 @@ export async function acquireBootLock(fleet) {
     if (aheadOnArrival === null) aheadOnArrival = Math.max(0, queue.indexOf(ticket));
     const waitedMs = Number((process.hrtime.bigint() - startedAt) / 1000000n);
     // Arrival order still decides service; the width only changes how many of the
-    // front of the queue are being served at once.
-    if (queue.indexOf(ticket) < BOOT_LOCK_WIDTH) {
+    // front of the queue are being served at once. A ticket that is NOT in the
+    // queue indexes to -1, which is inside any width - so the position has to be
+    // real before it can be compared. bootQueue() returns [] whenever the
+    // directory cannot be read, and run-parallel.sh removes that directory, so
+    // without this every waiter would read "I hold the lock" at the same moment
+    // and the semaphore would be silently defeated - exactly the contention it
+    // exists to prevent. Holding instead means the wait ends at the explicit
+    // wedged error, which is the honest signal.
+    const position = queue.indexOf(ticket);
+    if (position >= 0 && position < BOOT_LOCK_WIDTH) {
       heldSince = process.hrtime.bigint();
       report(`acquired waited_ms=${waitedMs} ahead_on_arrival=${aheadOnArrival} width=${BOOT_LOCK_WIDTH} ${heldFleet} pid=${process.pid}`);
       return;

--- a/test-infra/runner/framework/boot-lock.js
+++ b/test-infra/runner/framework/boot-lock.js
@@ -3,13 +3,17 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 // ---- host-wide boot semaphore ----
-// Fleet boot is the only CPU-heavy phase a suite has: every node in the fleet
-// starts its own dockerd and runs FluxOS DB prep at once. When two suites' boots
-// overlap under run-parallel.sh, they starve each other and a healthy node can
-// blow its event-wait budget while merely slow (observed in the 42-suite gate:
-// suite 22's second fleet booted at load ~15 on 16 cores and mongo collection
-// prep crawled at 7-17s a step). Running fleets are cheap, so serialise just the
+// Fleet boot is the heaviest phase a suite has: every node in the fleet starts its
+// own dockerd and runs FluxOS DB prep at once. Overlapping boots contend, and a
+// healthy node can blow its event-wait budget while merely slow (observed in the
+// 42-suite gate: suite 22's second fleet booted at load ~15 on 16 cores and mongo
+// collection prep crawled at 7-17s a step). Running fleets are cheap, so bound the
 // boot phase host-wide and let everything else overlap.
+//
+// BOOT_LOCK_WIDTH is how many fleets may boot at once. Two ten-node fleets booting
+// together each take ~37s where one alone takes ~25s, so the pair completes in the
+// time 1.5 boots would cost serially: they do contend, but the overlap wins. The
+// gate is ~89% boot-lock-held wall clock, so that ratio is most of its duration.
 //
 // The queue is ORDERED BY ARRIVAL, and that is the whole point. A protocol that
 // has every waiter race the same atomic create when the lock frees serves whoever
@@ -27,10 +31,14 @@ import { join } from 'node:path';
 // after a suite is killed mid-boot.
 export const BOOT_LOCK_DIR = process.env.E2E_BOOT_LOCK_DIR ?? join(tmpdir(), 'e2e-boot-lock');
 const BOOT_LOCK_POLL_MS = Number(process.env.E2E_BOOT_LOCK_POLL_MS ?? 250);
+// How many fleets may boot at once. Held below MAXN so a gate still spends most of
+// itself running suites rather than booting them; 1 restores strict serialisation.
+export const BOOT_LOCK_WIDTH = Math.max(1, Number(process.env.E2E_BOOT_LOCK_WIDTH ?? 2));
 // Generous against a FIFO queue: the worst honest wait is the suites ahead of you
-// times one boot, so ~5 boots at MAXN=6. Reaching this means the queue is wedged,
-// not busy, and it stays well inside run-all.sh's 1800s per-suite backstop so the
-// failure is reported by the lock rather than by a SIGKILL that explains nothing.
+// divided by the width, times one boot - ~5 boots at MAXN=6 and width 1, fewer as
+// the width rises. Reaching this means the queue is wedged, not busy, and it stays
+// well inside run-all.sh's 1800s per-suite backstop so the failure is reported by
+// the lock rather than by a SIGKILL that explains nothing.
 export const BOOT_LOCK_MAX_WAIT_MS = Number(process.env.E2E_BOOT_LOCK_MAX_WAIT_MS ?? 600000);
 
 const sleep = (ms) => new Promise((resolve) => { setTimeout(resolve, ms); });
@@ -106,18 +114,21 @@ export async function acquireBootLock(fleet) {
     const queue = bootQueue();
     if (aheadOnArrival === null) aheadOnArrival = Math.max(0, queue.indexOf(ticket));
     const waitedMs = Number((process.hrtime.bigint() - startedAt) / 1000000n);
-    if (queue[0] === ticket) {
+    // Arrival order still decides service; the width only changes how many of the
+    // front of the queue are being served at once.
+    if (queue.indexOf(ticket) < BOOT_LOCK_WIDTH) {
       heldSince = process.hrtime.bigint();
-      report(`acquired waited_ms=${waitedMs} ahead_on_arrival=${aheadOnArrival} ${heldFleet} pid=${process.pid}`);
+      report(`acquired waited_ms=${waitedMs} ahead_on_arrival=${aheadOnArrival} width=${BOOT_LOCK_WIDTH} ${heldFleet} pid=${process.pid}`);
       return;
     }
     if (waitedMs > BOOT_LOCK_MAX_WAIT_MS) {
       const ahead = queue.indexOf(ticket);
-      const holder = queue[0] ? ticketOrder(queue[0])[1] : 'none';
+      const holders = queue.slice(0, BOOT_LOCK_WIDTH).map((t) => ticketOrder(t)[1]);
       releaseBootLock();
       throw new Error(
         `boot lock: waited ${Math.round(waitedMs / 1000)}s for ${BOOT_LOCK_DIR}, `
-        + `still ${ahead < 0 ? 'unknown' : ahead} ahead in the queue (holder pid ${holder}). `
+        + `still ${ahead < 0 ? 'unknown' : ahead} ahead in the queue `
+        + `(width ${BOOT_LOCK_WIDTH}, holder pids ${holders.length ? holders.join(',') : 'none'}). `
         + 'The queue is wedged, not merely busy.',
       );
     }

--- a/test-infra/runner/framework/boot-lock.js
+++ b/test-infra/runner/framework/boot-lock.js
@@ -109,10 +109,18 @@ export async function acquireBootLock(fleet) {
   heldTicket = ticket;
   heldFleet = fleetShape(fleet);
   const startedAt = process.hrtime.bigint();
-  let aheadOnArrival = null;
+  let aheadOnArrival; // undefined until the first queue read; null = position unknown
   for (;;) {
     const queue = bootQueue();
-    if (aheadOnArrival === null) aheadOnArrival = Math.max(0, queue.indexOf(ticket));
+    if (aheadOnArrival === undefined) {
+      // Same -1 the wait error below refuses to conflate. A ticket that is not in
+      // the queue has no position, and reporting one as 0 reads as "arrived to an
+      // empty queue" - the most misleading value available, because bootQueue()
+      // returns [] exactly when the directory cannot be read, which is the
+      // defeated-semaphore case this lock exists to make visible.
+      const arrivalPosition = queue.indexOf(ticket);
+      aheadOnArrival = arrivalPosition < 0 ? null : arrivalPosition;
+    }
     const waitedMs = Number((process.hrtime.bigint() - startedAt) / 1000000n);
     // Arrival order still decides service; the width only changes how many of the
     // front of the queue are being served at once. A ticket that is NOT in the
@@ -126,7 +134,7 @@ export async function acquireBootLock(fleet) {
     const position = queue.indexOf(ticket);
     if (position >= 0 && position < BOOT_LOCK_WIDTH) {
       heldSince = process.hrtime.bigint();
-      report(`acquired waited_ms=${waitedMs} ahead_on_arrival=${aheadOnArrival} width=${BOOT_LOCK_WIDTH} ${heldFleet} pid=${process.pid}`);
+      report(`acquired waited_ms=${waitedMs} ahead_on_arrival=${aheadOnArrival ?? 'unknown'} width=${BOOT_LOCK_WIDTH} ${heldFleet} pid=${process.pid}`);
       return;
     }
     if (waitedMs > BOOT_LOCK_MAX_WAIT_MS) {

--- a/test-infra/runner/framework/boot-lock.js
+++ b/test-infra/runner/framework/boot-lock.js
@@ -73,6 +73,7 @@ export function bootQueue() {
 
 let heldTicket = null;
 let heldSince = null;
+let heldFleet = '';
 
 // Queued-vs-held is the number the lock's WIDTH turns on, and nothing recorded it:
 // a suite's wall time is boot plus however long it sat behind five siblings, and the
@@ -82,11 +83,23 @@ let heldSince = null;
 // counted as a result.
 const report = (fields) => { console.log(`# boot-lock ${fields}`); };
 
-export async function acquireBootLock() {
+// The fleet's shape is what explains held_ms, and a duration without it is two
+// populations stirred together: nodes boot in parallel, so fleet size moves the cost
+// by a few times rather than in proportion, and `syncthing: 'binary'` gives every node
+// its own daemon instead of one shared stub. Both axes are needed to tell whether the
+// width can vary BY fleet - two small boots overlapping is a different question from
+// two ten-node ones. Carried on both lines so each is self-describing: a process takes
+// the lock once per fleet it builds, so a pid does not pair an acquire with its release.
+const fleetShape = ({
+  nodes = 0, deferred = 0, legacy = 0, syncthing = 'stub',
+} = {}) => `nodes=${nodes} deferred=${deferred} legacy=${legacy} syncthing=${syncthing}`;
+
+export async function acquireBootLock(fleet) {
   mkdirSync(BOOT_LOCK_DIR, { recursive: true });
   const ticket = `${Date.now()}-${process.pid}`;
   writeFileSync(join(BOOT_LOCK_DIR, ticket), '');
   heldTicket = ticket;
+  heldFleet = fleetShape(fleet);
   const startedAt = process.hrtime.bigint();
   let aheadOnArrival = null;
   for (;;) {
@@ -95,7 +108,7 @@ export async function acquireBootLock() {
     const waitedMs = Number((process.hrtime.bigint() - startedAt) / 1000000n);
     if (queue[0] === ticket) {
       heldSince = process.hrtime.bigint();
-      report(`acquired waited_ms=${waitedMs} ahead_on_arrival=${aheadOnArrival} pid=${process.pid}`);
+      report(`acquired waited_ms=${waitedMs} ahead_on_arrival=${aheadOnArrival} ${heldFleet} pid=${process.pid}`);
       return;
     }
     if (waitedMs > BOOT_LOCK_MAX_WAIT_MS) {
@@ -117,7 +130,7 @@ export function releaseBootLock() {
   // Null when the wait timed out rather than succeeded, which is a queue that never
   // held the lock and must not report a boot duration.
   if (heldSince !== null) {
-    report(`released held_ms=${Number((process.hrtime.bigint() - heldSince) / 1000000n)} pid=${process.pid}`);
+    report(`released held_ms=${Number((process.hrtime.bigint() - heldSince) / 1000000n)} ${heldFleet} pid=${process.pid}`);
     heldSince = null;
   }
   try {

--- a/test-infra/runner/framework/container.js
+++ b/test-infra/runner/framework/container.js
@@ -6,25 +6,37 @@ export async function execInContainer(container, command) {
   return { stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode, output: result.output };
 }
 
-// Give a node a second address on the fleet network, so it answers there as well
-// as where it started.
+// Move a node to a different address on the fleet network: the new one goes on,
+// the old one comes off.
 //
-// The other half of an address change. Telling the network a node moved is not
-// enough on its own: the availability check that gates the whole path has a PEER
-// dial the address the node now claims, so a node that claims an address nothing
-// answers on reads as unreachable rather than as moved. The nodes run privileged,
-// so the address is simply added to the interface - no renumbering, no restart,
-// and every existing connection survives because the original address stays.
+// This is what an address change IS, and doing it for real is what makes the rest
+// of the fixture honest. Its peers then find it unreachable at the old address
+// because it genuinely is not there - no packet filter simulating it, and nothing
+// hidden from the node list, so they still recognise it as the sender of the
+// fluxipchanged broadcast that follows.
+//
+// The timing matters and is measured. A probe to an address that is gone fails
+// with EHOSTUNREACH at ~3.1s (ARP gives up), NOT a hang - so a peer's own probe
+// budget of 5s sees a failure rather than a timeout, and it answers the asking
+// node inside that node's 7s budget. Those margins are why this works where
+// dropping packets did not: a dropped probe burns the full 5s, and the answer
+// then arrives after the asker has already given up, which reads as "I could not
+// ask" rather than "you are unreachable" - a different branch entirely, and one
+// that never consults benchmark.
 //
 // @param {object} container The node's container.
-// @param {string} ip Bare address to add, inside the fleet's own /24.
-export async function addNodeAddress(container, ip, { prefix = 24, iface = 'eth0' } = {}) {
-  const r = await execInContainer(container, `ip addr add ${ip}/${prefix} dev ${iface}`);
-  // Already present is the state we wanted, not a failure.
-  if (r.exitCode !== 0 && !/File exists/i.test(r.output || '')) {
-    throw new Error(`addNodeAddress: could not add ${ip}/${prefix} to ${iface}: ${r.output}`);
+// @param {string} to Bare address to move to, inside the fleet's own /24.
+// @param {string} from Bare address to give up.
+export async function moveNodeAddress(container, to, from, { prefix = 24, iface = 'eth0' } = {}) {
+  const add = await execInContainer(container, `ip addr add ${to}/${prefix} dev ${iface}`);
+  if (add.exitCode !== 0 && !/File exists/i.test(add.output || '')) {
+    throw new Error(`moveNodeAddress: could not add ${to}/${prefix} to ${iface}: ${add.output}`);
   }
-  return ip;
+  const del = await execInContainer(container, `ip addr del ${from}/${prefix} dev ${iface}`);
+  if (del.exitCode !== 0 && !/Cannot assign|not exist/i.test(del.output || '')) {
+    throw new Error(`moveNodeAddress: could not remove ${from}/${prefix} from ${iface}: ${del.output}`);
+  }
+  return to;
 }
 
 // Make a node unreachable to the named peers, without taking it off the network.

--- a/test-infra/runner/framework/container.js
+++ b/test-infra/runner/framework/container.js
@@ -36,6 +36,14 @@ export async function addNodeAddress(container, ip, { prefix = 24, iface = 'eth0
 // probe fail, which is what a node needs before it will ask benchmark whether its
 // address changed.
 //
+// REJECT rather than DROP, and the difference decides whether this works at all.
+// A peer asked whether it can reach this node probes it and answers within the
+// asker's own timeout budget. Dropped packets blackhole, so that probe burns its
+// full timeout and the peer answers too late - the asker times out on the PEER and
+// reads "I could not ask" instead of "I am unreachable", which retries without ever
+// consulting benchmark. Refusing fails the probe instantly, so the answer arrives
+// in time and says what it is meant to say.
+//
 // Named peers rather than the subnet: the runner reaches the node from the docker
 // gateway on that same /24, so a blanket rule would cut off the very client doing
 // the asserting.
@@ -46,7 +54,7 @@ export async function addNodeAddress(container, ip, { prefix = 24, iface = 'eth0
 export async function blockPeerAccess(container, peerIps, apiPort) {
   for (const peerIp of peerIps) {
     // eslint-disable-next-line no-await-in-loop
-    const r = await execInContainer(container, `iptables -I INPUT -p tcp --dport ${apiPort} -s ${peerIp} -j DROP`);
+    const r = await execInContainer(container, `iptables -I INPUT -p tcp --dport ${apiPort} -s ${peerIp} -j REJECT --reject-with tcp-reset`);
     if (r.exitCode !== 0) {
       throw new Error(`blockPeerAccess: could not drop ${peerIp} -> :${apiPort}: ${r.output}`);
     }
@@ -59,7 +67,7 @@ export async function blockPeerAccess(container, peerIps, apiPort) {
 export async function unblockPeerAccess(container, peerIps, apiPort) {
   for (const peerIp of peerIps) {
     // eslint-disable-next-line no-await-in-loop
-    await execInContainer(container, `iptables -D INPUT -p tcp --dport ${apiPort} -s ${peerIp} -j DROP`);
+    await execInContainer(container, `iptables -D INPUT -p tcp --dport ${apiPort} -s ${peerIp} -j REJECT --reject-with tcp-reset`);
   }
 }
 

--- a/test-infra/runner/framework/container.js
+++ b/test-infra/runner/framework/container.js
@@ -6,6 +6,63 @@ export async function execInContainer(container, command) {
   return { stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode, output: result.output };
 }
 
+// Give a node a second address on the fleet network, so it answers there as well
+// as where it started.
+//
+// The other half of an address change. Telling the network a node moved is not
+// enough on its own: the availability check that gates the whole path has a PEER
+// dial the address the node now claims, so a node that claims an address nothing
+// answers on reads as unreachable rather than as moved. The nodes run privileged,
+// so the address is simply added to the interface - no renumbering, no restart,
+// and every existing connection survives because the original address stays.
+//
+// @param {object} container The node's container.
+// @param {string} ip Bare address to add, inside the fleet's own /24.
+export async function addNodeAddress(container, ip, { prefix = 24, iface = 'eth0' } = {}) {
+  const r = await execInContainer(container, `ip addr add ${ip}/${prefix} dev ${iface}`);
+  // Already present is the state we wanted, not a failure.
+  if (r.exitCode !== 0 && !/File exists/i.test(r.output || '')) {
+    throw new Error(`addNodeAddress: could not add ${ip}/${prefix} to ${iface}: ${r.output}`);
+  }
+  return ip;
+}
+
+// Make a node unreachable to the named peers, without taking it off the network.
+//
+// The node keeps its address, its list entry and its outbound connections; what
+// stops is inbound traffic to its API port FROM those peers. That is what a node
+// whose address has moved looks like from the outside - still listed where it was,
+// no longer answering there - and it is the state that makes a peer's availability
+// probe fail, which is what a node needs before it will ask benchmark whether its
+// address changed.
+//
+// Named peers rather than the subnet: the runner reaches the node from the docker
+// gateway on that same /24, so a blanket rule would cut off the very client doing
+// the asserting.
+//
+// @param {object} container The node's container.
+// @param {string[]} peerIps Bare addresses whose traffic to drop.
+// @param {number} apiPort The node's API port.
+export async function blockPeerAccess(container, peerIps, apiPort) {
+  for (const peerIp of peerIps) {
+    // eslint-disable-next-line no-await-in-loop
+    const r = await execInContainer(container, `iptables -I INPUT -p tcp --dport ${apiPort} -s ${peerIp} -j DROP`);
+    if (r.exitCode !== 0) {
+      throw new Error(`blockPeerAccess: could not drop ${peerIp} -> :${apiPort}: ${r.output}`);
+    }
+  }
+  return peerIps;
+}
+
+// Undo blockPeerAccess. Tolerates a rule that is already gone so teardown after a
+// failed test cannot fail in its own right.
+export async function unblockPeerAccess(container, peerIps, apiPort) {
+  for (const peerIp of peerIps) {
+    // eslint-disable-next-line no-await-in-loop
+    await execInContainer(container, `iptables -D INPUT -p tcp --dport ${apiPort} -s ${peerIp} -j DROP`);
+  }
+}
+
 export async function listAppContainers(container, { all = false } = {}) {
   const flag = all ? ' -a' : '';
   const { stdout } = await execInContainer(container,

--- a/test-infra/runner/framework/daemon-control.js
+++ b/test-infra/runner/framework/daemon-control.js
@@ -81,6 +81,27 @@ export async function setNodeAddress(node, reported, { scope = 'all' } = {}) {
   return post(`/node-address/${String(node).split(':')[0]}`, { reported, scope });
 }
 
+/**
+ * Hide a node from its peers' view of the network, so they answer "not available"
+ * for it without probing anything.
+ *
+ * A peer asked whether it can reach a node consults its node list first and answers
+ * outright when the address is not in it. That is an answer, not a timeout, so it
+ * arrives inside the asker's budget every time - which is what makes an unreachable
+ * node a deterministic fixture rather than a race.
+ *
+ * The node keeps seeing itself: it has its own confirmed-list gate to pass before it
+ * will run the availability check at all.
+ */
+export async function hideNodeFromPeers(node) {
+  return post(`/node-visibility/${String(node).split(':')[0]}`, { hidden: true });
+}
+
+/** Put a node back into its peers' view. */
+export async function revealNodeToPeers(node) {
+  return post(`/node-visibility/${String(node).split(':')[0]}`, { hidden: false });
+}
+
 /** Put a node's address back to where it really is. */
 export async function clearNodeAddress(node) {
   return post(`/node-address/${String(node).split(':')[0]}`, {});

--- a/test-infra/runner/framework/daemon-control.js
+++ b/test-infra/runner/framework/daemon-control.js
@@ -56,6 +56,21 @@ export async function queueAppTx(appHash) {
   return post('/queue-app-tx', { appHash });
 }
 
+// -- Public address, as benchmark reports it --
+
+/**
+ * Report a public address for a node other than the one it is actually at. The
+ * container is untouched - only benchmark's answer moves, and that answer is where
+ * a node learns its own address changed. `node` is where it really is.
+ */
+export async function reportPublicIp(node, reported) {
+  return post('/public-ip', { node, reported });
+}
+
+export async function clearReportedPublicIp(node) {
+  return post('/public-ip', { node });
+}
+
 // -- Per-node status --
 
 export async function setNodeStatus(ip, status) {

--- a/test-infra/runner/framework/daemon-control.js
+++ b/test-infra/runner/framework/daemon-control.js
@@ -56,19 +56,34 @@ export async function queueAppTx(appHash) {
   return post('/queue-app-tx', { appHash });
 }
 
-// -- Public address, as benchmark reports it --
+// -- Where the network believes a node is --
 
 /**
- * Report a public address for a node other than the one it is actually at. The
- * container is untouched - only benchmark's answer moves, and that answer is where
- * a node learns its own address changed. `node` is where it really is.
+ * Move a node's address as the whole network sees it: what benchmark tells the
+ * node about itself (which is where it learns its address changed), what
+ * getpublicip answers, its node status, and its entry in the deterministic list.
+ *
+ * The container is untouched. `node` is where it really is - the address its
+ * requests arrive from - and that never moves, so the fleet stays reachable and
+ * every other node keeps talking to it exactly as before.
+ *
+ * A bare address keeps the node's own api port.
+ *
+ * `scope: 'all'` (default) moves every answer at once - an address change already
+ * settled. `scope: 'publicip'` moves only benchmark's public-IP probe, leaving the
+ * node listed and reporting itself where it was: the state a node is in the moment
+ * its address moves, and the only one in which it can notice.
+ *
+ * @param {string} node Where the node really is.
+ * @param {string} reported The address the network should now carry for it.
  */
-export async function reportPublicIp(node, reported) {
-  return post('/public-ip', { node, reported });
+export async function setNodeAddress(node, reported, { scope = 'all' } = {}) {
+  return post(`/node-address/${String(node).split(':')[0]}`, { reported, scope });
 }
 
-export async function clearReportedPublicIp(node) {
-  return post('/public-ip', { node });
+/** Put a node's address back to where it really is. */
+export async function clearNodeAddress(node) {
+  return post(`/node-address/${String(node).split(':')[0]}`, {});
 }
 
 // -- Per-node status --

--- a/test-infra/runner/framework/node-client.js
+++ b/test-infra/runner/framework/node-client.js
@@ -236,6 +236,7 @@ export function nodeClient(nodeNum) {
         'message:dispatched',
         'reconciler:actuated',
         'reconciler:desiredChanged',
+        'app:operatorIntent',
         'reconciler:swept',
       ]) {
         eventSource.addEventListener(name, (e) => {

--- a/test-infra/runner/framework/node-client.js
+++ b/test-infra/runner/framework/node-client.js
@@ -4,8 +4,11 @@ import { getSubnetConfig } from './subnet-config.js';
 import { infraDeathError, offInfraDeath, onInfraDeath } from './infra-death.js';
 
 export function nodeClient(nodeNum) {
-  const ip = getSubnetConfig().nodeIp(nodeNum);
-  const url = `http://${ip}:16127`;
+  // Not constants: a node's address can change, and a client bound to where the
+  // node USED to be is a client that cannot see it any more. Every request and the
+  // event stream read these, so following a node is a matter of re-pointing them.
+  let ip = getSubnetConfig().nodeIp(nodeNum);
+  let url = `http://${ip}:16127`;
 
   async function get(path) {
     const res = await fetch(`${url}${path}`);
@@ -252,6 +255,31 @@ export function nodeClient(nodeNum) {
     });
   }
 
+  /**
+   * Follow this node to a new address.
+   *
+   * The harness reaches a node at a fixed address, so a node that genuinely moves
+   * becomes invisible to its own client - every request goes to where it was, and
+   * the event stream dies with the address. That makes an address change untestable
+   * for the wrong reason: not because the product failed, but because the observer
+   * was left behind.
+   *
+   * The event stream is reconnected, so events emitted between the move and this
+   * call are not in the buffer. Callers that need to span the move should take their
+   * baseline from what this returns rather than from before it.
+   *
+   * @param {string} newIp The address the node now answers on.
+   * @returns {Promise<number>} The last event id after reconnecting, as a baseline.
+   */
+  async function followTo(newIp) {
+    const wasStreaming = Boolean(eventSource);
+    if (wasStreaming) disconnectEventStream();
+    ip = newIp;
+    url = `http://${ip}:16127`;
+    if (wasStreaming) await connectEventStream();
+    return getLastEventId();
+  }
+
   function disconnectEventStream() {
     if (eventSource) {
       eventSource.close();
@@ -329,8 +357,9 @@ export function nodeClient(nodeNum) {
   }
 
   return {
-    ip,
-    url,
+    get ip() { return ip; },
+    get url() { return url; },
+    followTo,
     num: nodeNum,
     get,
     getAuthed,

--- a/test-infra/runner/framework/test-env.js
+++ b/test-infra/runner/framework/test-env.js
@@ -582,7 +582,9 @@ export async function createTestEnv({
   const declaredMs = (hookCtx && typeof hookCtx.timeout === 'function') ? hookCtx.timeout() : 0;
   if (declaredMs > 0) hookCtx.timeout(declaredMs + BOOT_LOCK_MAX_WAIT_MS + 30000);
   const queuedFrom = process.hrtime.bigint();
-  await acquireBootLock();
+  await acquireBootLock({
+    nodes, deferred: deferredNodes, legacy: legacyNodes.length, syncthing,
+  });
   if (declaredMs > 0) {
     const queuedMs = Number((process.hrtime.bigint() - queuedFrom) / 1000000n);
     hookCtx.timeout(declaredMs + queuedMs);

--- a/test-infra/runner/framework/wait.js
+++ b/test-infra/runner/framework/wait.js
@@ -234,6 +234,19 @@ export async function waitForReconcileActuated(node, identifier, action, timeout
   );
 }
 
+// The moment an operator's stop/start/kill/restart became durable, which is the
+// point anything else has to be ordered against: an actuation on the previous
+// intent arriving AFTER this is the interleaving the per-key slot exists to stop.
+// stopped: true | false (omit to match any)
+export async function waitForOperatorIntent(node, identifier, stopped, timeout = 60000, opts) {
+  return node.waitForEvent(
+    'app:operatorIntent',
+    (d) => d.identifier === identifier && (stopped === undefined || d.stopped === stopped),
+    timeout,
+    opts,
+  );
+}
+
 // state: 'running' | 'stopped' (omit to match any)
 export async function waitForReconcilerDesiredChanged(node, identifier, state, timeout = 60000, opts) {
   return node.waitForEvent(
@@ -290,14 +303,23 @@ export async function waitForOperation(node, jobId, zelidauth, { timeout = 18000
  * event id up front so events already buffered before the call are ignored.
  * Use for "the reconciler must NOT start this container" (e.g. syncthing S10).
  */
-export async function assertNoEvent(node, name, predicate = () => true, windowMs = 5000) {
-  const afterId = node.getLastEventId();
+export async function assertNoEvent(node, name, predicate = () => true, windowMs = 5000, { afterId } = {}) {
+  // Anchored where the caller cares, not where the caller happens to be standing.
+  // "From now" is right for asserting a steady state holds, and wrong wherever the
+  // event being ruled out could already have landed - the gap between a request
+  // and the container settling is exactly where an interleaving shows up, and an
+  // anchor taken after the settling has already stepped over it.
+  //
+  // Never anchor across a node restart: the event ring is in-memory, so ids begin
+  // again and a pre-restart anchor filters out everything that follows it - the
+  // assertion then passes because it is looking at nothing.
+  const anchorId = afterId ?? node.getLastEventId();
   await sleepUnlessInfraDead(windowMs);
   // A dead infra container makes "no event arrived" trivially true, so this
   // assertion would PASS on a void run. Fail it instead.
   throwIfInfraDead();
   const match = node.getEventBuffer().find(
-    (e) => e.event === name && e.id > afterId && predicate(e.data),
+    (e) => e.event === name && e.id > anchorId && predicate(e.data),
   );
   if (match) {
     throw new Error(`Expected no '${name}' event within ${windowMs}ms but got: ${JSON.stringify(match.data)}`);

--- a/test-infra/runner/tests/21-spawner-deferrals.js
+++ b/test-infra/runner/tests/21-spawner-deferrals.js
@@ -72,19 +72,28 @@ function anyDeferralEvent(env, appName, reason) {
   );
 }
 
+// One fleet per NODE TYPE, not one per scenario. The five scenarios here differ
+// only in the app they register - three on Arcane nodes, two on Legacy - and a
+// fleet boot is the most expensive thing this suite does: ten nodes, each building
+// its own full index set on the shared mongod. Booting an identical fleet three
+// times to register three different apps against it spends ~2,800 index builds to
+// learn nothing, and leaves the suite still running when the rest of a gate is at
+// its busiest, which is how its last fleet came to overshoot a hook budget.
+//
+// Each app is still registered immediately before its own tests, so the scenarios
+// stay isolated in the way that matters: no test depends on another's app, and a
+// deferral is observed against the app that caused it.
 
-// --- Arcane node tests (default — all nodes have FLUXOS_PATH) ---
+// --- Arcane node tests (default - all nodes have FLUXOS_PATH) ---
 
-describe('Arcane: non-enterprise app deferred as non_enterprise_on_arcane', function () {
+describe('Arcane spawner deferrals', function () {
   let env;
   dumpLogsOnFailure(() => env);
-  const appName = `e2earcdefer${Date.now()}`;
 
   before(async function () {
     this.timeout(300000);
     env = await createTestEnv({ hookCtx: this, nodes: 10, tickerAutostart: false });
     await bootAndPeer(env);
-    await registerApp(env, appName);
   });
 
   after(async function () {
@@ -92,96 +101,87 @@ describe('Arcane: non-enterprise app deferred as non_enterprise_on_arcane', func
     await env?.teardown();
   });
 
-  it('should defer with reason non_enterprise_on_arcane', async function () {
-    this.timeout(60000);
-    const deferred = await anyDeferralEvent(env, appName, 'non_enterprise_on_arcane');
-    expect(deferred.reason).to.equal('non_enterprise_on_arcane');
+  describe('non-enterprise app deferred as non_enterprise_on_arcane', function () {
+    const appName = `e2earcdefer${Date.now()}`;
+
+    before(async function () {
+      this.timeout(180000);
+      await registerApp(env, appName);
+    });
+
+    it('should defer with reason non_enterprise_on_arcane', async function () {
+      this.timeout(60000);
+      const deferred = await anyDeferralEvent(env, appName, 'non_enterprise_on_arcane');
+      expect(deferred.reason).to.equal('non_enterprise_on_arcane');
+    });
+
+    it('should install after deferral expires', async function () {
+      this.timeout(180000);
+      await Promise.any(
+        env.clients.map((c) => waitForAppInstalled(c, appName, 120000)),
+      );
+    });
   });
 
-  it('should install after deferral expires', async function () {
-    this.timeout(180000);
-    await Promise.any(
-      env.clients.map((c) => waitForAppInstalled(c, appName, 120000)),
-    );
-  });
-});
+  describe('enterprise app deferred for static_ip', function () {
+    const appName = `e2eentstatip${Date.now()}`;
 
-describe('Arcane: enterprise app deferred for static_ip', function () {
-  let env;
-  dumpLogsOnFailure(() => env);
-  const appName = `e2eentstatip${Date.now()}`;
+    before(async function () {
+      this.timeout(180000);
+      await registerApp(env, appName, { enterprise: true, staticip: false });
+    });
 
-  before(async function () {
-    this.timeout(300000);
-    env = await createTestEnv({ hookCtx: this, nodes: 10, tickerAutostart: false });
-    await bootAndPeer(env);
-    await registerApp(env, appName, { enterprise: true, staticip: false });
-  });
+    it('should defer with reason static_ip and enterprise delay', async function () {
+      this.timeout(60000);
+      const deferred = await anyDeferralEvent(env, appName, 'static_ip');
+      expect(deferred.reason).to.equal('static_ip');
+      expect(deferred.delayMs).to.equal(200);
+    });
 
-  after(async function () {
-    this.timeout(30000);
-    await env?.teardown();
+    it('should install after deferral expires', async function () {
+      this.timeout(180000);
+      await Promise.any(
+        env.clients.map((c) => waitForAppInstalled(c, appName, 120000)),
+      );
+    });
   });
 
-  it('should defer with reason static_ip and enterprise delay', async function () {
-    this.timeout(60000);
-    const deferred = await anyDeferralEvent(env, appName, 'static_ip');
-    expect(deferred.reason).to.equal('static_ip');
-    expect(deferred.delayMs).to.equal(200);
-  });
+  describe('enterprise app deferred for datacenter', function () {
+    const appName = `e2eentdc${Date.now()}`;
 
-  it('should install after deferral expires', async function () {
-    this.timeout(180000);
-    await Promise.any(
-      env.clients.map((c) => waitForAppInstalled(c, appName, 120000)),
-    );
-  });
-});
+    before(async function () {
+      this.timeout(180000);
+      await registerApp(env, appName, { enterprise: true, staticip: true });
+    });
 
-describe('Arcane: enterprise app deferred for datacenter', function () {
-  let env;
-  dumpLogsOnFailure(() => env);
-  const appName = `e2eentdc${Date.now()}`;
+    it('should defer with reason datacenter and enterprise delay', async function () {
+      this.timeout(60000);
+      const deferred = await anyDeferralEvent(env, appName, 'datacenter');
+      expect(deferred.reason).to.equal('datacenter');
+      expect(deferred.delayMs).to.equal(250);
+    });
 
-  before(async function () {
-    this.timeout(300000);
-    env = await createTestEnv({ hookCtx: this, nodes: 10, tickerAutostart: false });
-    await bootAndPeer(env);
-    await registerApp(env, appName, { enterprise: true, staticip: true });
-  });
-
-  after(async function () {
-    this.timeout(30000);
-    await env?.teardown();
-  });
-
-  it('should defer with reason datacenter and enterprise delay', async function () {
-    this.timeout(60000);
-    const deferred = await anyDeferralEvent(env, appName, 'datacenter');
-    expect(deferred.reason).to.equal('datacenter');
-    expect(deferred.delayMs).to.equal(250);
-  });
-
-  it('should install after deferral expires', async function () {
-    this.timeout(180000);
-    await Promise.any(
-      env.clients.map((c) => waitForAppInstalled(c, appName, 120000)),
-    );
+    it('should install after deferral expires', async function () {
+      this.timeout(180000);
+      await Promise.any(
+        env.clients.map((c) => waitForAppInstalled(c, appName, 120000)),
+      );
+    });
   });
 });
 
 // --- Legacy node tests (all nodes without FLUXOS_PATH) ---
 
-describe('Legacy: non-enterprise app deferred for static_ip', function () {
+describe('Legacy spawner deferrals', function () {
   let env;
   dumpLogsOnFailure(() => env);
-  const appName = `e2elegstatip${Date.now()}`;
 
   before(async function () {
     this.timeout(300000);
-    env = await createTestEnv({ hookCtx: this, nodes: 10, legacyNodes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], tickerAutostart: false });
+    env = await createTestEnv({
+      hookCtx: this, nodes: 10, legacyNodes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], tickerAutostart: false,
+    });
     await bootAndPeer(env);
-    await registerApp(env, appName, { staticip: false });
   });
 
   after(async function () {
@@ -189,50 +189,49 @@ describe('Legacy: non-enterprise app deferred for static_ip', function () {
     await env?.teardown();
   });
 
-  it('should defer with reason static_ip and standard delay', async function () {
-    this.timeout(60000);
-    const deferred = await anyDeferralEvent(env, appName, 'static_ip');
-    expect(deferred.reason).to.equal('static_ip');
-    expect(deferred.delayMs).to.equal(400);
+  describe('non-enterprise app deferred for static_ip', function () {
+    const appName = `e2elegstatip${Date.now()}`;
+
+    before(async function () {
+      this.timeout(180000);
+      await registerApp(env, appName, { staticip: false });
+    });
+
+    it('should defer with reason static_ip and standard delay', async function () {
+      this.timeout(60000);
+      const deferred = await anyDeferralEvent(env, appName, 'static_ip');
+      expect(deferred.reason).to.equal('static_ip');
+      expect(deferred.delayMs).to.equal(400);
+    });
+
+    it('should install after deferral expires', async function () {
+      this.timeout(180000);
+      await Promise.any(
+        env.clients.map((c) => waitForAppInstalled(c, appName, 120000)),
+      );
+    });
   });
 
-  it('should install after deferral expires', async function () {
-    this.timeout(180000);
-    await Promise.any(
-      env.clients.map((c) => waitForAppInstalled(c, appName, 120000)),
-    );
+  describe('non-enterprise app deferred for datacenter', function () {
+    const appName = `e2elegdc${Date.now()}`;
+
+    before(async function () {
+      this.timeout(180000);
+      await registerApp(env, appName, { staticip: true });
+    });
+
+    it('should defer with reason datacenter and standard delay', async function () {
+      this.timeout(60000);
+      const deferred = await anyDeferralEvent(env, appName, 'datacenter');
+      expect(deferred.reason).to.equal('datacenter');
+      expect(deferred.delayMs).to.equal(500);
+    });
+
+    it('should install after deferral expires', async function () {
+      this.timeout(180000);
+      await Promise.any(
+        env.clients.map((c) => waitForAppInstalled(c, appName, 120000)),
+      );
+    });
   });
 });
-
-describe('Legacy: non-enterprise app deferred for datacenter', function () {
-  let env;
-  dumpLogsOnFailure(() => env);
-  const appName = `e2elegdc${Date.now()}`;
-
-  before(async function () {
-    this.timeout(300000);
-    env = await createTestEnv({ hookCtx: this, nodes: 10, legacyNodes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], tickerAutostart: false });
-    await bootAndPeer(env);
-    await registerApp(env, appName, { staticip: true });
-  });
-
-  after(async function () {
-    this.timeout(30000);
-    await env?.teardown();
-  });
-
-  it('should defer with reason datacenter and standard delay', async function () {
-    this.timeout(60000);
-    const deferred = await anyDeferralEvent(env, appName, 'datacenter');
-    expect(deferred.reason).to.equal('datacenter');
-    expect(deferred.delayMs).to.equal(500);
-  });
-
-  it('should install after deferral expires', async function () {
-    this.timeout(180000);
-    await Promise.any(
-      env.clients.map((c) => waitForAppInstalled(c, appName, 120000)),
-    );
-  });
-});
-

--- a/test-infra/runner/tests/30-reconciler-exit0-restart.js
+++ b/test-infra/runner/tests/30-reconciler-exit0-restart.js
@@ -50,6 +50,17 @@ describe('reconciler restarts a cleanly-exited (exit 0) container by default', f
     const evt = await waitForReconcileActuated(client, identifier, 'started', 90000, { afterId });
     expect(evt.data.exitCode).to.equal(0); // genuinely restarted from a clean exit 0
 
+    // and it went back WITHOUT being paced. The crash ladder answers a container
+    // that cannot stay up; an operator stopping their own app is not that, and
+    // pacing it is what turns a deliberate restart into a customer-visible outage.
+    // A container whose image discards its payload's exit status still gets caught,
+    // but by the burst window rather than by this code - see suite 54.
+    const paced = client.getEventBuffer().filter((e) => e.event === 'reconciler:actuated'
+      && e.id > afterId && e.id <= evt.id
+      && e.data.identifier === identifier
+      && e.data.action === 'backoff');
+    expect(paced, 'a single clean exit carries no evidence of a fault').to.have.lengthOf(0);
+
     await waitFor(async () => {
       const status = await getAppContainerStatus(client.container, appName);
       return status && status.status.startsWith('Up');

--- a/test-infra/runner/tests/32-reconciler-operator-restart-clears-lock.js
+++ b/test-infra/runner/tests/32-reconciler-operator-restart-clears-lock.js
@@ -5,7 +5,9 @@ import { getAppContainerStatus } from '../framework/container.js';
 import { authenticate } from '../auth.js';
 import { appOwnerKey } from '../framework/keys.js';
 import { bootAndPeer, seedSimpleApp } from '../framework/reconciler-suite.js';
-import { waitForUp, waitForDown, assertNoEvent } from '../framework/wait.js';
+import {
+  waitForUp, waitForDown, assertNoEvent, waitForReconcileActuated,
+} from '../framework/wait.js';
 import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
 
 // B4 end-to-end: a user apprestart is an explicit "make it run" - it must clear
@@ -52,5 +54,35 @@ describe('apprestart clears the operator stop lock (app stays running)', functio
     await assertNoEvent(client, 'reconciler:actuated', (d) => d.identifier === identifier && d.action === 'stopped', 15000);
     const status = await getAppContainerStatus(client.container, appName);
     expect(status && status.status.startsWith('Up')).to.equal(true);
+  });
+
+  // The restart above is a start: the container was down, so "make it run" and
+  // "bounce it" are the same act and either implementation satisfies it. A
+  // restart of a container that is ALREADY running is the case the durable
+  // generation exists for, and nothing else drives it.
+  it('bounces a container that is already running', async function () {
+    this.timeout(180000);
+    const client = env.clients[idx];
+    await waitForUp(client, appName, 'running before the restart');
+
+    const auth = await authenticate(client.url, appOwnerKey());
+    // Anchored before the request: apprestart holds until the pass has run, so
+    // the actuation can already be in the buffer by the time it returns.
+    const beforeId = client.getLastEventId();
+    await client.getAuthed(`/apps/apprestart/${appName}`, auth.zelidauth);
+
+    const bounced = await waitForReconcileActuated(client, identifier, 'restarted', 120000, { afterId: beforeId });
+    expect(bounced.data.reason, 'the operator asked for it, not a heal or a crash').to.equal('operatorRequested');
+    await waitForUp(client, appName, 'running again after the bounce');
+
+    // The request is a level, and a level nothing marks as reached is a loop -
+    // every later pass would read the same request and bounce it again. Not a
+    // quiet window, which would pass just as well if no pass had run at all: the
+    // bounce emits its own die event, so a pass provably follows it, and this
+    // window contains that pass.
+    await assertNoEvent(client, 'reconciler:actuated', (d) => d.identifier === identifier && d.action === 'restarted', 30000, { afterId: bounced.id });
+
+    const status = await getAppContainerStatus(client.container, appName);
+    expect(status && status.status.startsWith('Up'), 'and it is left running').to.equal(true);
   });
 });

--- a/test-infra/runner/tests/32-reconciler-operator-stop-durable.js
+++ b/test-infra/runner/tests/32-reconciler-operator-stop-durable.js
@@ -2,7 +2,7 @@ import { describe, it, before, after } from 'mocha';
 import { expect } from 'chai';
 import { createTestEnv } from '../framework/test-env.js';
 import { authenticate } from '../auth.js';
-import { appOwnerKey } from '../framework/keys.js';
+import { appOwnerKey, nodeKey } from '../framework/keys.js';
 import { getAppContainerStatus } from '../framework/container.js';
 import {
   waitFor, waitForReconcileActuated, assertNoEvent, waitForOperatorIntent,
@@ -80,5 +80,53 @@ describe('reconciler honours a durable operator stop', function () {
     const auth2 = await authenticate(client.url, appOwnerKey());
     await client.getAuthed(`/apps/appstart/${appName}`, auth2.zelidauth);
     await waitForUp(client, appName, 'running again after appstart');
+  });
+
+  // A kill is the same desired state as a stop carrying a mode, so the mode is
+  // the only thing that distinguishes them from outside. Asserting the container
+  // stopped would pass just as well against a graceful stop.
+  it('kills on appkill, and says the stop was forced', async function () {
+    this.timeout(180000);
+    const client = env.clients[idx];
+    await waitForUp(client, appName, 'running before appkill');
+
+    const auth = await authenticate(client.url, appOwnerKey());
+    const beforeId = client.getLastEventId();
+    const res = await client.getAuthed(`/apps/appkill/${appName}`, auth.zelidauth);
+    expect(res.status, 'the endpoint exists and answers').to.equal('success');
+
+    const stopped = await waitForReconcileActuated(client, identifier, 'stopped', 120000, { afterId: beforeId });
+    expect(stopped.data.forced, 'a kill, not a graceful stop').to.equal(true);
+    await waitForDown(client, appName, 'stopped after appkill');
+
+    const auth2 = await authenticate(client.url, appOwnerKey());
+    await client.getAuthed(`/apps/appstart/${appName}`, auth2.zelidauth);
+    await waitForUp(client, appName, 'running again after appstart');
+  });
+
+  // The node operator hosts the container and keeps every ordinary lifecycle
+  // control over it. Ending someone else's app abruptly is not theirs to order.
+  // Both halves matter: a privilege check that refused everything would pass the
+  // first assertion on its own.
+  it('refuses the node operator a kill, while still allowing them a stop', async function () {
+    this.timeout(180000);
+    const client = env.clients[idx];
+    await waitForUp(client, appName, 'running before the operator acts');
+
+    const operator = await authenticate(client.url, nodeKey(idx + 1));
+
+    const killed = await client.getAuthed(`/apps/appkill/${appName}`, operator.zelidauth);
+    expect(killed.status, 'the node operator cannot order a kill').to.equal('error');
+    expect(killed.data.code).to.equal(401);
+    const stillUp = await getAppContainerStatus(client.container, appName);
+    expect(stillUp && stillUp.status.startsWith('Up'), 'and the container is untouched').to.equal(true);
+
+    const stopped = await client.getAuthed(`/apps/appstop/${appName}`, operator.zelidauth);
+    expect(stopped.status, 'but a stop is still theirs to order').to.equal('success');
+    await waitForDown(client, appName, 'stopped by the node operator');
+
+    const auth = await authenticate(client.url, appOwnerKey());
+    await client.getAuthed(`/apps/appstart/${appName}`, auth.zelidauth);
+    await waitForUp(client, appName, 'running again for the suites that follow');
   });
 });

--- a/test-infra/runner/tests/32-reconciler-operator-stop-durable.js
+++ b/test-infra/runner/tests/32-reconciler-operator-stop-durable.js
@@ -4,7 +4,9 @@ import { createTestEnv } from '../framework/test-env.js';
 import { authenticate } from '../auth.js';
 import { appOwnerKey } from '../framework/keys.js';
 import { getAppContainerStatus } from '../framework/container.js';
-import { waitFor, waitForReconcileActuated, assertNoEvent } from '../framework/wait.js';
+import {
+  waitFor, waitForReconcileActuated, assertNoEvent, waitForOperatorIntent,
+} from '../framework/wait.js';
 import { bootAndPeer, seedSimpleApp } from '../framework/reconciler-suite.js';
 import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
 
@@ -55,11 +57,15 @@ describe('reconciler honours a durable operator stop', function () {
     const auth = await authenticate(client.url, appOwnerKey());
     const stopRes = await client.getAuthed(`/apps/appstop/${appName}`, auth.zelidauth);
     expect(stopRes.status).to.equal('success');
+    // Anchored on the intent, not on the container settling: a pass that read the
+    // lock before this landed and acted after it does so while waitForDown is
+    // still running, which is in front of an anchor taken below it.
+    const intent = await waitForOperatorIntent(client, identifier, true);
     await waitForDown(client, appName, 'stopped after appstop');
 
     // the die event from the stop triggers a reconcile; operatorStopped must win,
     // so it is never restarted.
-    await assertNoEvent(client, 'reconciler:actuated', (d) => d.identifier === identifier && d.action === 'started', 8000);
+    await assertNoEvent(client, 'reconciler:actuated', (d) => d.identifier === identifier && d.action === 'started', 8000, { afterId: intent.id });
 
     // durable across a FluxOS restart: the boot reconcile re-enqueues every
     // component, but operatorStopped (mongo) keeps this one stopped.

--- a/test-infra/runner/tests/35-reconciler-masterslave-election.js
+++ b/test-infra/runner/tests/35-reconciler-masterslave-election.js
@@ -172,10 +172,14 @@ describe('reconciler enforces masterSlave g: election', function () {
 
     const body = await backupDone;
     expect(body).to.not.match(/Unauthorized/i);
-    // What the app does AFTER the hold is released is not this test's property
-    // and not this branch's behaviour: the backup's own stop earns a rung on the
-    // restart ladder here, so the elected primary is paced back up over minutes.
-    // The convergence assertion lives with the change that makes a deliberate
-    // stop earn nothing.
+
+    // The hold is released, and the elected primary converges back to running
+    // without serving a backoff rung first. This is the end-to-end reading of
+    // "a rung is earned by evidence of a fault": the suite has started and
+    // stopped this app repeatedly by now, and the backup stopped it once more,
+    // none of which is a fault. Counting those would put it on the five-minute
+    // rung, so a window of two minutes is what tells the two apart - the app is
+    // either back within a cycle or it is being paced.
+    await waitFor(() => isUp(a, appName), { timeout: 120000, interval: 3000, label: 'app running again after the backup released' });
   });
 });

--- a/test-infra/runner/tests/35-reconciler-masterslave-election.js
+++ b/test-infra/runner/tests/35-reconciler-masterslave-election.js
@@ -180,6 +180,13 @@ describe('reconciler enforces masterSlave g: election', function () {
     // none of which is a fault. Counting those would put it on the five-minute
     // rung, so a window of two minutes is what tells the two apart - the app is
     // either back within a cycle or it is being paced.
+    //
+    // Proven here for an image that shuts down cleanly, which is the scope of the
+    // rule today: the test app traps SIGTERM and exits 0 (test-app.c), so the
+    // backup's stop leaves no failure code behind. An image that does NOT trap it
+    // exits 143 and IS paced for the same stop - the exit code cannot tell a drain
+    // from a fault, and teaching the ladder to needs desired state rather than the
+    // corpse. This suite would not notice that, and is not the place to.
     await waitFor(() => isUp(a, appName), { timeout: 120000, interval: 3000, label: 'app running again after the backup released' });
   });
 });

--- a/test-infra/runner/tests/45-reconciler-stop-during-stream-outage.js
+++ b/test-infra/runner/tests/45-reconciler-stop-during-stream-outage.js
@@ -5,7 +5,9 @@ import { getAppContainerStatus, restartDockerd } from '../framework/container.js
 import { authenticate } from '../auth.js';
 import { appOwnerKey } from '../framework/keys.js';
 import { bootAndPeer, seedSimpleApp } from '../framework/reconciler-suite.js';
-import { waitForUp, waitForDown, assertNoEvent } from '../framework/wait.js';
+import {
+  waitForUp, waitForDown, assertNoEvent, waitForOperatorIntent,
+} from '../framework/wait.js';
 import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
 
 // B6 end-to-end: a deliberate stop whose die event is LOST (docker event stream
@@ -50,12 +52,17 @@ describe('deliberate stop during an event-stream outage neither wedges nor flaps
     const auth = await authenticate(client.url, appOwnerKey());
     const stopRes = await client.getAuthed(`/apps/appstop/${appName}`, auth.zelidauth);
     expect(stopRes.status).to.equal('success');
+    // The interleaving this suite exists to catch puts the wrong start BEFORE the
+    // container goes down, so an assertion anchored after waitForDown has already
+    // stepped past it. Anchor on the intent instead - the id survives the stream
+    // outage, which a wall-clock or a last-seen-id anchor taken here would not.
+    const intent = await waitForOperatorIntent(client, identifier, true);
     await waitForDown(client, appName, 'stopped during the stream outage');
 
     // the lost die event must cost nothing: no restart against the operator
     // lock (reconnect sweep + boot-style reconciles all see operatorStopped),
     // and no flapping start/stop loop
-    await assertNoEvent(client, 'reconciler:actuated', (d) => d.identifier === identifier && d.action === 'started', 20000);
+    await assertNoEvent(client, 'reconciler:actuated', (d) => d.identifier === identifier && d.action === 'started', 20000, { afterId: intent.id });
     const status = await getAppContainerStatus(client.container, appName, { all: true });
     expect(status && status.status.startsWith('Up')).to.not.equal(true);
 

--- a/test-infra/runner/tests/52-masterslave-operator-stop-recovery.js
+++ b/test-infra/runner/tests/52-masterslave-operator-stop-recovery.js
@@ -102,6 +102,38 @@ describe('masterSlave recovery after an operator stop', function () {
     await env?.teardown();
   });
 
+  // appstart used to probe docker for "is this container running" and refuse the
+  // start when it was not, reporting the app as skipped. On a masterSlave app
+  // that answers a different question from the one asked: the election decides
+  // which node may run it, and a node that is not the writer is not a node that
+  // failed to start. It clears the lock and reports what the reconciler will do.
+  //
+  // Runs before anything here stops an instance, so a non-running holder is one
+  // the ELECTION is holding - after that, it could be one an operator stopped,
+  // which is a different answer and would pass for the wrong reason.
+  it('reports the election, not a start, for an instance it is not electing', async function () {
+    this.timeout(90000);
+    const flags = await runningFlags();
+    expect(flags.filter(Boolean), 'exactly one holder runs it, or the election has not settled').to.have.lengthOf(1);
+    const standby = holders[flags.indexOf(false)];
+    expect(standby, 'and at least one holder is being held, or this proves nothing').to.not.equal(undefined);
+    const client = env.clients[standby];
+
+    const auth = await authenticate(client.url, appOwnerKey());
+    const res = await client.getAuthed(`/apps/appstart/${appName}`, auth.zelidauth);
+
+    expect(res.status).to.equal('success');
+    expect(res.data, 'a node the election is holding must never be told its app started')
+      .to.not.equal(`Application ${appName} started`);
+    expect(res.data, 'and the operator is told which of the two it is').to.match(
+      new RegExp(`^Application ${appName} will be started: .*election`),
+    );
+
+    // The lock is lifted either way - the veto was the operator's, the run
+    // decision is the election's - so it starts the moment it is elected.
+    expect(await isUp(client, appName), 'and it did not start it anyway').to.equal(false);
+  });
+
   it('keeps an operator-stopped instance down instead of re-electing it', async function () {
     this.timeout(75000);
     const flags = await runningFlags();

--- a/test-infra/runner/tests/54-reconciler-burst-ceiling.js
+++ b/test-infra/runner/tests/54-reconciler-burst-ceiling.js
@@ -1,0 +1,83 @@
+import { describe, it, before, after } from 'mocha';
+import { expect } from 'chai';
+import { createTestEnv } from '../framework/test-env.js';
+import { waitForReconcileActuated } from '../framework/wait.js';
+import { bootAndPeer, seedTestApp } from '../framework/reconciler-suite.js';
+import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
+
+// The crash ladder is driven by evidence of a fault, and Docker's exit code cannot
+// supply it in one direction: an image whose entrypoint is a wrapper script ending
+// in `exit 0` reports a clean stop for a segfault, and no init we wrap around the
+// container can recover a status the image already discarded. Palworld's official
+// image does exactly this - its start.sh ends `exit 0` unconditionally, so a
+// SIGSEGV and an operator's own shutdown are the same number to us.
+//
+// So a clean exit is never paced on the code alone, and the burst window is what
+// catches the containers whose code lied. This suite drives that shape for real:
+// EXIT_CODE=0 with EXIT_AFTER_S makes a container that dies on its own, fast, and
+// reports success every time - the only defence against it is the ceiling.
+//
+// The unit tests cover the arithmetic against a stubbed Docker. What only a real
+// fleet proves is that a genuine exit-0 container loops the reconciler at all, and
+// that the ceiling closes it.
+
+describe('reconciler ceiling paces a container that restarts too fast to be healthy', function () {
+  let env;
+  dumpLogsOnFailure(() => env);
+  let idx; let identifier;
+  const appName = `e2eburst${Date.now()}`;
+
+  before(async function () {
+    this.timeout(600000);
+    // This exercises one node's own reconciler against its own container, so the
+    // fleet exists to make that node a real one rather than to be peered with.
+    // Three is the floor: the discovery mesh is a ring needing 2*minOutgoing+1
+    // nodes to close, so three can only carry minOutgoing 1, and the app-submission
+    // door checks the inbound count too.
+    env = await createTestEnv({
+      hookCtx: this,
+      nodes: 3,
+      tickerAutostart: false,
+      configOverrides: {
+        fluxapps: { minOutgoing: 1, minIncoming: 1 },
+      },
+    });
+    await bootAndPeer(env, { minOutbound: 1, minInbound: 1 });
+    // exits 0 on its own after 2s: a fault the exit code hides, restarting far
+    // faster than the burst window
+    ({ index: idx, identifier } = await seedTestApp(env, { name: appName, exitCode: 0, exitAfterS: 2 }));
+  });
+
+  after(async function () {
+    this.timeout(30000);
+    await env?.teardown();
+  });
+
+  it('restarts a clean exit unpaced until the burst window fills, then enters the ladder', async function () {
+    this.timeout(240000);
+    const client = env.clients[idx];
+
+    // The count is config.fluxapps.restartBurstCount (5) inside the window; asserting
+    // the mechanism rather than the constant keeps this from breaking on a retune.
+    const backoff = await waitForReconcileActuated(client, identifier, 'backoff', 180000);
+    expect(backoff.data.crashed, 'the exit code said success - only the burst rate gave it away').to.equal(false);
+    expect(backoff.data.waitMs, 'the trip disposes into the crash ladder, not a terminal state').to.be.greaterThan(0);
+
+    // everything the reconciler did to this component before it first paced it
+    const priorStarts = client.getEventBuffer().filter((e) => e.event === 'reconciler:actuated'
+      && e.id < backoff.id
+      && e.data.identifier === identifier
+      && e.data.action === 'started');
+    const priorBackoffs = client.getEventBuffer().filter((e) => e.event === 'reconciler:actuated'
+      && e.id < backoff.id
+      && e.data.identifier === identifier
+      && e.data.action === 'backoff');
+
+    // the install's own first start reports exitCode null (a container that has
+    // never run is not a death), so count the restarts that followed a clean exit
+    const afterCleanExit = priorStarts.filter((e) => e.data.exitCode === 0);
+
+    expect(priorBackoffs, 'a clean exit must not be paced before the window fills').to.have.lengthOf(0);
+    expect(afterCleanExit.length, 'several clean exits went back immediately first').to.be.greaterThan(1);
+  });
+});

--- a/test-infra/runner/tests/54-reconciler-burst-ceiling.js
+++ b/test-infra/runner/tests/54-reconciler-burst-ceiling.js
@@ -21,6 +21,19 @@ import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
 // fleet proves is that a genuine exit-0 container loops the reconciler at all, and
 // that the ceiling closes it.
 
+// Compressed ladder: immediate, then 5s, 10s, 30s, 60s.
+const LADDER_MS = [0, 5000, 10000, 30000, 60000];
+// A run this long clears the ladder. Shorter than the 30s rung on purpose - that
+// is the whole shape of the defect this suite reaches.
+const STABLE_RUN_MS = 20000;
+// Five 2s lifetimes fit inside it, so the ceiling can fill.
+const BURST_WINDOW_MS = 60000;
+
+// The relationship, asserted rather than assumed. Production ships 15m against
+// 10m; if a retune here ever left every rung shorter than the window, the test
+// below would pass while never reaching the branch it targets.
+const DEEP_RUNG_MS = LADDER_MS.find((ms) => ms > STABLE_RUN_MS);
+
 describe('reconciler ceiling paces a container that restarts too fast to be healthy', function () {
   let env;
   dumpLogsOnFailure(() => env);
@@ -34,12 +47,29 @@ describe('reconciler ceiling paces a container that restarts too fast to be heal
     // Three is the floor: the discovery mesh is a ring needing 2*minOutgoing+1
     // nodes to close, so three can only carry minOutgoing 1, and the app-submission
     // door checks the inbound count too.
+    // The ladder and the stable-run window are compressed together, because what
+    // this suite needs is not small numbers but a preserved RELATIONSHIP: a rung
+    // longer than the window that clears the ladder. Production has that at 15m
+    // against 10m; here it is 30s against 20s. Compress one without the other and
+    // no rung outlasts the window, the clearing branch is never reached, and the
+    // suite goes green having stopped testing the thing it exists for.
+    //
+    // Floors, not preferences: the app runs 2s before exiting, and the harness
+    // does not compress a container's own runtime - so a rung near 2s would be
+    // swamped by it. The burst window has to outlast five of those lifetimes
+    // (~10s) or the ceiling can never fill.
     env = await createTestEnv({
       hookCtx: this,
       nodes: 3,
       tickerAutostart: false,
       configOverrides: {
-        fluxapps: { minOutgoing: 1, minIncoming: 1 },
+        fluxapps: {
+          minOutgoing: 1,
+          minIncoming: 1,
+          crashBackoffDelaysMs: LADDER_MS,
+          crashBackoffStableRunMs: STABLE_RUN_MS,
+          restartBurstWindowMs: BURST_WINDOW_MS,
+        },
       },
     });
     await bootAndPeer(env, { minOutbound: 1, minInbound: 1 });
@@ -79,5 +109,60 @@ describe('reconciler ceiling paces a container that restarts too fast to be heal
 
     expect(priorBackoffs, 'a clean exit must not be paced before the window fills').to.have.lengthOf(0);
     expect(afterCleanExit.length, 'several clean exits went back immediately first').to.be.greaterThan(1);
+  });
+
+  // The rung that outlasts the stable-run window is where the ladder used to
+  // clear itself. restartWaitMs measures how long the component ran from its last
+  // rung, and a component only earned one when its exit reported a fault or the
+  // burst window was full - the window empties while it sits out a wait, so the
+  // gap being measured was the wait itself. Fifteen minutes stopped read as
+  // fifteen minutes running, the ladder cleared, and the climb restarted at the
+  // bottom, forever, never reaching the cap.
+  //
+  // The unit tests pin the arithmetic. What only a fleet shows is a real
+  // container serving a real wait and the ladder still standing afterwards.
+  it('does not clear the ladder on the wait it just served', async function () {
+    this.timeout(300000);
+    const client = env.clients[idx];
+
+    expect(DEEP_RUNG_MS, 'no rung outlasts the stable-run window, so nothing below reaches the branch').to.not.equal(undefined);
+
+    // Anchored here: the suite's first test leaves a climb already in the buffer,
+    // and an unanchored search reads whichever rung it happens to land on.
+    const fromId = client.getLastEventId();
+
+    // Climb until a wait longer than a stable run is handed out. waitMs is what
+    // REMAINS of the rung, not the rung - the reconciler re-enqueues during a
+    // wait, so one rung reports several times, each smaller than the last.
+    // Matching at-or-above the rung length finds its first report.
+    const deep = await client.waitForEvent(
+      'reconciler:actuated',
+      (d) => d.identifier === identifier && d.action === 'backoff' && d.waitMs >= DEEP_RUNG_MS,
+      240000,
+      { afterId: fromId },
+    );
+    expect(deep.data.crashed, 'still a clean exit - the ceiling is what put it here').to.equal(false);
+
+    // Serve the rung out: the container comes back, dies again, and the pass that
+    // follows either holds its place on the ladder or starts over.
+    await client.waitForEvent(
+      'reconciler:actuated',
+      (d) => d.identifier === identifier && d.action === 'started',
+      DEEP_RUNG_MS + 60000,
+      { afterId: deep.id },
+    );
+
+    const next = await client.waitForEvent(
+      'reconciler:actuated',
+      (d) => d.identifier === identifier && d.action === 'backoff',
+      DEEP_RUNG_MS + 60000,
+      { afterId: deep.id },
+    );
+
+    // The rung, not the remaining wait. A ladder cleared by the wait it just
+    // served comes back at rung 1, having read the time the component spent
+    // stopped as time it spent running.
+    expect(next.data.rung, 'the wait it served is not evidence that it ran')
+      .to.be.at.least(deep.data.rung);
   });
 });

--- a/test-infra/runner/tests/56-address-change-restarts-apps.js
+++ b/test-infra/runner/tests/56-address-change-restarts-apps.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { createTestEnv } from '../framework/test-env.js';
 import { pushImage } from '../framework/registry-helper.js';
 import { buildSeedableApp } from '../framework/seed-helper.js';
-import { getAppContainerStatus, blockPeerAccess, unblockPeerAccess } from '../framework/container.js';
+import { getAppContainerStatus, moveNodeAddress } from '../framework/container.js';
 import { setNodeAddress, clearNodeAddress } from '../framework/daemon-control.js';
 import { REGISTRY_REPO_HOST, getSubnetConfig } from '../framework/subnet-config.js';
 import { waitFor, waitForReconcileActuated } from '../framework/wait.js';
@@ -27,10 +27,21 @@ const subnet = getSubnetConfig();
 // Moving them together instead describes a change already settled everywhere, which
 // no node ever has to detect.
 //
-// And the node stops answering its PEERS at the old address (blockPeerAccess), which
-// is what an address change looks like from the outside. That is what the path
-// requires: a node only asks benchmark whether its address moved after a peer has
-// failed to reach it, so a node that is still perfectly reachable never asks.
+// And the node actually moves (moveNodeAddress): the new address goes on its
+// interface and the old one comes off. Its peers then find it unreachable at the
+// old address because it genuinely is not there, which is what the path requires -
+// a node only asks benchmark whether its address moved after a peer has failed to
+// reach it, so a node that is still perfectly reachable never asks.
+//
+// Moving it for real rather than simulating unreachability is what lets both
+// assertions hold at once. The node list is untouched, so peers still recognise it
+// as the sender of the fluxipchanged broadcast below - hiding it from their lists
+// would make them answer "unreachable" just as reliably and then reject that
+// broadcast as coming from a stranger.
+//
+// The client follows it (followTo). The harness otherwise reaches a node at a fixed
+// address, so a node that really moves goes blind to its own client and the suite
+// fails because the observer was left behind rather than because anything broke.
 //
 // Leaving the list alone matters twice over. It is what lets the node pass its own
 // confirmed-list check and run the availability check at all - and it is what lets
@@ -39,8 +50,6 @@ const subnet = getSubnetConfig();
 //
 // Three nodes, not ten: one node runs the app and the others are there to be
 // peers. No election is involved, so there is no quorum to satisfy.
-
-const API_PORT = 16127;
 
 const COMPONENT_A = 'alpha';
 const COMPONENT_B = 'beta';
@@ -59,7 +68,6 @@ describe('a node whose address changed restarts the apps that stay', function ()
   let baseline;
   let peerIdx;
   let peerBaseline;
-  let peerIps = [];
   const appName = `e2eipchg${Date.now()}`;
   const idA = `${COMPONENT_A}_${appName}`;
   const idB = `${COMPONENT_B}_${appName}`;
@@ -107,25 +115,21 @@ describe('a node whose address changed restarts the apps that stay', function ()
       label: 'both components running before the address moves',
     });
 
-    // Taken before the move, so a restart that had already happened cannot be read
-    // as this one's.
-    baseline = client.getLastEventId();
     peerIdx = (idx + 1) % env.clients.length;
     peerBaseline = env.clients[peerIdx].getLastEventId();
 
-    peerIps = env.clients.map((_, i) => subnet.nodeIp(i + 1)).filter((_, i) => i !== idx);
-    // Unreachable to its peers first, then the probe moves. In that order the node
-    // cannot conclude it is fine before it has anything to compare.
-    await blockPeerAccess(client.container, peerIps, API_PORT);
+    // The node moves first, then the probe reports it. In that order the node cannot
+    // conclude it is fine before it has anything to compare.
+    await moveNodeAddress(client.container, movedIp, nodeIp);
+    // Follow it, or every assertion below is made against an address nothing answers
+    // on. The reconnect resets the buffer, so the baseline is taken from here.
+    baseline = await client.followTo(movedIp);
     await setNodeAddress(nodeIp, movedIp, { scope: 'publicip' });
   });
 
   after(async function () {
     this.timeout(60000);
     await clearNodeAddress(nodeIp).catch(() => {});
-    if (peerIps.length) {
-      await unblockPeerAccess(env.clients[idx].container, peerIps, API_PORT).catch(() => {});
-    }
     await env?.teardown();
   });
 

--- a/test-infra/runner/tests/56-address-change-restarts-apps.js
+++ b/test-infra/runner/tests/56-address-change-restarts-apps.js
@@ -3,10 +3,8 @@ import { expect } from 'chai';
 import { createTestEnv } from '../framework/test-env.js';
 import { pushImage } from '../framework/registry-helper.js';
 import { buildSeedableApp } from '../framework/seed-helper.js';
-import { getAppContainerStatus } from '../framework/container.js';
-import {
-  reportPublicIp, clearReportedPublicIp, getJournal, clearJournal,
-} from '../framework/daemon-control.js';
+import { getAppContainerStatus, blockPeerAccess, unblockPeerAccess } from '../framework/container.js';
+import { setNodeAddress, clearNodeAddress } from '../framework/daemon-control.js';
 import { REGISTRY_REPO_HOST, getSubnetConfig } from '../framework/subnet-config.js';
 import { waitFor, waitForReconcileActuated } from '../framework/wait.js';
 import { bootAndPeer, seedAndInstall } from '../framework/reconciler-suite.js';
@@ -14,20 +12,35 @@ import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
 
 const subnet = getSubnetConfig();
 
-// When a node's public address moves, every app that stays has to come up on the
-// new one. The app here is COMPOSED, and that is the whole fixture: a composed app
-// has no container under its bare app name - its containers are
-// `<component>_<app>` - so anything restarting it by that name resolves nothing.
-// Both components must come back, which is only true if the restart is asked for
-// per component.
+// When a node's address moves, every app that stays has to come up on the new one.
+// The app here is COMPOSED, and that is the whole fixture: a composed app has no
+// container under its bare app name - its containers are `<component>_<app>` - so
+// anything restarting it by that name resolves nothing. Both components must come
+// back, which is only true if the restart is asked for per component.
 //
-// The address moves by changing what benchmark ANSWERS, not by renumbering the
-// container: adjustExternalIP compares getpublicip against userconfig, so the node
-// detects the change with its network untouched and every peer still reachable.
+// The fixture reproduces the state a node is actually in when its address moves,
+// which is the only state in which it can notice.
 //
-// Asserted on the reconciler's own actuations, because that is the property -
-// the address change hands the surviving apps over as durable restart requests
-// and the reconciler is what carries them out.
+// Benchmark's public-IP probe reads the NEW address while everything else - its own
+// reported address, its status, its entry in the deterministic list - still says the
+// old one (`scope: 'publicip'`). Those two answers disagreeing IS the detection.
+// Moving them together instead describes a change already settled everywhere, which
+// no node ever has to detect.
+//
+// And the node stops answering its PEERS at the old address (blockPeerAccess), which
+// is what an address change looks like from the outside. That is what the path
+// requires: a node only asks benchmark whether its address moved after a peer has
+// failed to reach it, so a node that is still perfectly reachable never asks.
+//
+// Leaving the list alone matters twice over. It is what lets the node pass its own
+// confirmed-list check and run the availability check at all - and it is what lets
+// its peers ACCEPT the fluxipchanged broadcast afterwards, since they resolve the
+// sender by the OLD address the message carries.
+//
+// Three nodes, not ten: one node runs the app and the others are there to be
+// peers. No election is involved, so there is no quorum to satisfy.
+
+const API_PORT = 16127;
 
 const COMPONENT_A = 'alpha';
 const COMPONENT_B = 'beta';
@@ -43,14 +56,23 @@ describe('a node whose address changed restarts the apps that stay', function ()
   let idx;
   let nodeIp;
   let movedIp;
+  let baseline;
+  let peerIdx;
+  let peerBaseline;
+  let peerIps = [];
   const appName = `e2eipchg${Date.now()}`;
   const idA = `${COMPONENT_A}_${appName}`;
   const idB = `${COMPONENT_B}_${appName}`;
 
   before(async function () {
     this.timeout(360000);
-    env = await createTestEnv({ hookCtx: this, nodes: 10, tickerAutostart: false });
-    await bootAndPeer(env);
+    env = await createTestEnv({
+      hookCtx: this,
+      nodes: 3,
+      tickerAutostart: false,
+      configOverrides: { fluxapps: { minOutgoing: 1, minIncoming: 1 } },
+    });
+    await bootAndPeer(env, { minOutbound: 1, minInbound: 1 });
 
     await pushImage(appName, 'v1');
     const component = (name, port) => ({
@@ -74,40 +96,57 @@ describe('a node whose address changed restarts the apps that stay', function ()
     });
     idx = await seedAndInstall(env, app);
     nodeIp = subnet.nodeIp(idx + 1);
-    // Inside the fleet's own subnet, so it is an address the node has no reason to
-    // reject as malformed, and one no other node in the run occupies.
+    // Inside the fleet's own /24, so the node can hold it on the same interface and
+    // its peers can route to it; high enough that no node in the run occupies it.
     movedIp = nodeIp.replace(/\.\d+$/, '.240');
-  });
 
-  after(async function () {
-    this.timeout(60000);
-    await clearReportedPublicIp(nodeIp).catch(() => {});
-    await env?.teardown();
-  });
-
-  it('restarts every component of a composed app, not just the first', async function () {
-    // The collision check that reads the address runs on a 60s cycle, and each
-    // component's restart queues behind the reconciler's own pacing.
-    this.timeout(300000);
     const client = env.clients[idx];
-
     await waitFor(async () => (await isUp(client, idA)) && (await isUp(client, idB)), {
       timeout: 120000,
       interval: 3000,
       label: 'both components running before the address moves',
     });
 
-    // Baselines taken before the change, so a restart that had already happened
-    // cannot be read as this one's.
-    const after = client.getLastEventId();
-    await clearJournal();
+    // Taken before the move, so a restart that had already happened cannot be read
+    // as this one's.
+    baseline = client.getLastEventId();
+    peerIdx = (idx + 1) % env.clients.length;
+    peerBaseline = env.clients[peerIdx].getLastEventId();
 
-    await reportPublicIp(nodeIp, movedIp);
+    peerIps = env.clients.map((_, i) => subnet.nodeIp(i + 1)).filter((_, i) => i !== idx);
+    // Unreachable to its peers first, then the probe moves. In that order the node
+    // cannot conclude it is fine before it has anything to compare.
+    await blockPeerAccess(client.container, peerIps, API_PORT);
+    await setNodeAddress(nodeIp, movedIp, { scope: 'publicip' });
+  });
+
+  after(async function () {
+    this.timeout(60000);
+    await clearNodeAddress(nodeIp).catch(() => {});
+    if (peerIps.length) {
+      await unblockPeerAccess(env.clients[idx].container, peerIps, API_PORT).catch(() => {});
+    }
+    await env?.teardown();
+  });
+
+  it('restarts every component of a composed app, not just the first', async function () {
+    // Detection is not immediate and cannot be hurried: a node only asks benchmark
+    // about its address after a peer has failed to reach it, and it takes several
+    // availability cycles - the collision check re-arms on a 60s timer - to get
+    // there. Measured at ~4 minutes from the block to the broadcast, so this covers
+    // that plus the reconciler actuating the restarts it queued, which follows.
+    //
+    // This is the LATER of the two events the suite waits on: the handler records
+    // the restart intents, broadcasts, and only then does the reconciler act. Test
+    // two's marker has already arrived by the time this one does, and is served from
+    // the event buffer rather than waited for.
+    this.timeout(480000);
+    const client = env.clients[idx];
 
     // Both, each on its own identifier. Asserting only component A would pass on a
     // node that never reached component B, which is precisely the failure here.
-    await waitForReconcileActuated(client, idA, 'restarted', 180000, { afterId: after });
-    await waitForReconcileActuated(client, idB, 'restarted', 180000, { afterId: after });
+    await waitForReconcileActuated(client, idA, 'restarted', 360000, { afterId: baseline });
+    await waitForReconcileActuated(client, idB, 'restarted', 360000, { afterId: baseline });
 
     await waitFor(async () => (await isUp(client, idA)) && (await isUp(client, idB)), {
       timeout: 120000,
@@ -116,19 +155,30 @@ describe('a node whose address changed restarts the apps that stay', function ()
     });
   });
 
-  it('carries on past the apps to the work that follows them', async function () {
-    // The apps are not the end of the handler: a confirmation transaction is sent
-    // AFTER the loop that deals with them. An app-handling failure that escaped
-    // the loop would take that with it, so the transaction arriving is what proves
-    // the handler ran to the end rather than stopping at the first composed app.
+  it('tells the rest of the fleet, which is work that follows the app loop', async function () {
+    // The apps are not the end of the handler: the fluxipchanged broadcast is sent
+    // AFTER the loop that deals with them. An app-handling failure that escaped the
+    // loop would take that with it, so a PEER seeing the change is what distinguishes
+    // a handler that ran to the end from one that stopped at the first composed app.
+    //
+    // Asserted on a peer rather than on the mover, and on this message rather than on
+    // the confirmation transaction that follows it: adjustExternalIP is the only
+    // sender of fluxipchanged, whereas createConfirmationTransaction is also sent by
+    // the collateral-takeover path in checkDeterministicNodesCollisions - so that RPC
+    // arriving would not have told us which handler ran.
     this.timeout(120000);
-    const client = env.clients[idx];
+    const peer = env.clients[peerIdx];
 
-    await waitFor(async () => {
-      const journal = await getJournal({ method: 'createconfirmationtransaction', sourceIp: nodeIp });
-      return journal.total > 0;
-    }, { timeout: 90000, interval: 3000, label: 'the confirmation transaction that follows the app loop' });
+    // The addresses are carried as ip:port, so compare the address alone rather
+    // than by prefix - .10 is a prefix of .100.
+    const seen = await peer.waitForEvent(
+      'network:ipchanged',
+      (d) => d.oldIP?.split(':')[0] === nodeIp && d.newIP?.split(':')[0] === movedIp,
+      90000,
+      { afterId: peerBaseline },
+    );
 
-    expect(await isUp(client, idA), 'and the app is still running').to.equal(true);
+    expect(seen.data.newIP.split(':')[0], 'the peer was told the new address').to.equal(movedIp);
+    expect(await isUp(env.clients[idx], idA), 'and the app is still running').to.equal(true);
   });
 });

--- a/test-infra/runner/tests/56-address-change-restarts-apps.js
+++ b/test-infra/runner/tests/56-address-change-restarts-apps.js
@@ -1,0 +1,134 @@
+import { describe, it, before, after } from 'mocha';
+import { expect } from 'chai';
+import { createTestEnv } from '../framework/test-env.js';
+import { pushImage } from '../framework/registry-helper.js';
+import { buildSeedableApp } from '../framework/seed-helper.js';
+import { getAppContainerStatus } from '../framework/container.js';
+import {
+  reportPublicIp, clearReportedPublicIp, getJournal, clearJournal,
+} from '../framework/daemon-control.js';
+import { REGISTRY_REPO_HOST, getSubnetConfig } from '../framework/subnet-config.js';
+import { waitFor, waitForReconcileActuated } from '../framework/wait.js';
+import { bootAndPeer, seedAndInstall } from '../framework/reconciler-suite.js';
+import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
+
+const subnet = getSubnetConfig();
+
+// When a node's public address moves, every app that stays has to come up on the
+// new one. The app here is COMPOSED, and that is the whole fixture: a composed app
+// has no container under its bare app name - its containers are
+// `<component>_<app>` - so anything restarting it by that name resolves nothing.
+// Both components must come back, which is only true if the restart is asked for
+// per component.
+//
+// The address moves by changing what benchmark ANSWERS, not by renumbering the
+// container: adjustExternalIP compares getpublicip against userconfig, so the node
+// detects the change with its network untouched and every peer still reachable.
+//
+// Asserted on the reconciler's own actuations, because that is the property -
+// the address change hands the surviving apps over as durable restart requests
+// and the reconciler is what carries them out.
+
+const COMPONENT_A = 'alpha';
+const COMPONENT_B = 'beta';
+
+async function isUp(client, identifier) {
+  const status = await getAppContainerStatus(client.container, identifier);
+  return Boolean(status && status.status.startsWith('Up'));
+}
+
+describe('a node whose address changed restarts the apps that stay', function () {
+  let env;
+  dumpLogsOnFailure(() => env);
+  let idx;
+  let nodeIp;
+  let movedIp;
+  const appName = `e2eipchg${Date.now()}`;
+  const idA = `${COMPONENT_A}_${appName}`;
+  const idB = `${COMPONENT_B}_${appName}`;
+
+  before(async function () {
+    this.timeout(360000);
+    env = await createTestEnv({ hookCtx: this, nodes: 10, tickerAutostart: false });
+    await bootAndPeer(env);
+
+    await pushImage(appName, 'v1');
+    const component = (name, port) => ({
+      name,
+      description: 'address-change component',
+      repotag: `${REGISTRY_REPO_HOST}/${appName}:v1`,
+      ports: [port],
+      domains: [''],
+      environmentParameters: [],
+      commands: [],
+      containerPorts: [80],
+      containerData: '/tmp',
+      cpu: 0.1,
+      ram: 100,
+      hdd: 1,
+      repoauth: '',
+    });
+    const app = await buildSeedableApp({
+      name: appName,
+      compose: [component(COMPONENT_A, 31801), component(COMPONENT_B, 31802)],
+    });
+    idx = await seedAndInstall(env, app);
+    nodeIp = subnet.nodeIp(idx + 1);
+    // Inside the fleet's own subnet, so it is an address the node has no reason to
+    // reject as malformed, and one no other node in the run occupies.
+    movedIp = nodeIp.replace(/\.\d+$/, '.240');
+  });
+
+  after(async function () {
+    this.timeout(60000);
+    await clearReportedPublicIp(nodeIp).catch(() => {});
+    await env?.teardown();
+  });
+
+  it('restarts every component of a composed app, not just the first', async function () {
+    // The collision check that reads the address runs on a 60s cycle, and each
+    // component's restart queues behind the reconciler's own pacing.
+    this.timeout(300000);
+    const client = env.clients[idx];
+
+    await waitFor(async () => (await isUp(client, idA)) && (await isUp(client, idB)), {
+      timeout: 120000,
+      interval: 3000,
+      label: 'both components running before the address moves',
+    });
+
+    // Baselines taken before the change, so a restart that had already happened
+    // cannot be read as this one's.
+    const after = client.getLastEventId();
+    await clearJournal();
+
+    await reportPublicIp(nodeIp, movedIp);
+
+    // Both, each on its own identifier. Asserting only component A would pass on a
+    // node that never reached component B, which is precisely the failure here.
+    await waitForReconcileActuated(client, idA, 'restarted', 180000, { afterId: after });
+    await waitForReconcileActuated(client, idB, 'restarted', 180000, { afterId: after });
+
+    await waitFor(async () => (await isUp(client, idA)) && (await isUp(client, idB)), {
+      timeout: 120000,
+      interval: 3000,
+      label: 'both components running again after the address moved',
+    });
+  });
+
+  it('carries on past the apps to the work that follows them', async function () {
+    // The apps are not the end of the handler: a confirmation transaction is sent
+    // AFTER the loop that deals with them. An app-handling failure that escaped
+    // the loop would take that with it, so the transaction arriving is what proves
+    // the handler ran to the end rather than stopping at the first composed app.
+    this.timeout(120000);
+    const client = env.clients[idx];
+
+    await waitFor(async () => {
+      const journal = await getJournal({ method: 'createconfirmationtransaction', sourceIp: nodeIp });
+      return journal.total > 0;
+    }, { timeout: 90000, interval: 3000, label: 'the confirmation transaction that follows the app loop' });
+
+    expect(await isUp(client, idA), 'and the app is still running').to.equal(true);
+  });
+});

--- a/tests/unit/appController.test.js
+++ b/tests/unit/appController.test.js
@@ -4,7 +4,6 @@ const config = require('config');
 const dbHelper = require('../../ZelBack/src/services/dbHelper');
 const appController = require('../../ZelBack/src/services/appManagement/appController');
 const dockerService = require('../../ZelBack/src/services/dockerService');
-const registryManager = require('../../ZelBack/src/services/appDatabase/registryManager');
 const appInspector = require('../../ZelBack/src/services/appManagement/appInspector');
 const appsRuntimeState = require('../../ZelBack/src/services/appManagement/appsRuntimeState');
 const appReconciler = require('../../ZelBack/src/services/appMonitoring/appReconciler');
@@ -16,6 +15,38 @@ const { requireMongo } = require('./dbTestHelper');
 
 describe('appController tests', () => {
   before(requireMongo);
+
+
+  // The handlers ask what an app is actually MADE OF rather than reading compose
+  // off a stored spec, so a fixture has to say what is installed here and what its
+  // components are. Ids mirror componentIdsOf for a readable spec.
+  function stubInstalledApp(spec) {
+    // eslint-disable-next-line global-require
+    const appQueryService = require('../../ZelBack/src/services/appQuery/appQueryService');
+    const ids = (spec.version >= 4 && Array.isArray(spec.compose))
+      ? spec.compose.map((c) => `${c.name}_${spec.name}`)
+      : [spec.name];
+    if (!appQueryService.installedApps.restore) sinon.stub(appQueryService, 'installedApps');
+    appQueryService.installedApps.resolves({ status: 'success', data: [spec] });
+    if (!appReconciler.componentIdsOf.restore) sinon.stub(appReconciler, 'componentIdsOf');
+    appReconciler.componentIdsOf.resolves(ids);
+    return ids;
+  }
+
+  function stubNoInstalledApp() {
+    // eslint-disable-next-line global-require
+    const appQueryService = require('../../ZelBack/src/services/appQuery/appQueryService');
+    if (!appQueryService.installedApps.restore) sinon.stub(appQueryService, 'installedApps');
+    appQueryService.installedApps.resolves({ status: 'success', data: [] });
+  }
+
+  function stubInstalledComponentApp(component, appName) {
+    return stubInstalledApp({
+      name: appName,
+      version: 4,
+      compose: [{ name: component }, { name: 'other' }],
+    });
+  }
 
   let verificationHelperStub;
   let db;
@@ -53,12 +84,12 @@ describe('appController tests', () => {
         await mutate();
         return true;
       });
-      sinon.stub(appReconciler, 'dockerActual').resolves({ reachable: true, running: true });
+      sinon.stub(appReconciler, 'dockerActual').resolves({ reachable: true, exists: true, running: true });
     });
 
     it('should start app and return success message', async () => {
       verificationHelperStub.resolves(true);
-      sinon.stub(registryManager, 'getApplicationSpecifications').resolves({
+      stubInstalledApp({
         name: 'TestApp',
         version: 3,
       });
@@ -124,6 +155,8 @@ describe('appController tests', () => {
     it('should handle component start for component names', async () => {
       verificationHelperStub.resolves(true);
 
+      stubInstalledComponentApp('Component', 'TestApp');
+
       const req = {
         params: { appname: 'Component_TestApp' },
         query: {},
@@ -142,7 +175,7 @@ describe('appController tests', () => {
 
     it('should start all components for version 4+ apps', async () => {
       verificationHelperStub.resolves(true);
-      sinon.stub(registryManager, 'getApplicationSpecifications').resolves({
+      stubInstalledApp({
         name: 'ComposedApp',
         version: 4,
         compose: [
@@ -176,11 +209,11 @@ describe('appController tests', () => {
 
     it('should report the election, not a start, for a component held by its decider', async () => {
       verificationHelperStub.resolves(true);
-      sinon.stub(registryManager, 'getApplicationSpecifications').resolves({
+      stubInstalledApp({
         name: 'TestApp',
         version: 3,
       });
-      appReconciler.dockerActual.resolves({ reachable: true, running: false });
+      appReconciler.dockerActual.resolves({ reachable: true, exists: true, running: false });
       sinon.stub(appReconciler, 'desiredRunState').resolves({ desired: null, reason: 'awaitingController' });
 
       const req = {
@@ -202,7 +235,7 @@ describe('appController tests', () => {
 
     it('should report an unreachable docker rather than claiming a start', async () => {
       verificationHelperStub.resolves(true);
-      sinon.stub(registryManager, 'getApplicationSpecifications').resolves({
+      stubInstalledApp({
         name: 'TestApp',
         version: 3,
       });
@@ -252,7 +285,7 @@ describe('appController tests', () => {
 
     it('should stop app and return success message', async () => {
       verificationHelperStub.resolves(true);
-      sinon.stub(registryManager, 'getApplicationSpecifications').resolves({
+      stubInstalledApp({
         name: 'TestApp',
         version: 3,
       });
@@ -281,7 +314,7 @@ describe('appController tests', () => {
     it('should stop all components for version 4+ apps in reverse order', async () => {
       verificationHelperStub.resolves(true);
       sinon.stub(appsRuntimeState, 'setOperatorStopped').resolves();
-      sinon.stub(registryManager, 'getApplicationSpecifications').resolves({
+      stubInstalledApp({
         name: 'ComposedApp',
         version: 4,
         compose: [
@@ -318,6 +351,8 @@ describe('appController tests', () => {
       verificationHelperStub.resolves(true);
       sinon.stub(appsRuntimeState, 'setOperatorStopped').resolves();
 
+      stubInstalledComponentApp('Component', 'TestApp');
+
       const req = {
         params: { appname: 'Component_TestApp' },
         query: {},
@@ -346,6 +381,8 @@ describe('appController tests', () => {
       globalState.bootContainerStateSettled = true;
       sinon.stub(appReconciler, 'dockerActual').resolves({ reachable: false, running: false });
 
+      stubInstalledComponentApp('Component', 'TestApp');
+
       const req = { params: { appname: 'Component_TestApp' }, query: {} };
       const res = { json: sinon.fake((param) => param) };
       await appController.appStop(req, res);
@@ -360,7 +397,9 @@ describe('appController tests', () => {
       verificationHelperStub.resolves(true);
       sinon.stub(appsRuntimeState, 'setOperatorStopped').resolves();
       globalState.bootContainerStateSettled = true;
-      sinon.stub(appReconciler, 'dockerActual').resolves({ reachable: true, running: false });
+      sinon.stub(appReconciler, 'dockerActual').resolves({ reachable: true, exists: true, running: false });
+
+      stubInstalledComponentApp('Component', 'TestApp');
 
       const req = { params: { appname: 'Component_TestApp' }, query: {} };
       const res = { json: sinon.fake((param) => param) };
@@ -378,6 +417,8 @@ describe('appController tests', () => {
       // that converges rather than a stopped container that gets restarted.
       verificationHelperStub.resolves(true);
       const setOperatorStopped = sinon.stub(appsRuntimeState, 'setOperatorStopped').resolves();
+
+      stubInstalledComponentApp('Component', 'TestApp');
 
       const req = { params: { appname: 'Component_TestApp' }, query: {} };
       const res = { json: sinon.fake((param) => param) };
@@ -397,6 +438,8 @@ describe('appController tests', () => {
       sinon.stub(appsRuntimeState, 'setOperatorStopped').resolves();
       const clearControllerDesired = sinon.stub(appReconciler, 'clearControllerDesired');
 
+      stubInstalledComponentApp('Component', 'TestApp');
+
       const req = { params: { appname: 'Component_TestApp' }, query: {} };
       const res = { json: sinon.fake((param) => param) };
       await appController.appStop(req, res);
@@ -411,6 +454,8 @@ describe('appController tests', () => {
       verificationHelperStub.resolves(true);
       sinon.stub(appsRuntimeState, 'setOperatorStopped').resolves();
       const clearControllerDesired = sinon.stub(appReconciler, 'clearControllerDesired');
+
+      stubInstalledComponentApp('Component', 'TestApp');
 
       const req = { params: { appname: 'Component_TestApp' }, query: {} };
       const res = { json: sinon.fake((param) => param) };
@@ -427,7 +472,7 @@ describe('appController tests', () => {
       publishStub = sinon.stub(fluxEventBus, 'publish');
       sinon.stub(appsRuntimeState, 'setOperatorStopped').resolves();
       sinon.stub(appsRuntimeState, 'requestRestart').resolves();
-      sinon.stub(appReconciler, 'dockerActual').resolves({ reachable: true, running: false });
+      sinon.stub(appReconciler, 'dockerActual').resolves({ reachable: true, exists: true, running: false });
     });
 
     const intents = () => publishStub.getCalls()
@@ -440,6 +485,8 @@ describe('appController tests', () => {
         await mutate();
         return true;
       });
+
+      stubInstalledComponentApp('Component', 'TestApp');
 
       const req = { params: { appname: 'Component_TestApp' }, query: {} };
       const res = { json: sinon.fake((param) => param) };
@@ -456,8 +503,9 @@ describe('appController tests', () => {
         await mutate();
         return true;
       });
-      appReconciler.dockerActual.resolves({ reachable: true, running: true });
+      appReconciler.dockerActual.resolves({ reachable: true, exists: true, running: true });
 
+      stubInstalledComponentApp('Component', 'TestApp');
       const res = { json: sinon.fake((param) => param) };
       await appController.appKill({ params: { appname: 'Component_TestApp' }, query: {} }, res);
       await appController.appRestart({ params: { appname: 'Component_TestApp' }, query: {} }, res);
@@ -485,6 +533,8 @@ describe('appController tests', () => {
         return true;
       });
 
+      stubInstalledComponentApp('Component', 'TestApp');
+
       const req = { params: { appname: 'Component_TestApp' }, query: {} };
       const res = { json: sinon.fake((param) => param) };
       await appController.appStop(req, res);
@@ -499,6 +549,8 @@ describe('appController tests', () => {
         await mutate();
         return true;
       });
+
+      stubInstalledComponentApp('Component', 'TestApp');
 
       const req = { params: { appname: 'Component_TestApp' }, query: {} };
       const res = { json: sinon.fake((param) => param) };
@@ -519,12 +571,12 @@ describe('appController tests', () => {
         await mutate();
         return true;
       });
-      sinon.stub(appReconciler, 'dockerActual').resolves({ reachable: true, running: true });
+      sinon.stub(appReconciler, 'dockerActual').resolves({ reachable: true, exists: true, running: true });
     });
 
     it('should restart app and return success message', async () => {
       verificationHelperStub.resolves(true);
-      sinon.stub(registryManager, 'getApplicationSpecifications').resolves({
+      stubInstalledApp({
         name: 'TestApp',
         version: 3,
       });
@@ -550,7 +602,7 @@ describe('appController tests', () => {
 
     it('should restart all components for version 4+ apps', async () => {
       verificationHelperStub.resolves(true);
-      sinon.stub(registryManager, 'getApplicationSpecifications').resolves({
+      stubInstalledApp({
         name: 'ComposedApp',
         version: 4,
         compose: [
@@ -600,7 +652,7 @@ describe('appController tests', () => {
     it('clears the operator stop lock and raises the generation together (v1-3 app)', async () => {
       verificationHelperStub.resolves(true);
       const setOperatorStopped = sinon.stub(appsRuntimeState, 'setOperatorStopped').resolves();
-      sinon.stub(registryManager, 'getApplicationSpecifications').resolves({ name: 'TestApp', version: 3 });
+      stubInstalledApp({ name: 'TestApp', version: 3 });
 
       const req = { params: { appname: 'TestApp' }, query: {} };
       const res = { json: sinon.fake((param) => param) };
@@ -616,7 +668,7 @@ describe('appController tests', () => {
     it('clears every component lock before restarting a composed app', async () => {
       verificationHelperStub.resolves(true);
       const setOperatorStopped = sinon.stub(appsRuntimeState, 'setOperatorStopped').resolves();
-      sinon.stub(registryManager, 'getApplicationSpecifications').resolves({
+      stubInstalledApp({
         name: 'ComposedApp',
         version: 4,
         compose: [{ name: 'Component1' }, { name: 'Component2' }],
@@ -634,6 +686,7 @@ describe('appController tests', () => {
       verificationHelperStub.resolves(true);
       const setOperatorStopped = sinon.stub(appsRuntimeState, 'setOperatorStopped').resolves();
 
+      stubInstalledComponentApp('Component1', 'ComposedApp');
       const req = { params: { appname: 'Component1_ComposedApp' }, query: {} };
       const res = { json: sinon.fake((param) => param) };
       await appController.appRestart(req, res);
@@ -647,13 +700,15 @@ describe('appController tests', () => {
     it('lifts the lock for a synced component the election holds, and says so', async () => {
       verificationHelperStub.resolves(true);
       const setOperatorStopped = sinon.stub(appsRuntimeState, 'setOperatorStopped').resolves();
-      sinon.stub(registryManager, 'getApplicationSpecifications').resolves({
+      stubInstalledApp({
         name: 'ComposedApp',
         version: 4,
         compose: [{ name: 'Gcomp', containerData: 'g:/data' }],
       });
-      appReconciler.dockerActual.resolves({ reachable: true, running: false });
+      appReconciler.dockerActual.resolves({ reachable: true, exists: true, running: false });
       sinon.stub(appReconciler, 'desiredRunState').resolves({ desired: null, reason: 'awaitingController' });
+
+      stubInstalledComponentApp('Gcomp', 'ComposedApp');
 
       const req = { params: { appname: 'Gcomp_ComposedApp' }, query: {} };
       const res = { json: sinon.fake((param) => param) };
@@ -673,12 +728,14 @@ describe('appController tests', () => {
         await mutate();
         return true;
       });
-      sinon.stub(appReconciler, 'dockerActual').resolves({ reachable: true, running: false });
+      sinon.stub(appReconciler, 'dockerActual').resolves({ reachable: true, exists: true, running: false });
     });
 
     it('records the kill as a forced stop and leaves the signal to the reconciler', async () => {
       verificationHelperStub.resolves(true);
       const setOperatorStopped = sinon.stub(appsRuntimeState, 'setOperatorStopped').resolves();
+
+      stubInstalledComponentApp('Component', 'TestApp');
 
       const req = { params: { appname: 'Component_TestApp' }, query: {} };
       const res = { json: sinon.fake((param) => param) };
@@ -693,7 +750,7 @@ describe('appController tests', () => {
 
     it('should kill app and return success message', async () => {
       verificationHelperStub.resolves(true);
-      sinon.stub(registryManager, 'getApplicationSpecifications').resolves({
+      stubInstalledApp({
         name: 'TestApp',
         version: 3,
       });
@@ -717,7 +774,7 @@ describe('appController tests', () => {
     it('should kill all components for version 4+ apps', async () => {
       verificationHelperStub.resolves(true);
       const setOperatorStopped = sinon.stub(appsRuntimeState, 'setOperatorStopped').resolves();
-      sinon.stub(registryManager, 'getApplicationSpecifications').resolves({
+      stubInstalledApp({
         name: 'ComposedApp',
         version: 4,
         compose: [
@@ -750,7 +807,7 @@ describe('appController tests', () => {
 
     it('reports pending rather than killed when docker cannot be reached', async () => {
       verificationHelperStub.resolves(true);
-      sinon.stub(registryManager, 'getApplicationSpecifications').resolves({
+      stubInstalledApp({
         name: 'TestApp',
         version: 3,
       });
@@ -764,9 +821,63 @@ describe('appController tests', () => {
       expect(result.data).to.equal('Application TestApp will be killed: docker is not reachable');
     });
 
+    // An enterprise spec keeps its component names inside an encrypted blob, so the
+    // stored compose is empty. Deriving ids from it addressed NOTHING and then
+    // reported success, because zero components all reached stopped.
+    it('stops every component of an enterprise app, whose stored compose is empty', async () => {
+      verificationHelperStub.resolves(true);
+      const setOperatorStopped = sinon.stub(appsRuntimeState, 'setOperatorStopped').resolves();
+      // eslint-disable-next-line global-require
+      const appQueryService = require('../../ZelBack/src/services/appQuery/appQueryService');
+      sinon.stub(appQueryService, 'installedApps').resolves({
+        status: 'success',
+        data: [{ name: 'EntApp', version: 8, enterprise: 'encrypted-blob', compose: [] }],
+      });
+      sinon.stub(appReconciler, 'componentIdsOf').resolves(['api_EntApp', 'db_EntApp']);
+
+      const res = { json: sinon.fake((param) => param) };
+      await appController.appStop({ params: { appname: 'EntApp' }, query: {} }, res);
+
+      expect(setOperatorStopped.callCount, 'both components must be addressed').to.equal(2);
+      const addressed = setOperatorStopped.getCalls().map((c) => c.args[0]).sort();
+      expect(addressed).to.deep.equal(['api_EntApp', 'db_EntApp']);
+    });
+
+    // A component name was taken verbatim, so a typo wrote a durable operator lock
+    // under a component that does not exist. Nothing clears one, and it holds the
+    // real component down if one is ever created with that name.
+    it('refuses a component that is not one of the app\'s, and writes no lock', async () => {
+      verificationHelperStub.resolves(true);
+      const setOperatorStopped = sinon.stub(appsRuntimeState, 'setOperatorStopped').resolves();
+      stubInstalledComponentApp('Real', 'TestApp');
+
+      const res = { json: sinon.fake((param) => param) };
+      await appController.appStop({ params: { appname: 'Bogus_TestApp' }, query: {} }, res);
+
+      const result = res.json.firstCall.args[0];
+      expect(result.status).to.equal('error');
+      sinon.assert.notCalled(setOperatorStopped);
+    });
+
+    // "nothing there" settled as "stopped", so a command against a container that
+    // does not exist answered that it had been stopped.
+    it('does not report a container that is not installed as stopped', async () => {
+      verificationHelperStub.resolves(true);
+      sinon.stub(appsRuntimeState, 'setOperatorStopped').resolves();
+      appReconciler.dockerActual.resolves({ reachable: true, exists: false, running: false });
+      stubInstalledApp({ name: 'TestApp', version: 3 });
+
+      const res = { json: sinon.fake((param) => param) };
+      await appController.appStop({ params: { appname: 'TestApp' }, query: {} }, res);
+
+      const message = JSON.stringify(res.json.firstCall.args[0]);
+      expect(message, 'must not claim a stop').to.not.match(/TestApp stopped/);
+      expect(message).to.match(/not installed on this node/);
+    });
+
     it('should return error if app not found', async () => {
       verificationHelperStub.resolves(true);
-      sinon.stub(registryManager, 'getApplicationSpecifications').resolves(null);
+      stubNoInstalledApp();
 
       const req = {
         params: { appname: 'NonExistentApp' },
@@ -786,7 +897,7 @@ describe('appController tests', () => {
     // operator, and ending someone else's app abruptly is not theirs to order.
     it('asks for a privilege that excludes the node operator', async () => {
       verificationHelperStub.resolves(true);
-      sinon.stub(registryManager, 'getApplicationSpecifications').resolves({ name: 'TestApp', version: 3 });
+      stubInstalledApp({ name: 'TestApp', version: 3 });
 
       const req = { params: { appname: 'TestApp' }, query: {} };
       const res = { json: sinon.fake((param) => param) };

--- a/tests/unit/appController.test.js
+++ b/tests/unit/appController.test.js
@@ -168,6 +168,10 @@ describe('appController tests', () => {
       // half-started is the failure this covers.
       sinon.assert.calledWith(appsRuntimeState.setOperatorStopped, 'Component1_ComposedApp', false);
       sinon.assert.calledWith(appsRuntimeState.setOperatorStopped, 'Component2_ComposedApp', false);
+      // Forward, and pinned: a start is the direction a stop is the reverse OF, so
+      // reversing both would satisfy the stop test and still be wrong here.
+      expect(appsRuntimeState.setOperatorStopped.firstCall.args[0]).to.equal('Component1_ComposedApp');
+      expect(appsRuntimeState.setOperatorStopped.secondCall.args[0]).to.equal('Component2_ComposedApp');
     });
 
     it('should report the election, not a start, for a component held by its decider', async () => {
@@ -303,6 +307,11 @@ describe('appController tests', () => {
       // half-stopped is the failure this covers.
       sinon.assert.calledWith(appsRuntimeState.setOperatorStopped, 'Component1_ComposedApp', true);
       sinon.assert.calledWith(appsRuntimeState.setOperatorStopped, 'Component2_ComposedApp', true);
+      // And in reverse, which is the half calledWith cannot see - it holds whether
+      // the components are addressed forwards or backwards. The call index is the
+      // only thing that pins the order this test is named for.
+      expect(appsRuntimeState.setOperatorStopped.firstCall.args[0]).to.equal('Component2_ComposedApp');
+      expect(appsRuntimeState.setOperatorStopped.secondCall.args[0]).to.equal('Component1_ComposedApp');
     });
 
     it('should handle component stop', async () => {
@@ -733,6 +742,10 @@ describe('appController tests', () => {
       // is the failure this covers.
       sinon.assert.calledWith(setOperatorStopped, 'Component1_ComposedApp', true, { force: true });
       sinon.assert.calledWith(setOperatorStopped, 'Component2_ComposedApp', true, { force: true });
+      // A kill goes down in the same reverse order as a stop - it is the same
+      // shutdown, without the drain.
+      expect(setOperatorStopped.firstCall.args[0]).to.equal('Component2_ComposedApp');
+      expect(setOperatorStopped.secondCall.args[0]).to.equal('Component1_ComposedApp');
     });
 
     it('reports pending rather than killed when docker cannot be reached', async () => {

--- a/tests/unit/appController.test.js
+++ b/tests/unit/appController.test.js
@@ -843,6 +843,35 @@ describe('appController tests', () => {
       expect(addressed).to.deep.equal(['api_EntApp', 'db_EntApp']);
     });
 
+    // Runs the REAL componentIdsOf, deliberately. Every other test here stubs it
+    // and so states what it returns rather than checking it - which is what let
+    // its two branches drift apart. An app whose spec will not decrypt has its
+    // components enumerated from docker, which namespaces every name it holds,
+    // and operatorTargetIds checks the operator's component name against that
+    // list: a `flux`-prefixed entry refused the very component it names.
+    it('honours a component command against an app whose spec will not decrypt', async () => {
+      verificationHelperStub.resolves(true);
+      const setOperatorStopped = sinon.stub(appsRuntimeState, 'setOperatorStopped').resolves();
+      // eslint-disable-next-line global-require
+      const appQueryService = require('../../ZelBack/src/services/appQuery/appQueryService');
+      const stored = {
+        name: 'EntApp', version: 8, enterprise: 'encrypted-blob', compose: [],
+      };
+      sinon.stub(appQueryService, 'installedApps').resolves({ status: 'success', data: [stored] });
+      sinon.stub(appQueryService, 'decryptEnterpriseApps').resolves({ readable: [], unreadable: [stored], inPlace: [stored] });
+      sinon.stub(dockerService, 'dockerListContainers').resolves([
+        { Names: ['/fluxapi_EntApp'] },
+        { Names: ['/fluxdb_EntApp'] },
+      ]);
+
+      const res = { json: sinon.fake((param) => param) };
+      await appController.appStop({ params: { appname: 'api_EntApp' }, query: {} }, res);
+
+      const result = res.json.firstCall.args[0];
+      expect(result.data, 'the component must not be refused as uninstalled').to.equal('Application api_EntApp stopped');
+      sinon.assert.calledOnceWithExactly(setOperatorStopped, 'api_EntApp', true, { force: false });
+    });
+
     // A component name was taken verbatim, so a typo wrote a durable operator lock
     // under a component that does not exist. Nothing clears one, and it holds the
     // real component down if one is ever created with that name.

--- a/tests/unit/appController.test.js
+++ b/tests/unit/appController.test.js
@@ -11,6 +11,7 @@ const appReconciler = require('../../ZelBack/src/services/appMonitoring/appRecon
 const globalState = require('../../ZelBack/src/services/utils/globalState');
 const bootGateAtStart = globalState.bootContainerStateSettled;
 const fluxNetworkHelper = require('../../ZelBack/src/services/fluxNetworkHelper');
+const fluxEventBus = require('../../ZelBack/src/services/utils/fluxEventBus');
 const { requireMongo } = require('./dbTestHelper');
 
 describe('appController tests', () => {
@@ -44,6 +45,15 @@ describe('appController tests', () => {
     beforeEach(() => {
       sinon.stub(dockerService, 'appDockerStart').resolves('Flux App TestApp successfully started.');
       sinon.stub(appInspector, 'startAppMonitoring');
+      sinon.stub(appsRuntimeState, 'setOperatorStopped').resolves();
+      // Runs the caller's mutate so the intent write stays observable, and
+      // reports the pass as run so the outcome below is the probe's answer
+      // rather than "no reconcile yet".
+      sinon.stub(appReconciler, 'applyIntent').callsFake(async (id, mutate) => {
+        await mutate();
+        return true;
+      });
+      sinon.stub(appReconciler, 'dockerActual').resolves({ reachable: true, running: true });
     });
 
     it('should start app and return success message', async () => {
@@ -65,7 +75,14 @@ describe('appController tests', () => {
 
       const result = res.json.firstCall.args[0];
       expect(result.status).to.equal('success');
-      sinon.assert.calledOnce(dockerService.appDockerStart);
+      expect(result.data).to.equal('Application TestApp started');
+      // The handler no longer drives the container: whether it may run is the
+      // election's decision, and the reconciler is the one that consults it.
+      sinon.assert.notCalled(dockerService.appDockerStart);
+      sinon.assert.calledWith(appsRuntimeState.setOperatorStopped, 'TestApp', false);
+      // startAppMonitoring wipes statsStore, so a second caller alongside the
+      // reconciler's own call would discard the series the charts read.
+      sinon.assert.notCalled(appInspector.startAppMonitoring);
     });
 
     it('should return error if no app name provided', async () => {
@@ -119,8 +136,8 @@ describe('appController tests', () => {
 
       const result = res.json.firstCall.args[0];
       expect(result.status).to.equal('success');
-      sinon.assert.calledOnce(dockerService.appDockerStart);
-      sinon.assert.calledWith(dockerService.appDockerStart, 'Component_TestApp');
+      sinon.assert.notCalled(dockerService.appDockerStart);
+      sinon.assert.calledWith(appsRuntimeState.setOperatorStopped, 'Component_TestApp', false);
     });
 
     it('should start all components for version 4+ apps', async () => {
@@ -146,9 +163,59 @@ describe('appController tests', () => {
 
       const result = res.json.firstCall.args[0];
       expect(result.status).to.equal('success');
-      sinon.assert.calledTwice(dockerService.appDockerStart);
-      sinon.assert.calledWith(dockerService.appDockerStart, 'Component1_ComposedApp');
-      sinon.assert.calledWith(dockerService.appDockerStart, 'Component2_ComposedApp');
+      sinon.assert.notCalled(dockerService.appDockerStart);
+      // Every component gets the intent, not just the first - a composed app
+      // half-started is the failure this covers.
+      sinon.assert.calledWith(appsRuntimeState.setOperatorStopped, 'Component1_ComposedApp', false);
+      sinon.assert.calledWith(appsRuntimeState.setOperatorStopped, 'Component2_ComposedApp', false);
+    });
+
+    it('should report the election, not a start, for a component held by its decider', async () => {
+      verificationHelperStub.resolves(true);
+      sinon.stub(registryManager, 'getApplicationSpecifications').resolves({
+        name: 'TestApp',
+        version: 3,
+      });
+      appReconciler.dockerActual.resolves({ reachable: true, running: false });
+      sinon.stub(appReconciler, 'desiredRunState').resolves({ desired: null, reason: 'awaitingController' });
+
+      const req = {
+        params: { appname: 'TestApp' },
+        query: {},
+      };
+      const res = {
+        json: sinon.fake((param) => param),
+      };
+
+      await appController.appStart(req, res);
+
+      const result = res.json.firstCall.args[0];
+      // A synced component runs on the node the election made the writer, so
+      // "not started here" is the correct outcome - and saying which of the two
+      // it is stops an operator retrying against a decision that already holds.
+      expect(result.data).to.equal('Application TestApp will be started: waiting for the election');
+    });
+
+    it('should report an unreachable docker rather than claiming a start', async () => {
+      verificationHelperStub.resolves(true);
+      sinon.stub(registryManager, 'getApplicationSpecifications').resolves({
+        name: 'TestApp',
+        version: 3,
+      });
+      appReconciler.dockerActual.resolves({ reachable: false, running: false });
+
+      const req = {
+        params: { appname: 'TestApp' },
+        query: {},
+      };
+      const res = {
+        json: sinon.fake((param) => param),
+      };
+
+      await appController.appStart(req, res);
+
+      const result = res.json.firstCall.args[0];
+      expect(result.data).to.equal('Application TestApp will be started: docker is not reachable');
     });
 
     it('should handle global start parameter', async () => {
@@ -201,7 +268,10 @@ describe('appController tests', () => {
       // The handler no longer drives the container. Two writers to one container
       // is what let an operator stop interleave with a reconcile pass.
       sinon.assert.notCalled(dockerService.appDockerStop);
-      sinon.assert.calledOnce(appInspector.stopAppMonitoring);
+      // Monitoring goes with the container, so the reconciler turns it off when
+      // it stops one. Stopping it here turned the sampler off for a container
+      // the stop had not reached.
+      sinon.assert.notCalled(appInspector.stopAppMonitoring);
     });
 
     it('should stop all components for version 4+ apps in reverse order', async () => {
@@ -304,7 +374,7 @@ describe('appController tests', () => {
       const res = { json: sinon.fake((param) => param) };
       await appController.appStop(req, res);
 
-      sinon.assert.calledOnceWithExactly(setOperatorStopped, 'Component_TestApp', true);
+      sinon.assert.calledOnceWithExactly(setOperatorStopped, 'Component_TestApp', true, { force: false });
       sinon.assert.notCalled(dockerService.appDockerStop);
     });
 
@@ -341,9 +411,106 @@ describe('appController tests', () => {
     });
   });
 
+  describe('operator intent event', () => {
+    let publishStub;
+
+    beforeEach(() => {
+      publishStub = sinon.stub(fluxEventBus, 'publish');
+      sinon.stub(appsRuntimeState, 'setOperatorStopped').resolves();
+      sinon.stub(appsRuntimeState, 'requestRestart').resolves();
+      sinon.stub(appReconciler, 'dockerActual').resolves({ reachable: true, running: false });
+    });
+
+    const intents = () => publishStub.getCalls()
+      .filter((c) => c.args[0] === 'app:operatorIntent')
+      .map((c) => c.args[1]);
+
+    it('announces a stop, with the mode it was asked for', async () => {
+      verificationHelperStub.resolves(true);
+      sinon.stub(appReconciler, 'applyIntent').callsFake(async (id, mutate) => {
+        await mutate();
+        return true;
+      });
+
+      const req = { params: { appname: 'Component_TestApp' }, query: {} };
+      const res = { json: sinon.fake((param) => param) };
+      await appController.appStop(req, res);
+
+      expect(intents()).to.deep.equal([{
+        identifier: 'Component_TestApp', stopped: true, force: false, restartRequested: false,
+      }]);
+    });
+
+    it('announces a kill as a forced stop and a restart as a start that asked for one', async () => {
+      verificationHelperStub.resolves(true);
+      sinon.stub(appReconciler, 'applyIntent').callsFake(async (id, mutate) => {
+        await mutate();
+        return true;
+      });
+      appReconciler.dockerActual.resolves({ reachable: true, running: true });
+
+      const res = { json: sinon.fake((param) => param) };
+      await appController.appKill({ params: { appname: 'Component_TestApp' }, query: {} }, res);
+      await appController.appRestart({ params: { appname: 'Component_TestApp' }, query: {} }, res);
+
+      expect(intents()).to.deep.equal([
+        {
+          identifier: 'Component_TestApp', stopped: true, force: true, restartRequested: false,
+        },
+        {
+          identifier: 'Component_TestApp', stopped: false, force: false, restartRequested: true,
+        },
+      ]);
+    });
+
+    // The whole point of the event is to be the ordering point, and it can only
+    // be that if it is published while the slot is still held - after the write,
+    // so it never claims an intent that did not persist, and before the pass,
+    // which awaitPass would otherwise put first.
+    it('is published inside the slot, before the pass runs', async () => {
+      verificationHelperStub.resolves(true);
+      let announcedWhileHeld = null;
+      sinon.stub(appReconciler, 'applyIntent').callsFake(async (id, mutate) => {
+        await mutate();
+        announcedWhileHeld = intents().length;
+        return true;
+      });
+
+      const req = { params: { appname: 'Component_TestApp' }, query: {} };
+      const res = { json: sinon.fake((param) => param) };
+      await appController.appStop(req, res);
+
+      expect(announcedWhileHeld, 'the intent must be announced while the slot is still held').to.equal(1);
+    });
+
+    it('says nothing when the intent could not be written', async () => {
+      verificationHelperStub.resolves(true);
+      appsRuntimeState.setOperatorStopped.rejects(new Error('mongo is down'));
+      sinon.stub(appReconciler, 'applyIntent').callsFake(async (id, mutate) => {
+        await mutate();
+        return true;
+      });
+
+      const req = { params: { appname: 'Component_TestApp' }, query: {} };
+      const res = { json: sinon.fake((param) => param) };
+      await appController.appStop(req, res);
+
+      // An announced intent that never persisted is worse than silence: a
+      // consumer would order actuations against a lock that is not there.
+      expect(intents()).to.deep.equal([]);
+      expect(res.json.firstCall.args[0].status).to.equal('error');
+    });
+  });
+
   describe('appRestart tests', () => {
     beforeEach(() => {
       sinon.stub(dockerService, 'appDockerRestart').resolves('Flux App TestApp successfully restarted.');
+      sinon.stub(appsRuntimeState, 'requestRestart').resolves();
+      sinon.stub(appReconciler, 'applyIntent').callsFake(async (id, mutate) => {
+        await mutate();
+        return true;
+      });
+      sinon.stub(appReconciler, 'dockerActual').resolves({ reachable: true, running: true });
     });
 
     it('should restart app and return success message', async () => {
@@ -365,7 +532,11 @@ describe('appController tests', () => {
 
       const result = res.json.firstCall.args[0];
       expect(result.status).to.equal('success');
-      sinon.assert.calledOnce(dockerService.appDockerRestart);
+      expect(result.data).to.equal('Application TestApp restarted');
+      // The bounce is the reconciler's: a restart is a level it converges to, so
+      // there is no window between this handler deciding and a pass deciding.
+      sinon.assert.notCalled(dockerService.appDockerRestart);
+      sinon.assert.calledOnceWithExactly(appsRuntimeState.requestRestart, 'TestApp');
     });
 
     it('should restart all components for version 4+ apps', async () => {
@@ -391,7 +562,9 @@ describe('appController tests', () => {
 
       const result = res.json.firstCall.args[0];
       expect(result.status).to.equal('success');
-      sinon.assert.calledTwice(dockerService.appDockerRestart);
+      sinon.assert.notCalled(dockerService.appDockerRestart);
+      sinon.assert.calledWith(appsRuntimeState.requestRestart, 'Component1_ComposedApp');
+      sinon.assert.calledWith(appsRuntimeState.requestRestart, 'Component2_ComposedApp');
     });
 
     it('should return unauthorized if user not authorized', async () => {
@@ -412,97 +585,89 @@ describe('appController tests', () => {
       expect(result.data.code).to.equal(401);
     });
 
-    // A user-initiated restart is an explicit "make it run": it must clear the
-    // durable operator stop lock (same semantics and scope as appStart), and
-    // BEFORE the docker operation - if FluxOS dies mid-restart the worst case
-    // is then lock-cleared+stopped, which the reconciler converges to running
-    // (user intent). Without this, stop -> restart leaves the lock set and the
-    // reconciler silently re-stops the app at its next trigger.
-    it('clears the operator stop lock before restarting (v1-3 app)', async () => {
+    // A restart is an explicit "make it run": it clears the durable operator stop
+    // lock with the same scope as appStart. Without it, stop -> restart leaves the
+    // lock set and the reconciler silently re-stops the app at its next trigger.
+    it('clears the operator stop lock and raises the generation together (v1-3 app)', async () => {
       verificationHelperStub.resolves(true);
-      sinon.stub(registryManager, 'getApplicationSpecifications').resolves({
-        name: 'TestApp',
-        version: 3,
-      });
       const setOperatorStopped = sinon.stub(appsRuntimeState, 'setOperatorStopped').resolves();
+      sinon.stub(registryManager, 'getApplicationSpecifications').resolves({ name: 'TestApp', version: 3 });
 
       const req = { params: { appname: 'TestApp' }, query: {} };
       const res = { json: sinon.fake((param) => param) };
       await appController.appRestart(req, res);
 
-      sinon.assert.calledOnceWithExactly(setOperatorStopped, 'TestApp', false);
-      sinon.assert.callOrder(setOperatorStopped, dockerService.appDockerRestart);
+      sinon.assert.calledOnceWithExactly(setOperatorStopped, 'TestApp', false, { force: false });
+      // Both land inside one applyIntent slot, so a pass can never read the
+      // cleared lock without the raised generation and leave the container alone.
+      sinon.assert.callOrder(setOperatorStopped, appsRuntimeState.requestRestart);
+      sinon.assert.calledOnce(appReconciler.applyIntent);
     });
 
     it('clears every component lock before restarting a composed app', async () => {
       verificationHelperStub.resolves(true);
+      const setOperatorStopped = sinon.stub(appsRuntimeState, 'setOperatorStopped').resolves();
       sinon.stub(registryManager, 'getApplicationSpecifications').resolves({
         name: 'ComposedApp',
         version: 4,
-        compose: [
-          { name: 'Component1', containerData: '/data' },
-          { name: 'Component2', containerData: '/data' },
-        ],
+        compose: [{ name: 'Component1' }, { name: 'Component2' }],
       });
-      const setOperatorStopped = sinon.stub(appsRuntimeState, 'setOperatorStopped').resolves();
 
       const req = { params: { appname: 'ComposedApp' }, query: {} };
       const res = { json: sinon.fake((param) => param) };
       await appController.appRestart(req, res);
 
-      sinon.assert.calledWith(setOperatorStopped, 'Component1_ComposedApp', false);
-      sinon.assert.calledWith(setOperatorStopped, 'Component2_ComposedApp', false);
-      sinon.assert.callOrder(setOperatorStopped, dockerService.appDockerRestart);
+      sinon.assert.calledWith(setOperatorStopped, 'Component1_ComposedApp', false, { force: false });
+      sinon.assert.calledWith(setOperatorStopped, 'Component2_ComposedApp', false, { force: false });
     });
 
     it('clears only the named component lock on a component restart', async () => {
       verificationHelperStub.resolves(true);
-      sinon.stub(registryManager, 'getApplicationSpecifications').resolves({
-        name: 'ComposedApp',
-        version: 4,
-        compose: [
-          { name: 'Component1', containerData: '/data' },
-          { name: 'Component2', containerData: '/data' },
-        ],
-      });
       const setOperatorStopped = sinon.stub(appsRuntimeState, 'setOperatorStopped').resolves();
 
       const req = { params: { appname: 'Component1_ComposedApp' }, query: {} };
       const res = { json: sinon.fake((param) => param) };
       await appController.appRestart(req, res);
 
-      sinon.assert.calledOnceWithExactly(setOperatorStopped, 'Component1_ComposedApp', false);
-      sinon.assert.callOrder(setOperatorStopped, dockerService.appDockerRestart);
+      sinon.assert.calledOnceWithExactly(setOperatorStopped, 'Component1_ComposedApp', false, { force: false });
     });
 
-    // The g:-skip path avoids a direct docker restart of a not-running g:
-    // component (the election governs it), but the user's stop-veto must still
-    // be lifted so the election MAY start it - appStart's existing semantics.
-    it('still clears the lock when a g: component restart is skipped', async () => {
+    // A synced component the election holds elsewhere still gets its lock lifted -
+    // the stop veto is the operator's, the run decision is the election's - but it
+    // is reported as held rather than as restarted.
+    it('lifts the lock for a synced component the election holds, and says so', async () => {
       verificationHelperStub.resolves(true);
+      const setOperatorStopped = sinon.stub(appsRuntimeState, 'setOperatorStopped').resolves();
       sinon.stub(registryManager, 'getApplicationSpecifications').resolves({
         name: 'ComposedApp',
         version: 4,
         compose: [{ name: 'Gcomp', containerData: 'g:/data' }],
       });
-      sinon.stub(dockerService, 'dockerListContainers').resolves([]); // g: component not running
-      const setOperatorStopped = sinon.stub(appsRuntimeState, 'setOperatorStopped').resolves();
+      appReconciler.dockerActual.resolves({ reachable: true, running: false });
+      sinon.stub(appReconciler, 'desiredRunState').resolves({ desired: null, reason: 'awaitingController' });
 
       const req = { params: { appname: 'Gcomp_ComposedApp' }, query: {} };
       const res = { json: sinon.fake((param) => param) };
       await appController.appRestart(req, res);
 
-      sinon.assert.calledOnceWithExactly(setOperatorStopped, 'Gcomp_ComposedApp', false);
-      sinon.assert.notCalled(dockerService.appDockerRestart); // skip preserved
+      sinon.assert.calledOnceWithExactly(setOperatorStopped, 'Gcomp_ComposedApp', false, { force: false });
+      const result = res.json.firstCall.args[0];
+      expect(result.data).to.equal('Application Gcomp_ComposedApp will be restarted: waiting for the election');
+      sinon.assert.notCalled(dockerService.appDockerRestart);
     });
   });
 
   describe('appKill tests', () => {
     beforeEach(() => {
       sinon.stub(dockerService, 'appDockerKill').resolves('Flux App TestApp successfully killed.');
+      sinon.stub(appReconciler, 'applyIntent').callsFake(async (id, mutate) => {
+        await mutate();
+        return true;
+      });
+      sinon.stub(appReconciler, 'dockerActual').resolves({ reachable: true, running: false });
     });
 
-    it('sets the operator lock BEFORE the docker kill on the component path (crash-safe ordering)', async () => {
+    it('records the kill as a forced stop and leaves the signal to the reconciler', async () => {
       verificationHelperStub.resolves(true);
       const setOperatorStopped = sinon.stub(appsRuntimeState, 'setOperatorStopped').resolves();
 
@@ -510,8 +675,11 @@ describe('appController tests', () => {
       const res = { json: sinon.fake((param) => param) };
       await appController.appKill(req, res);
 
-      sinon.assert.calledOnceWithExactly(setOperatorStopped, 'Component_TestApp', true);
-      sinon.assert.callOrder(setOperatorStopped, dockerService.appDockerKill);
+      // A kill is the same desired state as a stop carrying a mode, so the choice
+      // of signal sits with the reconciler that stops the container rather than
+      // in a handler racing it.
+      sinon.assert.calledOnceWithExactly(setOperatorStopped, 'Component_TestApp', true, { force: true });
+      sinon.assert.notCalled(dockerService.appDockerKill);
     });
 
     it('should kill app and return success message', async () => {
@@ -533,11 +701,13 @@ describe('appController tests', () => {
 
       const result = res.json.firstCall.args[0];
       expect(result.status).to.equal('success');
-      sinon.assert.calledOnce(dockerService.appDockerKill);
+      expect(result.data).to.equal('Application TestApp killed');
+      sinon.assert.notCalled(dockerService.appDockerKill);
     });
 
-    it('should kill all components for version 4+ apps in reverse order', async () => {
+    it('should kill all components for version 4+ apps', async () => {
       verificationHelperStub.resolves(true);
+      const setOperatorStopped = sinon.stub(appsRuntimeState, 'setOperatorStopped').resolves();
       sinon.stub(registryManager, 'getApplicationSpecifications').resolves({
         name: 'ComposedApp',
         version: 4,
@@ -559,7 +729,26 @@ describe('appController tests', () => {
 
       const result = res.json.firstCall.args[0];
       expect(result.status).to.equal('success');
-      sinon.assert.calledTwice(dockerService.appDockerKill);
+      // Force reaches every component: a composed app half-killed and half-drained
+      // is the failure this covers.
+      sinon.assert.calledWith(setOperatorStopped, 'Component1_ComposedApp', true, { force: true });
+      sinon.assert.calledWith(setOperatorStopped, 'Component2_ComposedApp', true, { force: true });
+    });
+
+    it('reports pending rather than killed when docker cannot be reached', async () => {
+      verificationHelperStub.resolves(true);
+      sinon.stub(registryManager, 'getApplicationSpecifications').resolves({
+        name: 'TestApp',
+        version: 3,
+      });
+      appReconciler.dockerActual.resolves({ reachable: false, running: false });
+
+      const req = { params: { appname: 'TestApp' }, query: {} };
+      const res = { json: sinon.fake((param) => param) };
+      await appController.appKill(req, res);
+
+      const result = res.json.firstCall.args[0];
+      expect(result.data).to.equal('Application TestApp will be killed: docker is not reachable');
     });
 
     it('should return error if app not found', async () => {
@@ -578,7 +767,31 @@ describe('appController tests', () => {
 
       const result = res.json.firstCall.args[0];
       expect(result.status).to.equal('error');
-      expect(result.data.message).to.include('Application not found');
+    });
+
+    // Narrower than its siblings on purpose: appownerabove admits the node
+    // operator, and ending someone else's app abruptly is not theirs to order.
+    it('asks for a privilege that excludes the node operator', async () => {
+      verificationHelperStub.resolves(true);
+      sinon.stub(registryManager, 'getApplicationSpecifications').resolves({ name: 'TestApp', version: 3 });
+
+      const req = { params: { appname: 'TestApp' }, query: {} };
+      const res = { json: sinon.fake((param) => param) };
+      await appController.appKill(req, res);
+
+      expect(verificationHelperStub.firstCall.args[0]).to.equal('appownerorfluxteam');
+    });
+
+    it('refuses a caller the narrower privilege rejects', async () => {
+      verificationHelperStub.resolves(false);
+
+      const req = { params: { appname: 'TestApp' }, query: {} };
+      const res = { json: sinon.fake((param) => param) };
+      await appController.appKill(req, res);
+
+      const result = res.json.firstCall.args[0];
+      expect(result.status).to.equal('error');
+      expect(result.data.code).to.equal(401);
     });
   });
 

--- a/tests/unit/appController.test.js
+++ b/tests/unit/appController.test.js
@@ -872,6 +872,33 @@ describe('appController tests', () => {
       sinon.assert.calledOnceWithExactly(setOperatorStopped, 'api_EntApp', true, { force: false });
     });
 
+    // An installed app whose parts cannot be worked out - the spec will not
+    // decrypt and the docker fallback comes back with nothing - wrote no intent,
+    // settled vacuously against an empty list and answered that the app had been
+    // stopped. Zero components all reach "stopped" by construction, so every
+    // check downstream agreed. It has to be refused, in terms that say nothing
+    // happened.
+    it('refuses a command it cannot address, rather than reporting it done', async () => {
+      verificationHelperStub.resolves(true);
+      const setOperatorStopped = sinon.stub(appsRuntimeState, 'setOperatorStopped').resolves();
+      // eslint-disable-next-line global-require
+      const appQueryService = require('../../ZelBack/src/services/appQuery/appQueryService');
+      const stored = {
+        name: 'EntApp', version: 8, enterprise: 'encrypted-blob', compose: [],
+      };
+      sinon.stub(appQueryService, 'installedApps').resolves({ status: 'success', data: [stored] });
+      sinon.stub(appQueryService, 'decryptEnterpriseApps').resolves({ readable: [], unreadable: [stored], inPlace: [stored] });
+      sinon.stub(dockerService, 'dockerListContainers').resolves([]);
+
+      const res = { json: sinon.fake((param) => param) };
+      await appController.appStop({ params: { appname: 'EntApp' }, query: {} }, res);
+
+      const result = res.json.firstCall.args[0];
+      expect(result.status, 'a command that addressed nothing must not report success').to.equal('error');
+      expect(result.data.message).to.match(/cannot determine its components/);
+      sinon.assert.notCalled(setOperatorStopped);
+    });
+
     // A component name was taken verbatim, so a typo wrote a durable operator lock
     // under a component that does not exist. Nothing clears one, and it holds the
     // real component down if one is ever created with that name.

--- a/tests/unit/appController.test.js
+++ b/tests/unit/appController.test.js
@@ -8,6 +8,8 @@ const registryManager = require('../../ZelBack/src/services/appDatabase/registry
 const appInspector = require('../../ZelBack/src/services/appManagement/appInspector');
 const appsRuntimeState = require('../../ZelBack/src/services/appManagement/appsRuntimeState');
 const appReconciler = require('../../ZelBack/src/services/appMonitoring/appReconciler');
+const globalState = require('../../ZelBack/src/services/utils/globalState');
+const bootGateAtStart = globalState.bootContainerStateSettled;
 const fluxNetworkHelper = require('../../ZelBack/src/services/fluxNetworkHelper');
 const { requireMongo } = require('./dbTestHelper');
 
@@ -32,6 +34,10 @@ describe('appController tests', () => {
 
   afterEach(() => {
     sinon.restore();
+    // globalState is a shared module, so a test that opens the boot gate leaves
+    // it open for every test after it in this process - including files mocha
+    // runs later. Restored explicitly; sinon does not own it.
+    globalState.bootContainerStateSettled = bootGateAtStart;
   });
 
   describe('appStart tests', () => {
@@ -192,12 +198,15 @@ describe('appController tests', () => {
 
       const result = res.json.firstCall.args[0];
       expect(result.status).to.equal('success');
-      sinon.assert.calledOnce(dockerService.appDockerStop);
+      // The handler no longer drives the container. Two writers to one container
+      // is what let an operator stop interleave with a reconcile pass.
+      sinon.assert.notCalled(dockerService.appDockerStop);
       sinon.assert.calledOnce(appInspector.stopAppMonitoring);
     });
 
     it('should stop all components for version 4+ apps in reverse order', async () => {
       verificationHelperStub.resolves(true);
+      sinon.stub(appsRuntimeState, 'setOperatorStopped').resolves();
       sinon.stub(registryManager, 'getApplicationSpecifications').resolves({
         name: 'ComposedApp',
         version: 4,
@@ -219,12 +228,16 @@ describe('appController tests', () => {
 
       const result = res.json.firstCall.args[0];
       expect(result.status).to.equal('success');
-      // Should be called in reverse order
-      sinon.assert.calledTwice(dockerService.appDockerStop);
+      sinon.assert.notCalled(dockerService.appDockerStop);
+      // Every component gets the intent, not just the first - a composed app
+      // half-stopped is the failure this covers.
+      sinon.assert.calledWith(appsRuntimeState.setOperatorStopped, 'Component1_ComposedApp', true);
+      sinon.assert.calledWith(appsRuntimeState.setOperatorStopped, 'Component2_ComposedApp', true);
     });
 
     it('should handle component stop', async () => {
       verificationHelperStub.resolves(true);
+      sinon.stub(appsRuntimeState, 'setOperatorStopped').resolves();
 
       const req = {
         params: { appname: 'Component_TestApp' },
@@ -238,14 +251,52 @@ describe('appController tests', () => {
 
       const result = res.json.firstCall.args[0];
       expect(result.status).to.equal('success');
-      sinon.assert.calledOnce(dockerService.appDockerStop);
-      sinon.assert.calledWith(dockerService.appDockerStop, 'Component_TestApp');
+      sinon.assert.notCalled(dockerService.appDockerStop);
+      sinon.assert.calledWith(appsRuntimeState.setOperatorStopped, 'Component_TestApp', true);
     });
 
-    it('sets the operator lock BEFORE the docker stop on the component path (crash-safe ordering)', async () => {
-      // the whole-app path already locks first; lock-after means a crash between
-      // the docker stop and the lock write leaves a stopped container the
-      // reconciler will restart against the operator's intent
+    it('reports pending, not failure, when docker cannot be reached', async () => {
+      // The old direct call threw here - AFTER the lock had been written - so an
+      // operator was told their stop failed while it was durable and would apply
+      // the moment docker returned. They retry against an app that is already
+      // stopping. Pending is the true answer.
+      verificationHelperStub.resolves(true);
+      sinon.stub(appsRuntimeState, 'setOperatorStopped').resolves();
+      // The boot gate holds every enqueue until daemon/DB are ready, and a
+      // handler that never got a pass reports pending for that reason instead.
+      globalState.bootContainerStateSettled = true;
+      sinon.stub(appReconciler, 'dockerActual').resolves({ reachable: false, running: false });
+
+      const req = { params: { appname: 'Component_TestApp' }, query: {} };
+      const res = { json: sinon.fake((param) => param) };
+      await appController.appStop(req, res);
+
+      const result = res.json.firstCall.args[0];
+      expect(result.status).to.equal('success');
+      expect(result.data).to.contain('will be stopped');
+      expect(result.data).to.contain('docker is not reachable');
+    });
+
+    it('reports stopped only once the container is actually down', async () => {
+      verificationHelperStub.resolves(true);
+      sinon.stub(appsRuntimeState, 'setOperatorStopped').resolves();
+      globalState.bootContainerStateSettled = true;
+      sinon.stub(appReconciler, 'dockerActual').resolves({ reachable: true, running: false });
+
+      const req = { params: { appname: 'Component_TestApp' }, query: {} };
+      const res = { json: sinon.fake((param) => param) };
+      await appController.appStop(req, res);
+
+      const result = res.json.firstCall.args[0];
+      expect(result.data).to.equal('Application Component_TestApp stopped');
+    });
+
+    it('writes the intent and leaves the container to the reconciler', async () => {
+      // This replaces an ordering assertion - lock before docker stop - whose
+      // premise was that the handler stops the container. It does not: the
+      // reconciler is the only actuator, so there is no second operation for the
+      // lock to be ordered against, and a crash after the write leaves an intent
+      // that converges rather than a stopped container that gets restarted.
       verificationHelperStub.resolves(true);
       const setOperatorStopped = sinon.stub(appsRuntimeState, 'setOperatorStopped').resolves();
 
@@ -254,7 +305,7 @@ describe('appController tests', () => {
       await appController.appStop(req, res);
 
       sinon.assert.calledOnceWithExactly(setOperatorStopped, 'Component_TestApp', true);
-      sinon.assert.callOrder(setOperatorStopped, dockerService.appDockerStop);
+      sinon.assert.notCalled(dockerService.appDockerStop);
     });
 
     it('retracts the controller desire so a released lock cannot restart it behind the election', async () => {

--- a/tests/unit/appInspector.test.js
+++ b/tests/unit/appInspector.test.js
@@ -93,6 +93,50 @@ describe('appInspector tests', () => {
     sinon.restore();
   });
 
+  describe('ensureAppMonitoring', () => {
+    let clock;
+
+    beforeEach(() => {
+      clock = sinon.useFakeTimers();
+    });
+
+    afterEach(() => {
+      appInspector.stopAppMonitoring('myapp', true);
+      clock.restore();
+    });
+
+    it('keeps the series a running monitor has already collected', () => {
+      appInspector.startAppMonitoring('myapp');
+      globalStateStub.appsMonitored.myapp.statsStore.push({ timestamp: 1, data: {} });
+
+      appInspector.ensureAppMonitoring('myapp');
+
+      // startAppMonitoring resets statsStore. The reconciler reaches a healthy
+      // container on every pass, so calling it there would discard the series
+      // the charts read, roughly once a minute.
+      expect(globalStateStub.appsMonitored.myapp.statsStore).to.have.lengthOf(1);
+    });
+
+    it('starts monitoring for an app that has none', () => {
+      appInspector.ensureAppMonitoring('myapp');
+
+      expect(globalStateStub.appsMonitored.myapp).to.not.equal(undefined);
+      expect(globalStateStub.appsMonitored.myapp.oneMinuteInterval).to.not.equal(null);
+    });
+
+    it('restarts a monitor that was stopped without deleting its data', () => {
+      appInspector.startAppMonitoring('myapp');
+      appInspector.stopAppMonitoring('myapp', false);
+      expect(globalStateStub.appsMonitored.myapp.oneMinuteInterval, 'a cleared interval must not still look live').to.equal(null);
+
+      appInspector.ensureAppMonitoring('myapp');
+
+      // The record survives a stop that kept its data, so "is this monitored"
+      // cannot be answered by the record's existence alone.
+      expect(globalStateStub.appsMonitored.myapp.oneMinuteInterval).to.not.equal(null);
+    });
+  });
+
   describe('startAppMonitoring - what one tick keeps', () => {
     // The first coverage of the docker -> stored direction. Everything else about
     // the sampler is asserted on samples handed to it already extracted, so what

--- a/tests/unit/appInstaller.test.js
+++ b/tests/unit/appInstaller.test.js
@@ -319,7 +319,7 @@ describe('appInstaller tests', () => {
       };
 
       verificationHelperStub.verifyPrivilege.withArgs('user', req).resolves(true);
-      verificationHelperStub.verifyPrivilege.withArgs('adminandfluxteam', req).resolves(true);
+      verificationHelperStub.verifyPrivilege.withArgs('fluxteam', req).resolves(true);
 
       const mockDb = { db: sinon.stub().returns('database') };
       dbHelperStub.databaseConnection.returns(mockDb);
@@ -332,6 +332,70 @@ describe('appInstaller tests', () => {
 
       expect(res.json.calledOnce).to.be.true;
       expect(logStub.error.called).to.be.true;
+    });
+  });
+
+  // Placing a registered app on a node is not the operator's call, for the same
+  // reason removing one is not. The temporary-message route is deliberately NOT
+  // closed with it - that is how an app is tested before it is registered.
+  describe('local install is not the node operator\'s to make', () => {
+    const nameInstall = () => ({ params: { appname: 'someCustomerApp' }, query: {} });
+
+    it('refuses a node admin installing a registered app by name', async () => {
+      const req = nameInstall();
+      const res = { json: sinon.stub(), setHeader: sinon.stub() };
+
+      verificationHelperStub.verifyPrivilege.withArgs('user', req).resolves(true);
+      // the node operator's own privilege - held, and no longer sufficient here
+      verificationHelperStub.verifyPrivilege.withArgs('adminandfluxteam', req).resolves(true);
+      verificationHelperStub.verifyPrivilege.withArgs('fluxteam', req).resolves(false);
+      messageVerifierStub.checkAppTemporaryMessageExistence.resolves(null);
+      messageHelperStub.errUnauthorizedMessage.returns({ status: 'error', data: { message: 'Unauthorized' } });
+
+      await appInstaller.installAppLocally(req, res);
+
+      expect(verificationHelperStub.verifyPrivilege.calledWith('fluxteam', req), 'the gate must ask for fluxteam').to.be.true;
+      expect(res.json.calledOnce).to.be.true;
+      expect(res.json.firstCall.args[0].data.message).to.equal('Unauthorized');
+    });
+
+    it('refuses a node admin on the test-install route too', async () => {
+      const req = nameInstall();
+      const res = { json: sinon.stub(), setHeader: sinon.stub() };
+
+      verificationHelperStub.verifyPrivilege.withArgs('user', req).resolves(true);
+      verificationHelperStub.verifyPrivilege.withArgs('adminandfluxteam', req).resolves(true);
+      verificationHelperStub.verifyPrivilege.withArgs('fluxteam', req).resolves(false);
+      messageVerifierStub.checkAppTemporaryMessageExistence.resolves(null);
+      messageHelperStub.errUnauthorizedMessage.returns({ status: 'error', data: { message: 'Unauthorized' } });
+
+      await appInstaller.testAppInstall(req, res);
+
+      expect(res.json.calledOnce).to.be.true;
+      expect(res.json.firstCall.args[0].data.message).to.equal('Unauthorized');
+    });
+
+    // The one that must keep working: an app under test is addressed by HASH and
+    // carries a temporary message, so it never reaches the by-name gate at all.
+    it('still lets any logged-in user install an app under test by its temporary message', async () => {
+      const req = { params: { appname: 'a1b2c3hash' }, query: {} };
+      const res = { json: sinon.stub(), setHeader: sinon.stub(), write: sinon.stub() };
+
+      verificationHelperStub.verifyPrivilege.withArgs('user', req).resolves(true);
+      verificationHelperStub.verifyPrivilege.withArgs('adminandfluxteam', req).resolves(false);
+      verificationHelperStub.verifyPrivilege.withArgs('fluxteam', req).resolves(false);
+      messageVerifierStub.checkAppTemporaryMessageExistence.resolves({
+        appSpecifications: { name: 'apptest', version: 3, owner: 'someone' },
+      });
+      messageHelperStub.errUnauthorizedMessage.returns({ status: 'error', data: { message: 'Unauthorized' } });
+
+      await appInstaller.installAppLocally(req, res);
+
+      // It got past the gate: no Unauthorized was returned, and the by-name
+      // privilege was never consulted because a temporary message was found.
+      const unauthorized = res.json.getCalls().some((c) => c.args[0]?.data?.message === 'Unauthorized');
+      expect(unauthorized, 'a temporary app must not be refused').to.equal(false);
+      expect(verificationHelperStub.verifyPrivilege.calledWith('fluxteam', req), 'the by-name gate must not be reached').to.be.false;
     });
   });
 
@@ -382,7 +446,7 @@ describe('appInstaller tests', () => {
       };
 
       verificationHelperStub.verifyPrivilege.withArgs('user', req).resolves(true);
-      verificationHelperStub.verifyPrivilege.withArgs('adminandfluxteam', req).resolves(true);
+      verificationHelperStub.verifyPrivilege.withArgs('fluxteam', req).resolves(true);
 
       const mockDb = { db: sinon.stub().returns('database') };
       dbHelperStub.databaseConnection.returns(mockDb);
@@ -430,7 +494,7 @@ describe('appInstaller tests', () => {
       };
 
       verificationHelperStub.verifyPrivilege.withArgs('user', req).resolves(true);
-      verificationHelperStub.verifyPrivilege.withArgs('adminandfluxteam', req).resolves(true);
+      verificationHelperStub.verifyPrivilege.withArgs('fluxteam', req).resolves(true);
 
       const mockDb = { db: sinon.stub().returns('database') };
       dbHelperStub.databaseConnection.returns(mockDb);

--- a/tests/unit/appReconciler.test.js
+++ b/tests/unit/appReconciler.test.js
@@ -853,6 +853,21 @@ describe('appReconciler tests', () => {
       expect(line).to.include('restarting too fast');
       expect(line, 'a clean exit must not be reported as a fault').to.not.include('exit 0');
     });
+
+    // waitMs is what REMAINS of the rung, and the worker re-enqueues during a
+    // wait, so one rung reports several times with a falling number. Support
+    // cannot tell how far a component has escalated from that alone. The same
+    // value rides the actuation event, which is where suite 54 reads it.
+    it('says how far up the ladder the backoff is, not only how long is left', async () => {
+      stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: false, Status: 'exited', ExitCode: 0 } });
+      stubs.appsRuntimeState.restartWaitMs.resolves(30 * 1000);
+      stubs.appsRuntimeState.getState.resolves({ restartHistory: [1, 2, 3] });
+
+      await appReconciler.reconcile('www_App');
+
+      const line = stubs.log.warn.getCalls().map((c) => c.args[0]).find((m) => m.includes('backing off'));
+      expect(line, 'three rungs stand, so this is the third').to.include('rung 3');
+    });
   });
 
   // The sync layer's first-run / new-app reset was previously an imperative

--- a/tests/unit/appReconciler.test.js
+++ b/tests/unit/appReconciler.test.js
@@ -1131,6 +1131,33 @@ describe('appReconciler tests', () => {
       const deferred = stubs.log.warn.getCalls().some((c) => /spec read failed, deferring/.test(c.args[0]));
       expect(deferred, 'should defer on decrypt failure, never act on still-encrypted data').to.equal(true);
     });
+
+    // The two branches read from different sources - compose for a readable
+    // spec, docker's own container names for an unreadable one - and docker
+    // namespaces every name it holds. The list must carry one spelling: every
+    // consumer up to now canonicalised on ingest and so could not tell them
+    // apart, which is what let the divergence stand until one compared the list
+    // against a component name an operator typed.
+    it('returns the bare component identifier whether or not the spec decrypted', async () => {
+      const plain = { name: 'Plain', version: 4, compose: [{ name: 'www', containerData: '/data' }] };
+      const encrypted = {
+        name: 'EntApp', version: 8, enterprise: 'CIPHERTEXT', compose: [],
+      };
+      stubs.appQueryService.decryptEnterpriseApps.callsFake(async (arr) => ({
+        readable: arr.filter((a) => !a.enterprise),
+        unreadable: arr.filter((a) => a.enterprise),
+        inPlace: arr,
+      }));
+      stubs.dockerService.dockerListContainers.resolves([
+        { Names: ['/fluxc1_EntApp'] },
+        { Names: ['/fluxc2_EntApp'] },
+      ]);
+
+      const ids = await appReconciler.componentIdsOf([plain, encrypted]);
+
+      expect(ids, 'docker-derived ids must be namespace-stripped like compose-derived ones')
+        .to.have.members(['www_Plain', 'c1_EntApp', 'c2_EntApp']);
+    });
   });
 
   // The sweep contract: enqueueAll must cover EVERY installed component -

--- a/tests/unit/appReconciler.test.js
+++ b/tests/unit/appReconciler.test.js
@@ -714,7 +714,7 @@ describe('appReconciler tests', () => {
         },
       });
       await appReconciler.reconcile('www_App');
-      sinon.assert.calledWithExactly(stubs.appsRuntimeState.restartWaitMs, 'www_App', Date.parse(finishedAt));
+      sinon.assert.calledWithExactly(stubs.appsRuntimeState.restartWaitMs, 'www_App', Date.parse(finishedAt), true);
     });
 
     it('passes no death evidence for a container that never ran (docker zero FinishedAt)', async () => {
@@ -724,7 +724,37 @@ describe('appReconciler tests', () => {
         },
       });
       await appReconciler.reconcile('www_App');
-      sinon.assert.calledWithExactly(stubs.appsRuntimeState.restartWaitMs, 'www_App', null);
+      sinon.assert.calledWithExactly(stubs.appsRuntimeState.restartWaitMs, 'www_App', null, false);
+    });
+
+    // The ladder exists to keep a broken container from hammering the node. An
+    // operator restarting their own app is not that, and pacing it turns a
+    // deliberate restart into what the customer experiences as an outage - so
+    // the verdict the reconciler forms here decides whether the ladder engages
+    // at all. exitCode alone cannot carry it: OOMKilled is a fault Docker
+    // reports separately, and a never-run container has no death to classify.
+    [
+      { name: 'a clean exit is not a fault', state: { Running: false, Status: 'exited', ExitCode: 0 }, crashed: false },
+      { name: 'a non-zero exit is', state: { Running: false, Status: 'exited', ExitCode: 1 }, crashed: true },
+      { name: 'a signal death is', state: { Running: false, Status: 'exited', ExitCode: 139 }, crashed: true },
+      { name: 'an OOM kill is, even reported alongside a clean exit code', state: { Running: false, Status: 'exited', ExitCode: 0, OOMKilled: true }, crashed: true },
+      { name: 'a container that has never run is not', state: { Running: false, Status: 'created', ExitCode: 0 }, crashed: false },
+    ].forEach(({ name, state, crashed }) => {
+      it(`classifies the stop for the ladder: ${name}`, async () => {
+        stubs.dockerService.dockerContainerInspect.resolves({ State: state });
+        await appReconciler.reconcile('www_App');
+        sinon.assert.calledWithMatch(stubs.appsRuntimeState.restartWaitMs, 'www_App', sinon.match.any, crashed);
+        sinon.assert.calledWithExactly(stubs.appsRuntimeState.recordRestart, 'www_App', crashed);
+      });
+    });
+
+    it('names the burst trip in the log, so support can tell it from a reported fault', async () => {
+      stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: false, Status: 'exited', ExitCode: 0 } });
+      stubs.appsRuntimeState.restartWaitMs.resolves(30 * 1000);
+      await appReconciler.reconcile('www_App');
+      const line = stubs.log.warn.getCalls().map((c) => c.args[0]).find((m) => m.includes('backing off'));
+      expect(line).to.include('restarting too fast');
+      expect(line, 'a clean exit must not be reported as a fault').to.not.include('exit 0');
     });
   });
 

--- a/tests/unit/appReconciler.test.js
+++ b/tests/unit/appReconciler.test.js
@@ -809,7 +809,7 @@ describe('appReconciler tests', () => {
         },
       });
       await appReconciler.reconcile('www_App');
-      sinon.assert.calledWithExactly(stubs.appsRuntimeState.restartWaitMs, 'www_App', Date.parse(finishedAt), true);
+      sinon.assert.calledWithExactly(stubs.appsRuntimeState.restartWaitMs, 'www_App', Date.parse(finishedAt));
     });
 
     it('passes no death evidence for a container that never ran (docker zero FinishedAt)', async () => {
@@ -819,15 +819,16 @@ describe('appReconciler tests', () => {
         },
       });
       await appReconciler.reconcile('www_App');
-      sinon.assert.calledWithExactly(stubs.appsRuntimeState.restartWaitMs, 'www_App', null, false);
+      sinon.assert.calledWithExactly(stubs.appsRuntimeState.restartWaitMs, 'www_App', null);
     });
 
     // The ladder exists to keep a broken container from hammering the node. An
     // operator restarting their own app is not that, and pacing it turns a
     // deliberate restart into what the customer experiences as an outage - so
-    // the verdict the reconciler forms here decides whether the ladder engages
-    // at all. exitCode alone cannot carry it: OOMKilled is a fault Docker
-    // reports separately, and a never-run container has no death to classify.
+    // the verdict the reconciler forms here decides whether a stop puts the
+    // component on the ladder. exitCode alone cannot carry it: OOMKilled is a
+    // fault Docker reports separately, and a never-run container has no death to
+    // classify.
     [
       { name: 'a clean exit is not a fault', state: { Running: false, Status: 'exited', ExitCode: 0 }, crashed: false },
       { name: 'a non-zero exit is', state: { Running: false, Status: 'exited', ExitCode: 1 }, crashed: true },
@@ -838,7 +839,8 @@ describe('appReconciler tests', () => {
       it(`classifies the stop for the ladder: ${name}`, async () => {
         stubs.dockerService.dockerContainerInspect.resolves({ State: state });
         await appReconciler.reconcile('www_App');
-        sinon.assert.calledWithMatch(stubs.appsRuntimeState.restartWaitMs, 'www_App', sinon.match.any, crashed);
+        // The verdict decides what earns a rung, not whether the wait applies:
+        // a component holding rungs is paced whatever its next exit reads.
         sinon.assert.calledWithExactly(stubs.appsRuntimeState.recordRestart, 'www_App', crashed);
       });
     });

--- a/tests/unit/appReconciler.test.js
+++ b/tests/unit/appReconciler.test.js
@@ -26,6 +26,8 @@ describe('appReconciler tests', () => {
         getDockerContainerOnly: sinon.stub().resolves(undefined),
         appDockerStart: sinon.stub().resolves(),
         appDockerStop: sinon.stub().resolves(),
+        appDockerKill: sinon.stub().resolves(),
+        appDockerRestart: sinon.stub().resolves(),
         appDockerForceRemove: sinon.stub().resolves(),
         getAppIdentifier: (id) => `flux${id}`,
         getAppDockerNameIdentifier: (id) => `/flux${id}`,
@@ -48,7 +50,7 @@ describe('appReconciler tests', () => {
         bootContainerStateSettled: true,
         waitForBootContainerStateSettled: () => Promise.resolve(),
       },
-      appInspector: { startAppMonitoring: sinon.stub(), stopAppMonitoring: sinon.stub() },
+      appInspector: { startAppMonitoring: sinon.stub(), ensureAppMonitoring: sinon.stub(), stopAppMonitoring: sinon.stub() },
       volumeService: {
         ensureMountPathsExist: sinon.stub().resolves(),
         ensureAppVolumeMounted: sinon.stub().resolves({ mounted: true, alreadyMounted: true }),
@@ -61,6 +63,10 @@ describe('appReconciler tests', () => {
         restartWaitMs: sinon.stub().resolves(0),
         recordRestart: sinon.stub().resolves(),
         recordExit: sinon.stub().resolves(),
+        // no pending restart and no force by default; the tests that exercise
+        // either set their own document
+        getState: sinon.stub().resolves({}),
+        recordRestartGeneration: sinon.stub().resolves(),
         // durable "I removed this container for a network heal" flag + its own ladder
         isNetworkHealRemoval: sinon.stub().resolves(false),
         setNetworkHealRemoval: sinon.stub().resolves(),
@@ -162,6 +168,95 @@ describe('appReconciler tests', () => {
       await appReconciler.reconcile('www_App');
       expect(stubs.dockerService.appDockerStop.calledOnceWith('www_App')).to.be.true;
       expect(stubs.dockerService.appDockerStart.called).to.be.false;
+    });
+
+    // The sampler runs on its own interval against a container id. Left on after
+    // a stop it inspects a stopped container once a minute, forever, and the only
+    // thing that used to stop it was the handler that no longer stops containers.
+    it('stops the stats monitor along with the container it stopped', async () => {
+      stubs.appsRuntimeState.isOperatorStopped.resolves(true);
+      stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: true, Status: 'running', ExitCode: 0 } });
+
+      await appReconciler.reconcile('www_App');
+
+      expect(stubs.dockerService.appDockerStop.calledOnceWith('www_App'), 'the container must actually be stopped, or the assertion below proves nothing').to.be.true;
+      expect(stubs.appInspector.stopAppMonitoring.calledOnceWith('www_App', false)).to.be.true;
+    });
+
+    // A stop docker never carried out still turned the sampler off, so the
+    // container kept running unwatched with no later pass to notice. The
+    // reconciler reaches a running container every pass; it is the one place that
+    // can put monitoring back.
+    it('puts monitoring back for a running container that has none', async () => {
+      stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: true, Status: 'running', ExitCode: 0 } });
+
+      await appReconciler.reconcile('www_App');
+
+      expect(stubs.appInspector.ensureAppMonitoring.calledOnceWith('www_App')).to.be.true;
+      // ensure, never start: startAppMonitoring resets statsStore, and this runs
+      // on every pass over a healthy container.
+      expect(stubs.appInspector.startAppMonitoring.called).to.be.false;
+    });
+
+    // An operator kill is a stop carrying a signal. The mode is durable so a
+    // crash between the request and the stop cannot quietly downgrade "kill now"
+    // into a graceful drain the operator did not ask for.
+    it('kills rather than stops when the operator asked for a force stop', async () => {
+      stubs.appsRuntimeState.isOperatorStopped.resolves(true);
+      stubs.appsRuntimeState.getState.resolves({ operatorStopForce: true });
+      stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: true, Status: 'running', ExitCode: 0 } });
+
+      await appReconciler.reconcile('www_App');
+
+      expect(stubs.dockerService.appDockerKill.calledOnceWith('www_App')).to.be.true;
+      expect(stubs.dockerService.appDockerStop.called, 'a forced stop must not also send the graceful one').to.be.false;
+    });
+
+    // The inverse, or the assertion above proves only that the flag was readable:
+    // a plain stop must stay graceful.
+    it('stops gracefully when the operator asked for a plain stop', async () => {
+      stubs.appsRuntimeState.isOperatorStopped.resolves(true);
+      stubs.appsRuntimeState.getState.resolves({ operatorStopForce: false });
+      stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: true, Status: 'running', ExitCode: 0 } });
+
+      await appReconciler.reconcile('www_App');
+
+      expect(stubs.dockerService.appDockerStop.calledOnceWith('www_App')).to.be.true;
+      expect(stubs.dockerService.appDockerKill.called).to.be.false;
+    });
+
+    it('bounces a running container whose restart generation is ahead of the one actuated', async () => {
+      stubs.appsRuntimeState.getState.resolves({ restartGeneration: 3, actuatedRestartGeneration: 2 });
+      stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: true, Status: 'running', ExitCode: 0 } });
+
+      await appReconciler.reconcile('www_App');
+
+      expect(stubs.dockerService.appDockerRestart.calledOnceWith('www_App')).to.be.true;
+      // Recorded, or the next pass bounces it again - the request is a level, and
+      // a level nothing marks as reached is a loop.
+      expect(stubs.appsRuntimeState.recordRestartGeneration.calledOnceWith('www_App', 3)).to.be.true;
+    });
+
+    it('leaves a running container alone once its restart generation is actuated', async () => {
+      stubs.appsRuntimeState.getState.resolves({ restartGeneration: 3, actuatedRestartGeneration: 3 });
+      stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: true, Status: 'running', ExitCode: 0 } });
+
+      await appReconciler.reconcile('www_App');
+
+      expect(stubs.dockerService.appDockerRestart.called).to.be.false;
+    });
+
+    // Restarting a stopped container IS starting it, so the start satisfies the
+    // request. Left pending, the pass that next finds it running would bounce a
+    // container the operator has just watched come up.
+    it('treats the start of a stopped container as the restart that was requested', async () => {
+      stubs.appsRuntimeState.getState.resolves({ restartGeneration: 4, actuatedRestartGeneration: 1 });
+
+      await appReconciler.reconcile('www_App'); // inspect default: stopped
+
+      expect(stubs.dockerService.appDockerStart.calledOnceWith('www_App'), 'the container must actually start, or the assertion below proves nothing').to.be.true;
+      expect(stubs.appsRuntimeState.recordRestartGeneration.calledWith('www_App', 4)).to.be.true;
+      expect(stubs.dockerService.appDockerRestart.called, 'a stopped container is started, never restarted').to.be.false;
     });
 
     it('leaves an operator-stopped container alone if already stopped', async () => {

--- a/tests/unit/appReconciler.test.js
+++ b/tests/unit/appReconciler.test.js
@@ -1484,4 +1484,62 @@ describe('appReconciler tests', () => {
       }
     });
   });
+  describe('applyIntent serialises an intent write against a reconcile pass', () => {
+    // The defect this closes: a pass reads isOperatorStopped, then acts on that
+    // answer once docker has replied. An operator stop landing in that gap is
+    // not seen, so the pass starts a container the operator has just stopped and
+    // the next pass stops it again - the flap suite 45 catches.
+    function blockDockerInspect() {
+      let release;
+      stubs.dockerService.dockerContainerInspect = sinon.stub().returns(new Promise((resolve) => {
+        release = () => resolve({ State: { Running: true, Status: 'running', ExitCode: 0 } });
+      }));
+      return () => release();
+    }
+
+    it('holds the write until a pass already deciding has finished', async () => {
+      const releaseInspect = blockDockerInspect();
+      appReconciler.enqueue('www_App');
+      await new Promise(setImmediate);
+
+      let written = false;
+      const intent = appReconciler.applyIntent('www_App', async () => { written = true; });
+      await new Promise(setImmediate);
+
+      // The pass is parked on docker with its desired-state answer already in
+      // hand. Writing now is exactly what it would fail to see.
+      expect(written, 'the write must not land while a pass is mid-decision').to.equal(false);
+
+      releaseInspect();
+      await intent;
+      expect(written, 'and must land once that pass is done').to.equal(true);
+    });
+
+    it('makes a pass requested during the write wait for it', async () => {
+      let releaseWrite;
+      const writing = new Promise((resolve) => { releaseWrite = resolve; });
+      const intent = appReconciler.applyIntent('www_App', () => writing);
+      await new Promise(setImmediate);
+
+      appReconciler.enqueue('www_App');
+      await new Promise(setImmediate);
+
+      // Held key: the request is coalesced, not started against the state this
+      // write is in the middle of replacing.
+      expect(stubs.dockerService.dockerContainerInspect.called,
+        'no pass may start against a half-written intent').to.equal(false);
+
+      releaseWrite();
+      await intent;
+    });
+
+    it('runs a pass once the write is durable', async () => {
+      // Convergence: the intent is worth nothing if nothing acts on it.
+      await appReconciler.applyIntent('www_App', async () => {});
+      await new Promise(setImmediate);
+
+      expect(stubs.dockerService.dockerContainerInspect.called).to.equal(true);
+    });
+  });
+
 });

--- a/tests/unit/appReconciler.test.js
+++ b/tests/unit/appReconciler.test.js
@@ -1533,6 +1533,24 @@ describe('appReconciler tests', () => {
       await intent;
     });
 
+    it('awaitPass holds the caller until the pass has finished', async () => {
+      // What the API contract rests on. appStop reports "stopped" rather than
+      // "asked to stop", so it must not answer before the reconciler has acted -
+      // otherwise it probes a container the pass has not reached yet and reports
+      // whatever it happened to find.
+      const releaseInspect = blockDockerInspect();
+      let settled = false;
+      const intent = appReconciler
+        .applyIntent('www_App', async () => {}, { awaitPass: true })
+        .then((r) => { settled = true; return r; });
+
+      await new Promise(setImmediate);
+      expect(settled, 'must not resolve while the pass is still running').to.equal(false);
+
+      releaseInspect();
+      expect(await intent, 'and reports that a pass ran').to.equal(true);
+    });
+
     it('runs a pass once the write is durable', async () => {
       // Convergence: the intent is worth nothing if nothing acts on it.
       await appReconciler.applyIntent('www_App', async () => {});

--- a/tests/unit/appReconciler.test.js
+++ b/tests/unit/appReconciler.test.js
@@ -259,6 +259,50 @@ describe('appReconciler tests', () => {
       expect(stubs.dockerService.appDockerRestart.called, 'a stopped container is started, never restarted').to.be.false;
     });
 
+    // The generation write is the only thing that stops the next pass bouncing the
+    // container again, so it surfaces rather than being swallowed - swallowed, a
+    // node whose reads work and whose writes do not restarted the app every verify
+    // interval forever, on the one path exempt from the backoff ladder. It is
+    // written LAST for the same reason: the bounce already happened, so a failed
+    // record must not also cost the bookkeeping a successful restart is owed.
+    it('a failed generation write keeps the bounce its bookkeeping, and fails the pass', async () => {
+      const onStarted = sinon.stub();
+      appReconciler.setOnContainerStarted(onStarted);
+      stubs.appsRuntimeState.getState.resolves({ restartGeneration: 3, actuatedRestartGeneration: 2 });
+      stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: true, Status: 'running', ExitCode: 0 } });
+      stubs.appsRuntimeState.recordRestartGeneration.rejects(new Error('not enough disk space'));
+
+      let thrown = null;
+      await appReconciler.reconcile('www_App').catch((e) => { thrown = e; });
+
+      expect(
+        stubs.dockerService.appDockerRestart.calledOnceWith('www_App'),
+        'the bounce must have happened, or the assertions below prove nothing',
+      ).to.be.true;
+      expect(
+        onStarted.calledOnceWith('www_App'),
+        'the notification is owed to a restart that happened - it is the record that failed, not the restart',
+      ).to.be.true;
+      expect(
+        thrown,
+        'the pass must fail, so the retry paces and bounds it instead of looping every verify interval',
+      ).to.be.an('error');
+    });
+
+    it('a failed generation write on the start path keeps the start notified, and fails the pass', async () => {
+      const onStarted = sinon.stub();
+      appReconciler.setOnContainerStarted(onStarted);
+      stubs.appsRuntimeState.getState.resolves({ restartGeneration: 4, actuatedRestartGeneration: 1 });
+      stubs.appsRuntimeState.recordRestartGeneration.rejects(new Error('not enough disk space'));
+
+      let thrown = null;
+      await appReconciler.reconcile('www_App').catch((e) => { thrown = e; }); // stopped -> start
+
+      expect(stubs.dockerService.appDockerStart.calledOnceWith('www_App')).to.be.true;
+      expect(onStarted.calledOnceWith('www_App')).to.be.true;
+      expect(thrown).to.be.an('error');
+    });
+
     it('leaves an operator-stopped container alone if already stopped', async () => {
       stubs.appsRuntimeState.isOperatorStopped.resolves(true);
       await appReconciler.reconcile('www_App'); // inspect default: stopped

--- a/tests/unit/appReconciler.test.js
+++ b/tests/unit/appReconciler.test.js
@@ -497,6 +497,37 @@ describe('appReconciler tests', () => {
       }
     });
 
+    // The operator's stop is the one support reaches for when a volume will not
+    // mount, and it outranks the controller's everywhere else in the pass. Reading
+    // only the controller here left a human's stop inert in exactly the state it
+    // exists for, with the container running on over the missing volume.
+    it('honors an OPERATOR stop even when the data volume cannot be mounted', async () => {
+      stubs.volumeService.ensureAppVolumeMounted.resolves({ mounted: false, reason: 'volume_file_missing' });
+      stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: true, Status: 'running', ExitCode: 0 } });
+      stubs.appsRuntimeState.operatorStopState.resolves({ stopped: true, force: false });
+
+      await appReconciler.reconcile('www_App');
+
+      expect(stubs.dockerService.appDockerStop.calledWith('www_App')).to.be.true;
+      expect(stubs.dockerService.appDockerKill.called, 'a plain stop is not a kill').to.be.false;
+      expect(stubs.dockerService.appDockerStart.called).to.be.false;
+      expect(stubs.volumeService.clearAppVolumeData.called).to.be.false;
+    });
+
+    // An appkill against an unmounted volume must still be a kill: this branch
+    // returns before the main actuation, so dropping the flag here downgrades the
+    // operator's hard kill to a graceful stop with nothing to say so.
+    it('honors an operator KILL as a kill when the data volume cannot be mounted', async () => {
+      stubs.volumeService.ensureAppVolumeMounted.resolves({ mounted: false, reason: 'volume_file_missing' });
+      stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: true, Status: 'running', ExitCode: 0 } });
+      stubs.appsRuntimeState.operatorStopState.resolves({ stopped: true, force: true });
+
+      await appReconciler.reconcile('www_App');
+
+      expect(stubs.dockerService.appDockerKill.calledWith('www_App')).to.be.true;
+      expect(stubs.dockerService.appDockerStop.called, 'a kill is not downgraded to a stop').to.be.false;
+    });
+
     it('mounts an unmounted volume and proceeds with the start', async () => {
       stubs.volumeService.ensureAppVolumeMounted.resolves({ mounted: true, alreadyMounted: false });
       await appReconciler.reconcile('www_App');

--- a/tests/unit/appReconciler.test.js
+++ b/tests/unit/appReconciler.test.js
@@ -60,6 +60,7 @@ describe('appReconciler tests', () => {
       },
       appsRuntimeState: {
         isOperatorStopped: sinon.stub().resolves(false),
+        operatorStopState: sinon.stub().resolves({ stopped: false, force: false }),
         restartWaitMs: sinon.stub().resolves(0),
         recordRestart: sinon.stub().resolves(),
         recordExit: sinon.stub().resolves(),
@@ -163,7 +164,7 @@ describe('appReconciler tests', () => {
     });
 
     it('stops a running container the operator has stopped', async () => {
-      stubs.appsRuntimeState.isOperatorStopped.resolves(true);
+      stubs.appsRuntimeState.operatorStopState.resolves({ stopped: true, force: false });
       stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: true, Status: 'running', ExitCode: 0 } });
       await appReconciler.reconcile('www_App');
       expect(stubs.dockerService.appDockerStop.calledOnceWith('www_App')).to.be.true;
@@ -174,7 +175,7 @@ describe('appReconciler tests', () => {
     // a stop it inspects a stopped container once a minute, forever, and the only
     // thing that used to stop it was the handler that no longer stops containers.
     it('stops the stats monitor along with the container it stopped', async () => {
-      stubs.appsRuntimeState.isOperatorStopped.resolves(true);
+      stubs.appsRuntimeState.operatorStopState.resolves({ stopped: true, force: false });
       stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: true, Status: 'running', ExitCode: 0 } });
 
       await appReconciler.reconcile('www_App');
@@ -202,8 +203,7 @@ describe('appReconciler tests', () => {
     // crash between the request and the stop cannot quietly downgrade "kill now"
     // into a graceful drain the operator did not ask for.
     it('kills rather than stops when the operator asked for a force stop', async () => {
-      stubs.appsRuntimeState.isOperatorStopped.resolves(true);
-      stubs.appsRuntimeState.getState.resolves({ operatorStopForce: true });
+      stubs.appsRuntimeState.operatorStopState.resolves({ stopped: true, force: true });
       stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: true, Status: 'running', ExitCode: 0 } });
 
       await appReconciler.reconcile('www_App');
@@ -215,14 +215,33 @@ describe('appReconciler tests', () => {
     // The inverse, or the assertion above proves only that the flag was readable:
     // a plain stop must stay graceful.
     it('stops gracefully when the operator asked for a plain stop', async () => {
-      stubs.appsRuntimeState.isOperatorStopped.resolves(true);
-      stubs.appsRuntimeState.getState.resolves({ operatorStopForce: false });
+      stubs.appsRuntimeState.operatorStopState.resolves({ stopped: true, force: false });
       stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: true, Status: 'running', ExitCode: 0 } });
 
       await appReconciler.reconcile('www_App');
 
       expect(stubs.dockerService.appDockerStop.calledOnceWith('www_App')).to.be.true;
       expect(stubs.dockerService.appDockerKill.called).to.be.false;
+    });
+
+    // The defect this closes: the lock and the mode were two reads of one
+    // document, and getState returns null for a read failure exactly as it does
+    // for "no record" - so a second read that failed reported no force flag and
+    // downgraded the operator's kill into a drain they never asked for. The mode
+    // now arrives with the decision that read it, so nothing later can contradict
+    // it. An empty getState here IS what that failed read looked like.
+    it('kills even when a later state read comes back empty', async () => {
+      stubs.appsRuntimeState.operatorStopState.resolves({ stopped: true, force: true });
+      stubs.appsRuntimeState.getState.resolves(null);
+      stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: true, Status: 'running', ExitCode: 0 } });
+
+      await appReconciler.reconcile('www_App');
+
+      expect(
+        stubs.dockerService.appDockerKill.calledOnceWith('www_App'),
+        'the operator asked for a kill - a read that came back empty must not quietly downgrade it',
+      ).to.be.true;
+      expect(stubs.dockerService.appDockerStop.called, 'and it must not also send the graceful stop').to.be.false;
     });
 
     it('bounces a running container whose restart generation is ahead of the one actuated', async () => {
@@ -304,7 +323,7 @@ describe('appReconciler tests', () => {
     });
 
     it('leaves an operator-stopped container alone if already stopped', async () => {
-      stubs.appsRuntimeState.isOperatorStopped.resolves(true);
+      stubs.appsRuntimeState.operatorStopState.resolves({ stopped: true, force: false });
       await appReconciler.reconcile('www_App'); // inspect default: stopped
       expect(stubs.dockerService.appDockerStop.called).to.be.false;
       expect(stubs.dockerService.appDockerStart.called).to.be.false;
@@ -341,7 +360,7 @@ describe('appReconciler tests', () => {
     // directions. A paused container the operator has stopped must end up
     // genuinely stopped, not left frozen because 'stop' had nothing to do.
     it('stops a paused container the operator has stopped, rather than leaving it frozen', async () => {
-      stubs.appsRuntimeState.isOperatorStopped.resolves(true);
+      stubs.appsRuntimeState.operatorStopState.resolves({ stopped: true, force: false });
       stubs.dockerService.dockerContainerInspect.resolves({
         State: {
           Running: true, Paused: true, Status: 'paused', ExitCode: 0,
@@ -763,7 +782,7 @@ describe('appReconciler tests', () => {
 
       it('does not stop a running operator-stopped component while its app is being restored', async () => {
         stubs.globalState.restoreInProgress.push('App');
-        stubs.appsRuntimeState.isOperatorStopped.resolves(true);
+        stubs.appsRuntimeState.operatorStopState.resolves({ stopped: true, force: false });
         stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: true, Status: 'running', ExitCode: 0 } });
         await appReconciler.reconcile('www_App');
         expect(stubs.dockerService.appDockerStop.called).to.be.false;
@@ -1283,14 +1302,14 @@ describe('appReconciler tests', () => {
       appReconciler.setOnContainerStarted(onStarted);
 
       // reconcile that stops an operator-stopped running container
-      stubs.appsRuntimeState.isOperatorStopped.resolves(true);
+      stubs.appsRuntimeState.operatorStopState.resolves({ stopped: true, force: false });
       stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: true, Status: 'running', ExitCode: 0 } });
       await appReconciler.reconcile('www_App');
       expect(stubs.dockerService.appDockerStop.calledOnce).to.be.true;
       expect(onStarted.called).to.be.false;
 
       // reconcile whose docker start throws
-      stubs.appsRuntimeState.isOperatorStopped.resolves(false);
+      stubs.appsRuntimeState.operatorStopState.resolves({ stopped: false, force: false });
       stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: false, Status: 'exited', ExitCode: 1 } });
       stubs.dockerService.appDockerStart.rejects(new Error('boom'));
       await appReconciler.reconcile('www_App').catch(() => {});
@@ -1358,7 +1377,7 @@ describe('appReconciler tests', () => {
     // The stop is the one actuation with no try/catch of its own, so a docker
     // failure there is a genuine unhandled throw rather than a contrived one.
     const operatorStopThatThrows = (message) => {
-      stubs.appsRuntimeState.isOperatorStopped.resolves(true);
+      stubs.appsRuntimeState.operatorStopState.resolves({ stopped: true, force: false });
       stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: true, Status: 'running', ExitCode: 0 } });
       stubs.dockerService.appDockerStop.rejects(new Error(message));
     };

--- a/tests/unit/appReconciler.test.js
+++ b/tests/unit/appReconciler.test.js
@@ -1305,6 +1305,100 @@ describe('appReconciler tests', () => {
     });
   });
 
+  // Every failure this file anticipates ends in one of two decisions: pace a retry
+  // (transient) or deliberately do not (an invalid spec no retry can fix). A pass
+  // that THROWS made neither, and was logged and forgotten - so with the operator's
+  // stop actuated by the reconciler rather than inline, a failed stop left the
+  // container running until the hourly sweep.
+  describe('unhandled pass failures', () => {
+    // The stop is the one actuation with no try/catch of its own, so a docker
+    // failure there is a genuine unhandled throw rather than a contrived one.
+    const operatorStopThatThrows = (message) => {
+      stubs.appsRuntimeState.isOperatorStopped.resolves(true);
+      stubs.dockerService.dockerContainerInspect.resolves({ State: { Running: true, Status: 'running', ExitCode: 0 } });
+      stubs.dockerService.appDockerStop.rejects(new Error(message));
+    };
+    // A pass is several awaits deep, and a retry lands through a timer callback
+    // that starts another one - drain microtasks until it has settled.
+    const settle = async () => {
+      for (let i = 0; i < 12; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise((resolve) => { setImmediate(resolve); });
+      }
+    };
+
+    it('retries a thrown pass instead of leaving the container to the hourly sweep', async () => {
+      const clock = sinon.useFakeTimers({ toFake: ['setTimeout'] });
+      operatorStopThatThrows('docker daemon is not running');
+
+      await appReconciler.enqueue('www_App');
+      expect(
+        stubs.dockerService.appDockerStop.callCount,
+        'the pass must actually have thrown, or the retry below proves nothing',
+      ).to.equal(1);
+
+      clock.tick(6000);
+      await settle();
+
+      expect(stubs.dockerService.appDockerStop.callCount, 'the failed stop must be retried').to.equal(2);
+      clock.restore();
+    });
+
+    it('stops after the bound, so a permanent fault is not a five-second loop forever', async () => {
+      const clock = sinon.useFakeTimers({ toFake: ['setTimeout'] });
+      operatorStopThatThrows('permanently broken');
+
+      await appReconciler.enqueue('www_App');
+      for (let i = 0; i < 6; i += 1) {
+        clock.tick(6000);
+        // eslint-disable-next-line no-await-in-loop
+        await settle();
+      }
+
+      // the first attempt plus UNHANDLED_FAILURE_RETRIES, and nothing after it:
+      // six further ticks arm nothing, which is the whole point of the bound
+      expect(stubs.dockerService.appDockerStop.callCount).to.equal(4);
+      expect(
+        stubs.log.error.getCalls().some((c) => /leaving it to the hourly sweep/.test(c.args[0])),
+        'the give-up must say so, or an operator cannot tell it from a failure still retrying',
+      ).to.be.true;
+      clock.restore();
+    });
+
+    it('clears the count on a pass that gets through, so a later fault gets the full budget', async () => {
+      const clock = sinon.useFakeTimers({ toFake: ['setTimeout'] });
+      operatorStopThatThrows('transient');
+
+      // exhaust the budget - nothing is armed after this
+      await appReconciler.enqueue('www_App');
+      for (let i = 0; i < 4; i += 1) {
+        clock.tick(6000);
+        // eslint-disable-next-line no-await-in-loop
+        await settle();
+      }
+      expect(stubs.dockerService.appDockerStop.callCount).to.equal(4);
+
+      // a pass that completes is the only evidence the fault has cleared
+      stubs.dockerService.appDockerStop.resolves();
+      await appReconciler.enqueue('www_App');
+      expect(stubs.dockerService.appDockerStop.callCount).to.equal(5);
+
+      // and the budget is whole again. Without the clear, this next pass would be
+      // the sixth consecutive failure, already past the bound, and arm nothing.
+      stubs.dockerService.appDockerStop.rejects(new Error('a new fault, later'));
+      await appReconciler.enqueue('www_App');
+      expect(stubs.dockerService.appDockerStop.callCount).to.equal(6);
+      clock.tick(6000);
+      await settle();
+
+      expect(
+        stubs.dockerService.appDockerStop.callCount,
+        'a fault after a healthy pass must get its own retries, not the exhausted budget',
+      ).to.equal(7);
+      clock.restore();
+    });
+  });
+
   describe('network-detach heal', () => {
     // A running container reported as detached from its own docker network (stale
     // libnetwork endpoint). isContainerDetachedFromNetwork is stubbed directly so

--- a/tests/unit/appUninstaller.test.js
+++ b/tests/unit/appUninstaller.test.js
@@ -138,6 +138,31 @@ describe('appUninstaller tests', () => {
       expect(verificationHelperStub.verifyPrivilege.called).to.be.true;
     });
 
+    // The gate IS the policy: hosting an app is not owning it, so ending one is
+    // the owner's call or the team's on their behalf. appownerabove and
+    // appownerorfluxteam differ in exactly one member - the node operator - so
+    // which of the two is asked for is the whole of what keeps them out, and
+    // asserting merely that a privilege was checked leaves that free to change.
+    // What each privilege admits is pinned in verificationHelperUtils.test.js
+    // ("FALSE for the node operator, who OrHigher admits"); this pins the hop
+    // between them.
+    it('gates an uninstall on the privilege that refuses the node operator', async () => {
+      const req = {
+        params: { appname: 'testapp' },
+        query: {},
+      };
+      const res = {
+        json: sinon.stub(),
+      };
+
+      verificationHelperStub.verifyPrivilege.resolves(false);
+      messageHelperStub.errUnauthorizedMessage.returns({ status: 'error' });
+
+      await appUninstaller.removeAppLocallyApi(req, res);
+
+      sinon.assert.calledOnceWithExactly(verificationHelperStub.verifyPrivilege, 'appownerorfluxteam', req, 'testapp');
+    });
+
     it('should handle missing appname parameter', async () => {
       const req = {
         params: {},

--- a/tests/unit/appsRuntimeState.test.js
+++ b/tests/unit/appsRuntimeState.test.js
@@ -295,14 +295,44 @@ describe('appsRuntimeState tests', () => {
       expect(await appsRuntimeState.restartWaitMs('www_App', null, false)).to.equal(0);
     });
 
+    // An operator restart is not "a clean exit" - it is appStart/appRestart
+    // clearing the lock, and the rungs go with it. Recognising it by exit code
+    // instead would hand the same exemption to a laundered segfault, which also
+    // exits 0, and walk it out of every wait the ladder had put it in.
     it('does not spend a rung built by earlier crashes on an operator restart', async () => {
       await appsRuntimeState.recordRestart('www_App', true);
       await appsRuntimeState.recordRestart('www_App', true);
-      expect(await appsRuntimeState.restartWaitMs('www_App', null, true), 'a crash is still paced').to.be.above(0);
+      expect(await appsRuntimeState.restartWaitMs('www_App'), 'a crash is still paced').to.be.above(0);
 
       clock.tick(1000);
-      expect(await appsRuntimeState.restartWaitMs('www_App', null, false), 'the operator is not').to.equal(0);
-      expect(store.get('www_App').restartHistory, 'and the rungs are still there for the next crash').to.have.lengthOf(2);
+      await appsRuntimeState.setOperatorStopped('www_App', false);
+
+      expect(await appsRuntimeState.restartWaitMs('www_App'), 'the operator is not').to.equal(0);
+      expect(store.get('www_App').restartHistory, 'the ladder went with the lock').to.deep.equal([]);
+    });
+
+    // The shape nothing else drives: a rung longer than a stable run, served in
+    // full, then a death. The wait is time the component spent stopped, and
+    // reading it as time the component spent running clears the ladder every
+    // time a long rung fires - so it never reaches the cap.
+    it('does not read a wait it just served as a stable run', async () => {
+      const id = 'www_App';
+      await appsRuntimeState.recordRestart(id, true);
+      await appsRuntimeState.recordRestart(id, true);
+      await appsRuntimeState.recordRestart(id, true);
+      expect(store.get(id).restartHistory, 'three rungs to reach one longer than a stable run').to.have.lengthOf(3);
+
+      const wait = await appsRuntimeState.restartWaitMs(id);
+      expect(wait, 'the rung must outlast STABLE_RUN_MS, or this proves nothing').to.be.above(appsRuntimeState.STABLE_RUN_MS);
+      clock.tick(wait);
+
+      // the wait ends: it starts, runs two seconds, and dies reporting success
+      await appsRuntimeState.recordRestart(id, false);
+      clock.tick(2000);
+      await appsRuntimeState.recordExit(id, 0);
+
+      expect(store.get(id).restartHistory, 'the ladder survived its own wait').to.have.lengthOf(4);
+      expect(await appsRuntimeState.restartWaitMs(id, Date.now()), 'and it climbs instead of starting over').to.be.above(0);
     });
 
     it('paces a container restarting faster than the burst window, whatever the exit code says', async () => {

--- a/tests/unit/appsRuntimeState.test.js
+++ b/tests/unit/appsRuntimeState.test.js
@@ -277,6 +277,82 @@ describe('appsRuntimeState tests', () => {
     });
   });
 
+  describe('a clean exit is not a crash (and the burst window is what catches the ones that lie)', () => {
+    // Docker's exit code cannot be trusted to mean "no fault": an image whose
+    // entrypoint is a wrapper script ending in `exit 0` reports a clean stop for
+    // a segfault, and nothing we wrap around the container can recover a status
+    // the image already threw away. So the code is used only in the direction it
+    // is sound - non-zero PROVES a fault, zero proves nothing - and the burst
+    // window is the backstop for everything the code hid.
+    let clock;
+
+    beforeEach(() => { clock = sinon.useFakeTimers({ now: 1_000_000_000 }); });
+    afterEach(() => clock.restore());
+
+    it('restarts a clean exit immediately and leaves the ladder untouched', async () => {
+      await appsRuntimeState.recordRestart('www_App', false);
+      expect(store.get('www_App').restartHistory, 'no ladder entry for a clean exit').to.be.undefined;
+      expect(await appsRuntimeState.restartWaitMs('www_App', null, false)).to.equal(0);
+    });
+
+    it('does not spend a rung built by earlier crashes on an operator restart', async () => {
+      await appsRuntimeState.recordRestart('www_App', true);
+      await appsRuntimeState.recordRestart('www_App', true);
+      expect(await appsRuntimeState.restartWaitMs('www_App', null, true), 'a crash is still paced').to.be.above(0);
+
+      clock.tick(1000);
+      expect(await appsRuntimeState.restartWaitMs('www_App', null, false), 'the operator is not').to.equal(0);
+      expect(store.get('www_App').restartHistory, 'and the rungs are still there for the next crash').to.have.lengthOf(2);
+    });
+
+    it('paces a container restarting faster than the burst window, whatever the exit code says', async () => {
+      const id = 'www_App';
+      for (let i = 0; i < appsRuntimeState.RESTART_BURST_COUNT; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        expect(await appsRuntimeState.restartWaitMs(id, null, false), `restart ${i} is free`).to.equal(0);
+        // eslint-disable-next-line no-await-in-loop
+        await appsRuntimeState.recordRestart(id, false);
+        clock.tick(1000);
+      }
+      expect(store.get(id).restartHistory, 'still no ladder entry while under the burst').to.be.undefined;
+
+      // the window is now full, so this restart is the one over the line
+      await appsRuntimeState.recordRestart(id, false);
+      expect(store.get(id).restartHistory, 'the trip is recorded as a crash would be').to.have.lengthOf(1);
+      expect(await appsRuntimeState.restartWaitMs(id, null, false)).to.equal(appsRuntimeState.BACKOFF_DELAYS_MS[1]);
+    });
+
+    it('never trips on restarts spaced wider than the window', async () => {
+      const id = 'www_App';
+      for (let i = 0; i < appsRuntimeState.RESTART_BURST_COUNT * 2; i += 1) {
+        clock.tick(appsRuntimeState.RESTART_BURST_WINDOW_MS);
+        // eslint-disable-next-line no-await-in-loop
+        expect(await appsRuntimeState.restartWaitMs(id, null, false), `restart ${i}`).to.equal(0);
+        // eslint-disable-next-line no-await-in-loop
+        await appsRuntimeState.recordRestart(id, false);
+      }
+      expect(store.get(id).restartHistory).to.be.undefined;
+    });
+
+    it('caps the burst window so a permanently restarting container cannot grow the document', async () => {
+      for (let i = 0; i < appsRuntimeState.RESTART_BURST_COUNT + 5; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await appsRuntimeState.recordRestart('www_App', false);
+      }
+      expect(store.get('www_App').autoRestartWindow).to.have.lengthOf(appsRuntimeState.RESTART_BURST_COUNT);
+    });
+
+    it('a deliberate start clears the burst window, not just the ladder', async () => {
+      for (let i = 0; i < appsRuntimeState.RESTART_BURST_COUNT; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await appsRuntimeState.recordRestart('www_App', false);
+      }
+      await appsRuntimeState.setOperatorStopped('www_App', false);
+      expect(store.get('www_App').autoRestartWindow).to.deep.equal([]);
+      expect(await appsRuntimeState.restartWaitMs('www_App', null, false), 'starts from clean').to.equal(0);
+    });
+  });
+
   describe('config-tunable ladder (harness compression)', () => {
     it('reads the ladder and stable-run window from config when present', () => {
       const tuned = proxyquire('../../ZelBack/src/services/appManagement/appsRuntimeState', {
@@ -285,12 +361,19 @@ describe('appsRuntimeState tests', () => {
         '../dockerService': { getBaseAppName: (id) => id },
         config: {
           database: { appslocal: { database: 'localzelapps', collections: { appsRuntimeState: 'zelappsruntimestate' } } },
-          fluxapps: { crashBackoffDelaysMs: [0, 1000, 2000], crashBackoffStableRunMs: 5000 },
+          fluxapps: {
+            crashBackoffDelaysMs: [0, 1000, 2000],
+            crashBackoffStableRunMs: 5000,
+            restartBurstCount: 3,
+            restartBurstWindowMs: 2000,
+          },
         },
       });
       expect(tuned.BACKOFF_DELAYS_MS).to.deep.equal([0, 1000, 2000]);
       expect(tuned.STABLE_RUN_MS).to.equal(5000);
       expect(tuned.MAX_HISTORY).to.equal(3);
+      expect(tuned.RESTART_BURST_COUNT).to.equal(3);
+      expect(tuned.RESTART_BURST_WINDOW_MS).to.equal(2000);
     });
   });
 

--- a/tests/unit/appsRuntimeState.test.js
+++ b/tests/unit/appsRuntimeState.test.js
@@ -346,7 +346,13 @@ describe('appsRuntimeState tests', () => {
       }
       expect(store.get(id).restartHistory, 'still no ladder entry while under the burst').to.be.undefined;
 
-      // the window is now full, so this restart is the one over the line
+      // The window is now full, so this restart is the one that carries the count
+      // over - and it is counted, not held. restartWaitMs runs ahead of
+      // recordRestart in the reconciler, so it sees an empty ladder and lets this
+      // one straight back; the rung is earned on its way past. Asserted because
+      // every comment describing the ceiling describes this step, and reordering
+      // the two calls would change it with nothing to object.
+      expect(await appsRuntimeState.restartWaitMs(id, null, false), 'the restart that crosses the line is not itself held').to.equal(0);
       await appsRuntimeState.recordRestart(id, false);
       expect(store.get(id).restartHistory, 'the trip is recorded as a crash would be').to.have.lengthOf(1);
       expect(await appsRuntimeState.restartWaitMs(id, null, false)).to.equal(appsRuntimeState.BACKOFF_DELAYS_MS[1]);

--- a/tests/unit/appsRuntimeState.test.js
+++ b/tests/unit/appsRuntimeState.test.js
@@ -522,6 +522,22 @@ describe('appsRuntimeState tests', () => {
       expect(thrown).to.be.an('error');
     });
 
+    // recordRestartGeneration reads like a recorder and sits among others that
+    // swallow, but it is not history: it is the only thing that stops the next
+    // pass bouncing the container again. Swallowed, a failed write read as
+    // "recorded", and a node whose reads work while its writes do not restarted
+    // the app every verify interval for as long as that lasted - on the one path
+    // deliberately exempt from the backoff ladder.
+    it('surfaces a failed restart-generation write rather than reporting it recorded', async () => {
+      updateStub.rejects(new Error('not enough disk space'));
+
+      let thrown = null;
+      await retryState.recordRestartGeneration('www_App', 5).catch((e) => { thrown = e; });
+
+      expect(thrown, 'the caller has to be able to tell the record did not land').to.be.an('error');
+      expect(thrown.message).to.match(/disk space/);
+    });
+
     it('propagates a lock-write failure to the caller (API must not report success)', async () => {
       // The stop lock is the contract that the reconciler will not restart the
       // app. Swallowing the write failure makes the API report success while the

--- a/tests/unit/appsRuntimeState.test.js
+++ b/tests/unit/appsRuntimeState.test.js
@@ -334,6 +334,40 @@ describe('appsRuntimeState tests', () => {
       expect(store.get(id).restartHistory).to.be.undefined;
     });
 
+    // How far the ceiling reaches is window/count, NOT the window: the check runs
+    // BEFORE the append, so the five entries it judges span five gaps. Nothing
+    // pinned that derived number, and the PR body described the reach as "a
+    // minute or two" while the shipped values reached twelve seconds.
+    const spacingIsPaced = async (id, spacingMs) => {
+      for (let i = 0; i < appsRuntimeState.RESTART_BURST_COUNT * 3; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        if (await appsRuntimeState.restartWaitMs(id, null, false) > 0) return true;
+        // eslint-disable-next-line no-await-in-loop
+        await appsRuntimeState.recordRestart(id, false);
+        clock.tick(spacingMs);
+      }
+      return false;
+    };
+
+    it('reaches restarts spaced window/count apart, and nothing slower', async () => {
+      const reach = appsRuntimeState.RESTART_BURST_WINDOW_MS / appsRuntimeState.RESTART_BURST_COUNT;
+      expect(await spacingIsPaced('atReach_App', reach), 'at the reach').to.equal(true);
+      expect(await spacingIsPaced('pastReach_App', reach + 1), 'one millisecond past it').to.equal(false);
+    });
+
+    // The reach is a product decision, not just a mechanism: an image that
+    // launders its exit status has no other protection, so what the shipped
+    // configuration actually catches is the whole guarantee. Asserted in seconds
+    // on purpose - a test derived from the same constants cannot notice them
+    // being retuned, which is how the twelve-second reach went unnoticed.
+    it('paces a laundered-exit container dying every 30 seconds', async () => {
+      expect(await spacingIsPaced('halfMinute_App', 30_000)).to.equal(true);
+    });
+
+    it('leaves a container restarting every 90 seconds alone', async () => {
+      expect(await spacingIsPaced('ninetySeconds_App', 90_000)).to.equal(false);
+    });
+
     it('caps the burst window so a permanently restarting container cannot grow the document', async () => {
       for (let i = 0; i < appsRuntimeState.RESTART_BURST_COUNT + 5; i += 1) {
         // eslint-disable-next-line no-await-in-loop

--- a/tests/unit/appsRuntimeState.test.js
+++ b/tests/unit/appsRuntimeState.test.js
@@ -645,6 +645,30 @@ describe('appsRuntimeState tests', () => {
       sinon.assert.called(logStub.warn);
     });
 
+    // The merge builds from an explicit field list, so a field nobody adds here
+    // is dropped silently. These two decide whether a container gets bounced and
+    // how it gets stopped, and losing either is invisible until it matters.
+    it('carries the restart request and the force mode through a merge', async () => {
+      docs = [
+        {
+          identifier: 'www_App', restartGeneration: 7, actuatedRestartGeneration: 7, updatedAt: 1000,
+        },
+        {
+          identifier: 'www_App', operatorStopForce: true, restartGeneration: 4, actuatedRestartGeneration: 2, updatedAt: 9000,
+        },
+      ];
+
+      await prepState.prepareCollection();
+
+      const merged = upserts[0].set;
+      // a kill must never merge down into a graceful stop
+      expect(merged.operatorStopForce).to.equal(true);
+      // highest request, lowest actuation: a restart asked for on either doc is
+      // still owed, so the container bounces once rather than not at all
+      expect(merged.restartGeneration).to.equal(7);
+      expect(merged.actuatedRestartGeneration).to.equal(2);
+    });
+
     it('trims a merged history to the ladder length', async () => {
       const longA = Array.from({ length: 6 }, (_, i) => i + 1);
       const longB = Array.from({ length: 6 }, (_, i) => i + 100);

--- a/tests/unit/appsRuntimeState.test.js
+++ b/tests/unit/appsRuntimeState.test.js
@@ -6,14 +6,19 @@ describe('appsRuntimeState tests', () => {
   let appsRuntimeState;
   let store; // fake collection: identifier -> doc
   let logStub;
+  let readFails;
 
   beforeEach(() => {
     store = new Map();
+    readFails = false;
     logStub = { info: sinon.stub(), warn: sinon.stub(), error: sinon.stub() };
 
     const dbHelperStub = {
       databaseConnection: () => ({ db: () => ({}) }),
-      findOneInDatabase: async (_db, _coll, query) => store.get(query.identifier) || null,
+      findOneInDatabase: async (_db, _coll, query) => {
+        if (readFails) throw new Error('connection reset');
+        return store.get(query.identifier) || null;
+      },
       // The fake honors projections the way mongo does: a query that stops
       // selecting a field loses that field here too. operatorStoppedIdentifiers
       // reads doc.identifier off an unauthenticated peer route, and a stub that
@@ -42,7 +47,15 @@ describe('appsRuntimeState tests', () => {
       },
       updateOneInDatabase: async (_db, _coll, query, update) => {
         const existing = store.get(query.identifier) || {};
-        store.set(query.identifier, { ...existing, ...update.$set });
+        const next = { ...existing, ...update.$set };
+        // $inc as mongo does it: add to what is there, and CREATE the field at the
+        // increment when there is nothing - which is the whole reason a counter can
+        // be raised without reading it first. A fake that ignored $inc would let a
+        // read-then-write implementation pass these tests unchanged.
+        Object.entries(update.$inc || {}).forEach(([field, by]) => {
+          next[field] = (existing[field] || 0) + by;
+        });
+        store.set(query.identifier, next);
       },
       removeDocumentsFromCollection: async (_db, _coll, query) => { store.delete(query.identifier); },
     };
@@ -55,6 +68,40 @@ describe('appsRuntimeState tests', () => {
   });
 
   afterEach(() => sinon.restore());
+
+  // The generation is raised BY the database. Read-then-write asked getState for the
+  // current number and got null for two different answers - "no record yet" and "the
+  // read failed" - so a failed read wrote 1 over a generation already past it, which
+  // the reconciler reads as nothing pending: reported, never done.
+  describe('requestRestart', () => {
+    it('creates the generation at 1 when the component has no record', async () => {
+      await appsRuntimeState.requestRestart('www_App');
+      expect((await appsRuntimeState.getState('www_App')).restartGeneration).to.equal(1);
+    });
+
+    it('raises an existing generation rather than restarting the count', async () => {
+      store.set('www_App', { identifier: 'www_App', restartGeneration: 7, actuatedRestartGeneration: 7 });
+      await appsRuntimeState.requestRestart('www_App');
+      expect((await appsRuntimeState.getState('www_App')).restartGeneration).to.equal(8);
+    });
+
+    it('raises it correctly even when the state cannot be read', async () => {
+      store.set('www_App', { identifier: 'www_App', restartGeneration: 7, actuatedRestartGeneration: 7 });
+      readFails = true;
+      await appsRuntimeState.requestRestart('www_App');
+      readFails = false;
+      expect((await appsRuntimeState.getState('www_App')).restartGeneration,
+        'a generation below the actuated one is never actuated').to.equal(8);
+    });
+
+    it('counts two concurrent requests as two', async () => {
+      await Promise.all([
+        appsRuntimeState.requestRestart('www_App'),
+        appsRuntimeState.requestRestart('www_App'),
+      ]);
+      expect((await appsRuntimeState.getState('www_App')).restartGeneration).to.equal(2);
+    });
+  });
 
   describe('operatorStopped', () => {
     it('persists the stop lock and reads it back', async () => {

--- a/tests/unit/configFallbacks.test.js
+++ b/tests/unit/configFallbacks.test.js
@@ -50,17 +50,35 @@ describe('config fallbacks match what config ships', () => {
     return text.slice(from);
   }
 
+  // Not a value any fallback evaluates to, so it can mean "this expression is not
+  // a literal" without colliding with one that legitimately reads false or null.
+  // undefined cannot: `?? undefined` is writable, and reading it as unparseable
+  // would report the wrong reason.
+  const UNPARSEABLE = Symbol('unparseable');
+
   /**
-   * Evaluates a fallback literal. Returns undefined when the expression is not a
-   * plain arithmetic or array literal, which the test reports as a failure rather
-   * than skipping - a guard that quietly covers half its cases is how the drift it
+   * Evaluates a fallback literal. Numbers, booleans, null, single-quoted strings
+   * and arithmetic over them - a boolean drifts from config exactly as a number
+   * does, and a guard that declines to compare one has stopped covering a whole
+   * class of the thing it exists for.
+   *
+   * Returns UNPARSEABLE for anything else - a named constant, or an expression
+   * over another variable - which the test reports as a failure rather than
+   * skipping. A guard that quietly covers half its cases is how the drift it
    * exists to catch got in.
    * @param {string} expr
-   * @returns {number|Array|undefined}
+   * @returns {number|boolean|null|string|Array|symbol}
    */
   function evaluate(expr) {
     const trimmed = expr.trim();
-    if (!/^[\d\s*+\-()[\],.]+$/.test(trimmed)) return undefined;
+    if (trimmed === 'true') return true;
+    if (trimmed === 'false') return false;
+    if (trimmed === 'null') return null;
+    // Matched rather than evaluated: admitting quotes to the whitelist below would
+    // widen what reaches Function() to arbitrary string content.
+    const quoted = trimmed.match(/^'([^'\\]*)'$/) || trimmed.match(/^"([^"\\]*)"$/);
+    if (quoted) return quoted[1];
+    if (!/^[\d\s*+\-()[\],.]+$/.test(trimmed)) return UNPARSEABLE;
     // The input is this repository's own source, read from disk, matched against
     // a digits-and-operators whitelist above.
     // eslint-disable-next-line no-new-func
@@ -101,7 +119,10 @@ describe('config fallbacks match what config ships', () => {
       expect(shipped, `config/default.js ships no fluxapps.${key}, so the literal is the only definition - either ship it or drop the fallback`).to.not.equal(undefined);
 
       const fallback = evaluate(expr);
-      expect(fallback, `the fallback for ${key} is not a plain literal (${expr.trim()}), so this guard cannot compare it - make it one, or the drift it exists to catch can hide here`).to.not.equal(undefined);
+      const unparseable = `the fallback for ${key} is ${expr.trim()}, which this guard cannot compare`
+        + ' against config - drop it (config ships the key, so it protects nothing) or make it a'
+        + ' literal; left as it is, the drift this exists to catch hides here';
+      expect(fallback, unparseable).to.not.equal(UNPARSEABLE);
 
       expect(fallback).to.deep.equal(shipped);
     });

--- a/tests/unit/configFallbacks.test.js
+++ b/tests/unit/configFallbacks.test.js
@@ -1,0 +1,109 @@
+const { expect } = require('chai');
+const fs = require('node:fs');
+const path = require('node:path');
+
+// Every `config.fluxapps.x ?? literal` in the service layer is a SECOND copy of a
+// value ZelBack/config/default.js already ships. Not one of them is a default the
+// module owns - config ships all forty - so the literal protects against nothing
+// reachable: app.js pins NODE_CONFIG_DIR to ZelBack/config/, and node-config's
+// NODE_CONFIG overlay deep-merges rather than replaces, so the key cannot go
+// missing on a node.
+//
+// What the copy does do is drift. restartBurstWindowMs was widened to 300000 in
+// config while the module's literal stayed at 60000, and nothing caught it: the
+// unit config supplies every key, so the fallback is never taken under test, and
+// the assertions that depend on the value read the constant rather than config.
+//
+// If a fallback is ever taken, it does not degrade gracefully either -
+// `Date.now() - x <= undefined` is false, so a missing burst window turns the
+// crash ceiling silently off rather than making it wrong.
+//
+// The long-term fix is config.get(), which throws by name on a missing key and
+// leaves one source of truth. That is 40 call sites here and 108 on the v9
+// lineage, so it is its own change. This holds the line until then: drift becomes
+// impossible to merge rather than merely impossible to write.
+describe('config fallbacks match what config ships', () => {
+  const SRC = path.join(__dirname, '../../ZelBack/src');
+  // eslint-disable-next-line global-require
+  const production = require('../../ZelBack/config/default');
+
+  /**
+   * The fallback expression following `??`, ending where the expression does:
+   * at a top-level `;` `,` or newline, or at the `)` that closes an enclosing
+   * call - `(config.fluxapps.x ?? 300000)` is the common inline shape.
+   * @param {string} text
+   * @param {number} from index just past the `??`
+   * @returns {string}
+   */
+  function readExpression(text, from) {
+    let depth = 0;
+    for (let i = from; i < text.length; i += 1) {
+      const ch = text[i];
+      if (ch === '(' || ch === '[') depth += 1;
+      else if (ch === ')' || ch === ']') {
+        if (depth === 0) return text.slice(from, i);
+        depth -= 1;
+      } else if (depth === 0 && (ch === ';' || ch === ',' || ch === '\n')) {
+        return text.slice(from, i);
+      }
+    }
+    return text.slice(from);
+  }
+
+  /**
+   * Evaluates a fallback literal. Returns undefined when the expression is not a
+   * plain arithmetic or array literal, which the test reports as a failure rather
+   * than skipping - a guard that quietly covers half its cases is how the drift it
+   * exists to catch got in.
+   * @param {string} expr
+   * @returns {number|Array|undefined}
+   */
+  function evaluate(expr) {
+    const trimmed = expr.trim();
+    if (!/^[\d\s*+\-()[\],.]+$/.test(trimmed)) return undefined;
+    // The input is this repository's own source, read from disk, matched against
+    // a digits-and-operators whitelist above.
+    // eslint-disable-next-line no-new-func
+    return Function(`"use strict"; return (${trimmed});`)();
+  }
+
+  function jsFiles(dir) {
+    return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) return jsFiles(full);
+      return entry.name.endsWith('.js') ? [full] : [];
+    });
+  }
+
+  const found = [];
+  jsFiles(SRC).forEach((file) => {
+    const text = fs.readFileSync(file, 'utf8');
+    const pattern = /config\.fluxapps\.([a-zA-Z0-9_]+)\s*\?\?/g;
+    let match = pattern.exec(text);
+    while (match) {
+      found.push({
+        key: match[1],
+        expr: readExpression(text, match.index + match[0].length),
+        file: path.relative(SRC, file),
+        line: text.slice(0, match.index).split('\n').length,
+      });
+      match = pattern.exec(text);
+    }
+  });
+
+  it('finds the fallbacks at all, so an empty sweep cannot pass every assertion below', () => {
+    expect(found.length).to.be.greaterThan(30);
+  });
+
+  found.forEach(({ key, expr, file, line }) => {
+    it(`${key} (${file}:${line}) falls back to the value config ships`, () => {
+      const shipped = production.fluxapps[key];
+      expect(shipped, `config/default.js ships no fluxapps.${key}, so the literal is the only definition - either ship it or drop the fallback`).to.not.equal(undefined);
+
+      const fallback = evaluate(expr);
+      expect(fallback, `the fallback for ${key} is not a plain literal (${expr.trim()}), so this guard cannot compare it - make it one, or the drift it exists to catch can hide here`).to.not.equal(undefined);
+
+      expect(fallback).to.deep.equal(shipped);
+    });
+  });
+});

--- a/tests/unit/fluxNetworkHelper.test.js
+++ b/tests/unit/fluxNetworkHelper.test.js
@@ -1387,6 +1387,75 @@ describe('fluxNetworkHelper tests', () => {
       sinon.assert.notCalled(appUninstallerStub.removeAppLocally);
       sinon.assert.calledOnce(onAddressChangedSpy);
     });
+
+    // An instance already at this address means the ports are taken, because one
+    // instance per IP is what the host port mapping allows. The node's own
+    // registration is not another instance - it stores its own running-app row
+    // locally, at the address benchmark reports - so what separates "the ports are
+    // gone" from "that row is me" is the port, and only the port.
+    // Each call needs an address no earlier test has used: adjustExternalIP keeps a
+    // cache of addresses it has already handled and returns before the app loop for
+    // a repeat, which leaves the assertions below passing for the wrong reason.
+    async function runWithLocations(locations, ownSocketAddress, newIp) {
+      appQueryServiceStub = {
+        installedApps: sinon.stub().resolves({
+          status: 'success',
+          data: [{ name: 'normalApp', version: 7, staticip: false }],
+        }),
+      };
+      registryManagerStub = { appLocation: sinon.stub().resolves(locations) };
+      appUninstallerStub = { removeAppLocally: sinon.stub().resolves() };
+      onAddressChangedSpy = sinon.stub().resolves();
+      enterpriseHelperStub = { checkAndDecryptAppSpecs: sinon.stub().callsFake((app) => Promise.resolve(app)) };
+      geolocationServiceStub = { setNodeGeolocation: sinon.stub() };
+      fluxCommunicationMessagesSenderStub = {
+        broadcastMessageToOutgoing: sinon.stub().resolves(),
+        broadcastMessageToIncoming: sinon.stub().resolves(),
+      };
+
+      const helper = proxyquire('../../ZelBack/src/services/fluxNetworkHelper', {
+        './appQuery/appQueryService': appQueryServiceStub,
+        './appDatabase/registryManager': registryManagerStub,
+        './appLifecycle/appUninstaller': appUninstallerStub,
+        './utils/enterpriseHelper': enterpriseHelperStub,
+        './geolocationService': geolocationServiceStub,
+        './fluxCommunicationMessagesSender': fluxCommunicationMessagesSenderStub,
+        './daemonService/daemonServiceWalletRpcs': daemonServiceWalletRpcs,
+        './serviceHelper': serviceHelper,
+        'fs/promises': { writeFile: writeFileStub },
+      });
+      helper.setStoredFluxBenchAllowed('6.2.0');
+      helper.setLocalSocketAddress(ownSocketAddress);
+      helper.setOnAddressChanged(onAddressChangedSpy);
+      await helper.adjustExternalIP(newIp);
+    }
+
+    it('keeps an app whose only instance at the new address is this node itself', async () => {
+      await runWithLocations(
+        [{ name: 'normalApp', ip: '192.168.1.110:16127' }],
+        '192.168.1.110:16127',
+        '192.168.1.110',
+      );
+
+      sinon.assert.notCalled(appUninstallerStub.removeAppLocally);
+      sinon.assert.calledOnce(onAddressChangedSpy);
+      const [staying] = onAddressChangedSpy.firstCall.args;
+      expect(staying.map((a) => a.name)).to.deep.equal(['normalApp']);
+    });
+
+    it('uninstalls an app another node already holds the ports for on this address', async () => {
+      // Same IP, different port: a UPnP sibling behind the shared address. The
+      // ports are genuinely gone, so this node cannot run it.
+      await runWithLocations(
+        [{ name: 'normalApp', ip: '192.168.1.111:16157' }],
+        '192.168.1.111:16127',
+        '192.168.1.111',
+      );
+
+      sinon.assert.calledOnce(appUninstallerStub.removeAppLocally);
+      sinon.assert.calledWith(appUninstallerStub.removeAppLocally, 'normalApp');
+      sinon.assert.notCalled(onAddressChangedSpy);
+    });
   });
 
   describe('checkDeterministicNodesCollisions tests', () => {

--- a/tests/unit/fluxNetworkHelper.test.js
+++ b/tests/unit/fluxNetworkHelper.test.js
@@ -1083,7 +1083,7 @@ describe('fluxNetworkHelper tests', () => {
     let appQueryServiceStub;
     let registryManagerStub;
     let appUninstallerStub;
-    let appControllerStub;
+    let onAddressChangedSpy;
     let enterpriseHelperStub;
     let geolocationServiceStub;
     let fluxCommunicationMessagesSenderStub;
@@ -1154,10 +1154,11 @@ describe('fluxNetworkHelper tests', () => {
         removeAppLocally: sinon.stub().resolves(),
       };
 
-      // Stub appController
-      appControllerStub = {
-        appDockerRestart: sinon.stub().resolves(),
-      };
+      // The apps that survive an address change are handed to whatever registered
+      // for one - serviceManager wires that to appReconciler.requestRestartOf.
+      // Nothing in this module knows what restarting an app involves, so the seam
+      // is what these tests assert on.
+      onAddressChangedSpy = sinon.stub().resolves();
 
       // Stub enterpriseHelper
       enterpriseHelperStub = {
@@ -1180,7 +1181,6 @@ describe('fluxNetworkHelper tests', () => {
         './appQuery/appQueryService': appQueryServiceStub,
         './appDatabase/registryManager': registryManagerStub,
         './appLifecycle/appUninstaller': appUninstallerStub,
-        './appManagement/appController': appControllerStub,
         './utils/enterpriseHelper': enterpriseHelperStub,
         './geolocationService': geolocationServiceStub,
         './fluxCommunicationMessagesSender': fluxCommunicationMessagesSenderStub,
@@ -1189,15 +1189,18 @@ describe('fluxNetworkHelper tests', () => {
         'fs/promises': { writeFile: writeFileStub },
       });
 
+      fluxNetworkHelperWithStubs.setOnAddressChanged(onAddressChangedSpy);
       await fluxNetworkHelperWithStubs.adjustExternalIP(newIp);
 
       // Verify static IP app was uninstalled
       sinon.assert.calledOnce(appUninstallerStub.removeAppLocally);
       sinon.assert.calledWith(appUninstallerStub.removeAppLocally, 'staticApp');
 
-      // Verify normal app was restarted (not uninstalled)
-      sinon.assert.calledOnce(appControllerStub.appDockerRestart);
-      sinon.assert.calledWith(appControllerStub.appDockerRestart, 'normalApp');
+      // Verify the normal app was handed over to be restarted, not uninstalled -
+      // as the whole surviving set, in one call
+      sinon.assert.calledOnce(onAddressChangedSpy);
+      const [staying] = onAddressChangedSpy.firstCall.args;
+      expect(staying.map((a) => a.name)).to.deep.equal(['normalApp']);
 
       // Verify geolocation service was called
       sinon.assert.calledOnce(geolocationServiceStub.setNodeGeolocation);
@@ -1226,9 +1229,7 @@ describe('fluxNetworkHelper tests', () => {
         removeAppLocally: sinon.stub().resolves(),
       };
 
-      appControllerStub = {
-        appDockerRestart: sinon.stub().resolves(),
-      };
+      onAddressChangedSpy = sinon.stub().resolves();
 
       // Stub enterpriseHelper to return decrypted specs with staticip: true
       enterpriseHelperStub = {
@@ -1253,7 +1254,6 @@ describe('fluxNetworkHelper tests', () => {
         './appQuery/appQueryService': appQueryServiceStub,
         './appDatabase/registryManager': registryManagerStub,
         './appLifecycle/appUninstaller': appUninstallerStub,
-        './appManagement/appController': appControllerStub,
         './utils/enterpriseHelper': enterpriseHelperStub,
         './geolocationService': geolocationServiceStub,
         './fluxCommunicationMessagesSender': fluxCommunicationMessagesSenderStub,
@@ -1262,6 +1262,7 @@ describe('fluxNetworkHelper tests', () => {
         'fs/promises': { writeFile: writeFileStub },
       });
 
+      fluxNetworkHelperWithStubs.setOnAddressChanged(onAddressChangedSpy);
       await fluxNetworkHelperWithStubs.adjustExternalIP(newIp);
 
       // Verify enterprise helper was called to decrypt specs
@@ -1294,9 +1295,7 @@ describe('fluxNetworkHelper tests', () => {
         removeAppLocally: sinon.stub().resolves(),
       };
 
-      appControllerStub = {
-        appDockerRestart: sinon.stub().resolves(),
-      };
+      onAddressChangedSpy = sinon.stub().resolves();
 
       // Stub enterpriseHelper to throw error
       enterpriseHelperStub = {
@@ -1316,7 +1315,6 @@ describe('fluxNetworkHelper tests', () => {
         './appQuery/appQueryService': appQueryServiceStub,
         './appDatabase/registryManager': registryManagerStub,
         './appLifecycle/appUninstaller': appUninstallerStub,
-        './appManagement/appController': appControllerStub,
         './utils/enterpriseHelper': enterpriseHelperStub,
         './geolocationService': geolocationServiceStub,
         './fluxCommunicationMessagesSender': fluxCommunicationMessagesSenderStub,
@@ -1325,11 +1323,12 @@ describe('fluxNetworkHelper tests', () => {
         'fs/promises': { writeFile: writeFileStub },
       });
 
+      fluxNetworkHelperWithStubs.setOnAddressChanged(onAddressChangedSpy);
       await fluxNetworkHelperWithStubs.adjustExternalIP(newIp);
 
       // Should skip the app entirely when decryption fails - neither uninstall nor restart
       sinon.assert.notCalled(appUninstallerStub.removeAppLocally);
-      sinon.assert.notCalled(appControllerStub.appDockerRestart);
+      sinon.assert.notCalled(onAddressChangedSpy);
     });
 
     it('should not uninstall v6 apps even with staticip field', async () => {
@@ -1354,9 +1353,7 @@ describe('fluxNetworkHelper tests', () => {
         removeAppLocally: sinon.stub().resolves(),
       };
 
-      appControllerStub = {
-        appDockerRestart: sinon.stub().resolves(),
-      };
+      onAddressChangedSpy = sinon.stub().resolves();
 
       enterpriseHelperStub = {
         checkAndDecryptAppSpecs: sinon.stub().callsFake((app) => Promise.resolve(app)),
@@ -1375,7 +1372,6 @@ describe('fluxNetworkHelper tests', () => {
         './appQuery/appQueryService': appQueryServiceStub,
         './appDatabase/registryManager': registryManagerStub,
         './appLifecycle/appUninstaller': appUninstallerStub,
-        './appManagement/appController': appControllerStub,
         './utils/enterpriseHelper': enterpriseHelperStub,
         './geolocationService': geolocationServiceStub,
         './fluxCommunicationMessagesSender': fluxCommunicationMessagesSenderStub,
@@ -1384,11 +1380,12 @@ describe('fluxNetworkHelper tests', () => {
         'fs/promises': { writeFile: writeFileStub },
       });
 
+      fluxNetworkHelperWithStubs.setOnAddressChanged(onAddressChangedSpy);
       await fluxNetworkHelperWithStubs.adjustExternalIP(newIp);
 
       // v6 apps should not be checked for staticip (only v7+)
       sinon.assert.notCalled(appUninstallerStub.removeAppLocally);
-      sinon.assert.calledOnce(appControllerStub.appDockerRestart);
+      sinon.assert.calledOnce(onAddressChangedSpy);
     });
   });
 

--- a/tests/unit/fluxNetworkHelper.test.js
+++ b/tests/unit/fluxNetworkHelper.test.js
@@ -1189,6 +1189,10 @@ describe('fluxNetworkHelper tests', () => {
         'fs/promises': { writeFile: writeFileStub },
       });
 
+      // Each test proxyquires its OWN module instance, so the address has to be set
+      // on THAT one - the beforeEach sets it on the outer module, which this code
+      // never reads. A node reaches adjustExternalIP only once it knows itself.
+      fluxNetworkHelperWithStubs.setLocalSocketAddress('127.0.0.1:16127');
       fluxNetworkHelperWithStubs.setOnAddressChanged(onAddressChangedSpy);
       await fluxNetworkHelperWithStubs.adjustExternalIP(newIp);
 
@@ -1262,6 +1266,10 @@ describe('fluxNetworkHelper tests', () => {
         'fs/promises': { writeFile: writeFileStub },
       });
 
+      // Each test proxyquires its OWN module instance, so the address has to be set
+      // on THAT one - the beforeEach sets it on the outer module, which this code
+      // never reads. A node reaches adjustExternalIP only once it knows itself.
+      fluxNetworkHelperWithStubs.setLocalSocketAddress('127.0.0.1:16127');
       fluxNetworkHelperWithStubs.setOnAddressChanged(onAddressChangedSpy);
       await fluxNetworkHelperWithStubs.adjustExternalIP(newIp);
 
@@ -1323,6 +1331,10 @@ describe('fluxNetworkHelper tests', () => {
         'fs/promises': { writeFile: writeFileStub },
       });
 
+      // Each test proxyquires its OWN module instance, so the address has to be set
+      // on THAT one - the beforeEach sets it on the outer module, which this code
+      // never reads. A node reaches adjustExternalIP only once it knows itself.
+      fluxNetworkHelperWithStubs.setLocalSocketAddress('127.0.0.1:16127');
       fluxNetworkHelperWithStubs.setOnAddressChanged(onAddressChangedSpy);
       await fluxNetworkHelperWithStubs.adjustExternalIP(newIp);
 
@@ -1380,6 +1392,10 @@ describe('fluxNetworkHelper tests', () => {
         'fs/promises': { writeFile: writeFileStub },
       });
 
+      // Each test proxyquires its OWN module instance, so the address has to be set
+      // on THAT one - the beforeEach sets it on the outer module, which this code
+      // never reads. A node reaches adjustExternalIP only once it knows itself.
+      fluxNetworkHelperWithStubs.setLocalSocketAddress('127.0.0.1:16127');
       fluxNetworkHelperWithStubs.setOnAddressChanged(onAddressChangedSpy);
       await fluxNetworkHelperWithStubs.adjustExternalIP(newIp);
 
@@ -1441,6 +1457,23 @@ describe('fluxNetworkHelper tests', () => {
       sinon.assert.calledOnce(onAddressChangedSpy);
       const [staying] = onAddressChangedSpy.firstCall.args;
       expect(staying.map((a) => a.name)).to.deep.equal(['normalApp']);
+    });
+
+    // localSocketAddress is cleared whenever benchmark hiccups, and the change must
+    // survive that rather than be decided on it or dropped. Asserting the userconfig
+    // write did NOT happen is the point: that write is what marks the change handled,
+    // so an unwritten config is a change still pending for the next cycle.
+    it('defers the whole change, unwritten, when it does not know its own address', async () => {
+      await runWithLocations(
+        [{ name: 'normalApp', ip: '192.168.1.112:16157' }],
+        null,
+        '192.168.1.112',
+      );
+
+      sinon.assert.notCalled(appUninstallerStub.removeAppLocally);
+      sinon.assert.notCalled(onAddressChangedSpy);
+      sinon.assert.notCalled(writeFileStub);
+      sinon.assert.notCalled(geolocationServiceStub.setNodeGeolocation);
     });
 
     it('uninstalls an app another node already holds the ports for on this address', async () => {

--- a/tests/unit/globalconfig/default.js
+++ b/tests/unit/globalconfig/default.js
@@ -116,6 +116,8 @@ module.exports = {
   fluxapps: {
     crashBackoffDelaysMs: [0, 30000, 300000, 900000, 1800000],
     crashBackoffStableRunMs: 600000,
+    restartBurstCount: 5,
+    restartBurstWindowMs: 60000,
     // in flux main chain per month (blocksLasting)
     price: [
       { // any price fork can be done by adjusting object similarily.

--- a/tests/unit/globalconfig/default.js
+++ b/tests/unit/globalconfig/default.js
@@ -117,7 +117,7 @@ module.exports = {
     crashBackoffDelaysMs: [0, 30000, 300000, 900000, 1800000],
     crashBackoffStableRunMs: 600000,
     restartBurstCount: 5,
-    restartBurstWindowMs: 60000,
+    restartBurstWindowMs: 300000,
     // in flux main chain per month (blocksLasting)
     price: [
       { // any price fork can be done by adjusting object similarily.

--- a/tests/unit/routeWiring.test.js
+++ b/tests/unit/routeWiring.test.js
@@ -87,6 +87,7 @@ describe('route wiring', () => {
       { method: 'get', path: '/apps/appstart/:appname?/:global?' },
       { method: 'get', path: '/apps/appstop/:appname?/:global?' },
       { method: 'get', path: '/apps/apprestart/:appname?/:global?' },
+      { method: 'get', path: '/apps/appkill/:appname?' },
       { method: 'get', path: '/apps/apppause/:appname?/:global?' },
       { method: 'get', path: '/apps/appunpause/:appname?/:global?' },
       { method: 'get', path: '/apps/appremove/:appname?/:force?/:global?' },

--- a/tests/unit/verificationHelper.test.js
+++ b/tests/unit/verificationHelper.test.js
@@ -52,6 +52,16 @@ describe('verificationHelper tests', () => {
       stub.reset();
     });
 
+    it('should call verifyAppOwnerOrFluxTeamSession when flag "appownerorfluxteam" is passed', async () => {
+      const privilege = 'appownerorfluxteam';
+      const stub = sinon.stub(verificationHelperUtils, 'verifyAppOwnerOrFluxTeamSession').resolves(true);
+      const verifyPrivilegeResult = await verifyPrivilege(privilege, req, appName);
+
+      sinon.assert.calledOnceWithExactly(stub, req.headers, appName);
+      expect(verifyPrivilegeResult).to.be.true;
+      stub.reset();
+    });
+
     it('should call verifyAppOwnerOrHigherSession when flag "appownerabove" is passed', async () => {
       const privilege = 'appownerabove';
       const stub = sinon.stub(verificationHelperUtils, 'verifyAppOwnerOrHigherSession').resolves(true);

--- a/tests/unit/verificationHelperUtils.test.js
+++ b/tests/unit/verificationHelperUtils.test.js
@@ -807,5 +807,59 @@ describe('verificationHelperUtils tests', () => {
 
       expect(isOwnerOrHigherSession).to.be.false;
     });
+
+    // Shares this block's fixtures deliberately: the same identities, run through
+    // the narrower check, so the one that changes verdict is visible.
+    it('verifyAppOwnerOrFluxTeamSession: true for the app owner', async () => {
+      const headers = {
+        zelidauth: {
+          zelid: '1KPKzyp9VyB9ouAA4spZ48x8g32sxLVK6W',
+          loginPhrase: '1644935889016mtmbo4uah32tvvwrmzg4j8qzv04ba8g8n56cevn6b',
+          signature: 'H7xcWjpSt8jiAaPbkUsfY3ZutJJmI35MWkGsgWBj/fJHfk7ZKRoggzigdaESLGMDMb2MHlxAapr1sMYDbJkL/H4=',
+        },
+      };
+      expect(await verificationHelperUtils.verifyAppOwnerOrFluxTeamSession(headers, 'PolkadotNode')).to.be.true;
+    });
+
+    it('verifyAppOwnerOrFluxTeamSession: true for the flux team', async () => {
+      const headers = {
+        zelidauth: {
+          zelid: '1NH9BP155Rp3HSf5ef6NpUbE8JcyLRruAM',
+          loginPhrase: '1623904359736pja76q7y68deb4264olbml6o8gyhot2yvj5oevgv9k2',
+          signature: 'H4lWS4PcrR1tMo8RCLzeYYrd042tsJC9PteIKZvn091ZAYE4K9ydfri8M1KKWe905NHdS4LPPsClqvA4nY/G+II=',
+        },
+      };
+      expect(await verificationHelperUtils.verifyAppOwnerOrFluxTeamSession(headers, 'PolkadotNode')).to.be.true;
+    });
+
+    // The whole reason the narrower check exists. This identity is admitted by
+    // verifyAppOwnerOrHigherSession above - the assertion pairs with that one, and
+    // either passing alone would prove nothing.
+    it('verifyAppOwnerOrFluxTeamSession: FALSE for the node operator, who OrHigher admits', async () => {
+      const headers = {
+        zelidauth: {
+          zelid: '1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC',
+          loginPhrase: '16125160820394ddsh5skgwv0ipodku92y0jbwvpyj17bh68lzrjlxq9',
+          signature: 'IH9d68fk/dYQtuMlNN7ioc52MJ6ryRT0IYss6h/KCwVWGcbVNFoI8Jh6hIklRq+w2itV/6vs/xzCWp4TUdSWDBc=',
+        },
+      };
+      expect(
+        await verificationHelperUtils.verifyAppOwnerOrHigherSession(headers, 'PolkadotNode'),
+        'the node operator must actually be admitted by OrHigher, or the refusal below proves nothing',
+      ).to.be.true;
+      expect(await verificationHelperUtils.verifyAppOwnerOrFluxTeamSession(headers, 'PolkadotNode')).to.be.false;
+    });
+
+    it('verifyAppOwnerOrFluxTeamSession: false for a regular user', async () => {
+      const headers = {
+        zelidauth: {
+          zelid: '1E1NSwDHtvCziYP4CtgiDMcgvgZL64PhkR',
+          loginPhrase: '162797868130153vt9r89dzjjjfg6kf34ntf1d8aa5zqlk04j3zy8z40ni',
+          signature: 'IIwyGekXKejWRCnBKMb5Zn2ufi5ylnl3r/wmonoTDm7QCUoe5vZL0SXIwqxO7F8U3Q+kUJapRS2xlUe53KNmC9k=',
+        },
+      };
+      expect(await verificationHelperUtils.verifyAppOwnerOrFluxTeamSession(headers, 'PolkadotNode')).to.be.false;
+    });
+
   });
 });


### PR DESCRIPTION
## Overview

Two things, both about who decides a container's run state.

**The crash-recovery ladder paces faults, not every stop.** It used to pace all of them, so an operator restarting their own app walked the same escalating waits as a container that could not stay up. A customer restarting their Palworld server six times in twenty-one minutes reached the fifteen-minute rung, which from the outside is indistinguishable from the app refusing to come back. That is what the support ticket was about.

**Every operator command is desired state the reconciler converges to.** `appStart`, `appStop`, `appRestart` and `appKill` record the operator's intent and let the single actuator converge on it; no route in `appController` drives a container. Seventeen `appDockerStart`/`Stop`/`Restart`/`Kill` calls remain outside the reconciler — install, uninstall, redeploy and backup/restore, mount recovery, and the two-hourly sweep that stops containers FluxOS does not own — and those paths are not what this changes.

**First of three in the stack: `development ← this ← #1781 ← #1782`.** #1779 below has merged (`63327e97f`), so this targets `development` directly. #1781 and #1782 are based on this branch and merge in stack order.

## Why the exit code cannot decide this

The exit code was already persisted — `recordExit` writes `lastExitCode` beside `lastDiedAt` — and nothing read it. It is now an input, but only in the direction it is sound.

**For a container that went down on its own: non-zero, or `OOMKilled`, proves a fault, and zero proves nothing.** An image whose entrypoint is a wrapper script ending in `exit 0` reports a clean stop for a segfault. Palworld's official image does exactly this:

```sh
"${STARTCOMMAND[@]}"     # the game — segfaults here, $? = 139
LogAction "Ending Server"
exit 0                   # unconditional; the game's status is discarded
```

Its runtime state on a live node records `lastExitCode: 0` for a death confirmed as a SIGSEGV. No init we wrap around the container recovers this: the loss happens inside the image's own script, a level below anything we can inject, so `--init`/tini would faithfully propagate the zero that was already laundered.

Pacing on the code alone would therefore leave that class of container restarting without limit. That is what the ceiling is for, and why it consults nothing but the rate.

The qualifier at the top of this section is load-bearing, and the case it excludes is not yet handled. FluxOS stops containers deliberately — an election moving a `g:` primary, a backup taking the app down — and those go out as SIGTERM, so an image that does not trap it exits 143. This lineage reads that as a fault and books a rung, which paces a healthy app for the node's own tidy shutdown. It is an improvement on what it replaces, which paced every restart whatever the cause, but it is not the whole rule: the exit code is an unreliable narrator in both directions, and only one of them is addressed here. Teaching the ladder to recognise the node's own drains needs desired state to decide it rather than the exit code, and that is a follow-up PR rather than a widening of this one.

## The ceiling, and what it reaches

Five automatic restarts inside five minutes is itself evidence of a fault, whatever Docker reported. It disposes into the same ladder rather than into a failed state a human has to clear — nobody is watching a customer's node at 3am.

It is judged before the restart is recorded, against five entries spanning five gaps, so its reach is `window / count`. Measured against the real module:

```
every  59s   paced
every  60s   paced
every  61s   never paced, however long it continues
```

A container exiting in milliseconds trips it in about a second. Anything slower than one restart a minute is deliberately left alone.

## The ladder is measured against running, not against waiting

`restartWaitMs` clears the ladder once a component has genuinely run for `STABLE_RUN_MS`, and measures that from its last rung. A component holding rungs therefore earns one for every restart — otherwise the gap being measured is the wait the component just served, and any rung longer than ten minutes clears the ladder every time it fires.

The exit code decides what puts a component on the ladder; it does not decide whether it stays. `restartWaitMs` takes no `crashed` argument for that reason — whether to wait depends only on whether rungs stand.

Measured against the real module, driving the reconciler's own loop order for two hours with a container dying two seconds after every start:

| container | starts in 2h | rungs reached |
|---|---|---|
| reports exit 0 for a segfault | 12 | 30s, 5m, 15m, 30m cap |
| exits non-zero | 7 | 30s, 5m, 15m, 30m cap |
| healthy, runs for an hour | 2 | never paced |
| operator presses restart | — | never paced, ladder cleared |

An operator restart is recognised by the path it takes, not by its exit code: `appStart` and `appRestart` clear the operator lock, and `setOperatorStopped(id, false)` drops the rungs with it. Recognising it by exit code instead hands the same exemption to a laundered segfault, which also exits 0.

## Operator commands are desired state

`appStart` probed docker for "is this container running" and used the answer as a proxy for "should this node be running it". Those diverge both ways: a masterSlave primary whose container is stopped was refused a start though the election names it the writer, and a standby whose container happened to be up was started. It classified `g:` with `containerData.includes('g:')`, which `mountParser`'s own comment calls wrong — `'/data|g:/db'` matches while the flag sits in an invalid non-primary position.

The election owns that decision and the reconciler consults it on every pass, so the handler clears the lock and lets it decide. A component the election is holding is reported as pending, naming the election, rather than as skipped.

`appRestart` raises a durable restart generation; the reconciler bounces a running container once the generation passes the one it last actuated, and a start of a stopped container satisfies the same request. `appKill` records a durable force mode which the reconciler honours with `appDockerKill` where it stops the container.

Every one of the four reports what happened rather than what was asked for: `Application X stopped`, or `will be stopped: docker is not reachable`.

A command that addresses nothing is refused rather than reported done. The components are resolved before anything is written, and an app that is installed but whose parts this node cannot work out — a spec that will not decrypt, falling back to a container listing that is empty or that failed outright — yields none. Acting on that empty list wrote no intent and settled vacuously against nothing, so all four answered `Application X stopped` having touched nothing and recorded nothing for a later pass to pick up. They now say the app was not changed and why, worded for the operator: HomeUI shows the message verbatim.

## Monitoring follows the container

`startAppMonitoring` resets `statsStore`, and `appStart` called it on every request — so asking an app to start discarded the series the charts read. `appStop` stopped the sampler before knowing whether the stop had happened, so an unreachable docker left a running container unmonitored.

The reconciler owns both ends. It stops the sampler on each of the four paths where it stops a container, and `ensureAppMonitoring` puts one back for a running container that has none without resetting a live one.

## The kill endpoint

`appKill` was implemented, exported and covered by unit tests calling it directly, and no route registered it — on this lineage or on v9. Every route is a string literal, there is no dispatch table, and `executeAppGlobalCommand` builds a URL against the same route table, so a peer could not reach it either. `routeWiring.test.js` reads the real route table, so its absence now fails a test.

`appKill` and `appRemove` both ask for `appownerorfluxteam` rather than `appownerabove`, which takes the node operator out of both. Hosting an app is not owning it: an operator who can remove one can script that against every install and keep a customer's app off their node indefinitely, which the customer experiences as an app that will not stay deployed and cannot diagnose.

There is no operator need on the other side of that. An app cannot exceed what was bought — `Memory`, `MemorySwap`, `NanoCpus` and `StorageOpt` are set on the container from the spec, so an app inside its allocation is spending cycles the operator sold, and an app outside it is a containment defect to be fixed in the limits rather than papered over on one node. What an operator does keep is the control that is honest about its own cost: stop FluxOS, or drop the node, both of which give up the payment along with the obligation.

That reasoning does not stop at these two, and the rest is already decided. `appStart`, `appStop` and `appRestart` still ask for `appownerabove`, and a follow-up PR takes the remaining app control away from the node operator entirely, with the frontend controls narrowed alongside it — the same way this one lands with #150. It is separate only so that each gate ships with the control that exposes it.

`appownerorfluxteam` admits exactly `{owner, fluxTeam, fluxSupport}`, which is the same set the vetted-app branch below it admitted. That branch existed to keep the operator away from vetted apps, so with the operator out of the gate above it can no longer refuse anyone who reaches it. It goes, and with it two database reads and a vetted lookup on every uninstall.

The same reasoning closes the other end. `installapplocally` and `testappinstall` asked for `adminandfluxteam` on their by-name branch, which resolves an app from the marketplace, the global registry or a permanent message — so an operator reaching it chose *which* customer's app ran on hardware they control, and for a `g:`/`r:` app the new instance syncs that customer's data down to it. Both move to `fluxteam`. Leaving install open while closing remove would have left the operator able to place an app on their node and unable to take it off.

The temporary-message branch above them is deliberately untouched and stays open to any logged-in user: that is how an app is tested before it is registered, it is addressed by hash rather than by name, and it expires on its own via `temporaryAppAllowance`.

This is user-visible on a reachable route, so the frontend control that offered it is narrowed to fluxteam in RunOnFlux/fluxos-frontend#150. **The two land together.** `local.vue` renders Uninstall to `admin`, so this merging alone leaves a node operator pressing a button that now refuses them. The same PR fixes the panel refresh behind finding 5: `AppControl.vue` read `response.data.status` once and refetched once, so an accepted command showed a green toast beside a status that had not moved yet. It now refreshes on a spreading schedule (0/2/5/10/20s).

## Config fallbacks

`RESTART_BURST_WINDOW_MS` falls back to the value config ships. Every `config.fluxapps.x ?? literal` in the service layer is a second copy of a shipped value — forty keys, none of them a default the module owns — and `tests/unit/configFallbacks.test.js` compares each against `ZelBack/config/default.js`. An expression it cannot evaluate fails rather than being skipped.

`config.get()` removes the second copy entirely and throws by name on a missing key. That is 40 call sites here and 108 on the v9 lineage, so it is its own change.

## The boot-lock harness commits

Three commits touch only `test-infra/runner/framework/boot-lock.js` and its call site, and are named here because they are otherwise unexplained in a reconciler PR: *the boot lock says how long it queued and how long it held*, *a boot's duration is unreadable without the shape of the fleet*, and *the boot lock admits a bounded number of boots, not one*. They are named by subject rather than by hash: this branch is rebased whenever the one below it moves, and every hash in it changes when that happens.

Fleet boot is serialised host-wide by a semaphore, and nothing recorded what that cost. The first two make acquire report how long a build queued and how many were ahead of it, release report how long it held, and add the shape of the fleet being built — without which a hold duration mixes one-node and ten-node builds indistinguishably.

The third acts on what the first two measured: the gate was **89% boot-lock-held wall clock**, 4,439s of 4,978s across 130 boots, so its duration was very nearly the serial sum of the boots it serialised. The lock now admits `E2E_BOOT_LOCK_WIDTH` boots, default 2. Arrival order is untouched — the queue still drains in the order it formed, which keeps starvation structural rather than statistical.

Measured across two gates of the same 82 suites at `MAXN=6`, the same 130 boots and a near-identical fleet-size distribution:

| | width 1 | width 2 |
|---|---|---|
| gate wall clock | 4,978s | **4,192s** |
| queue wait, p50 | 87.8s | **24.1s** |
| queue wait, total | 11,697s | **3,747s** |
| lock held, p50 | 32.6s | 40.2s |
| lock held, total | 4,439s | 5,746s |

Boots contend and each costs more, but they overlap, and the overlap wins by 786 seconds. `E2E_BOOT_LOCK_WIDTH=1` restores the old behaviour without reverting the commit.

All three emit TAP comments (`# boot-lock ...`), so none can alter a result: `run-all.sh` tallies with `grep -c "^ok "`, anchored to line start.

## An address change no longer stops at the first composed app

`adjustExternalIP` restarted the apps that survive an address change by calling `appController.appDockerRestart(app.name)`. That resolves one container by name and a composed app has none under its bare app name — its containers are `<component>_<app>` — so the first one threw a `TypeError` that nothing caught, taking with it every app behind it in the loop, the `fluxipchanged` broadcast, the confirmation transaction and the geolocation update. One log line was the trace.

The surviving apps are now handed to `appReconciler.requestRestartOf` as durable per-component restart requests, through a seam (`setOnAddressChanged`, wired in `serviceManager`) rather than a require — `appUninstaller` requires `fluxNetworkHelper` and `appReconciler` requires `appUninstaller`, so reaching upward from the network layer closes a cycle, and twenty-odd app-layer modules import it. `componentIdsOf` is shared with `enqueueAll` so the rule for what components an app has, including the docker fallback for specs that will not decrypt, has one home.

## An address change no longer uninstalls the node's own apps

Before restarting an app, `adjustExternalIP` asks whether it is already running at the address being moved to, and force-removes it if so — on the sound principle that one instance per IP is what the host port mapping allows, so an instance already there means the ports are gone. It treated any answer as another node's. The node's own registration is one of those answers: it stores its own running-app row locally, at the address benchmark reports, so the row found at that address is usually itself. The app was removed — forced, and broadcast to the network — for being exactly where it belonged.

The address is still compared at IP granularity — that is the question being asked, and a UPnP sibling on another port holds the ports just as surely. Own-ness is the full socket address, which is what separates the two, using the same `socketAddressesMatch` test the collision check in that file already uses.

## A stop is honoured while a data volume is unavailable

The reconciler defers every actuation for a component whose data volume will not mount — a start there writes to the host filesystem instead of the volume. A stop is the exception, because it takes nothing from the app dir, and leaving a container running over a missing volume is the state the mount-safety hold exists to end.

That exception covers the operator's stop as well as the controller's. The operator's outranks the controller's everywhere else in a pass, and an unmountable volume is the state support reaches for a stop *in*, so a stop that waits for the mount is a stop that never arrives when it is wanted. The force flag is carried through it, so an `appkill` there is a kill rather than a graceful stop.

## An operator command addresses what the app is made of

The components a command acts on come from `appReconciler.componentIdsOf`, which decrypts the spec to enumerate them and falls back to the running containers when it cannot.

Reading `compose` off a stored spec answers neither case reliably. An enterprise app keeps its component names inside an encrypted blob, so its stored compose is empty — a whole-app command derived from it addresses nothing, and every one of zero components reaches its desired state, so it reports success. A component name taken verbatim addresses nothing either when it is not one of the app's, and still writes a durable operator lock under it that nothing clears.

`componentIdsOf` returns one spelling whichever source it used. Docker holds the namespaced name (`flux<component>_<app>`) where a decrypted compose gives the bare one, so the list carried either depending on whether the spec read. Every consumer until now canonicalised on ingest and so could not tell them apart; the membership check above compares the list against a name an operator typed, and refused every component-level command against an app whose spec would not decrypt. Stripped at the source, so one spelling reaches all three consumers.

`containersReachedStopped` distinguishes a container that is absent from one that is stopped. `dockerActual` reports `exists` separately from `running`, and reading the pair as one answered "stopped" for a container that was never there — the answer `appStart` already gave correctly.

## The restart generation is raised by the database

`requestRestart` issues an atomic increment rather than reading the current generation and writing one more than it. `getState` answers null both for "no record yet" and "the read failed", and treating the second as zero writes a generation below the one already actuated — which the reconciler reads as nothing pending, so the restart is reported and never happens. An increment has no such answer to misread, creates the field at 1 when there is no record, and counts two concurrent requests as two rather than losing one.

The upsert retry that protects a first write from a concurrent one is shared with `setFields` rather than copied, since without it the loser of that race is dropped silently.

## Changes

| file | change |
|---|---|
| `appController.js` | all four operator handlers record intent and probe the outcome; `app:operatorIntent` published from inside the reconciler's slot; `appDockerRestart` deleted |
| `appReconciler.js` | honours the restart generation and the force mode; owns monitoring on its stop and steady-state paths; `requestRestartOf`, and `componentIdsOf` shared with `enqueueAll` |
| `fluxNetworkHelper.js` | `setOnAddressChanged`; the surviving apps are handed over once; the duplicate check excludes the node's own registration |
| `serviceManager.js` | wires that seam to `appReconciler.requestRestartOf` |
| `appUninstaller.js` | `appownerorfluxteam` on the uninstall route; the vetted branch it made redundant removed |
| `appsRuntimeState.js` | `restartGeneration` / `operatorStopForce`; a component holding rungs earns one per restart; twin-merge carries all three |
| `appInspector.js` | `ensureAppMonitoring`; a cleared interval no longer looks live |
| `routes.js` | `/apps/appkill/:appname?` |
| `verificationHelper*.js` | `appownerorfluxteam` |
| `ZelBack/config/default.js` | `restartBurstCount: 5`, `restartBurstWindowMs: 300000` |

`globalState.stoppingContainers` stays. Its remaining consumers are the uninstaller, redeploy, backup/restore and mount recovery, none of which this touches. The network-change restart is no longer one of them.

## Testing

Unit suite **5,635 passing, 0 failing** (18 pending) on the current head. Both fixtures up — without mongo the run skips 682 tests and still exits 0, so a bare pass is not a result.

Every guarantee added here was mutated to prove the test would notice: the force mode ignored, every stop forced, the restart request never actuated, the bounce never recorded, a start not satisfying a pending request, a pending outcome reported as success, the handler driving docker again, the intent event published outside the slot, the route removed, the kill privilege widened, the uninstall privilege widened back to the one that admits the node operator, the component identifier left namespaced by one of its two sources, an empty component list reporting success, the ladder cleared by its own wait, and a fallback diverging from config.

Twenty-nine mutations run, twenty-eight caught. The one that was not is worth stating: it reverted a line measuring stability from the last restart in either array rather than from the last rung. Nothing failed, because a component holding rungs earns one for every restart — so the two are always the same value and the line could not change an outcome. It was removed rather than shipped.

One test was removed for being unable to fail, and one rewritten: it asserted that an operator restart is not paced but expressed that through the exit code, which is the exemption a laundered segfault also receives.

### On a fleet

The unit tests stub docker, so they prove a handler writes the right intent and nothing further. What a customer sees is a container's run state and a response string, and until now nothing drove either. Six tests were added to four existing suites, and one new suite covers the address-change path:

| suite | test |
|---|---|
| `32-…-restart-clears-lock` | apprestart bounces a container that is **already running**, and bounces it once. The suite's existing test restarts one that was down, which is a start — either implementation satisfies it, and the restart generation only decides anything when the container is up. |
| `32-…-operator-stop-durable` | appkill stops it, asserted on the `forced` flag — "the container stopped" passes against a graceful stop too. And the node operator is refused a kill while still allowed a stop, driven from the node's own identity, both halves. |
| `52-masterslave-…` | appstart on an instance the election is not electing reports the election rather than claiming a start. Runs first in that suite, before anything there stops an instance — after that, a non-running holder could be one an operator stopped, which is a different answer reaching the same assertion. |
| `54-…-burst-ceiling` | the ladder is not cleared by the wait it just served, reaching the rung that outlasts a stable run. |
| `35-…-masterslave-election` | a backup's stop costs the elected primary no rung: the hold is released and it converges back to running inside a cycle. The same assertion fails on the branch below, where every restart earns a rung and the component is on the five-minute one by then — so it discriminates against the behaviour this PR changes, proven by running it on both. |
| `56-address-change-restarts-apps` | **new.** Three nodes, one COMPOSED app. Both components restart on their own identifiers after the node's address moves, and a peer accepts the `fluxipchanged` broadcast — which is what distinguishes a handler that ran to the end from one that stopped at the first app. |

Suite 54 previously ran against production's ladder, so the only rung reachable inside a sane timeout was the first — everything past it, including the rung this PR's defect lived at, needed a twenty-one minute wait and so was never driven. Its ladder and stable-run window are now compressed together, preserving the relationship that matters (a rung outlasting the window that clears the ladder: 30s against 20s here, 15m against 10m in production) and asserting that relationship holds, because compressing one without the other leaves the suite green having stopped testing what it exists for.

The backoff actuation now carries the rung. `waitMs` is what *remains* of a rung and the worker re-enqueues during a wait, so one rung reports several times with a falling number and two backoffs cannot be compared — which is precisely the question a ladder that resets itself turns on. It reaches the log line too, so support can read how far a component has escalated rather than only how long is left.

Suite 56 changes a node's address for real rather than simulating one: the new address goes onto its interface and the old one comes off, and benchmark's public-IP probe reports the move while the deterministic list still says where it was. Its peers then fail to reach it at the old address because it genuinely is not there, which is what makes it ask benchmark whether it moved — a node that is still reachable never asks. The list being untouched is what lets those same peers still recognise it as the sender of the broadcast that follows.

Simulating either half breaks the other, which is why it is done properly: blocking the node's packets makes a peer's answer arrive after the asking node has given up, so it reads as "I could not ask" rather than "you are unreachable" and never reaches benchmark; hiding the node from peers' lists makes them answer promptly and then reject its broadcast as coming from a stranger.

Two harness assumptions had to go with it, both of them things an address change necessarily violates. The runner reached a node at a fixed address, so a node that moved went blind to its own client — `nodeClient.followTo` re-points it and reconnects. And the daemon stub identified a node by the address its requests arrive from, so a node that moved lost its identity, read its own address as the not-found fallback, and skipped its availability check on every cycle; it is now recognised at its reported address too.

Run against images rebuilt from the tree under test and verified from inside the image, not from build output. Suite 56 on the current head: 2 tests, 0 failures, twice consecutively at 3m35s and 2m32s. Suite 35: 4 tests, 0 failures.







