### PR TITLE
Test harness isolation: the fleet installs from itself and reaches nothing outside — and four production fixes it turned up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -392,3 +392,9 @@ test-infra/runner/test-logs/
 # mirrorImage). Content-addressed and re-fetchable, so only the first suite of
 # a gate pays for the download.
 test-infra/runner/.image-cache/
+
+# node-config loads this last, over everything in the pinned directory, so a
+# committed one would redirect a production node's endpoints. The harness writes
+# it inside the container at boot; it never belongs in the repo.
+ZelBack/config/local.js
+ZelBack/config/local-*.js

--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -538,6 +538,10 @@ module.exports = {
     stallNudgeMaxIntervalMs: 900000, // nudge backoff cap (15min)
     stallRemoveMinWindowMs: 1200000, // 20min minimum evidence window before removal
     stallRemoveMinNudges: 3, // nudges that must have failed before removal
+    // Where a legacy node installs syncthing from. Arcane nodes ship it in the image and
+    // never reach either of these.
+    aptSourceUrl: 'https://apt.syncthing.net/',
+    releaseKeyUrl: 'https://syncthing.net/release-key.gpg',
   },
   // enterpriseAppOwners moved to helpers/enterprisenodes.json (synced from github every 6h, see enterpriseConfig)
   enterprisePublicKeys: [ // list of whitelisted nodes indentity public keys. Most trusted node operators that are publicly known, kyc. Eg Flux team members, Titan.
@@ -596,7 +600,22 @@ module.exports = {
   },
   geolocation: {
     ipApiBaseUrl: 'http://ip-api.com',
-    statsApiBaseUrl: 'https://stats.runonflux.io',
+  },
+  // The network's statistics service. One host, several paths: node location,
+  // marketplace listings, app USD pricing, and the minimum module versions a node
+  // checks its syncthing against at boot.
+  stats: {
+    baseUrl: 'https://stats.runonflux.io',
+  },
+  pricing: {
+    fluxRatesBaseUrl: 'https://viprates.runonflux.io',
+    // Consulted only when the rates service above is unreachable.
+    coingeckoBaseUrl: 'https://api.coingecko.com',
+  },
+  mongodb: {
+    // Where a replacement server signing key is fetched from when the installed one
+    // has expired. The version is appended: /server-<major.minor>.asc
+    signingKeyBaseUrl: 'https://pgp.mongodb.com',
   },
   analytics: {
     url: 'https://cloudaudit.runonflux.io', // analytics server URL (e.g. 'https://analytics.runonflux.io'). Empty = disabled.

--- a/ZelBack/src/services/appSecurity/imageManager.js
+++ b/ZelBack/src/services/appSecurity/imageManager.js
@@ -290,7 +290,7 @@ async function getUserBlockedRepositores() {
       return userBlockedRepos;
     }
     const usableUserBlockedRepos = [];
-    const marketPlaceUrl = 'https://stats.runonflux.io/marketplace/listapps';
+    const marketPlaceUrl = `${config.stats.baseUrl}/marketplace/listapps`;
     const response = await axios.get(marketPlaceUrl);
     console.log(response);
     if (response && response.data && response.data.status === 'success') {

--- a/ZelBack/src/services/appSystem/fileOperationRecovery.js
+++ b/ZelBack/src/services/appSystem/fileOperationRecovery.js
@@ -3,6 +3,7 @@ const log = require('../../lib/log');
 const { appsFolder } = require('../utils/appConstants');
 const executor = require('./volumeExecutor');
 const { sessionForMountedVolume } = require('./volumeSession');
+const fluxEventBus = require('../utils/fluxEventBus');
 
 /**
  * Reclaim what a FluxOS restart left behind from in-flight file operations.
@@ -25,6 +26,19 @@ const { sessionForMountedVolume } = require('./volumeSession');
  * @returns {Promise<{containers: number, removed: number}>}
  */
 async function recoverInterruptedFileOperations() {
+  const result = await sweepEveryMountedVolume();
+  // Published on every path that completes, including the one that found nothing.
+  // "The sweep ran and had nothing to do" is a different fact from "the sweep has
+  // not run yet", and the log line below cannot express the first because it only
+  // fires when there was something to report. Anything that restarts a node to
+  // exercise boot recovery needs to know the pass is over: without a signal it can
+  // only guess, and a pass that lands after the guess reaches into whatever is
+  // running by then.
+  fluxEventBus.publish('fileops:recovered', result);
+  return result;
+}
+
+async function sweepEveryMountedVolume() {
   const containers = await executor.reapOrphanedContainers();
 
   let mounts = [];

--- a/ZelBack/src/services/appSystem/fileOperationRecovery.js
+++ b/ZelBack/src/services/appSystem/fileOperationRecovery.js
@@ -26,15 +26,21 @@ const fluxEventBus = require('../utils/fluxEventBus');
  * @returns {Promise<{containers: number, removed: number}>}
  */
 async function recoverInterruptedFileOperations() {
-  const result = await sweepEveryMountedVolume();
-  // Published on every path that completes, including the one that found nothing.
-  // "The sweep ran and had nothing to do" is a different fact from "the sweep has
-  // not run yet", and the log line below cannot express the first because it only
-  // fires when there was something to report. Anything that restarts a node to
-  // exercise boot recovery needs to know the pass is over: without a signal it can
-  // only guess, and a pass that lands after the guess reaches into whatever is
-  // running by then.
-  fluxEventBus.publish('fileops:recovered', result);
+  // Published on every path that ENDS the pass - the one that found nothing,
+  // and the one that threw. "The sweep ran and had nothing to do" is a
+  // different fact from "the sweep has not run yet", and the log line below
+  // cannot express the first because it only fires when there was something to
+  // report. Anything that restarts a node to exercise boot recovery needs to
+  // know the pass is over: without a signal it can only guess, and a pass that
+  // lands after the guess reaches into whatever is running by then. A throw
+  // still propagates - a startup that throws is retried, and the retry
+  // publishes again, which is safe for the same reason the sweep is.
+  let result = { containers: 0, removed: 0 };
+  try {
+    result = await sweepEveryMountedVolume();
+  } finally {
+    fluxEventBus.publish('fileops:recovered', result);
+  }
   return result;
 }
 

--- a/ZelBack/src/services/cloudUIUpdateService.js
+++ b/ZelBack/src/services/cloudUIUpdateService.js
@@ -1,7 +1,7 @@
 const config = require('config');
 const fs = require('fs');
 const path = require('path');
-const { exec } = require('child_process');
+const { execFile } = require('child_process');
 const axios = require('axios');
 const log = require('../lib/log');
 
@@ -109,7 +109,11 @@ function runUpdateScript() {
   return new Promise((resolve) => {
     log.info('CloudUI: Running update script...');
 
-    exec('npm run update:cloudui', { cwd: PROJECT_ROOT, timeout: 300000 }, (error, stdout, stderr) => {
+    // The script is handed the API host rather than knowing one. Config is the single
+    // source of truth for every endpoint a node reaches, and it lives in the directory
+    // fluxbench hashes - a hardcoded URL in the script, or one taken from the
+    // environment, would be outside that protection and unreachable by the harness.
+    execFile('npm', ['run', 'update:cloudui', '--', config.github.apiBaseUrl], { cwd: PROJECT_ROOT, timeout: 300000 }, (error, stdout, stderr) => {
       if (error) {
         log.error(`CloudUI update script error: ${error.message}`);
         if (stderr) {

--- a/ZelBack/src/services/fluxService.js
+++ b/ZelBack/src/services/fluxService.js
@@ -815,9 +815,9 @@ function getEnterpriseAppOwners(req, res) {
 function getMarketplaceURL(req, res) {
   const userconfig = globalThis.userconfig;
   const development = userconfig.initial.development || false;
-  let marketPlaceUrl = 'https://stats.runonflux.io/marketplace/listapps';
+  let marketPlaceUrl = `${config.stats.baseUrl}/marketplace/listapps`;
   if (development) {
-    marketPlaceUrl = 'https://stats.runonflux.io/marketplace/listdevapps';
+    marketPlaceUrl = `${config.stats.baseUrl}/marketplace/listdevapps`;
   }
   const message = messageHelper.createDataMessage(marketPlaceUrl);
   return res ? res.json(message) : message;

--- a/ZelBack/src/services/geolocationService.js
+++ b/ZelBack/src/services/geolocationService.js
@@ -118,7 +118,7 @@ async function setNodeGeolocation() {
           dataCenter: ipRes.data.hosting,
         };
       } else {
-        const statsApiUrl = `${config.geolocation.statsApiBaseUrl}/fluxlocation/${localIp}`;
+        const statsApiUrl = `${config.stats.baseUrl}/fluxlocation/${localIp}`;
         const statsRes = await serviceHelper.axiosGet(statsApiUrl);
         if (statsRes.data.status === 'success' && statsRes.data.data) {
           storedGeolocation = {

--- a/ZelBack/src/services/systemService.js
+++ b/ZelBack/src/services/systemService.js
@@ -705,6 +705,7 @@ async function monitorAptCache(event) {
 async function monitorSystem() {
   if (isArcane) return;
 
+  let installed = [];
   try {
     // ensureChronyd answers whether chrony ended up configured, which is true
     // both when it installed it and when it was already there. What it installed
@@ -729,19 +730,24 @@ async function monitorSystem() {
       ),
     };
 
-    const outcomes = await Promise.all(Object.values(checks));
     const names = Object.keys(checks);
-
-    // Published whether or not anything was installed, because "checked and had
-    // nothing to do" is a different fact from "has not run yet" and the logs
-    // below only speak in the first case. A node that is already provisioned -
-    // which is every node after its first boot - is otherwise indistinguishable
-    // from one whose checks have not started.
-    fluxEventBus.publish('system:packages-checked', {
-      installed: names.filter((_, i) => outcomes[i]),
+    const settled = await Promise.allSettled(Object.values(checks));
+    // Named individually rather than as one failure, so a log says which check
+    // could not answer instead of only that something could not.
+    settled.forEach((outcome, i) => {
+      if (outcome.status === 'rejected') log.error(`monitorSystem - the ${names[i]} check failed: ${outcome.reason?.message ?? outcome.reason}`);
     });
+    installed = names.filter((_, i) => settled[i].status === 'fulfilled' && settled[i].value);
   } catch (error) {
     log.error(error);
+  } finally {
+    // Published on every path out of here, including the ones that failed.
+    // "Checked and had nothing to do" is a different fact from "has not run
+    // yet", and a check that threw is a third - tried and could not. All three
+    // are silence to a waiter, which then waits out its whole timeout for an
+    // answer that is never coming, and a node already provisioned looks the
+    // same as one whose checks never started.
+    fluxEventBus.publish('system:packages-checked', { installed });
   }
 }
 

--- a/ZelBack/src/services/systemService.js
+++ b/ZelBack/src/services/systemService.js
@@ -569,6 +569,13 @@ async function monitorSyncthingPackage() {
 
         if (upToDate) return false;
 
+        // After the up-to-date return - a current node is not handed a keyring
+        // and a source it will never read - and BEFORE the sources rewrite: the
+        // rewrite fails on a node with no source file at all, and its failure
+        // must not stand between that node and the file being created, or the
+        // node warns once a day forever and never upgrades.
+        await addSyncthingRepository();
+
         // The sources changed at version 2.0.0 from stable, to stable-v2
         const hasNewSources = serviceHelper.minVersionSatisfy(
           currentSyncthingVersion,
@@ -584,10 +591,9 @@ async function monitorSyncthingPackage() {
         }
       }
 
-      // Here, rather than before the version check: a node whose syncthing is
-      // already current has nothing to install, and writing it a keyring and an
-      // apt source it will never read is work it did not ask for. Only a node
-      // that is about to install needs somewhere to install from.
+      // The uninstalled case: nothing on the system, so there is no version to
+      // judge and nothing to rewrite - the source is simply ensured before the
+      // install.
       await addSyncthingRepository();
 
       const upgraded = await ensurePackageVersion(

--- a/ZelBack/src/services/systemService.js
+++ b/ZelBack/src/services/systemService.js
@@ -76,6 +76,7 @@ async function aptRunner(options = {}) {
   // any apt after 1.9.11 has the DPkg::Lock::Timeout option.
   const params = [
     '-y', // Auto-answer yes to prompts
+    '--no-install-recommends', // Only what the package needs, not what it suggests
     '-o', `DPkg::Lock::Timeout=${timeout}`, // How long to wait for a lock
     '-o', 'Dpkg::Options::=--force-confdef', // Use default for new config files
     '-o', 'Dpkg::Options::=--force-confold', // Keep old config files on conflict
@@ -530,8 +531,6 @@ async function monitorSyncthingPackage() {
   try {
     if (syncthingTimer) return;
 
-    await addSyncthingRepository();
-
     const versionChecker = async () => {
       const {
         data: { data },
@@ -571,6 +570,12 @@ async function monitorSyncthingPackage() {
           }
         }
       }
+
+      // Here, rather than before the version check: a node whose syncthing is
+      // already current has nothing to install, and writing it a keyring and an
+      // apt source it will never read is work it did not ask for. Only a node
+      // that is about to install needs somewhere to install from.
+      await addSyncthingRepository();
 
       const upgraded = await ensurePackageVersion(
         'syncthing',

--- a/ZelBack/src/services/systemService.js
+++ b/ZelBack/src/services/systemService.js
@@ -98,6 +98,14 @@ async function aptRunner(options = {}) {
     params: envParams,
   });
 
+  // A fact, not a cadence: a legacy boot runs a handful of apt commands, and
+  // WHICH of them completed - and in what order - is the only direct evidence
+  // that the queue carried on past one that failed. Published at the single point
+  // every apt command passes through, on both exits, so a reader sees the failure
+  // and the work behind it as two events rather than inferring the second from
+  // packages appearing on disk some time later.
+  fluxEventBus.publish('system:apt-command', { command: options.command, ok: !error });
+
   // this is so this command can be retried by the worker runner
   if (error) throw error;
 

--- a/ZelBack/src/services/systemService.js
+++ b/ZelBack/src/services/systemService.js
@@ -24,10 +24,18 @@ const isArcane = Boolean(process.env.FLUXOS_PATH);
 let syncthingTimer = null;
 
 /**
- * A FIFO queue used to store and run apt commands
+ * A FIFO queue used to store and run apt commands.
+ *
+ * Built complete. A queue that arrives without its worker has to be finished off
+ * later by whoever happens to get there first, and until they do it silently
+ * accepts work it cannot run - so its behaviour depends on call order, and a test
+ * that touches it inherits whatever the last one left behind.
  * @type {fifoQueue.FifoQueue}
  */
-const aptQueue = new fifoQueue.FifoQueue();
+// eslint-disable-next-line no-use-before-define
+const aptQueue = new fifoQueue.FifoQueue({ worker: aptRunner });
+// eslint-disable-next-line no-use-before-define
+aptQueue.on('failed', monitorAptCache);
 
 /**
  * For testing
@@ -130,7 +138,15 @@ async function queueAptGetCommand(command, options = {}) {
 
   const wait = options.wait || false;
   const commandOptions = { command, params, timeout: options.timeout };
-  const workerOptions = { retries: options.retries };
+  // Every worker option the caller set, not just retries. updateAptCache asks for
+  // retainErrors: false so a failed update is dropped rather than left at the head
+  // of the queue; dropping that request here left the queue holding a task it was
+  // told to bin, ready to run again the moment anything resumed it.
+  const workerOptions = {
+    retries: options.retries,
+    retryDelay: options.retryDelay,
+    retainErrors: options.retainErrors,
+  };
   return aptQueue.push({ commandOptions, workerOptions }, wait);
 }
 
@@ -673,9 +689,6 @@ async function monitorSystem() {
   if (isArcane) return;
 
   try {
-    aptQueue.addWorker(aptRunner);
-    aptQueue.on('failed', monitorAptCache);
-
     // don't await these, let the queue deal with it
 
     // ubuntu 18.04 -> 24.04 all share this package

--- a/ZelBack/src/services/systemService.js
+++ b/ZelBack/src/services/systemService.js
@@ -135,11 +135,16 @@ async function cacheUpdateTime() {
 
 /**
  * @param {string} command The command to run
- * @param {{params?: Array, timeout?: number, retries?: number, wait?: Boolean}} options
+ * @param {{params?: Array, timeout?: number, retries?: number, retryDelay?: number,
+ *   retainErrors?: boolean, wait?: Boolean}} options
  *
  * params: params to pass to command
- * timeout: how many seconds to wait (60 default)
- * retries: how many times to retry (3 default)
+ * timeout: how many seconds to wait (180 default)
+ * retries: how many times to retry (queue default, 5)
+ * retryDelay: how long to wait between attempts in ms (queue default, 60000)
+ * retainErrors: keep a failed task and try it again later rather than dropping
+ *   it (queue default, true). Every one of these is forwarded, so an option left
+ *   unset takes the queue's default rather than this function's.
  * wait: should the queue item be awaited
  *
  * @returns {Promise<Object | void>}

--- a/ZelBack/src/services/systemService.js
+++ b/ZelBack/src/services/systemService.js
@@ -522,8 +522,13 @@ async function ensurePackageVersion(systemPackage, requiredVersion, currentVersi
 
     if (!actualVersion) {
       log.info(`Package ${systemPackage} not found on system`);
-      await upgradePackage(systemPackage);
-      return true; // Package was installed/upgraded
+      // upgradePackage answers whether it FAILED. This branch used to discard that
+      // and report the install regardless, so an apt-get that could not find the
+      // package read back the same as one that installed it. The upgrade branch
+      // below has always read it.
+      const installError = await upgradePackage(systemPackage);
+      if (installError) log.error(`Package ${systemPackage} could not be installed`);
+      return !installError;
     }
 
     log.info(`Package ${systemPackage} version ${actualVersion} found`);

--- a/ZelBack/src/services/systemService.js
+++ b/ZelBack/src/services/systemService.js
@@ -37,6 +37,12 @@ let syncthingTimer = null;
 const aptQueue = new fifoQueue.FifoQueue({ worker: aptRunner });
 // eslint-disable-next-line no-use-before-define
 aptQueue.on('failed', monitorAptCache);
+// The queue has stopped handing this one back. Worth saying out loud: the caller
+// took its error long ago, so without this the work is simply never done again and
+// nothing ever mentions it.
+aptQueue.on('abandoned', ({ options, error, cycles }) => {
+  log.error(`Giving up on apt-get ${options.command} after ${cycles} attempts: ${error.message}`);
+});
 
 /**
  * For testing

--- a/ZelBack/src/services/systemService.js
+++ b/ZelBack/src/services/systemService.js
@@ -14,6 +14,7 @@ const log = require('../lib/log');
 const serviceHelper = require('./serviceHelper');
 const syncthingService = require('./syncthingService');
 const fifoQueue = require('./utils/fifoQueue');
+const fluxEventBus = require('./utils/fluxEventBus');
 const daemonServiceUtils = require('./daemonService/daemonServiceUtils');
 
 const isArcane = Boolean(process.env.FLUXOS_PATH);
@@ -548,7 +549,7 @@ async function monitorSyncthingPackage() {
           minSyncthingVersion,
         );
 
-        if (upToDate) return;
+        if (upToDate) return false;
 
         // The sources changed at version 2.0.0 from stable, to stable-v2
         const hasNewSources = serviceHelper.minVersionSatisfy(
@@ -560,7 +561,7 @@ async function monitorSyncthingPackage() {
           const updated = await updateSyncthingRepository();
           if (!updated) {
             log.warn('Failed to update syncthing repository sources, skipping syncthing upgrade');
-            return;
+            return false;
           }
         }
       }
@@ -576,13 +577,18 @@ async function monitorSyncthingPackage() {
         log.info('Syncthing upgraded, restarting to load new binary...');
         await syncthingService.systemRestart(null, null).catch(() => { });
       }
+
+      return upgraded;
     };
 
-    await versionChecker();
+    const upgraded = await versionChecker();
 
     syncthingTimer = setInterval(versionChecker, 1000 * 60 * 60 * 24); // 24 hours
+
+    return upgraded;
   } catch (error) {
     log.error(error);
+    return false;
   }
 }
 
@@ -689,18 +695,40 @@ async function monitorSystem() {
   if (isArcane) return;
 
   try {
-    // don't await these, let the queue deal with it
+    // ensureChronyd answers whether chrony ended up configured, which is true
+    // both when it installed it and when it was already there. What it installed
+    // is a different question, and only the package can answer it.
+    const chronyWasPresent = Boolean(await getPackageVersion('chrony'));
 
-    // ubuntu 18.04 -> 24.04 all share this package
-    setImmediate(() => ensurePackageVersion('ca-certificates', '20230311'));
-    // 18.04 == 1.187
-    // 20.04 == 1.206
-    // 22.04 == 1.218
-    // Debian 12 = 1.219
-    setImmediate(() => ensurePackageVersion('netcat-openbsd', '1.187'));
-    setImmediate(() => monitorSyncthingPackage());
-    // eslint-disable-next-line no-use-before-define
-    setImmediate(() => ensureChronyd());
+    // Started together and reported on together. The queue still serialises the
+    // apt work behind them, so running them concurrently costs nothing; the
+    // caller does not await monitorSystem, so the boot does not wait either.
+    const checks = {
+      // ubuntu 18.04 -> 24.04 all share this package
+      'ca-certificates': ensurePackageVersion('ca-certificates', '20230311'),
+      // 18.04 == 1.187
+      // 20.04 == 1.206
+      // 22.04 == 1.218
+      // Debian 12 = 1.219
+      'netcat-openbsd': ensurePackageVersion('netcat-openbsd', '1.187'),
+      syncthing: monitorSyncthingPackage(),
+      // eslint-disable-next-line no-use-before-define
+      chrony: ensureChronyd().then(
+        async () => !chronyWasPresent && Boolean(await getPackageVersion('chrony')),
+      ),
+    };
+
+    const outcomes = await Promise.all(Object.values(checks));
+    const names = Object.keys(checks);
+
+    // Published whether or not anything was installed, because "checked and had
+    // nothing to do" is a different fact from "has not run yet" and the logs
+    // below only speak in the first case. A node that is already provisioned -
+    // which is every node after its first boot - is otherwise indistinguishable
+    // from one whose checks have not started.
+    fluxEventBus.publish('system:packages-checked', {
+      installed: names.filter((_, i) => outcomes[i]),
+    });
   } catch (error) {
     log.error(error);
   }

--- a/ZelBack/src/services/systemService.js
+++ b/ZelBack/src/services/systemService.js
@@ -26,29 +26,37 @@ let syncthingTimer = null;
 
 /**
  * A FIFO queue used to store and run apt commands.
- *
- * Built complete. A queue that arrives without its worker has to be finished off
- * later by whoever happens to get there first, and until they do it silently
- * accepts work it cannot run - so its behaviour depends on call order, and a test
- * that touches it inherits whatever the last one left behind.
- * @type {fifoQueue.FifoQueue}
+ * @type {fifoQueue.FifoQueue|null}
  */
-// eslint-disable-next-line no-use-before-define
-const aptQueue = new fifoQueue.FifoQueue({ worker: aptRunner });
-// eslint-disable-next-line no-use-before-define
-aptQueue.on('failed', monitorAptCache);
-// The queue has stopped handing this one back. Worth saying out loud: the caller
-// took its error long ago, so without this the work is simply never done again and
-// nothing ever mentions it.
-aptQueue.on('abandoned', ({ options, error, cycles }) => {
-  log.error(`Giving up on apt-get ${options.command} after ${cycles} attempts: ${error.message}`);
-});
+let aptQueue = null;
 
 /**
- * For testing
+ * The apt queue, built on first use.
+ *
+ * Built COMPLETE, and built LATE. Complete because a queue that arrives without
+ * its worker has to be finished off later by whoever happens to get there first,
+ * and until they do it silently accepts work it cannot run - so its behaviour
+ * depends on call order, and a test that touches it inherits whatever the last
+ * one left behind. Late because a module that is merely imported should not have
+ * started anything: an Arcane node never queues apt work at all, and a script or
+ * a test reaching in here for one unrelated function should not acquire a worker
+ * it did not ask for. Constructing the whole thing on first use is what satisfies
+ * both - there is no window in which the queue exists without its worker.
+ *
  * @returns {fifoQueue.FifoQueue}
  */
 function getQueue() {
+  if (aptQueue) return aptQueue;
+
+  aptQueue = new fifoQueue.FifoQueue({ worker: aptRunner });
+  aptQueue.on('failed', monitorAptCache);
+  // The queue has stopped handing this one back. Worth saying out loud: the caller
+  // took its error long ago, so without this the work is simply never done again and
+  // nothing ever mentions it.
+  aptQueue.on('abandoned', ({ options, error, cycles }) => {
+    log.error(`Giving up on apt-get ${options.command} after ${cycles} attempts: ${error.message}`);
+  });
+
   return aptQueue;
 }
 
@@ -155,7 +163,7 @@ async function queueAptGetCommand(command, options = {}) {
     retryDelay: options.retryDelay,
     retainErrors: options.retainErrors,
   };
-  return aptQueue.push({ commandOptions, workerOptions }, wait);
+  return getQueue().push({ commandOptions, workerOptions }, wait);
 }
 
 /**
@@ -622,7 +630,7 @@ async function monitorAptCache(event) {
   // than apt-get install)
   if (options.command === 'update') {
     // we don't need to log here, as the error gets logged automatically by runCommand
-    aptQueue.resume();
+    getQueue().resume();
     return;
   }
 
@@ -659,7 +667,7 @@ async function monitorAptCache(event) {
     // eslint-disable-next-line no-await-in-loop
     const { error: lockCheckError } = await serviceHelper.runCommand('apt-get', { runAsRoot: true, params: ['check'] });
     if (!lockCheckError) {
-      aptQueue.resume();
+      getQueue().resume();
       return;
     }
 
@@ -691,12 +699,12 @@ async function monitorAptCache(event) {
 
   const { error: checkError } = await serviceHelper.runCommand('apt-get', { runAsRoot: true, params: ['check'] });
   if (!checkError) {
-    aptQueue.resume();
+    getQueue().resume();
     return;
   }
 
   log.error('Unable to run apt-get command(s), clearing the queue and resetting state.');
-  aptQueue.clear();
+  getQueue().clear();
 }
 
 /**

--- a/ZelBack/src/services/systemService.js
+++ b/ZelBack/src/services/systemService.js
@@ -321,12 +321,12 @@ async function addSyncthingRepository() {
   const packageName = 'syncthing';
   // syncthing does this weird
   const dist = 'syncthing';
-  const sourceUrl = 'https://apt.syncthing.net/';
+  const sourceUrl = config.syncthing.aptSourceUrl;
   const components = ['stable-v2'];
   const sourceOptions = ['signed-by=/usr/share/keyrings/syncthing-archive-keyring.gpg'];
 
   // keyring vars
-  const keyUrl = 'https://syncthing.net/release-key.gpg';
+  const keyUrl = config.syncthing.releaseKeyUrl;
   const keyringName = 'syncthing-archive-keyring.gpg';
 
   // this will log errors
@@ -513,7 +513,7 @@ async function monitorSyncthingPackage() {
       const {
         data: { data },
       } = await axios
-        .get('https://stats.runonflux.io/getmodulesminimumversions', {
+        .get(`${config.stats.baseUrl}/getmodulesminimumversions`, {
           timeout: 10000,
         })
         .catch((error) => {
@@ -766,10 +766,10 @@ async function mongodGpgKeyVeryfity() {
     const versionMatch = stdout.match(/MongoDB (\d+\.\d+) Release Signing Key/);
     if (expiredMatch) {
       if (versionMatch) {
-        const keyUrl = `https://pgp.mongodb.com/server-${versionMatch[1]}.asc`;
+        const keyUrl = `${config.mongodb.signingKeyBaseUrl}/server-${versionMatch[1]}.asc`;
         const filePath = '/usr/share/keyrings/mongodb-archive-keyring.gpg';
         log.info(`MongoDB version: ${versionMatch[1]}`);
-        log.info(`GPG URL: https://pgp.mongodb.com/server-${versionMatch[1]}.asc`);
+        log.info(`GPG URL: ${keyUrl}`);
         log.info(`The key has expired on ${expiredMatch[1]}`);
         const command = `curl -fsSL ${keyUrl} | sudo gpg --batch --yes -o ${filePath} --dearmor`;
         // eslint-disable-next-line no-shadow

--- a/ZelBack/src/services/utils/appSpecHelpers.js
+++ b/ZelBack/src/services/utils/appSpecHelpers.js
@@ -352,7 +352,7 @@ async function getAppFiatAndFluxPrice(req, res) {
       if (myLongCache.has('appPrices')) {
         appPrices.push(myLongCache.get('appPrices'));
       } else {
-        let response = await axios.get('https://stats.runonflux.io/apps/getappspecsusdprice', axiosConfig).catch((error) => log.error(error));
+        let response = await axios.get(`${config.stats.baseUrl}/apps/getappspecsusdprice`, axiosConfig).catch((error) => log.error(error));
         if (response && response.data && response.data.status === 'success') {
           myLongCache.set('appPrices', response.data.data);
           appPrices.push(response.data.data);
@@ -441,7 +441,7 @@ async function getAppFiatAndFluxPrice(req, res) {
       if (gSyncthgApp) {
         actualPriceToPay *= 0.8;
       }
-      const marketplaceResponse = await axios.get('https://stats.runonflux.io/marketplace/listapps').catch((error) => log.error(error));
+      const marketplaceResponse = await axios.get(`${config.stats.baseUrl}/marketplace/listapps`).catch((error) => log.error(error));
       let marketPlaceApps = [];
       if (marketplaceResponse && marketplaceResponse.data && marketplaceResponse.data.status === 'success') {
         marketPlaceApps = marketplaceResponse.data.data;
@@ -490,7 +490,7 @@ async function getAppFiatAndFluxPrice(req, res) {
       if (myShortCache.has('fluxRates')) {
         fluxUSDRate = myShortCache.get('fluxRates');
       } else {
-        fiatRates = await axios.get('https://viprates.runonflux.io/rates', axiosConfig).catch((error) => log.error(error));
+        fiatRates = await axios.get(`${config.pricing.fluxRatesBaseUrl}/rates`, axiosConfig).catch((error) => log.error(error));
         if (fiatRates && fiatRates.data) {
           const rateObj = fiatRates.data[0].find((rate) => rate.code === 'USD');
           if (!rateObj) {
@@ -503,7 +503,7 @@ async function getAppFiatAndFluxPrice(req, res) {
           fluxUSDRate = rateObj.rate * btcRateforFlux;
           myShortCache.set('fluxRates', fluxUSDRate);
         } else {
-          fiatRates = await axios.get('https://api.coingecko.com/api/v3/simple/price?vs_currencies=usd&ids=zelcash', axiosConfig);
+          fiatRates = await axios.get(`${config.pricing.coingeckoBaseUrl}/api/v3/simple/price?vs_currencies=usd&ids=zelcash`, axiosConfig);
           if (fiatRates && fiatRates.data && fiatRates.data.zelcash && fiatRates.data.zelcash.usd) {
             fluxUSDRate = fiatRates.data.zelcash.usd;
             myShortCache.set('fluxRates', fluxUSDRate);

--- a/ZelBack/src/services/utils/fifoQueue.js
+++ b/ZelBack/src/services/utils/fifoQueue.js
@@ -16,6 +16,8 @@ class FifoQueue extends EventEmitter {
 
   static get defaultRetainErrors() { return true; }
 
+  static get defaultMaxRetainCycles() { return 3; }
+
   /**
    * The main queue
    */
@@ -49,6 +51,11 @@ class FifoQueue extends EventEmitter {
     this.retryDelay = options.retryDelay ?? FifoQueue.defaultRetryDelay;
     this.maxSize = options.maxSize ?? FifoQueue.defaultMaxSize; // 0 infinite
     this.retainErrors = options.retainErrors ?? FifoQueue.defaultRetainErrors;
+    // How many times a retained task is handed back to the worker before the queue
+    // gives up on it. Retaining is what lets a task outlive a bad moment; without a
+    // ceiling it also lets one that can never succeed be retried for the life of
+    // the process.
+    this.maxRetainCycles = options.maxRetainCycles ?? FifoQueue.defaultMaxRetainCycles;
   }
 
   /**
@@ -209,9 +216,26 @@ class FifoQueue extends EventEmitter {
           this.halted = true;
         }
         // Can get halted externally too.
-        // we put this task back at the start of the queue and bail.
         if (this.halted) {
-          if (retainErrors) this.#list.unshift(props);
+          // To the BACK of the queue. At the front it is handed straight back to
+          // the worker on the next resume, ahead of everything else - so a task
+          // that cannot succeed is retried forever and nothing queued behind it
+          // ever runs. One package apt could not find is enough to stop a node
+          // installing any of the others.
+          //
+          // And only so many times. Each resume grants a fresh ladder of retries,
+          // so without a ceiling the pair of retain-and-resume is unbounded: the
+          // ladder ends, whatever is listening resumes the queue, and it begins
+          // again. Given up on rather than dropped silently - the caller already
+          // has its error, but nothing else would ever learn the work was
+          // abandoned.
+          const cycles = (props[2] ?? 0) + 1;
+          if (retainErrors && cycles <= this.maxRetainCycles) {
+            props[2] = cycles;
+            this.#list.push(props);
+          } else if (retainErrors) {
+            this.emit('abandoned', { options: commandOptions, error, cycles });
+          }
           break;
         }
 

--- a/ZelBack/src/services/utils/fifoQueue.js
+++ b/ZelBack/src/services/utils/fifoQueue.js
@@ -75,11 +75,17 @@ class FifoQueue extends EventEmitter {
   }
 
   /**
-   * Setter for worker
+   * Setter for worker. A queue has one worker for its lifetime; prefer passing it
+   * to the constructor so the queue is never in a state where it accepts work it
+   * cannot run.
    * @param {() => Promise<void>} worker
+   * @throws {Error} If a worker is already set
    */
   addWorker(worker) {
-    if (this.worker) return;
+    // Refused rather than ignored. Silently keeping the first worker leaves the
+    // caller believing its own was installed, and the queue then runs somebody
+    // else's - which is a difference nothing downstream can see.
+    if (this.worker) throw new Error('FifoQueue already has a worker');
 
     this.worker = worker;
     if (this.workAvailable) this.finished = this.work();
@@ -195,7 +201,11 @@ class FifoQueue extends EventEmitter {
         if (!retriesRemaining) {
           // the emit callback runs before the resolve (resolve is awaited)
           resolve({ error });
-          this.emit('failed', { options, error });
+          // commandOptions, not the raw payload: a listener asks what failed, and
+          // for a payload of the {commandOptions, workerOptions} shape the command
+          // is a level down. Emitting the payload put it out of reach, so every
+          // listener test against it silently matched nothing.
+          this.emit('failed', { options: commandOptions, error });
           this.halted = true;
         }
         // Can get halted externally too.

--- a/ZelBack/src/services/utils/fifoQueue.js
+++ b/ZelBack/src/services/utils/fifoQueue.js
@@ -110,6 +110,13 @@ class FifoQueue extends EventEmitter {
    */
   resume() {
     this.halted = false;
+    // A 'failed' listener resumes from INSIDE the work loop, where work() returns
+    // at once because working is already true. Assigning that already-resolved
+    // promise to finished would tell clear() the queue is idle while a worker is
+    // still in flight, and clear() then wipes the list out from under it - a path
+    // systemService reaches on exactly the failures this listener handles. The
+    // running loop reads the flag itself, so there is nothing to start.
+    if (this.working) return;
     this.finished = this.work();
   }
 
@@ -208,12 +215,20 @@ class FifoQueue extends EventEmitter {
         if (!retriesRemaining) {
           // the emit callback runs before the resolve (resolve is awaited)
           resolve({ error });
+          // Halted BEFORE the emit, never after. An emit is a synchronous yield:
+          // the listener runs right here, and it is allowed to resume the queue -
+          // monitorAptCache does exactly that, synchronously, for a failed
+          // apt-get update. A halt written after the emit silently undoes that
+          // resume, the loop breaks out with work still queued, and nothing ever
+          // starts it again: push() only calls work() when it is not already
+          // working, and working goes false on the way out. Settle our own state,
+          // then notify.
+          this.halted = true;
           // commandOptions, not the raw payload: a listener asks what failed, and
           // for a payload of the {commandOptions, workerOptions} shape the command
           // is a level down. Emitting the payload put it out of reach, so every
           // listener test against it silently matched nothing.
           this.emit('failed', { options: commandOptions, error });
-          this.halted = true;
         }
         // Can get halted externally too.
         if (this.halted) {
@@ -238,6 +253,12 @@ class FifoQueue extends EventEmitter {
           }
           break;
         }
+
+        // Not halted, so a listener resumed from inside the emit above and the
+        // queue carries on - but this task's ladder is still over. Falling
+        // through would sleep out the retry delay with nothing left to retry,
+        // stalling every task behind it for the full interval.
+        if (!retriesRemaining) break;
 
         // wait default 10 seconds between retries
         // eslint-disable-next-line no-await-in-loop

--- a/apiServer.js
+++ b/apiServer.js
@@ -8,6 +8,13 @@ if (typeof AbortController === 'undefined') {
 }
 
 process.env.NODE_CONFIG_DIR = `${__dirname}/ZelBack/config/`;
+// The directory is pinned above so config loads from the one fluxbench
+// hashes. NODE_CONFIG is the same door: the config package merges whatever
+// JSON it holds over every file, after the directory is settled, so leaving
+// it open redirects any endpoint without touching a hashed file - the one
+// redirect tamper detection cannot see. Deleted rather than emptied, because
+// an empty value is parsed and fails rather than being ignored.
+delete process.env.NODE_CONFIG;
 
 const fs = require('node:fs');
 const http = require('node:http');

--- a/app.js
+++ b/app.js
@@ -1,4 +1,11 @@
 process.env.NODE_CONFIG_DIR = `${__dirname}/ZelBack/config/`;
+// The directory is pinned above so config loads from the one fluxbench
+// hashes. NODE_CONFIG is the same door: the config package merges whatever
+// JSON it holds over every file, after the directory is settled, so leaving
+// it open redirects any endpoint without touching a hashed file - the one
+// redirect tamper detection cannot see. Deleted rather than emptied, because
+// an empty value is parsed and fails rather than being ignored.
+delete process.env.NODE_CONFIG;
 
 const log = require('./ZelBack/src/lib/log');
 const path = require('path');

--- a/homeServer.js
+++ b/homeServer.js
@@ -1,4 +1,11 @@
 process.env.NODE_CONFIG_DIR = `${__dirname}/ZelBack/config/`;
+// The directory is pinned above so config loads from the one fluxbench
+// hashes. NODE_CONFIG is the same door: the config package merges whatever
+// JSON it holds over every file, after the directory is settled, so leaving
+// it open redirects any endpoint without touching a hashed file - the one
+// redirect tamper detection cannot see. Deleted rather than emptied, because
+// an empty value is parsed and fails rather than being ignored.
+delete process.env.NODE_CONFIG;
 // Flux Home configuration
 const config = require('config');
 const compression = require('compression');

--- a/scripts/update-cloudui.sh
+++ b/scripts/update-cloudui.sh
@@ -24,7 +24,20 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 TEMP_DIR=$(mktemp -d)
 REPO="RunOnFlux/fluxos-frontend"
 CLOUDUI_DIR="$PROJECT_ROOT/CloudUI"
-RELEASE_API="https://api.github.com/repos/$REPO/releases/latest"
+
+# The API host is supplied by the caller, which reads it from ZelBack's config. It is
+# deliberately NOT defaulted and NOT read from the environment: config lives in the
+# directory fluxbench hashes, so a node cannot be pointed somewhere else without the
+# tampering being detected, and an environment variable would hand that back to whoever
+# starts the process. A caller that forgets the argument gets a failure, never a silent
+# fetch from the public internet.
+API_BASE_URL="${1:-}"
+if [ -z "$API_BASE_URL" ]; then
+    echo "Error: no API base URL given."
+    echo "Usage: $0 <api-base-url>    (e.g. https://api.github.com)"
+    exit 1
+fi
+RELEASE_API="$API_BASE_URL/repos/$REPO/releases/latest"
 
 echo "=========================================="
 echo "  FluxOS CloudUI Update Script"

--- a/scripts/update-cloudui.sh
+++ b/scripts/update-cloudui.sh
@@ -4,8 +4,11 @@
 # Downloads the latest dist.tar.gz from fluxos-frontend GitHub releases,
 # verifies the SHA256 checksum, and updates the CloudUI folder.
 #
-# Usage: npm run update:cloudui
-#        or: bash scripts/update-cloudui.sh
+# The API base URL is required - see the note on API_BASE_URL below for why it is
+# an argument rather than a default or an environment variable.
+#
+# Usage: npm run update:cloudui -- <api-base-url>
+#        or: bash scripts/update-cloudui.sh <api-base-url>
 #
 # Output:
 # - CloudUI/ folder with the latest frontend build

--- a/test-infra/Dockerfile.fluxos
+++ b/test-infra/Dockerfile.fluxos
@@ -1,4 +1,4 @@
-FROM ubuntu:26.04
+FROM ubuntu:26.04 AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -28,81 +28,82 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-# Syncthing, pinned, installed at BUILD time.
+# The packages FluxOS installs on a legacy node, and the repository it installs
+# them from.
 #
-# On a node FluxOS installs it itself: systemService adds syncthing's own apt
-# repository and keyring, installs the package, and re-checks daily (it also
-# migrates the source from stable to stable-v2). A harness must not do that
-# during a run - it would reach the internet, and the version under test would
-# be whatever the repo served that day. As a build arg the layer is cached,
-# every node gets the same binary, and moving the version is a deliberate
-# one-line act.
+# monitorSystem() returns immediately when FLUXOS_PATH is set, so this path only
+# runs on legacy nodes - and there it really installs, over the internet, inside
+# every boot. Resolving the closure at build time and serving it to the fleet
+# closes that without taking the install path out of the test: a seeded node
+# still runs monitorSystem() for real and finds its prerequisites satisfied, and
+# a suite that wants the install itself purges them first.
 #
-# A side effect worth knowing: with syncthing already on PATH, syncthingService's
-# older installSyncthingIdempotently - which still shells out to
-# helpers/installSyncthing.sh, deleted in 25153f259 when the apt path replaced
-# it - finds `syncthing --version` succeeds and returns without touching it.
-# That is a consequence of the image being complete, not a mechanism relied on.
+# The stage builds on `base`, not on ubuntu directly, because the closure is
+# whatever apt resolves against THIS image's package state. Computed against a
+# barer image it would name packages the node already has and miss ones it does
+# not.
 #
-# Pinned to what the fleet runs: chud reports
-#   syncthing v2.0.15 "Hafnium Hornet" (go1.26.0 linux-amd64) 2026-02-11 [noupgrade]
-# installed there as a Debian package from syncthing's own repo. The release
-# tarball is the same build, and pins without depending on a package mirror.
-# The release publishes exactly one checksum file, PGP-clearsigned:
-# sha256sum.txt.asc - singular "sum", always .asc. There is no unsigned variant
-# to fall back to, so a guess at another name is a 404, not an alternative.
-#
-# The chain is: the vendored key signs the checksum list, the checksum list
-# covers the tarball. Without the signature step the hashes would establish only
-# that the download was not corrupted - both files come from one origin over one
-# TLS connection, so whoever could serve a bad tarball could serve a matching
-# hash beside it. The key is vendored rather than fetched so that it is pinned
-# in git and reviewed, not trusted on first use at build time.
-#
-# The checksum line is read from gpg's verified output, never from the file as
-# downloaded. The same key signs every release's checksum list, so a valid
-# signature alone does not prove the list is THIS release's - a substituted
-# list from another release, with our filename appended outside the signed
-# block, would pass a raw-file grep on the strength of a signature that never
-# covered the appended line. --decrypt emits only the signed text, so appended
-# text does not exist to be matched, and a list that does not name our tarball
-# yields no line at all, which sha256sum -c refuses.
-ARG SYNCTHING_VERSION=v2.0.15
-# The key that must have signed the checksums. Pinned here as well as vendored
-# so that swapping the key file alone does not silently change who is trusted.
-#
-# The verdict is read from --status-fd, NOT from gpg's exit code, and that is
-# deliberate: the file carries a second signature from a retired key
-# (37C84554E7E0A261E4F76E1ED26E6ED000654A3E) that syncthing no longer publishes,
-# so gpg reports NO_PUBKEY for it and exits 2 even when the signature that
-# matters is perfectly good. Asserting VALIDSIG for the pinned fingerprint says
-# exactly what we mean - this key signed this file - and is indifferent to how
-# many other signatures ride along. Do NOT add `set -o pipefail` here or gate on
-# `gpg --verify` succeeding: both reinstate that exit code and the build fails
-# on a valid release.
-ARG SYNCTHING_RELEASE_FPR=FBA2E162F2F44657B38F0309E5665F9BD5970C47
+# Recommends are deliberately not suppressed. aptRunner passes no
+# --no-install-recommends, so a node's own install pulls them - that is where
+# shared-mime-info comes from - and a repository built without them would be
+# missing packages the node goes on to ask for.
+FROM base AS debcache
+
 COPY test-infra/syncthing-release-key.asc /tmp/syncthing-release-key.asc
-RUN arch="$(dpkg --print-architecture)" \
-    && case "$arch" in \
-         amd64) starch=amd64 ;; \
-         arm64) starch=arm64 ;; \
-         *) echo "unsupported architecture for syncthing: $arch" >&2; exit 1 ;; \
-       esac \
-    && tarball="syncthing-linux-${starch}-${SYNCTHING_VERSION}.tar.gz" \
-    && base="https://github.com/syncthing/syncthing/releases/download/${SYNCTHING_VERSION}" \
-    && curl -fsSL -o "/tmp/${tarball}" "${base}/${tarball}" \
-    && curl -fsSL -o /tmp/sha256sum.txt.asc "${base}/sha256sum.txt.asc" \
-    && export GNUPGHOME=/tmp/gnupg \
-    && mkdir -p "$GNUPGHOME" && chmod 700 "$GNUPGHOME" \
-    && gpg --batch --quiet --import /tmp/syncthing-release-key.asc \
-    && gpg --batch --status-fd=1 --verify /tmp/sha256sum.txt.asc 2>/dev/null \
-         | grep -q "^\[GNUPG:\] VALIDSIG ${SYNCTHING_RELEASE_FPR} " \
-    && (cd /tmp && gpg --batch --decrypt sha256sum.txt.asc 2>/dev/null | grep " ${tarball}\$" | sha256sum -c -) \
-    && tar -xzf "/tmp/${tarball}" -C /tmp \
-    && install -m 0755 "/tmp/syncthing-linux-${starch}-${SYNCTHING_VERSION}/syncthing" /usr/local/bin/syncthing \
-    && rm -rf "/tmp/${tarball}" /tmp/sha256sum.txt.asc /tmp/syncthing-release-key.asc \
-         "$GNUPGHOME" "/tmp/syncthing-linux-${starch}-${SYNCTHING_VERSION}" \
+COPY test-infra/build-apt-repo.sh /usr/local/bin/build-apt-repo.sh
+
+# Syncthing's repository carries only its two most recent releases, so there is
+# no older version to pin to and no build arg that could hold one. The version
+# is whatever it serves at build time, recorded in the repository so that
+# whoever has to agree with it can read it rather than restate it. That is also
+# how a production node gets syncthing: from the image it was built with.
+#
+# The key is vendored rather than fetched so the repository it authenticates is
+# pinned in git and reviewed, not trusted on first use at build time.
+RUN gpg --dearmor -o /usr/share/keyrings/syncthing-archive-keyring.gpg /tmp/syncthing-release-key.asc \
+    && echo "deb [signed-by=/usr/share/keyrings/syncthing-archive-keyring.gpg] https://apt.syncthing.net/ syncthing stable-v2" \
+         > /etc/apt/sources.list.d/syncthing.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends dpkg-dev apt-utils \
+    && rm -rf /var/cache/apt/archives/*.deb \
+    && apt-get install -y --download-only chrony syncthing netcat-openbsd \
+    && chmod +x /usr/local/bin/build-apt-repo.sh \
+    && /usr/local/bin/build-apt-repo.sh /opt/flux-apt-repo
+
+FROM base
+
+# The repository travels in the image because the stub that serves it to the
+# fleet copies it from here: what a node installs at runtime is then the same
+# file it was seeded with, not a second download that can differ.
+COPY --from=debcache /opt/flux-apt-repo /opt/flux-apt-repo
+
+# Every source that reaches the internet goes, including the two this Dockerfile
+# added for its own build - docker's and nodesource's outlive the layer that
+# needed them, so any later apt-get update refreshes them, which is egress that
+# exists in no product source file. Removing the directory wholesale rather than
+# naming files means a source added later cannot be missed here.
+#
+# The base packages are served from the image over file:// because FluxOS never
+# writes this source and serving it over HTTP would cover nothing. The one
+# source FluxOS does write - syncthing's - is pointed at the stub over HTTP by
+# config, so the keyring fetch, the source write and apt's HTTP transport are
+# all exercised as they are on a node.
+#
+# Seeded here, so a normal fleet boots into the steady state.
+RUN rm -f /etc/apt/sources.list.d/* /etc/apt/sources.list \
+    && cp /opt/flux-apt-repo/keyring.gpg /usr/share/keyrings/flux-e2e-archive-keyring.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/flux-e2e-archive-keyring.gpg] file:///opt/flux-apt-repo ubuntu main" \
+         > /etc/apt/sources.list.d/flux-e2e.list \
+    && apt-get update \
+    && apt-get install -y chrony syncthing netcat-openbsd \
+    && rm -rf /var/cache/apt/archives/*.deb \
     && syncthing --version
+
+# The package index stays. A node has one, and upgradePackage refreshes the cache
+# without forcing - cacheUpdateTime falls back to the mtime of /var/lib/apt/lists,
+# which on a freshly built image is minutes old, so the refresh is skipped as
+# recent. Emptied, the index is then both absent and apparently current, and every
+# install fails with `Unable to locate package` before reaching the network at all.
 
 WORKDIR /flux
 

--- a/test-infra/build-apt-repo.sh
+++ b/test-infra/build-apt-repo.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Turns the .debs apt has already downloaded into a signed apt repository.
+#
+# Run inside the image build, after `apt-get install --download-only` has
+# populated the archive cache. What lands in the cache IS the dependency
+# closure apt resolved against this image's exact package state, so the
+# repository is complete by construction rather than by a maintained list -
+# nothing here names a package or a version.
+#
+# Two distributions over one pool. FluxOS writes the syncthing source itself
+# (systemService addSyncthingRepository) and its distribution and component are
+# fixed at `syncthing`/`stable-v2`, so the repository has to answer to that
+# name; the base packages have no such constraint and use `ubuntu`/`main`.
+# Both index the same pool, so a package needed by either is present in both.
+set -eu
+
+REPO="${1:?usage: build-apt-repo.sh <repo-dir>}"
+ARCH="$(dpkg --print-architecture)"
+
+mkdir -p "$REPO/pool"
+cp /var/cache/apt/archives/*.deb "$REPO/pool/"
+
+# The signing key is generated here, not vendored. It signs nothing that exists
+# outside this image, and a private key committed to git invites reuse somewhere
+# it would matter. The public half ships in the repository as keyring.gpg.
+export GNUPGHOME=/tmp/flux-apt-repo-gnupg
+mkdir -p "$GNUPGHOME"
+chmod 700 "$GNUPGHOME"
+gpg --batch --quiet --passphrase '' \
+    --quick-generate-key 'Flux E2E Apt Repository' rsa3072 sign never
+
+cd "$REPO"
+for dist in ubuntu syncthing; do
+  if [ "$dist" = 'syncthing' ]; then component='stable-v2'; else component='main'; fi
+  target="dists/$dist/$component/binary-$ARCH"
+
+  mkdir -p "$target"
+  dpkg-scanpackages --arch "$ARCH" pool /dev/null > "$target/Packages"
+  gzip -9cn "$target/Packages" > "$target/Packages.gz"
+
+  apt-ftparchive \
+    -o "APT::FTPArchive::Release::Origin=flux-e2e" \
+    -o "APT::FTPArchive::Release::Suite=$dist" \
+    -o "APT::FTPArchive::Release::Codename=$dist" \
+    -o "APT::FTPArchive::Release::Components=$component" \
+    -o "APT::FTPArchive::Release::Architectures=$ARCH" \
+    release "dists/$dist" > "dists/$dist/Release"
+
+  # InRelease (inline signature) rather than a detached Release.gpg: apt prefers
+  # it, and it is one file to serve instead of two that can disagree.
+  gpg --batch --yes --clearsign -o "dists/$dist/InRelease" "dists/$dist/Release"
+done
+
+gpg --batch --yes --export > "$REPO/keyring.gpg"
+rm -rf "$GNUPGHOME"
+
+# The installed syncthing version is whatever the upstream repository served at
+# build time, so nothing downstream may hardcode it. Recorded here for the stub
+# that answers the minimum-version check, which has to agree with the image or
+# the check compares against a version no node has.
+dpkg-deb -f "$(ls "$REPO"/pool/syncthing_*.deb | head -1)" Version > "$REPO/syncthing.version"

--- a/test-infra/build-images.sh
+++ b/test-infra/build-images.sh
@@ -44,7 +44,10 @@ build_fluxos() {
 
 build_stub() {
   echo "==> flux-e2e-$1:${TAG}"
-  docker build -t "flux-e2e-$1:${TAG}" "test-infra/$1"
+  # The tag reaches every stub so one can build FROM the node image under the same
+  # tag; a stub whose Dockerfile declares no such ARG ignores it. external-http-stub
+  # does, which is why fluxos-01 is built first.
+  docker build --build-arg "FLUX_E2E_TAG=${TAG}" -t "flux-e2e-$1:${TAG}" "test-infra/$1"
 }
 
 targets=("$@")

--- a/test-infra/build-images.sh
+++ b/test-infra/build-images.sh
@@ -15,6 +15,11 @@
 #
 # Pass image names to build a subset:
 #   FLUX_E2E_TAG=placement ./test-infra/build-images.sh fluxos-01 external-http-stub
+#
+# Every image is stamped with `flux.e2e.src`, the digest of the sources it was
+# built from (test-infra/image-digest.sh). verify-images.sh recomputes that from
+# the working tree before a run and refuses to start when they differ, so an
+# image left behind by another branch cannot quietly decide a gate.
 set -euo pipefail
 
 TAG="${FLUX_E2E_TAG:-latest}"
@@ -35,19 +40,26 @@ build_fluxos() {
   # and is easy to forget after a clean. Not guarded on the script existing: it
   # is present on every lineage, and a guard there would let this produce a
   # complete image set with no binary in it - which surfaces as eight suites
-  # failing twenty minutes later, looking like product bugs.
+  # failing twenty minutes later, looking like product bugs. Built BEFORE the
+  # digest is taken - it sits in the build context, so it is part of what the
+  # image is.
   echo "==> test-app binary"
   bash test-infra/test-app/build.sh
   echo "==> flux-e2e-fluxos-01:${TAG}"
-  docker build -f test-infra/Dockerfile.fluxos -t "flux-e2e-fluxos-01:${TAG}" .
+  docker build -f test-infra/Dockerfile.fluxos \
+    --label "flux.e2e.src=$(test-infra/image-digest.sh fluxos-01)" \
+    -t "flux-e2e-fluxos-01:${TAG}" .
 }
 
 build_stub() {
   echo "==> flux-e2e-$1:${TAG}"
   # The tag reaches every stub so one can build FROM the node image under the same
   # tag; a stub whose Dockerfile declares no such ARG ignores it. external-http-stub
-  # does, which is why fluxos-01 is built first.
-  docker build --build-arg "FLUX_E2E_TAG=${TAG}" -t "flux-e2e-$1:${TAG}" "test-infra/$1"
+  # does, which is why fluxos-01 is built first - and why its digest folds in the
+  # node image's, so a stale base makes the stub read stale too.
+  docker build --build-arg "FLUX_E2E_TAG=${TAG}" \
+    --label "flux.e2e.src=$(test-infra/image-digest.sh "$1")" \
+    -t "flux-e2e-$1:${TAG}" "test-infra/$1"
 }
 
 targets=("$@")

--- a/test-infra/config/shared.js
+++ b/test-infra/config/shared.js
@@ -29,6 +29,10 @@ module.exports = {
     stallNudgeMaxIntervalMs: 12000,
     stallRemoveMinWindowMs: 30000,
     stallRemoveMinNudges: 2,
+    // The repository a legacy node installs syncthing from, served by the external
+    // stub out of the node image rather than by apt.syncthing.net.
+    aptSourceUrl: 'http://198.18.0.6:3000/apt/',
+    releaseKeyUrl: 'http://198.18.0.6:3000/apt/keyring.gpg',
   },
   system: {
     bootIdPath: '/tmp/flux-boot-config/boot-id',

--- a/test-infra/config/shared.js
+++ b/test-infra/config/shared.js
@@ -4,7 +4,15 @@ module.exports = {
   fluxTeamFluxID: '19J4Ef396goaQhrqgNLTFvtCXYqjFAx2Js',
   daemon: { host: '198.18.0.3' },
   benchmark: { host: '198.18.0.3' },
-  upnp: { gatewayUrl: '', nodeIp: '' },
+  // upnpService builds its client at module load, and with no gateway URL the client
+  // discovers one by SSDP - every node multicasting to 239.255.255.250:1900 for the life of
+  // the run. Naming a gateway replaces discovery with a fixed device, which is the point of
+  // the hook. The stub serves a device description with no WAN connection service, so
+  // support verification fails exactly as it does today and no node believes it has UPnP -
+  // the behaviour is unchanged, only the searching stops.
+  // nodeIp stays empty as in production: it is the node's own address for a port mapping,
+  // it cannot be a shared constant, and no mapping is ever made because verification fails.
+  upnp: { gatewayUrl: 'http://198.18.0.6:3000/upnp/device.xml', nodeIp: '' },
   // Empty disables analytics. The app default is the live cloudaudit endpoint and
   // the fleet network has egress, so without this a run reports suite activity -
   // generated app names, fixture identities, 198.18.x addresses - as real traffic.
@@ -47,8 +55,13 @@ module.exports = {
   },
   geolocation: {
     ipApiBaseUrl: 'http://198.18.0.6:3000',
-    statsApiBaseUrl: 'http://198.18.0.6:3000',
   },
+  stats: { baseUrl: 'http://198.18.0.6:3000' },
+  pricing: {
+    fluxRatesBaseUrl: 'http://198.18.0.6:3000',
+    coingeckoBaseUrl: 'http://198.18.0.6:3000',
+  },
+  mongodb: { signingKeyBaseUrl: 'http://198.18.0.6:3000' },
   // the stub serves iplocation.bin.gz, so harness nodes exercise the real
   // table reader rather than skipping it. Its default artifact puts the whole
   // harness range in ONE organisation, which is the single-fault-domain

--- a/test-infra/entrypoint.sh
+++ b/test-infra/entrypoint.sh
@@ -60,10 +60,6 @@ if [ -n "$FLUX_TEST_CONFIG" ]; then
   '
 fi
 
-if [ "$FLUX_DISCOVERY_AUTOSTART" = "true" ]; then
-  sed -i 's/discoveryAutostart: false/discoveryAutostart: true/' /flux/ZelBack/shared.js
-fi
-
 # The image ships these installed, which is the state a node is in on every boot
 # after its first. A suite that wants to exercise the install asks for a node
 # without them, and gets one here - before FluxOS starts, so monitorSystem()

--- a/test-infra/entrypoint.sh
+++ b/test-infra/entrypoint.sh
@@ -3,6 +3,17 @@ set -e
 
 ip addr add 169.254.43.43/32 dev lo 2>/dev/null || true
 
+# The runner's per-node config arrives as JSON and is written here as local.js,
+# which node-config loads from the pinned config directory after every other file.
+# It used to arrive as NODE_CONFIG, but the config package merges that variable
+# over every file regardless of which directory is pinned - a redirect of any
+# endpoint that leaves no trace in the directory fluxbench hashes. The entry
+# points delete it now, so this is how a fleet configures its nodes: through a
+# file, like production, rather than through an environment the hash cannot see.
+if [ -n "$FLUX_TEST_CONFIG" ]; then
+  printf 'module.exports = %s;\n' "$FLUX_TEST_CONFIG" > /flux/ZelBack/config/local.js
+fi
+
 # App installs mount each app's FLUXFSVOL via `mount -o loop`. Loop devices are a
 # shared host-kernel resource (not namespaced); the kernel default pool (max_loop,
 # typically 8) is small and on-demand creation races under concurrent installs, so a
@@ -60,8 +71,8 @@ if [ "$FLUX_SYNCTHING_MODE" = "binary" ]; then
   # generates its own identity on first run, which is what gives each node a
   # distinct device id, and FluxOS then sets discovery off, NAT off and
   # listenAddresses to apiport+2 through the API exactly as it does on a node.
-  # The endpoint is decided by the runner through NODE_CONFIG, which the config
-  # package merges over the mounted shared.js. No socat either way: whoever
+  # The endpoint is decided by the runner through the local.js written above,
+  # which node-config loads last. No socat either way: whoever
   # starts the daemon, it binds apiport+2 itself.
   #
   # WHO starts it depends on the node type, and SYNCTHING_PATH is the same

--- a/test-infra/entrypoint.sh
+++ b/test-infra/entrypoint.sh
@@ -39,6 +39,19 @@ if [ "$FLUX_DISCOVERY_AUTOSTART" = "true" ]; then
   sed -i 's/discoveryAutostart: false/discoveryAutostart: true/' /flux/ZelBack/shared.js
 fi
 
+# The image ships these installed, which is the state a node is in on every boot
+# after its first. A suite that wants to exercise the install asks for a node
+# without them, and gets one here - before FluxOS starts, so monitorSystem()
+# meets the same absence a real first boot does.
+#
+# Purge, not remove: a removed package leaves its configuration behind and
+# dpkg-query reports `deinstall ok config-files`, which is neither installed nor
+# absent. getPackageVersion returns '' for that as well as for absent, so the
+# node would behave plausibly while sitting in a state no real node is ever in.
+if [ "$FLUX_APT_SEEDED" = "false" ]; then
+  DEBIAN_FRONTEND=noninteractive apt-get purge -y chrony syncthing netcat-openbsd >/dev/null 2>&1 || true
+fi
+
 # Syncthing listens on apiport+2 in production. The availability checker tests
 # that port.
 SYNCTHING_LISTEN_PORT=$((${FLUX_API_PORT:-16127} + 2))

--- a/test-infra/entrypoint.sh
+++ b/test-infra/entrypoint.sh
@@ -73,6 +73,18 @@ if [ "$FLUX_APT_SEEDED" = "false" ]; then
   DEBIAN_FRONTEND=noninteractive apt-get purge -y chrony syncthing netcat-openbsd >/dev/null 2>&1 || true
 fi
 
+# A source apt cannot reach, ALONGSIDE the good one rather than instead of it.
+# apt-get update then exits non-zero exactly as it does on a real node behind an
+# unreachable mirror, an expired key or a DNS blip - while the packages queued
+# behind that failure stay installable from the repository the image built, so a
+# node that survives the failure still finishes its checks. Replacing the good
+# source instead would fail the installs too, and prove only that a broken node
+# stays broken.
+if [ "$FLUX_APT_BAD_SOURCE" = "true" ]; then
+  echo "deb [trusted=yes] file:///opt/flux-apt-repo-does-not-exist ubuntu main" \
+    > /etc/apt/sources.list.d/flux-e2e-unreachable.list
+fi
+
 # Syncthing listens on apiport+2 in production. The availability checker tests
 # that port.
 SYNCTHING_LISTEN_PORT=$((${FLUX_API_PORT:-16127} + 2))

--- a/test-infra/entrypoint.sh
+++ b/test-infra/entrypoint.sh
@@ -3,17 +3,6 @@ set -e
 
 ip addr add 169.254.43.43/32 dev lo 2>/dev/null || true
 
-# The runner's per-node config arrives as JSON and is written here as local.js,
-# which node-config loads from the pinned config directory after every other file.
-# It used to arrive as NODE_CONFIG, but the config package merges that variable
-# over every file regardless of which directory is pinned - a redirect of any
-# endpoint that leaves no trace in the directory fluxbench hashes. The entry
-# points delete it now, so this is how a fleet configures its nodes: through a
-# file, like production, rather than through an environment the hash cannot see.
-if [ -n "$FLUX_TEST_CONFIG" ]; then
-  printf 'module.exports = %s;\n' "$FLUX_TEST_CONFIG" > /flux/ZelBack/config/local.js
-fi
-
 # App installs mount each app's FLUXFSVOL via `mount -o loop`. Loop devices are a
 # shared host-kernel resource (not namespaced); the kernel default pool (max_loop,
 # typically 8) is small and on-demand creation races under concurrent installs, so a
@@ -44,6 +33,31 @@ fi
 if [ -n "$NODE_CONFIG_DIR" ] && [ -d "$NODE_CONFIG_DIR" ]; then
   cp "$NODE_CONFIG_DIR"/default.js /flux/ZelBack/config/local.js
   cp "$(dirname "$NODE_CONFIG_DIR")/shared.js" /flux/ZelBack/ 2>/dev/null || true
+fi
+
+# The runner's own overrides arrive as JSON and are merged OVER the per-node file
+# copied above, which is where the per-node database names come from - replacing
+# that file rather than merging would take them with it.
+#
+# They used to arrive as NODE_CONFIG. The config package merges that variable over
+# every file whatever directory is pinned, so it could redirect any endpoint
+# without touching the directory fluxbenchd hashes - the one change tamper
+# detection cannot see. The entry points delete it now, and this carries the same
+# content to the same place through a file instead.
+if [ -n "$FLUX_TEST_CONFIG" ]; then
+  node -e '
+    const fs = require("fs");
+    const target = "/flux/ZelBack/config/local.js";
+    const base = fs.existsSync(target) ? require(target) : {};
+    const isPlain = (v) => v && typeof v === "object" && !Array.isArray(v);
+    const merge = (a, b) => {
+      const out = { ...a };
+      for (const [k, v] of Object.entries(b)) out[k] = isPlain(v) && isPlain(a[k]) ? merge(a[k], v) : v;
+      return out;
+    };
+    const merged = merge(base, JSON.parse(process.env.FLUX_TEST_CONFIG));
+    fs.writeFileSync(target, `module.exports = ${JSON.stringify(merged, null, 2)};\n`);
+  '
 fi
 
 if [ "$FLUX_DISCOVERY_AUTOSTART" = "true" ]; then

--- a/test-infra/external-http-stub/Dockerfile
+++ b/test-infra/external-http-stub/Dockerfile
@@ -1,3 +1,11 @@
+# The apt repository comes out of the node image rather than being rebuilt here:
+# the packages this stub serves are then the same files the node was seeded with,
+# and there is no second download that could resolve to different versions. That
+# makes flux-e2e-fluxos-01 a build dependency of this stub - build-images.sh
+# builds it first and passes its tag through.
+ARG FLUX_E2E_TAG=latest
+FROM flux-e2e-fluxos-01:${FLUX_E2E_TAG} AS nodeimage
+
 FROM node:20-slim
 
 WORKDIR /app
@@ -6,6 +14,8 @@ COPY package.json ./
 RUN npm install --production
 
 COPY index.js ./
+
+COPY --from=nodeimage /opt/flux-apt-repo /repo
 
 EXPOSE 3000 3001
 

--- a/test-infra/external-http-stub/index.js
+++ b/test-infra/external-http-stub/index.js
@@ -308,6 +308,18 @@ const state = {
   tamperingBlocklist: [],
   latestRelease: { tag_name: 'v0.0.0', name: 'stub-release' },
   geolocation: {},
+  // The syncthing the node image ships (Dockerfile.fluxos SYNCTHING_VERSION). Serving the
+  // version the fleet already has is what makes the boot-time check a no-op; a suite that
+  // wants the upgrade path raises this instead of reaching syncthing's own service.
+  moduleMinimumVersions: { syncthing: '2.0.15', docker: '26.1.2' },
+  marketplaceApps: [],
+  appSpecsUsdPrice: [],
+  // Fixed rates, so a price assertion is arithmetic rather than a bet on the market.
+  // usdPerBtc * btcPerFlux is what the caller multiplies out, and it must equal usdPerFlux
+  // so the coingecko fallback cannot change an answer.
+  usdPerBtc: 100000,
+  btcPerFlux: 0.000002,
+  usdPerFlux: 0.2,
   // published below; null in either representation serves a 404, which leaves
   // nodes tableless on the /16 arithmetic
   ipLocation: null,
@@ -454,6 +466,53 @@ app.get('/repos/:owner/:repo/releases/latest', (req, res) => {
 
 app.get('/repos/:owner/:repo', (req, res) => {
   res.json({ full_name: `${req.params.owner}/${req.params.repo}` });
+});
+
+// UPnP: a device description with no WANIPConnection service. upnpService is pointed here
+// so its client stops searching for a gateway by SSDP multicast; support verification then
+// fails on the missing service, which is the same verdict a node reaches today, so no node
+// changes its mind about having UPnP.
+app.get('/upnp/device.xml', (req, res) => {
+  res.type('text/xml').send(
+    '<?xml version="1.0"?>'
+    + '<root xmlns="urn:schemas-upnp-org:device-1-0">'
+    + '<device><deviceType>urn:schemas-upnp-org:device:InternetGatewayDevice:1</deviceType>'
+    + '<friendlyName>flux-e2e-stub-gateway</friendlyName><serviceList /></device>'
+    + '</root>',
+  );
+});
+
+// Stats: the minimum module versions a node checks its own syncthing against at boot.
+// The harness names the version its image ships, so the check is satisfied and no upgrade
+// is attempted; a suite exercising the upgrade path raises it through the control port.
+app.get('/getmodulesminimumversions', (req, res) => {
+  res.json({ status: 'success', data: state.moduleMinimumVersions });
+});
+
+// Stats: marketplace listings. Empty by default - a suite that needs a listed app puts one
+// in through the control port rather than depending on what the live marketplace holds.
+app.get('/marketplace/listapps', (req, res) => {
+  res.json({ status: 'success', data: state.marketplaceApps });
+});
+
+app.get('/marketplace/listdevapps', (req, res) => {
+  res.json({ status: 'success', data: state.marketplaceApps });
+});
+
+// Stats: per-spec USD pricing.
+app.get('/apps/getappspecsusdprice', (req, res) => {
+  res.json({ status: 'success', data: state.appSpecsUsdPrice });
+});
+
+// Pricing: viprates.runonflux.io/rates. The real service answers a two-element array -
+// [fiatRates, coinRates] - and the caller reads USD from the first and FLUX from the second.
+app.get('/rates', (req, res) => {
+  res.json([[{ code: 'USD', rate: state.usdPerBtc }], { FLUX: state.btcPerFlux }]);
+});
+
+// Pricing: the coingecko fallback, reached only when /rates above is unavailable.
+app.get('/api/v3/simple/price', (req, res) => {
+  res.json({ zelcash: { usd: state.usdPerFlux } });
 });
 
 // Geolocation: ip-api.com format (primary)

--- a/test-infra/external-http-stub/index.js
+++ b/test-infra/external-http-stub/index.js
@@ -768,7 +768,15 @@ function startResolver() {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
-      upstream.close();
+      // answer() also runs as the upstream's own error handler, and close()
+      // throws on a socket that never bound - from inside an error handler
+      // nothing catches, so one unlucky query would take the resolver down for
+      // the whole run. An uncloseable socket is left to the garbage collector.
+      try {
+        upstream.close();
+      } catch {
+        // nothing to close
+      }
       if (!resolved) dnsAttempts.push({ name, node: rinfo.address, at: new Date().toISOString() });
       server.send(response, rinfo.port, rinfo.address);
     };

--- a/test-infra/external-http-stub/index.js
+++ b/test-infra/external-http-stub/index.js
@@ -803,7 +803,29 @@ function startResolver() {
     upstream.send(query, 53, '127.0.0.11');
   });
 
-  server.bind(53, () => console.log('External HTTP stub resolver on port 53'));
+  // A dgram socket with no 'error' listener turns any failure into an uncaught
+  // exception. The failure that actually happens is the bind - port 53 already
+  // held, usually by the previous run's container on its way out - and without a
+  // listener the stub dies on a stack trace that mentions neither DNS nor the
+  // port, while every node in the fleet silently fails to resolve anything. That
+  // reads as a fleet-wide product fault and is nothing of the kind.
+  //
+  // Fatal on purpose: a resolver that never bound is not a resolver, and the run
+  // should say so at startup rather than eighty suites later. Errors after the
+  // bind cost one query and are logged, which this handler covers for free.
+  let bound = false;
+  server.on('error', (error) => {
+    if (!bound) {
+      console.error(`External HTTP stub resolver could not bind to 53: ${error.message}`);
+      process.exit(1);
+    }
+    console.error(`External HTTP stub resolver socket error: ${error.message}`);
+  });
+
+  server.bind(53, () => {
+    bound = true;
+    console.log('External HTTP stub resolver on port 53');
+  });
 }
 
 startResolver();

--- a/test-infra/external-http-stub/index.js
+++ b/test-infra/external-http-stub/index.js
@@ -1,4 +1,5 @@
 const zlib = require('zlib');
+const dgram = require('dgram');
 const fs = require('fs');
 const express = require('express');
 
@@ -715,6 +716,89 @@ control.post('/reset', (req, res) => {
 control.get('/health', (req, res) => {
   res.json({ status: 'ok' });
 });
+
+// Every name a node asked for that nothing on the fleet could answer, with the
+// node that asked. A suite asserts this is empty; when it is not, the failure
+// names the host and the node instead of describing itself as slow.
+control.get('/dns-attempts', (req, res) => {
+  res.json({ attempts: dnsAttempts });
+});
+
+control.post('/dns-attempts/reset', (req, res) => {
+  dnsAttempts.length = 0;
+  res.json({ ok: true });
+});
+
+// The fleet's resolver.
+//
+// Blocking a network is not the same as failing loudly on it: a blocked packet
+// surfaces as a timeout, and a timeout reads as slowness rather than as a node
+// reaching somewhere it should not. So the nodes resolve here instead, and a name
+// the fleet cannot answer comes back NXDOMAIN at once, recorded against the node
+// that asked for it.
+//
+// Fleet names still resolve, because this relays to its own embedded Docker
+// resolver at 127.0.0.11 - the same one that knows every container alias on this
+// network. Relaying rather than answering means aliases need no list here and
+// cannot drift from the ones the runner actually creates.
+const dnsAttempts = [];
+
+function questionName(query) {
+  // QNAME begins after the 12-byte header, as length-prefixed labels ending in 0.
+  let offset = 12;
+  const labels = [];
+  while (offset < query.length) {
+    const len = query[offset];
+    if (len === 0 || len > 63) break;
+    labels.push(query.subarray(offset + 1, offset + 1 + len).toString('ascii'));
+    offset += len + 1;
+  }
+  return labels.join('.');
+}
+
+function startResolver() {
+  const server = dgram.createSocket('udp4');
+
+  server.on('message', (query, rinfo) => {
+    const name = questionName(query);
+    const upstream = dgram.createSocket('udp4');
+    let settled = false;
+
+    const answer = (response, resolved) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      upstream.close();
+      if (!resolved) dnsAttempts.push({ name, node: rinfo.address, at: new Date().toISOString() });
+      server.send(response, rinfo.port, rinfo.address);
+    };
+
+    // NXDOMAIN built from the query: same id and question, QR and RCODE 3 set.
+    const refuse = () => {
+      const response = Buffer.from(query);
+      response[2] |= 0x80;
+      response[3] = (response[3] & 0xf0) | 0x03;
+      answer(response, false);
+    };
+
+    // Short, because this is the whole point: an unanswerable name must fail now
+    // rather than at whatever deadline the caller happens to carry.
+    const timer = setTimeout(refuse, 300);
+
+    upstream.on('error', refuse);
+    upstream.on('message', (response) => {
+      const rcode = response[3] & 0x0f;
+      if (rcode === 0) answer(response, true);
+      else refuse();
+    });
+
+    upstream.send(query, 53, '127.0.0.11');
+  });
+
+  server.bind(53, () => console.log('External HTTP stub resolver on port 53'));
+}
+
+startResolver();
 
 app.listen(PORT, () => {
   console.log(`External HTTP stub listening on port ${PORT}`);

--- a/test-infra/external-http-stub/index.js
+++ b/test-infra/external-http-stub/index.js
@@ -1,4 +1,5 @@
 const zlib = require('zlib');
+const fs = require('fs');
 const express = require('express');
 
 const PORT = parseInt(process.env.STUB_PORT || '3000', 10);
@@ -301,6 +302,24 @@ function newRouteCounters() {
 const IPLOCATION_JSON_ROUTE = '/iplocation.json';
 const IPLOCATION_BINARY_ROUTE = '/iplocation.bin.gz';
 
+// The apt repository copied out of the node image at build time, served to the fleet
+// so a legacy node installs its packages from here instead of from the internet. It is
+// the same tree the image seeded itself from, so a node that purges and reinstalls gets
+// the file it started with.
+const APT_REPO_DIR = '/repo';
+
+/**
+ * The syncthing version the node image ships, recorded by the repository build.
+ * Absent only if the stub image was built against a node image without one, which is
+ * a build-ordering fault worth failing loudly on rather than papering over with a
+ * default that would quietly make the minimum-version check meaningless.
+ */
+function imageSyncthingVersion() {
+  const recorded = fs.readFileSync(`${APT_REPO_DIR}/syncthing.version`, 'utf8').trim();
+  if (!recorded) throw new Error(`${APT_REPO_DIR}/syncthing.version is empty`);
+  return recorded;
+}
+
 const state = {
   blockedRepositories: [],
   vettedRepositories: [],
@@ -308,10 +327,13 @@ const state = {
   tamperingBlocklist: [],
   latestRelease: { tag_name: 'v0.0.0', name: 'stub-release' },
   geolocation: {},
-  // The syncthing the node image ships (Dockerfile.fluxos SYNCTHING_VERSION). Serving the
-  // version the fleet already has is what makes the boot-time check a no-op; a suite that
-  // wants the upgrade path raises this instead of reaching syncthing's own service.
-  moduleMinimumVersions: { syncthing: '2.0.15', docker: '26.1.2' },
+  // The syncthing the node image ships, read from the repository the image was built
+  // with rather than restated here. Serving the version the fleet already has is what
+  // makes the boot-time check a no-op; a suite that wants the upgrade path raises this
+  // instead of reaching syncthing's own service. A restated version goes stale silently:
+  // it moves whenever the image is rebuilt, and a minimum every node exceeds asserts
+  // nothing at all.
+  moduleMinimumVersions: { syncthing: imageSyncthingVersion(), docker: '26.1.2' },
   marketplaceApps: [],
   appSpecsUsdPrice: [],
   // Fixed rates, so a price assertion is arithmetic rather than a bet on the market.
@@ -481,6 +503,14 @@ app.get('/upnp/device.xml', (req, res) => {
     + '</root>',
   );
 });
+
+// The apt repository a legacy node installs syncthing from. FluxOS writes this source
+// itself (systemService addSyncthingRepository) from config.syncthing.aptSourceUrl, and
+// fetches the keyring from config.syncthing.releaseKeyUrl, so both are pointed here and
+// the keyring fetch, the source write, apt's HTTP transport and signature verification
+// all run exactly as they do on a node - against a repository that never leaves the
+// fleet network.
+app.use('/apt', express.static(APT_REPO_DIR, { fallthrough: false }));
 
 // Stats: the minimum module versions a node checks its own syncthing against at boot.
 // The harness names the version its image ships, so the check is satisfied and no upgrade

--- a/test-infra/image-digest.sh
+++ b/test-infra/image-digest.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Prints the digest of the sources an image is built from.
+#
+# An image name is fixed but its contents are not, and nothing else ties a built
+# image to the tree it came from. A stub rebuilt on another branch, or simply not
+# rebuilt after its source moved, runs against this branch's suites and fails
+# looking like a product bug - suites 87/88/90 died in a `before each` calling a
+# stub endpoint the image did not carry, which reads as a restore defect and is
+# not one. Stamping this digest at build time and comparing it before a run turns
+# that into a refusal with a name on it.
+#
+# The digest covers the BUILD CONTEXT, not a marker someone remembered to add:
+# a marker proves one line, and picking one per change is the same memory test
+# that fails in the first place.
+#
+#   usage: image-digest.sh fluxos-01 | image-digest.sh <stub-dir-name>
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+if command -v sha256sum >/dev/null 2>&1; then HASH=sha256sum; else HASH="shasum -a 256"; fi
+
+# Hash every file under the given roots, path included, order fixed. LC_ALL=C so
+# the sort is byte order on any host, and -print0/-0 so a path with a space in it
+# cannot split a filename into two. An empty result is a failure, not a digest:
+# this refuses runs, so it must never hand back something that merely looks like
+# an answer.
+digest_roots() {
+  local out
+  out="$(find "$@" -type f -print0 2>/dev/null \
+    | LC_ALL=C sort -z \
+    | xargs -0 -r $HASH \
+    | $HASH | cut -d' ' -f1)"
+  [ -n "$out" ] || { echo "image-digest: hashed nothing under: $*" >&2; return 3; }
+  printf '%s\n' "$out"
+}
+
+# fluxos-01 is built with `COPY . .` from the repo root, so its context is every
+# top-level entry .dockerignore does not exclude. Derived from the file rather
+# than restated here: a new exclusion would otherwise change what docker bakes
+# without changing what this measures.
+fluxos_roots() {
+  local ignore=() line entry skip i
+  while IFS= read -r line || [ -n "$line" ]; do
+    line="${line%%#*}"
+    line="$(printf '%s' "$line" | tr -d '[:space:]')"
+    [ -n "$line" ] && ignore+=("$line")
+  done < .dockerignore
+
+  for entry in * .[!.]*; do
+    [ -e "$entry" ] || continue
+    skip=0
+    for i in "${ignore[@]:-}"; do [ "$entry" = "$i" ] && skip=1; done
+    [ "$skip" -eq 0 ] && printf '%s\n' "$entry"
+  done
+}
+
+image="${1:?usage: image-digest.sh <fluxos-01|stub-dir-name>}"
+
+if [ "$image" = "fluxos-01" ]; then
+  roots=()
+  while IFS= read -r entry; do roots+=("$entry"); done < <(fluxos_roots)
+  [ "${#roots[@]}" -gt 0 ] || { echo "image-digest: empty build context" >&2; exit 3; }
+  digest_roots "${roots[@]}"
+  exit 0
+fi
+
+dir="test-infra/$image"
+[ -d "$dir" ] || { echo "image-digest: no such image source: $dir" >&2; exit 2; }
+
+# A stub that builds FROM the node image inherits its contents, so a stale
+# fluxos-01 makes the stub stale too even when its own directory has not moved.
+# external-http-stub is the one that does this today; the ARG is what says so.
+if grep -q 'FLUX_E2E_TAG' "$dir/Dockerfile" 2>/dev/null; then
+  base="$("$0" fluxos-01)" || exit 3
+  own="$(digest_roots "$dir")" || exit 3
+  printf '%s\n%s\n' "$own" "$base" | $HASH | cut -d' ' -f1
+else
+  digest_roots "$dir"
+fi

--- a/test-infra/image-digest.sh
+++ b/test-infra/image-digest.sh
@@ -28,7 +28,7 @@ if command -v sha256sum >/dev/null 2>&1; then HASH=sha256sum; else HASH="shasum 
 # an answer.
 digest_roots() {
   local out
-  out="$(find "$@" -type f -print0 2>/dev/null \
+  out="$(find "$@" -type f -not -path 'test-infra/runner/*' -print0 2>/dev/null \
     | LC_ALL=C sort -z \
     | xargs -0 -r $HASH \
     | $HASH | cut -d' ' -f1)"
@@ -40,6 +40,13 @@ digest_roots() {
 # top-level entry .dockerignore does not exclude. Derived from the file rather
 # than restated here: a new exclusion would otherwise change what docker bakes
 # without changing what this measures.
+#
+# test-infra/runner is the one exception, and it is a principled one rather than
+# a list: the runner DRIVES the fleet from the host and never executes inside a
+# node container, so a suite edit changes bytes the image carries but nothing it
+# does. Counting it would force a full node rebuild for every suite tweak - the
+# kind of friction that gets a check bypassed, which costs more than it saves.
+# Excluded for the stubs too, where it can never match anything.
 fluxos_roots() {
   local ignore=() line entry skip i
   while IFS= read -r line || [ -n "$line" ]; do

--- a/test-infra/runner/framework/external-http-control.js
+++ b/test-infra/runner/framework/external-http-control.js
@@ -41,3 +41,45 @@ export async function stageArtifact(name, base64, { declaredLength = null } = {}
 export function artifactUrl(name) {
   return `http://${HOST}:${SERVE_PORT}/artifact/${name}`;
 }
+
+/**
+ * Every name a node asked for that nothing on the fleet could answer.
+ *
+ * The fleet network has no route off it, so a hardcoded address cannot reach
+ * anywhere - but blocking alone only turns it into a timeout, and a timeout reads
+ * as a slow test rather than as a node reaching somewhere it should not. The
+ * resolver records instead, so this list names the host and the node that wanted
+ * it.
+ *
+ * @returns {Promise<Array<{name: string, node: string, at: string}>>}
+ */
+export async function dnsAttempts() {
+  const res = await fetch(`${CONTROL}/dns-attempts`);
+  const { attempts } = await res.json();
+  return attempts;
+}
+
+/**
+ * Forget every recorded attempt. Called before the window a suite intends to
+ * assert over, so it measures its own fleet rather than whatever ran before it.
+ */
+export async function resetDnsAttempts() {
+  return post('/dns-attempts/reset');
+}
+
+/**
+ * Fail naming the host and the node, rather than leaving a caller to compare
+ * lists. `allowed` is for a suite that means to reach something - it should be
+ * rare enough that writing the name down is the easy part.
+ *
+ * @param {{allowed?: string[]}} [opts]
+ */
+export async function expectNoUnexpectedDns({ allowed = [] } = {}) {
+  const unexpected = (await dnsAttempts()).filter((a) => !allowed.includes(a.name));
+  if (!unexpected.length) return;
+
+  const detail = unexpected
+    .map((a) => `${a.name} (node ${a.node})`)
+    .join(', ');
+  throw new Error(`nodes reached for names the fleet does not serve: ${detail}`);
+}

--- a/test-infra/runner/framework/node-client.js
+++ b/test-infra/runner/framework/node-client.js
@@ -217,6 +217,7 @@ export function nodeClient(nodeNum) {
         'syncthing:holderExcluded',
         'syncthing:passComplete',
         'system:packages-checked',
+        'system:apt-command',
         'spawner:blocked',
         'spawner:deferred',
         'spawner:installFailed',

--- a/test-infra/runner/framework/node-client.js
+++ b/test-infra/runner/framework/node-client.js
@@ -216,6 +216,7 @@ export function nodeClient(nodeNum) {
         'syncthing:holderRetained',
         'syncthing:holderExcluded',
         'syncthing:passComplete',
+        'system:packages-checked',
         'spawner:blocked',
         'spawner:deferred',
         'spawner:installFailed',

--- a/test-infra/runner/framework/node-client.js
+++ b/test-infra/runner/framework/node-client.js
@@ -193,6 +193,7 @@ export function nodeClient(nodeNum) {
         'daemon:unreachable',
         'dos:changed',
         'explorer:ready',
+        'fileops:recovered',
         'messageCapability:changed',
         'networkstate:updated',
         'orchestrator:started',

--- a/test-infra/runner/framework/test-env.js
+++ b/test-infra/runner/framework/test-env.js
@@ -892,17 +892,17 @@ async function _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, conf
     // of syncthing would simply never get it back.
     if (!aptSeeded && isLegacy) nodeEnv.FLUX_APT_SEEDED = 'false';
     // Point the node's config at the base-derived infra IPs. The mounted config
-    // files (shared.js / node-NN) carry the default 198.18 addresses; NODE_CONFIG
-    // is deep-merged over them by the `config` package, so under a non-default base
-    // these overrides take effect (and are a no-op when base === '198.18'). Explicit
-    // test overrides still win (merged on top of this).
+    // files carry the default 198.18 addresses; this is written into the node's
+    // config directory as local.js, which node-config loads after them, so under a
+    // non-default base these overrides take effect (and are a no-op when
+    // base === '198.18'). Explicit test overrides still win (merged on top of this).
     const infraOverride = {
       database: { url: MONGO_IP },
       daemon: { host: DAEMON_IP },
       benchmark: { host: DAEMON_IP },
       // FluxOS builds its syncthing API base from config at module load, so in
-      // binary mode the node has to be pointed at its own daemon. NODE_CONFIG is
-      // merged OVER the mounted shared.js, so this is the only place that wins.
+      // binary mode the node has to be pointed at its own daemon. local.js is
+      // loaded after the mounted files, so this is the only place that wins.
       syncthing: {
         ip: syncthing === 'binary' ? '127.0.0.1' : SYNCTHING_IP,
         // The apt repository and its signing key, served by the external stub out of
@@ -937,7 +937,13 @@ async function _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, conf
       fluxapps: derivePeerThresholds(nodes, stubPeers.length),
     };
     const nodeConfig = mergeConfigs(infraOverride, mergeConfigs(configOverrides, nodeConfigOverrides[i]));
-    nodeEnv.NODE_CONFIG = JSON.stringify(nodeConfig);
+    // Handed over as a file rather than as NODE_CONFIG. The config package merges
+    // that variable over every file, which is a redirect no hash can see, so the
+    // entry points delete it - production has no environment path into config at
+    // all now. The entrypoint writes this JSON into the pinned config directory
+    // instead, where node-config picks it up as local.js and the same override
+    // arrives through a file like every other one.
+    nodeEnv.FLUX_TEST_CONFIG = JSON.stringify(nodeConfig);
 
     // Wait on an HTTP poll of the node's own /flux/version, not Docker's health
     // state machine: under a contended 10-node fleet boot, Wait.forHealthCheck()

--- a/test-infra/runner/framework/test-env.js
+++ b/test-infra/runner/framework/test-env.js
@@ -886,7 +886,6 @@ async function _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, conf
       }
     }
     if (!isLegacy) nodeEnv.FLUXOS_PATH = '/flux';
-    if (discoveryAutostart) nodeEnv.FLUX_DISCOVERY_AUTOSTART = 'true';
     // Legacy only, because it is the only node type that installs anything:
     // monitorSystem() returns on sight of FLUXOS_PATH, so an Arcane node purged
     // of syncthing would simply never get it back.
@@ -934,7 +933,16 @@ async function _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, conf
       // there is nothing to remember and nothing to keep in step - see
       // peer-topology.js. A suite TESTING a threshold sets its own in
       // configOverrides, which merges over this and wins.
-      fluxapps: derivePeerThresholds(nodes, stubPeers.length),
+      fluxapps: {
+        ...derivePeerThresholds(nodes, stubPeers.length),
+        // Travels as configuration, like every other override. It used to be an
+        // env var the entrypoint sed into shared.js - but the merged config is
+        // written by REQUIRING the per-node file, which spreads shared.js at
+        // that moment and freezes the result, so a patch applied to shared.js
+        // afterwards landed on a file nothing read again. Discovery then never
+        // started for the suites that asked for it.
+        discoveryAutostart,
+      },
     };
     const nodeConfig = mergeConfigs(infraOverride, mergeConfigs(configOverrides, nodeConfigOverrides[i]));
     // Handed over as a file rather than as NODE_CONFIG. The config package merges

--- a/test-infra/runner/framework/test-env.js
+++ b/test-infra/runner/framework/test-env.js
@@ -557,10 +557,16 @@ export async function createTestEnv({
   hookCtx = null, nodes = 1, deferredNodes = 0, legacyNodes = [], stubPeers = [],
   configOverrides = null, nodeConfigOverrides = {}, nodeTiers = null, dataCenter = true,
   tickerAutostart = false, discoveryAutostart = false, nodeStatusOverrides = {},
-  rpcFailures = [], bootContext = 'running', initialHeight = DEFAULT_INITIAL_HEIGHT, syncthing = 'stub',
+  rpcFailures = [], bootContext = 'running', initialHeight = DEFAULT_INITIAL_HEIGHT, syncthing = 'stub', aptSeeded = true,
 } = {}) {
   if (syncthing !== 'stub' && syncthing !== 'binary') {
     throw new Error(`createTestEnv: syncthing must be 'stub' or 'binary', got '${syncthing}'`);
+  }
+  // Only a legacy node ever installs its own packages, so unseeding a fleet without
+  // one strips nothing and tests nothing. Refused rather than ignored: a flag that
+  // silently does nothing reads as covered.
+  if (!aptSeeded && legacyNodes.length === 0) {
+    throw new Error('createTestEnv: aptSeeded: false needs legacyNodes - no other node type installs packages');
   }
   // The boot-lock queue wait must not count against the suite's hook budget.
   // Mocha enforces a hook's timeout twice: the watchdog timer (which would fire
@@ -600,7 +606,7 @@ export async function createTestEnv({
     // mongo starts, i.e. inside the fleet boot, where the waits at risk are the
     // boot's own.
     await startInfraDeathWatch(env);
-    await _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, configOverrides, nodeConfigOverrides, nodeTiers, dataCenter, tickerAutostart, discoveryAutostart, nodeStatusOverrides, rpcFailures, bootContext, initialHeight, syncthing);
+    await _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, configOverrides, nodeConfigOverrides, nodeTiers, dataCenter, tickerAutostart, discoveryAutostart, nodeStatusOverrides, rpcFailures, bootContext, initialHeight, syncthing, aptSeeded);
     return env;
   } catch (err) {
     // Boot failed: the env owns everything started so far. The shared teardown
@@ -629,7 +635,7 @@ function mergeConfigs(base, override) {
   return result;
 }
 
-async function _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, configOverrides, nodeConfigOverrides, nodeTiers, dataCenter, tickerAutostart, discoveryAutostart, nodeStatusOverrides, rpcFailures, bootContext, initialHeight, syncthing = 'stub') {
+async function _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, configOverrides, nodeConfigOverrides, nodeTiers, dataCenter, tickerAutostart, discoveryAutostart, nodeStatusOverrides, rpcFailures, bootContext, initialHeight, syncthing = 'stub', aptSeeded = true) {
   // Everything built here registers onto the env shell as it comes up, so a
   // boot-phase throw leaves the partial state reachable (see makeEnvShell).
   const {
@@ -855,6 +861,10 @@ async function _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, conf
     }
     if (!isLegacy) nodeEnv.FLUXOS_PATH = '/flux';
     if (discoveryAutostart) nodeEnv.FLUX_DISCOVERY_AUTOSTART = 'true';
+    // Legacy only, because it is the only node type that installs anything:
+    // monitorSystem() returns on sight of FLUXOS_PATH, so an Arcane node purged
+    // of syncthing would simply never get it back.
+    if (!aptSeeded && isLegacy) nodeEnv.FLUX_APT_SEEDED = 'false';
     // Point the node's config at the base-derived infra IPs. The mounted config
     // files (shared.js / node-NN) carry the default 198.18 addresses; NODE_CONFIG
     // is deep-merged over them by the `config` package, so under a non-default base
@@ -867,7 +877,14 @@ async function _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, conf
       // FluxOS builds its syncthing API base from config at module load, so in
       // binary mode the node has to be pointed at its own daemon. NODE_CONFIG is
       // merged OVER the mounted shared.js, so this is the only place that wins.
-      syncthing: { ip: syncthing === 'binary' ? '127.0.0.1' : SYNCTHING_IP },
+      syncthing: {
+        ip: syncthing === 'binary' ? '127.0.0.1' : SYNCTHING_IP,
+        // The apt repository and its signing key, served by the external stub out of
+        // the node image. A legacy node writes this source and fetches this key itself
+        // on first boot; pointed here it does both without leaving the fleet network.
+        aptSourceUrl: `http://${EXTERNAL_STUB_IP}:3000/apt/`,
+        releaseKeyUrl: `http://${EXTERNAL_STUB_IP}:3000/apt/keyring.gpg`,
+      },
       github: { rawBaseUrl: `http://${EXTERNAL_STUB_IP}:3000`, apiBaseUrl: `http://${EXTERNAL_STUB_IP}:3000` },
       geolocation: { ipApiBaseUrl: `http://${EXTERNAL_STUB_IP}:3000` },
       stats: { baseUrl: `http://${EXTERNAL_STUB_IP}:3000` },

--- a/test-infra/runner/framework/test-env.js
+++ b/test-infra/runner/framework/test-env.js
@@ -583,7 +583,7 @@ export async function createTestEnv({
   hookCtx = null, nodes = 1, deferredNodes = 0, legacyNodes = [], stubPeers = [],
   configOverrides = null, nodeConfigOverrides = {}, nodeTiers = null, dataCenter = true,
   tickerAutostart = false, discoveryAutostart = false, nodeStatusOverrides = {},
-  rpcFailures = [], bootContext = 'running', initialHeight = DEFAULT_INITIAL_HEIGHT, syncthing = 'stub', aptSeeded = true,
+  rpcFailures = [], bootContext = 'running', initialHeight = DEFAULT_INITIAL_HEIGHT, syncthing = 'stub', aptSeeded = true, aptBadSource = false,
 } = {}) {
   if (syncthing !== 'stub' && syncthing !== 'binary') {
     throw new Error(`createTestEnv: syncthing must be 'stub' or 'binary', got '${syncthing}'`);
@@ -593,6 +593,9 @@ export async function createTestEnv({
   // silently does nothing reads as covered.
   if (!aptSeeded && legacyNodes.length === 0) {
     throw new Error('createTestEnv: aptSeeded: false needs legacyNodes - no other node type installs packages');
+  }
+  if (aptBadSource && legacyNodes.length === 0) {
+    throw new Error('createTestEnv: aptBadSource needs legacyNodes - no other node type runs apt');
   }
   // The boot-lock queue wait must not count against the suite's hook budget.
   // Mocha enforces a hook's timeout twice: the watchdog timer (which would fire
@@ -632,7 +635,7 @@ export async function createTestEnv({
     // mongo starts, i.e. inside the fleet boot, where the waits at risk are the
     // boot's own.
     await startInfraDeathWatch(env);
-    await _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, configOverrides, nodeConfigOverrides, nodeTiers, dataCenter, tickerAutostart, discoveryAutostart, nodeStatusOverrides, rpcFailures, bootContext, initialHeight, syncthing, aptSeeded);
+    await _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, configOverrides, nodeConfigOverrides, nodeTiers, dataCenter, tickerAutostart, discoveryAutostart, nodeStatusOverrides, rpcFailures, bootContext, initialHeight, syncthing, aptSeeded, aptBadSource);
     return env;
   } catch (err) {
     // Boot failed: the env owns everything started so far. The shared teardown
@@ -661,7 +664,7 @@ function mergeConfigs(base, override) {
   return result;
 }
 
-async function _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, configOverrides, nodeConfigOverrides, nodeTiers, dataCenter, tickerAutostart, discoveryAutostart, nodeStatusOverrides, rpcFailures, bootContext, initialHeight, syncthing = 'stub', aptSeeded = true) {
+async function _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, configOverrides, nodeConfigOverrides, nodeTiers, dataCenter, tickerAutostart, discoveryAutostart, nodeStatusOverrides, rpcFailures, bootContext, initialHeight, syncthing = 'stub', aptSeeded = true, aptBadSource = false) {
   // Everything built here registers onto the env shell as it comes up, so a
   // boot-phase throw leaves the partial state reachable (see makeEnvShell).
   const {
@@ -890,6 +893,7 @@ async function _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, conf
     // monitorSystem() returns on sight of FLUXOS_PATH, so an Arcane node purged
     // of syncthing would simply never get it back.
     if (!aptSeeded && isLegacy) nodeEnv.FLUX_APT_SEEDED = 'false';
+    if (aptBadSource && isLegacy) nodeEnv.FLUX_APT_BAD_SOURCE = 'true';
     // Point the node's config at the base-derived infra IPs. The mounted config
     // files carry the default 198.18 addresses; this is written into the node's
     // config directory as local.js, which node-config loads after them, so under a

--- a/test-infra/runner/framework/test-env.js
+++ b/test-infra/runner/framework/test-env.js
@@ -869,7 +869,14 @@ async function _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, conf
       // merged OVER the mounted shared.js, so this is the only place that wins.
       syncthing: { ip: syncthing === 'binary' ? '127.0.0.1' : SYNCTHING_IP },
       github: { rawBaseUrl: `http://${EXTERNAL_STUB_IP}:3000`, apiBaseUrl: `http://${EXTERNAL_STUB_IP}:3000` },
-      geolocation: { ipApiBaseUrl: `http://${EXTERNAL_STUB_IP}:3000`, statsApiBaseUrl: `http://${EXTERNAL_STUB_IP}:3000` },
+      geolocation: { ipApiBaseUrl: `http://${EXTERNAL_STUB_IP}:3000` },
+      stats: { baseUrl: `http://${EXTERNAL_STUB_IP}:3000` },
+      pricing: {
+        fluxRatesBaseUrl: `http://${EXTERNAL_STUB_IP}:3000`,
+        coingeckoBaseUrl: `http://${EXTERNAL_STUB_IP}:3000`,
+      },
+      mongodb: { signingKeyBaseUrl: `http://${EXTERNAL_STUB_IP}:3000` },
+      upnp: { gatewayUrl: `http://${EXTERNAL_STUB_IP}:3000/upnp/device.xml` },
       // Every base URL a node fetches from belongs here, not just in
       // config/shared.js: a run claims its own /24, so an address baked into the
       // shared config is only correct for the run that happens to claim the

--- a/test-infra/runner/framework/test-env.js
+++ b/test-infra/runner/framework/test-env.js
@@ -136,6 +136,7 @@ class StaticIpContainer extends GenericContainer {
   #staticIp;
   #networkName;
   #aliases = [];
+  #dnsServer;
 
   withStaticIp(networkName, ip, aliases = []) {
     this.#staticIp = ip;
@@ -144,10 +145,27 @@ class StaticIpContainer extends GenericContainer {
     return this;
   }
 
+  withDnsServer(ip) {
+    this.#dnsServer = ip;
+    return this;
+  }
+
   async beforeContainerCreated() {
     // Tag with this run's label so run-all.sh's between-suite cleanup can scope
     // removal to its own fleet (see runLabels()).
     this.createOpts.Labels = { ...(this.createOpts.Labels || {}), ...runLabels() };
+    if (this.#dnsServer) {
+      // hostConfig, NOT createOpts.HostConfig: testcontainers creates the container
+      // with `{ ...createOpts, HostConfig: this.hostConfig }`, so anything written to
+      // createOpts.HostConfig here is overwritten wholesale before it is ever sent.
+      // It is the property testcontainers mutates itself (withTmpFs, withCapAdd) and
+      // it is still being written after this hook, so writing it here holds.
+      //
+      // Docker keeps 127.0.0.11 as the container's nameserver either way; this is the
+      // upstream its embedded resolver forwards to, which is where a name the fleet
+      // does not serve ends up.
+      this.hostConfig.Dns = [this.#dnsServer];
+    }
     if (this.#staticIp && this.#networkName) {
       this.createOpts.NetworkingConfig = {
         EndpointsConfig: {
@@ -172,6 +190,14 @@ async function createNetwork() {
   await client.container.dockerode.createNetwork({
     Name: networkName,
     Driver: 'bridge',
+    // No route off the fleet. Every endpoint a node reaches is served on this
+    // network, so anything still leaving it is a hardcoded address nobody has
+    // found yet - and the point of Phase 3 is that it is found by a test rather
+    // than by a packet capture months later.
+    //
+    // The runner addresses nodes by static IP on this subnet and uses no
+    // published ports anywhere, so its own reach into the fleet is unaffected.
+    Internal: true,
     Labels: { 'org.testcontainers.session-id': reaper.sessionId, ...runLabels() },
     IPAM: {
       Driver: 'default',
@@ -920,6 +946,12 @@ async function _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, conf
     const builder = new StaticIpContainer(image('flux-e2e-fluxos-01'))
       .withPrivilegedMode()
       .withStaticIp(networkName, nodeIp)
+      // Nodes resolve through the stub, which answers fleet names by relaying to
+      // Docker's own resolver and refuses everything else at once - so a name
+      // nothing on this fleet serves fails immediately, named and attributed,
+      // instead of stalling whatever asked for it until its own deadline.
+      // Only the nodes: the stub resolves normally, or it would relay to itself.
+      .withDnsServer(EXTERNAL_STUB_IP)
       .withExtraHosts(fdmExtraHosts(FDM_IP))
       .withBindMounts(bindMounts)
       .withLogConsumer(logCollector)

--- a/test-infra/runner/framework/wait.js
+++ b/test-infra/runner/framework/wait.js
@@ -1,4 +1,4 @@
-import { getAppContainerStatus } from './container.js';
+import { getAppContainerStatus, restartFluxos } from './container.js';
 import { throwIfInfraDead, sleepUnlessInfraDead } from './infra-death.js';
 
 export async function waitFor(condition, { timeout = 60000, interval = 2000, label = '' } = {}) {
@@ -39,6 +39,30 @@ export async function waitForDaemonPolled(node, predicate = () => true, timeout 
 
 export async function waitForDaemonReady(node, timeout = 60000, opts) {
   return node.waitForEvent('daemon:polled', () => true, timeout, opts);
+}
+
+export async function waitForFileOpsRecovered(node, predicate = () => true, timeout = 120000, opts) {
+  return node.waitForEvent('fileops:recovered', predicate, timeout, opts);
+}
+
+// Restart a node and return only once its boot recovery pass has finished.
+//
+// restartFluxos alone returns when /flux/version answers, and the API is up long
+// before the boot sweep runs - so a test that restarts and asserts immediately is
+// reading the state from BEFORE the thing it restarted for. Two ways that bites: the
+// assertions pass against the pre-sweep state and prove nothing, and the sweep then
+// lands during whatever runs next and eats its fixtures. Both were observed together
+// in suite 72, where the D1 marker regression passed without the sweep having run and
+// the following test lost its fixture to it.
+//
+// The id is snapshotted BEFORE the kill on purpose. The bus seeds its ids from the
+// monotonic clock precisely so they stay monotonic across a restart, which is what
+// makes afterId a sound filter here: the previous boot's event cannot satisfy this
+// wait, and a fresh process cannot mint an id that looks older than one already seen.
+export async function restartFluxosAndAwaitRecovery(node, { readyTimeoutMs, recoveryTimeoutMs = 120000 } = {}) {
+  const afterId = node.getLastEventId();
+  await restartFluxos(node.container, readyTimeoutMs ? { readyTimeoutMs } : {});
+  return waitForFileOpsRecovered(node, () => true, recoveryTimeoutMs, { afterId });
 }
 
 export async function waitForBlockProcessed(node, predicate = () => true, timeout = 30000, opts) {

--- a/test-infra/runner/framework/wait.js
+++ b/test-infra/runner/framework/wait.js
@@ -53,6 +53,13 @@ export async function waitForPackagesChecked(node, predicate = () => true, timeo
   return node.waitForEvent('system:packages-checked', predicate, timeout, opts);
 }
 
+// One apt command completing, as a fact rather than as packages turning up on
+// disk later. `opts.afterId` is what makes a second call mean "the NEXT one",
+// which is how a test says "the queue carried on past the one that failed".
+export async function waitForAptCommand(node, predicate = () => true, timeout = 60000, opts) {
+  return node.waitForEvent('system:apt-command', predicate, timeout, opts);
+}
+
 // Restart a node and return only once its boot recovery pass has finished.
 //
 // restartFluxos alone returns when /flux/version answers, and the API is up long

--- a/test-infra/runner/framework/wait.js
+++ b/test-infra/runner/framework/wait.js
@@ -45,6 +45,14 @@ export async function waitForFileOpsRecovered(node, predicate = () => true, time
   return node.waitForEvent('fileops:recovered', predicate, timeout, opts);
 }
 
+// The boot's package checks are over, and the payload's `installed` says what
+// they did. A provisioned node has nothing else to go on: the packages are
+// present whether or not the checks ever ran, so presence alone cannot tell a
+// check that ran and found its work done from one that never started.
+export async function waitForPackagesChecked(node, predicate = () => true, timeout = 180000, opts) {
+  return node.waitForEvent('system:packages-checked', predicate, timeout, opts);
+}
+
 // Restart a node and return only once its boot recovery pass has finished.
 //
 // restartFluxos alone returns when /flux/version answers, and the API is up long

--- a/test-infra/runner/run-all.sh
+++ b/test-infra/runner/run-all.sh
@@ -16,6 +16,16 @@ set -uo pipefail
 
 cd "$(dirname "$0")" || exit 99
 
+# A targeted run is where a stale image bites hardest: one suite, failing in a
+# way that reads like the product. run-parallel checks once for the whole gate
+# and says so, so this does not repeat it 85 times.
+if [ -z "${E2E_IMAGES_VERIFIED:-}" ]; then
+  if ! "$PWD/../verify-images.sh"; then
+    echo "###ABORT images do not match the tree - see above."
+    exit 96
+  fi
+fi
+
 # A live FluxOS on this host owns BOTH container-name spaces: anything NOT
 # named zel*/flux* is stopped by its 2-hourly stopAllNonFluxRunningApps sweep
 # (killed suite 28's fleet mid-boot in the 2026-06-12 gate), and flux*/zel*

--- a/test-infra/runner/run-all.sh
+++ b/test-infra/runner/run-all.sh
@@ -119,7 +119,7 @@ release_base() { [ -n "${CLAIMED_BASE:-}" ] && rm -rf "${LOCK_ROOT:?}/$CLAIMED_B
 # bare-key pre-gate sweep or the manual pre-run clean.
 cleanup_on_exit() {
   if [ -n "${RUN_LABEL:-}" ]; then
-    docker ps -aq --filter "label=flux-e2e-run=$RUN_LABEL" | xargs -r docker rm -f >/dev/null 2>&1
+    docker ps -aq --filter "label=flux-e2e-run=$RUN_LABEL" | xargs -r docker rm -fv >/dev/null 2>&1
     # The base lock outlives the network: removal is not instantaneous - a
     # network with detaching endpoints refuses the rm, and one mid-removal
     # can be absent from ls while its subnet is still allocated - so a lock
@@ -159,7 +159,7 @@ for f in "${SUITES[@]}"; do
 
   # drop any orphaned objects THIS run leaked so a leak in one suite can't fail the
   # next — scoped to our own run label so a concurrent run-all's live fleet is untouched
-  docker ps -aq --filter "label=flux-e2e-run=$RUN_LABEL" | xargs -r docker rm -f >/dev/null 2>&1
+  docker ps -aq --filter "label=flux-e2e-run=$RUN_LABEL" | xargs -r docker rm -fv >/dev/null 2>&1
   docker network ls -q --filter "label=flux-e2e-run=$RUN_LABEL" | xargs -r docker network rm >/dev/null 2>&1
   docker volume ls -q --filter "label=flux-e2e-run=$RUN_LABEL" | xargs -r docker volume rm >/dev/null 2>&1
 

--- a/test-infra/runner/run-parallel.sh
+++ b/test-infra/runner/run-parallel.sh
@@ -52,6 +52,18 @@ if [ -z "${E2E_ALLOW_HOST_FLUXOS:-}" ]; then
   done
 fi
 
+# The other way a gate is wrong before it starts: an image built from an older
+# tree runs this branch's suites and fails as though the product were broken. A
+# stale syncthing-stub cost a whole 85-suite gate on 2026-08-11. Decide it once,
+# in a second, rather than let the suites discover it one confusing failure at a
+# time - and tell the per-suite runners it is settled so they do not each repeat
+# a check that walks the whole build context.
+if ! "$PWD/../verify-images.sh"; then
+  echo "###ABORT images do not match the tree - see above."
+  exit 96
+fi
+export E2E_IMAGES_VERIFIED=1
+
 LOGROOT="${E2E_LOG_DIR:-/tmp/e2e-logs}"
 MAXN="${MAXN:-3}"
 MIN_FREE_MB="${MIN_FREE_MB:-15000}"

--- a/test-infra/runner/run-parallel.sh
+++ b/test-infra/runner/run-parallel.sh
@@ -100,7 +100,15 @@ load_1m(){ cut -d' ' -f1 /proc/loadavg | cut -d. -f1; }   # integer part is enou
 sweep_harness_leftovers(){
   # scope to OUR label (key presence, any run id) - org.testcontainers=true would
   # also kill unrelated testcontainers projects sharing the box
-  docker ps -aq --filter label=flux-e2e-run | xargs -r docker rm -f >/dev/null 2>&1
+  #
+  # -v, or every force-removed container orphans its ANONYMOUS volumes. An image
+  # with a VOLUME directive (mongo declares /data/db) gets one per container, and
+  # they carry com.docker.volume.anonymous rather than our label - so the volume
+  # sweep below cannot see them and nothing ever reclaims them. Measured on chud
+  # after a gate: 34 dangling volumes, 8.9GB in local volumes with 2.2GB
+  # reclaimable. testcontainers' own teardown already passes removeVolumes, so this
+  # is only about the containers a sweep takes rather than a suite.
+  docker ps -aq --filter label=flux-e2e-run | xargs -r docker rm -fv >/dev/null 2>&1
   docker network ls --format '{{.ID}} {{.Name}}' | grep ' flux-test-' | awk '{print $1}' | xargs -r docker network rm >/dev/null 2>&1
   docker volume ls -q --filter label=flux-e2e-run | xargs -r docker volume rm >/dev/null 2>&1
   rm -rf /tmp/e2e-base-locks /tmp/e2e-boot-lock

--- a/test-infra/runner/tests/60-volume-mount-ownership.js
+++ b/test-infra/runner/tests/60-volume-mount-ownership.js
@@ -159,13 +159,33 @@ describe('FluxOS-owned volume mounting (no crontab) + inert unmounted app dirs',
     this.timeout(120000);
     const client = env.clients[0];
     const dir = appDir(syncName);
+    const vol = volFile(syncName);
 
-    // stop the container (releases the bind), unmount, then immediately probe a
-    // write on the bare dir - all in ONE shell so the monitor's 3s repair cycle
-    // cannot remount in between. The immutable mountpoint must refuse the write.
+    // Hold the backing file aside BEFORE anything can trigger a reconcile.
+    // getVolumeFilePath matches an exact name, so a renamed volume reads as
+    // volume_file_missing and ensureAppVolumeMounted returns without mounting.
+    //
+    // The stop cannot come first. Its die event drives a reconcile, and the
+    // reconciler mounts the volume before ANY actuation - correctly, since a
+    // start against a bare mountpoint would write to the host filesystem. So a
+    // probe that stops first is racing a repair it just asked for, and losing
+    // that race looks exactly like the leak this test exists to catch. Suite
+    // test 5 states the same rule: the broken state must fully exist before the
+    // die event fires. A rename does not disturb the loop mount, which holds the
+    // file by inode.
     const r = await execInContainer(client.container,
-      `docker stop ${appId(syncName)} >/dev/null 2>&1; umount ${dir} || exit 9; touch ${dir}/leak-probe 2>/dev/null; echo TOUCH_EXIT:$?`);
+      `mv ${vol} ${vol}.held || exit 8; `
+      + `docker stop ${appId(syncName)} >/dev/null 2>&1; `
+      + `umount ${dir} || exit 9; `
+      + `mountpoint -q ${dir}; echo MOUNTED:$?; `
+      + `touch ${dir}/leak-probe 2>/dev/null; echo TOUCH_EXIT:$?; `
+      + `mv ${vol}.held ${vol}`);
+    expect(r.exitCode, `could not hold the volume file aside: ${r.output}`).to.not.equal(8);
     expect(r.exitCode, `umount failed: ${r.output}`).to.not.equal(9);
+    // The probe only means anything against a bare dir. Asserted rather than
+    // assumed, so a remount that beat us is reported as such instead of being
+    // read as a leak.
+    expect(r.output.match(/MOUNTED:(\d+)/)?.[1], `still mounted at probe time: ${r.output}`).to.not.equal('0');
     const touchExit = r.output.match(/TOUCH_EXIT:(\d+)/)?.[1];
     expect(touchExit, `expected the bare-dir write to fail, got: ${r.output}`).to.not.equal('0');
 

--- a/test-infra/runner/tests/72-app-volume-file-operation-safety.js
+++ b/test-infra/runner/tests/72-app-volume-file-operation-safety.js
@@ -26,6 +26,11 @@ import {
 // passes. A security test that cannot fail is worse than no test.
 
 const OPERATION_UUID = '11111111-2222-4333-8444-555555555555';
+// A fixture uuid for the fake `.flux-op-<uuid>` staging dirs the boot-recovery
+// tests plant to prove the sweep's scope. The signal rework deleted this const
+// with its old users; the two prefix/own-data tests still plant staging dirs,
+// and their first execution (this stack's first full gate) found the hole.
+const STAGING_UUID = '66666666-7777-4888-8999-aaaaaaaaaaaa';
 
 describe('app volume file operations - safety and recovery', function () {
   let env;

--- a/test-infra/runner/tests/72-app-volume-file-operation-safety.js
+++ b/test-infra/runner/tests/72-app-volume-file-operation-safety.js
@@ -1,10 +1,10 @@
 import { describe, it, before, beforeEach, after } from 'mocha';
 import { expect } from 'chai';
 import { createTestEnv } from '../framework/test-env.js';
-import { execInContainer, restartFluxos } from '../framework/container.js';
+import { execInContainer } from '../framework/container.js';
 import { pushImage, mirrorExecutorImage, executorImageReference } from '../framework/registry-helper.js';
 import { buildSeedableApp } from '../framework/seed-helper.js';
-import { waitFor, waitForOperation } from '../framework/wait.js';
+import { waitFor, waitForOperation, restartFluxosAndAwaitRecovery } from '../framework/wait.js';
 import { bootAndPeer, installOnNodes } from '../framework/reconciler-suite.js';
 import { REGISTRY_REPO_HOST } from '../framework/subnet-config.js';
 import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
@@ -367,7 +367,7 @@ describe('app volume file operations - safety and recovery', function () {
       this.timeout(300000);
       await inNode(`mkdir -p ${root}/.flux-op-${OPERATION_UUID} && echo scratch > ${root}/.flux-op-${OPERATION_UUID}/partial`);
 
-      await restartFluxos(node.container);
+      await restartFluxosAndAwaitRecovery(node);
 
       await waitFor(async () => !await exists(node.container, `${root}/.flux-op-${OPERATION_UUID}`), {
         timeout: 60000, interval: 2000, label: 'abandoned staging reclaimed',
@@ -388,7 +388,7 @@ describe('app volume file operations - safety and recovery', function () {
       await seedVolumeTree(node.container, appName, { '.flux-op-backups/keep.txt': 'mine' });
       await inNode(`mkdir -p ${root}/.flux-op-${STAGING_UUID} && echo scratch > ${root}/.flux-op-${STAGING_UUID}/partial`);
 
-      await restartFluxos(node.container);
+      await restartFluxosAndAwaitRecovery(node);
 
       await waitFor(async () => !await exists(node.container, `${root}/.flux-op-${STAGING_UUID}`), {
         timeout: 60000, interval: 2000, label: 'the sweep has run (its own staging reclaimed)',
@@ -413,7 +413,7 @@ describe('app volume file operations - safety and recovery', function () {
       // would pass a premature check trivially.
       await inNode(`mkdir -p ${root}/.flux-op-${STAGING_UUID} && echo scratch > ${root}/.flux-op-${STAGING_UUID}/partial`);
 
-      await restartFluxos(node.container);
+      await restartFluxosAndAwaitRecovery(node);
       await waitFor(async () => !await exists(node.container, `${root}/.flux-op-${STAGING_UUID}`), {
         timeout: 60000, interval: 2000, label: 'the sweep has run (its own staging reclaimed)',
       });

--- a/test-infra/runner/tests/72-app-volume-file-operation-safety.js
+++ b/test-infra/runner/tests/72-app-volume-file-operation-safety.js
@@ -26,9 +26,6 @@ import {
 // passes. A security test that cannot fail is worse than no test.
 
 const OPERATION_UUID = '11111111-2222-4333-8444-555555555555';
-// A second one, for a case that needs an entry the sweep WILL act on beside an
-// entry it must not touch.
-const STAGING_UUID = '66666666-7777-4888-8999-aaaaaaaaaaaa';
 
 describe('app volume file operations - safety and recovery', function () {
   let env;

--- a/test-infra/runner/tests/94-legacy-package-provisioning.js
+++ b/test-infra/runner/tests/94-legacy-package-provisioning.js
@@ -16,7 +16,7 @@ import { describe, it, before, after } from 'mocha';
 import { expect } from 'chai';
 import { createTestEnv } from '../framework/test-env.js';
 import { execInContainer } from '../framework/container.js';
-import { waitForPackagesChecked } from '../framework/wait.js';
+import { waitForPackagesChecked, waitForAptCommand } from '../framework/wait.js';
 import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
 
 // ca-certificates is checked too, but the image satisfies it in both regimes and
@@ -27,6 +27,19 @@ const SEEDED_PACKAGES = ['chrony', 'syncthing', 'netcat-openbsd'];
 // with a lock wait of its own behind each. The seeded node answers in seconds
 // because it does nothing; this one has actual work to do.
 const INSTALL_TIMEOUT_MS = 480000;
+
+// Bounded by measurement, not by fear. The whole suite - three fleets, boots and
+// real installs - runs green in under a minute, because the repository is a
+// file:// directory in the image rather than a network mirror. A regression here
+// is a queue that stopped, so the wait is pure dead time: keep it short enough
+// that a red arrives promptly and generous enough that a loaded box cannot
+// invent one.
+const RESUMED_PROVISION_TIMEOUT_MS = 120000;
+
+// An event arrives the moment the command finishes, so this bounds a fact rather
+// than a poll: generous against a slow boot, and nothing like the dead time of
+// waiting to conclude that something never happened.
+const APT_EVENT_TIMEOUT_MS = 90000;
 
 async function installedVersion(client, systemPackage) {
   const { stdout } = await execInContainer(
@@ -101,6 +114,82 @@ describe('94 legacy package provisioning', function suite() {
     it('ends up with the same packages a seeded node starts with', async () => {
       await waitForPackagesChecked(env.clients[0], () => true, INSTALL_TIMEOUT_MS);
       for (const systemPackage of SEEDED_PACKAGES) {
+        const version = await installedVersion(env.clients[0], systemPackage);
+        expect(version, `${systemPackage} should be installed`).to.not.equal('');
+      }
+    });
+  });
+
+  // The third regime a real node boots into, and the one nothing covered: the
+  // packages are missing AND apt-get update fails. Every legacy boot queues an
+  // update ahead of the installs, so a node that cannot survive one failing never
+  // provisions itself at all - and an unreachable mirror, an expired repository
+  // key or a DNS blip is an ordinary Tuesday, not an exotic fault.
+  //
+  // The apt queue halts on a final failure and the cache monitor resumes it, and
+  // for a failed update it resumes SYNCHRONOUSLY, from inside the emit. A halt
+  // written after that emit undid the resume: the queue stopped with every
+  // install still queued behind it, nothing restarted it, and monitorSystem's
+  // allSettled never settled - so `system:packages-checked` was never published
+  // and chrony, syncthing and netcat never installed until FluxOS restarted.
+  //
+  // Asserted off the event bus, in order, because that is what it is for: the
+  // update failing and an apt command completing after it are both FACTS the
+  // product states, so the test reads them rather than inferring the second from
+  // packages appearing on disk some time later. The first wait doubles as the
+  // non-vacuity check - if the update did not fail, there is no such event and
+  // nothing below it can pass for the wrong reason.
+  describe('a node whose apt-get update fails', () => {
+    let env;
+    dumpLogsOnFailure(() => env);
+
+    before(async function hook() {
+      env = await createTestEnv({
+        hookCtx: this,
+        nodes: 1,
+        legacyNodes: [0],
+        tickerAutostart: false,
+        aptSeeded: false,
+        aptBadSource: true,
+      });
+    });
+
+    after(async () => {
+      await env?.teardown();
+    });
+
+    it('carries on to the work behind an update that failed', async () => {
+      // Two facts off the bus, in order, rather than packages appearing on disk
+      // minutes later: the update failed, and an apt command completed AFTER it.
+      // The second is the whole property - the queue survived - and afterId is
+      // what makes it "after" rather than "at some point".
+      const failed = await waitForAptCommand(
+        env.clients[0],
+        (d) => d.command === 'update' && d.ok === false,
+        APT_EVENT_TIMEOUT_MS,
+      );
+
+      const next = await waitForAptCommand(
+        env.clients[0],
+        (d) => d.ok === true,
+        APT_EVENT_TIMEOUT_MS,
+        { afterId: failed.id },
+      );
+
+      expect(next.data.command, 'the command after the failed update must be real work').to.equal('install');
+    });
+
+    it('reports the checks as complete, not merely done quietly', async () => {
+      // The event above proves the queue kept running; this proves monitorSystem's
+      // allSettled actually settled, which is the half that strands its caller.
+      const event = await waitForPackagesChecked(env.clients[0], () => true, RESUMED_PROVISION_TIMEOUT_MS);
+      expect(event.data.installed).to.have.members(SEEDED_PACKAGES);
+    });
+
+    it('ends up with the packages it was missing', async () => {
+      await waitForPackagesChecked(env.clients[0], () => true, RESUMED_PROVISION_TIMEOUT_MS);
+      for (const systemPackage of SEEDED_PACKAGES) {
+        // eslint-disable-next-line no-await-in-loop
         const version = await installedVersion(env.clients[0], systemPackage);
         expect(version, `${systemPackage} should be installed`).to.not.equal('');
       }

--- a/test-infra/runner/tests/94-legacy-package-provisioning.js
+++ b/test-infra/runner/tests/94-legacy-package-provisioning.js
@@ -1,0 +1,109 @@
+// A legacy node provisions its own packages; an Arcane node never does, because
+// monitorSystem returns on sight of FLUXOS_PATH. Both regimes a legacy node can
+// boot into are covered here:
+//
+//   seeded    - the packages are already there, which is every boot after the
+//               first. The checks must run and decide to do nothing.
+//   unseeded  - the packages are absent, which is the first boot. The checks must
+//               install them, from the repository the fleet serves.
+//
+// The assertions are on the `system:packages-checked` payload rather than on the
+// packages alone, and that is the whole point of the event: on a seeded node the
+// packages are present whether or not the checks ever ran, so presence proves
+// nothing about the code under test. `installed: []` proves the pass happened and
+// found its work done, which is a different fact from silence.
+import { describe, it, before, after } from 'mocha';
+import { expect } from 'chai';
+import { createTestEnv } from '../framework/test-env.js';
+import { execInContainer } from '../framework/container.js';
+import { waitForPackagesChecked } from '../framework/wait.js';
+import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
+
+// ca-certificates is checked too, but the image satisfies it in both regimes and
+// the entrypoint never purges it - removing it would break TLS before FluxOS ran.
+const SEEDED_PACKAGES = ['chrony', 'syncthing', 'netcat-openbsd'];
+
+// A first boot installs for real, and the apt queue runs one command at a time
+// with a lock wait of its own behind each. The seeded node answers in seconds
+// because it does nothing; this one has actual work to do.
+const INSTALL_TIMEOUT_MS = 480000;
+
+async function installedVersion(client, systemPackage) {
+  const { stdout } = await execInContainer(
+    client.container,
+    `dpkg-query --showformat='\${Version}|\${Status}' --show ${systemPackage} 2>/dev/null || true`,
+  );
+  const [version, status] = stdout.replace(/'/g, '').trim().split('|');
+  return status === 'install ok installed' ? version : '';
+}
+
+describe('94 legacy package provisioning', function suite() {
+  this.timeout(600000);
+
+  describe('a seeded node', () => {
+    let env;
+    dumpLogsOnFailure(() => env);
+
+    before(async function hook() {
+      env = await createTestEnv({
+        hookCtx: this, nodes: 1, legacyNodes: [0], tickerAutostart: false,
+      });
+    });
+
+    after(async () => {
+      await env?.teardown();
+    });
+
+    it('runs its package checks and installs nothing', async () => {
+      const event = await waitForPackagesChecked(env.clients[0]);
+      expect(event.data.installed).to.deep.equal([]);
+    });
+
+    it('has every package the image seeded', async () => {
+      for (const systemPackage of SEEDED_PACKAGES) {
+        const version = await installedVersion(env.clients[0], systemPackage);
+        expect(version, `${systemPackage} should be installed`).to.not.equal('');
+      }
+    });
+
+    it('carries syncthing as a dpkg package, the way a node does', async () => {
+      // The image installed it from the repository rather than unpacking a release
+      // tarball, so dpkg knows about it - which is what getPackageVersion reads. A
+      // tarball leaves that query empty and the version check with nothing to
+      // compare, so it would ask for an install on a node that already has one.
+      const version = await installedVersion(env.clients[0], 'syncthing');
+      expect(version).to.match(/^\d+\.\d+\.\d+/);
+    });
+  });
+
+  describe('an unseeded node', () => {
+    let env;
+    dumpLogsOnFailure(() => env);
+
+    before(async function hook() {
+      env = await createTestEnv({
+        hookCtx: this, nodes: 1, legacyNodes: [0], tickerAutostart: false, aptSeeded: false,
+      });
+    });
+
+    after(async () => {
+      await env?.teardown();
+    });
+
+    it('installs what it is missing, and says so', async () => {
+      // Asserted from the event, not from a probe taken before and after: the
+      // install runs inside the boot, so any probe racing it would sometimes read
+      // the finished state and pass without the install having been observed.
+      const event = await waitForPackagesChecked(env.clients[0], () => true, INSTALL_TIMEOUT_MS);
+      expect(event.data.installed).to.have.members(SEEDED_PACKAGES);
+    });
+
+    it('ends up with the same packages a seeded node starts with', async () => {
+      await waitForPackagesChecked(env.clients[0], () => true, INSTALL_TIMEOUT_MS);
+      for (const systemPackage of SEEDED_PACKAGES) {
+        const version = await installedVersion(env.clients[0], systemPackage);
+        expect(version, `${systemPackage} should be installed`).to.not.equal('');
+      }
+    });
+  });
+});

--- a/test-infra/runner/tests/95-fleet-reaches-nothing-outside.js
+++ b/test-infra/runner/tests/95-fleet-reaches-nothing-outside.js
@@ -1,0 +1,89 @@
+// The fleet has no route off itself, and this is what says so out loud.
+//
+// Closing the network is the easy half. On its own it turns a hardcoded address
+// into a timeout, and a timeout reads as a slow test - which is how the harness
+// spent months reaching stats.runonflux.io and api.github.com on every boot
+// without anyone noticing. The resolver refuses unknown names immediately and
+// records who asked, so the next address someone hardcodes fails here, naming
+// itself, at the moment it is written.
+//
+// A boot is the window that matters: it is where a node fetches its module
+// versions, its rates, its policy, its geolocation and - on a legacy node - its
+// packages. Both node types boot here because they reach for different things:
+// monitorSystem returns immediately on Arcane, so only the legacy node exercises
+// the apt path at all.
+import { describe, it, before, after } from 'mocha';
+import { createTestEnv } from '../framework/test-env.js';
+import { expectNoUnexpectedDns, resetDnsAttempts, dnsAttempts } from '../framework/external-http-control.js';
+import { waitForPackagesChecked, waitForBootSettled } from '../framework/wait.js';
+import { execInContainer } from '../framework/container.js';
+import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
+
+describe('95 the fleet reaches nothing outside itself', function suite() {
+  this.timeout(600000);
+
+  describe('a legacy node', () => {
+    let env;
+    dumpLogsOnFailure(() => env);
+
+    before(async function hook() {
+      env = await createTestEnv({
+        hookCtx: this, nodes: 1, legacyNodes: [0], tickerAutostart: false,
+      });
+      // From here on, what is recorded is this fleet's doing.
+      await resetDnsAttempts();
+    });
+
+    after(async () => {
+      await env?.teardown();
+    });
+
+    it('asks for nothing the fleet cannot answer, through a whole boot', async () => {
+      // Waited for rather than sampled: the package checks are the last thing a
+      // legacy boot does, and asserting before they run would pass on a node that
+      // simply had not reached out yet.
+      await waitForPackagesChecked(env.clients[0]);
+      await waitForBootSettled(env.clients[0]);
+
+      await expectNoUnexpectedDns();
+    });
+  });
+
+  describe('an arcane node', () => {
+    let env;
+    dumpLogsOnFailure(() => env);
+
+    before(async function hook() {
+      env = await createTestEnv({
+        hookCtx: this, nodes: 1, tickerAutostart: false,
+      });
+      await resetDnsAttempts();
+    });
+
+    after(async () => {
+      await env?.teardown();
+    });
+
+    it('asks for nothing the fleet cannot answer, through a whole boot', async () => {
+      await waitForBootSettled(env.clients[0]);
+
+      await expectNoUnexpectedDns();
+    });
+
+    it('records the name and the node when something does reach out', async () => {
+      // The instrument, proven on this fleet rather than assumed. A resolver that
+      // silently answered everything would leave the assertion above green for the
+      // rest of time, and nothing else in this suite would notice.
+      await resetDnsAttempts();
+      await execInContainer(
+        env.clients[0].container,
+        'getent hosts stats.runonflux.io >/dev/null 2>&1 || true',
+      );
+
+      const attempts = await dnsAttempts();
+      const seen = attempts.find((a) => a.name === 'stats.runonflux.io');
+      if (!seen) throw new Error('the resolver recorded nothing for a name the fleet does not serve');
+      if (!seen.node) throw new Error('the recorded attempt does not say which node asked');
+    });
+  });
+});

--- a/test-infra/verify-images.sh
+++ b/test-infra/verify-images.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Refuses a run whose images do not match the tree.
+#
+# The failure this exists to stop is silent: an image built from an older tree
+# runs this branch's suites and fails as though the product were broken. On
+# 2026-08-11 a syncthing-stub image four commits behind cost a full 85-suite
+# gate - suites 87, 88 and 90 died in a `before each` on an endpoint the image
+# did not carry, which reads exactly like a restore defect.
+#
+# Every image carries `flux.e2e.src`, stamped by build-images.sh with the digest
+# of its build context. Recompute that from the working tree and compare. An
+# image with NO label fails too: images built before this check existed cannot
+# be distinguished from correct ones, and treating unknown as fine is how the
+# check would be defeated on the very boxes that need it.
+#
+#   usage: verify-images.sh          # every image, at $FLUX_E2E_TAG
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+TAG="${FLUX_E2E_TAG:-latest}"
+
+# Derived, never listed - same rule as build-images.sh, so a lineage that adds a
+# stub gets it checked without editing this file.
+targets=(fluxos-01)
+for dir in test-infra/*/; do
+  [ -f "${dir}Dockerfile" ] && targets+=("$(basename "$dir")")
+done
+
+stale=()
+for target in "${targets[@]}"; do
+  image="flux-e2e-${target}:${TAG}"
+
+  if ! want="$(test-infra/image-digest.sh "$target" 2>/dev/null)"; then
+    stale+=("${image}|cannot compute a source digest for ${target}")
+    continue
+  fi
+
+  if ! have="$(docker image inspect "$image" --format '{{index .Config.Labels "flux.e2e.src"}}' 2>/dev/null)"; then
+    stale+=("${image}|not built under this tag")
+    continue
+  fi
+
+  case "$have" in
+    ''|'<no value>')
+      stale+=("${image}|built before images were stamped - cannot be trusted")
+      ;;
+    "$want") ;;
+    *)
+      stale+=("${image}|source moved since it was built (image ${have:0:12}, tree ${want:0:12})")
+      ;;
+  esac
+done
+
+if [ "${#stale[@]}" -eq 0 ]; then
+  echo "images verified against the tree (tag '${TAG}', ${#targets[@]} images)"
+  exit 0
+fi
+
+echo "REFUSING TO RUN - ${#stale[@]} image(s) do not match this tree:" >&2
+for entry in "${stale[@]}"; do
+  printf '  %-42s %s\n' "${entry%%|*}" "${entry#*|}" >&2
+done
+echo >&2
+echo "rebuild them, then run again:" >&2
+echo "  FLUX_E2E_TAG=${TAG} ./test-infra/build-images.sh" >&2
+exit 1

--- a/tests/unit/appController.test.js
+++ b/tests/unit/appController.test.js
@@ -10,7 +10,6 @@ const appReconciler = require('../../ZelBack/src/services/appMonitoring/appRecon
 const globalState = require('../../ZelBack/src/services/utils/globalState');
 const bootGateAtStart = globalState.bootContainerStateSettled;
 const fluxNetworkHelper = require('../../ZelBack/src/services/fluxNetworkHelper');
-const fluxEventBus = require('../../ZelBack/src/services/utils/fluxEventBus');
 const { requireMongo } = require('./dbTestHelper');
 
 describe('appController tests', () => {
@@ -465,103 +464,6 @@ describe('appController tests', () => {
     });
   });
 
-  describe('operator intent event', () => {
-    let publishStub;
-
-    beforeEach(() => {
-      publishStub = sinon.stub(fluxEventBus, 'publish');
-      sinon.stub(appsRuntimeState, 'setOperatorStopped').resolves();
-      sinon.stub(appsRuntimeState, 'requestRestart').resolves();
-      sinon.stub(appReconciler, 'dockerActual').resolves({ reachable: true, exists: true, running: false });
-    });
-
-    const intents = () => publishStub.getCalls()
-      .filter((c) => c.args[0] === 'app:operatorIntent')
-      .map((c) => c.args[1]);
-
-    it('announces a stop, with the mode it was asked for', async () => {
-      verificationHelperStub.resolves(true);
-      sinon.stub(appReconciler, 'applyIntent').callsFake(async (id, mutate) => {
-        await mutate();
-        return true;
-      });
-
-      stubInstalledComponentApp('Component', 'TestApp');
-
-      const req = { params: { appname: 'Component_TestApp' }, query: {} };
-      const res = { json: sinon.fake((param) => param) };
-      await appController.appStop(req, res);
-
-      expect(intents()).to.deep.equal([{
-        identifier: 'Component_TestApp', stopped: true, force: false, restartRequested: false,
-      }]);
-    });
-
-    it('announces a kill as a forced stop and a restart as a start that asked for one', async () => {
-      verificationHelperStub.resolves(true);
-      sinon.stub(appReconciler, 'applyIntent').callsFake(async (id, mutate) => {
-        await mutate();
-        return true;
-      });
-      appReconciler.dockerActual.resolves({ reachable: true, exists: true, running: true });
-
-      stubInstalledComponentApp('Component', 'TestApp');
-      const res = { json: sinon.fake((param) => param) };
-      await appController.appKill({ params: { appname: 'Component_TestApp' }, query: {} }, res);
-      await appController.appRestart({ params: { appname: 'Component_TestApp' }, query: {} }, res);
-
-      expect(intents()).to.deep.equal([
-        {
-          identifier: 'Component_TestApp', stopped: true, force: true, restartRequested: false,
-        },
-        {
-          identifier: 'Component_TestApp', stopped: false, force: false, restartRequested: true,
-        },
-      ]);
-    });
-
-    // The whole point of the event is to be the ordering point, and it can only
-    // be that if it is published while the slot is still held - after the write,
-    // so it never claims an intent that did not persist, and before the pass,
-    // which awaitPass would otherwise put first.
-    it('is published inside the slot, before the pass runs', async () => {
-      verificationHelperStub.resolves(true);
-      let announcedWhileHeld = null;
-      sinon.stub(appReconciler, 'applyIntent').callsFake(async (id, mutate) => {
-        await mutate();
-        announcedWhileHeld = intents().length;
-        return true;
-      });
-
-      stubInstalledComponentApp('Component', 'TestApp');
-
-      const req = { params: { appname: 'Component_TestApp' }, query: {} };
-      const res = { json: sinon.fake((param) => param) };
-      await appController.appStop(req, res);
-
-      expect(announcedWhileHeld, 'the intent must be announced while the slot is still held').to.equal(1);
-    });
-
-    it('says nothing when the intent could not be written', async () => {
-      verificationHelperStub.resolves(true);
-      appsRuntimeState.setOperatorStopped.rejects(new Error('mongo is down'));
-      sinon.stub(appReconciler, 'applyIntent').callsFake(async (id, mutate) => {
-        await mutate();
-        return true;
-      });
-
-      stubInstalledComponentApp('Component', 'TestApp');
-
-      const req = { params: { appname: 'Component_TestApp' }, query: {} };
-      const res = { json: sinon.fake((param) => param) };
-      await appController.appStop(req, res);
-
-      // An announced intent that never persisted is worse than silence: a
-      // consumer would order actuations against a lock that is not there.
-      expect(intents()).to.deep.equal([]);
-      expect(res.json.firstCall.args[0].status).to.equal('error');
-    });
-  });
 
   describe('appRestart tests', () => {
     beforeEach(() => {

--- a/tests/unit/appInstaller.test.js
+++ b/tests/unit/appInstaller.test.js
@@ -1098,7 +1098,6 @@ describe('appInstaller tests', () => {
         lockHeldWhenBroadcasting = globalStateStub.installationInProgress;
         return Promise.resolve();
       });
-      const fluxEventBusStub = { publish: sinon.stub(), subscribe: sinon.stub() };
       const dbHelperStubSuccess = {
         databaseConnection: sinon.stub().returns({ db: () => ({ collection: () => ({}) }) }),
         findInDatabase: sinon.stub().resolves([]),
@@ -1170,7 +1169,6 @@ describe('appInstaller tests', () => {
         '../pgpService': { decryptMessage: sinon.stub().resolves('user:token') },
         '../upnpService': { isUPNP: sinon.stub().returns(false), mapUpnpPort: sinon.stub().resolves(true) },
         '../utils/globalState': globalStateStub,
-        '../utils/fluxEventBus': fluxEventBusStub,
         '../utils/volumeService': { verifyAppVolumeMount: sinon.stub().resolves(), ensureMountPathsExist: sinon.stub().resolves() },
         '../../lib/log': logStub,
         '../utils/appConstants': proxyquire('../../ZelBack/src/services/utils/appConstants', { config: configStub }),

--- a/tests/unit/appSpawner.test.js
+++ b/tests/unit/appSpawner.test.js
@@ -219,9 +219,6 @@ describe('appSpawner tests', () => {
       '../utils/cacheManager': {
         FluxCacheManager: { oneHour: 3600000 },
       },
-      '../utils/fluxEventBus': {
-        publish: sinon.stub(),
-      },
       '../appMessaging/messageStore': {
         storeAppInstallingMessage: opts.withdrawalStub ?? sinon.stub().resolves(true),
         storeAppInstallingErrorMessage: opts.installingErrorStub ?? sinon.stub().resolves(true),

--- a/tests/unit/cloudUIUpdateService.test.js
+++ b/tests/unit/cloudUIUpdateService.test.js
@@ -4,11 +4,13 @@ const proxyquire = require('proxyquire');
 
 const { expect } = chai;
 
+const STUB_API_BASE = 'http://api-base-from-config.invalid';
+
 describe('cloudUIUpdateService tests', () => {
   let cloudUIUpdateService;
   let fsStub;
   let axiosStub;
-  let execStub;
+  let execFileStub;
   let logStub;
 
   beforeEach(() => {
@@ -22,7 +24,7 @@ describe('cloudUIUpdateService tests', () => {
       get: sinon.stub(),
     };
 
-    execStub = sinon.stub();
+    execFileStub = sinon.stub();
 
     logStub = {
       info: sinon.stub(),
@@ -49,7 +51,11 @@ describe('cloudUIUpdateService tests', () => {
       {
         fs: fsStub,
         axios: axiosStub,
-        child_process: { exec: execStub },
+        child_process: { execFile: execFileStub },
+        // Deliberately NOT the production value: asserting against
+        // config.github.apiBaseUrl would pass whether the service read config or kept
+        // the hardcoded https://api.github.com, because they are the same string.
+        config: { github: { apiBaseUrl: STUB_API_BASE } },
         '../lib/log': logStub,
       },
     );
@@ -269,14 +275,19 @@ describe('cloudUIUpdateService tests', () => {
 
       it('should run update script if CloudUI folder does not exist', async () => {
         fsStub.existsSync.returns(false);
-        execStub.callsFake((cmd, opts, callback) => {
+        execFileStub.callsFake((file, args, opts, callback) => {
           callback(null, 'success', '');
         });
 
         await cloudUIUpdateService.checkAndUpdateCloudUI();
 
-        sinon.assert.calledOnce(execStub);
+        sinon.assert.calledOnce(execFileStub);
         sinon.assert.calledWith(logStub.info, 'CloudUI: Folder missing or empty, installing...');
+        // The endpoint comes from config and is passed to the script. A script left to
+        // decide for itself reaches the public internet, which is what this prevents.
+        const [file, args] = execFileStub.firstCall.args;
+        expect(file).to.equal('npm');
+        expect(args).to.eql(['run', 'update:cloudui', '--', STUB_API_BASE]);
       });
 
       it('should run update script if version file does not exist', async () => {
@@ -286,13 +297,13 @@ describe('cloudUIUpdateService tests', () => {
         // Second call for getLocalVersionHash (version file doesn't exist)
         fsStub.existsSync.onCall(1).returns(false);
 
-        execStub.callsFake((cmd, opts, callback) => {
+        execFileStub.callsFake((file, args, opts, callback) => {
           callback(null, 'success', '');
         });
 
         await cloudUIUpdateService.checkAndUpdateCloudUI();
 
-        sinon.assert.calledOnce(execStub);
+        sinon.assert.calledOnce(execFileStub);
         sinon.assert.calledWith(logStub.info, 'CloudUI: No version file found, updating...');
       });
 
@@ -304,7 +315,7 @@ describe('cloudUIUpdateService tests', () => {
 
         await cloudUIUpdateService.checkAndUpdateCloudUI();
 
-        sinon.assert.notCalled(execStub);
+        sinon.assert.notCalled(execFileStub);
         sinon.assert.calledWith(logStub.info, 'CloudUI: Could not fetch remote version info, skipping update check');
       });
 
@@ -330,7 +341,7 @@ describe('cloudUIUpdateService tests', () => {
 
         await cloudUIUpdateService.checkAndUpdateCloudUI();
 
-        sinon.assert.notCalled(execStub);
+        sinon.assert.notCalled(execFileStub);
         sinon.assert.calledWith(logStub.info, 'CloudUI: Already up to date');
       });
 
@@ -356,7 +367,7 @@ describe('cloudUIUpdateService tests', () => {
         };
         axiosStub.get.resolves(mockRelease);
 
-        execStub.callsFake((cmd, opts, callback) => {
+        execFileStub.callsFake((file, args, opts, callback) => {
           // After update, return new hash
           fsStub.readFileSync.returns(remoteHash);
           callback(null, 'Updated successfully', '');
@@ -364,13 +375,13 @@ describe('cloudUIUpdateService tests', () => {
 
         await cloudUIUpdateService.checkAndUpdateCloudUI();
 
-        sinon.assert.calledOnce(execStub);
+        sinon.assert.calledOnce(execFileStub);
         sinon.assert.calledWith(logStub.info, 'CloudUI: New version detected, updating...');
       });
 
       it('should log error if update script fails', async () => {
         fsStub.existsSync.returns(false);
-        execStub.callsFake((cmd, opts, callback) => {
+        execFileStub.callsFake((file, args, opts, callback) => {
           callback(new Error('Script failed'), '', 'error output');
         });
 
@@ -394,8 +405,8 @@ describe('cloudUIUpdateService tests', () => {
             assets: [{ name: 'dist.tar.gz', digest: 'sha256:newhash' }],
           },
         });
-        // exec callback throws error
-        execStub.callsFake((cmd, opts, callback) => {
+        // the spawn itself throws, before any callback
+        execFileStub.callsFake(() => {
           throw new Error('Unexpected exec error');
         });
 
@@ -411,7 +422,7 @@ describe('cloudUIUpdateService tests', () => {
 
         await cloudUIUpdateService.checkAndUpdateCloudUI();
 
-        sinon.assert.notCalled(execStub);
+        sinon.assert.notCalled(execFileStub);
         sinon.assert.notCalled(axiosStub.get);
         sinon.assert.calledWith(logStub.info, 'CloudUI: Running on ArcaneOS, skipping update check (handled by watchdog)');
       });

--- a/tests/unit/fifoQueue.test.js
+++ b/tests/unit/fifoQueue.test.js
@@ -35,6 +35,15 @@ describe('FiFoQueue tests', () => {
 
       expect(queue.worker).to.equal(worker);
     });
+    it('should refuse a second worker rather than silently keeping the first', () => {
+      const worker = () => { };
+      const other = () => { };
+
+      const queue = new fifoQueue.FifoQueue({ worker });
+
+      expect(() => queue.addWorker(other)).to.throw('FifoQueue already has a worker');
+      expect(queue.worker).to.equal(worker);
+    });
     it('should not start work if work is avaiable but no worker present', () => {
       const queue = new fifoQueue.FifoQueue();
       queue.push('hi there');
@@ -120,6 +129,37 @@ describe('FiFoQueue tests', () => {
       expect(error).to.equal(0);
       expect(queue.working).to.equal(false);
       await queue.finished;
+    });
+
+    it('should drop a failed task the caller asked not to retain', async () => {
+      // Retained, the failed task sits at the head of the queue and runs again the
+      // instant anything resumes it - which the apt cache monitor does on every
+      // failure. With retries at 0 there is no delay between those attempts, so the
+      // pair of them spin flat out.
+      const worker = async () => { throw new Error('Simulated task error'); };
+
+      const queue = new fifoQueue.FifoQueue({ worker });
+
+      queue.push({ commandOptions: { command: 'update' }, workerOptions: { retries: 0, retainErrors: false } });
+      await queue.finished;
+
+      expect(queue.length).to.equal(0);
+    });
+
+    it('should name the failed command in the event, not the payload wrapping it', async () => {
+      // A listener asks what failed. For the {commandOptions, workerOptions} shape
+      // the command is a level down, so emitting the payload put it out of reach and
+      // every test against it matched nothing at all.
+      let seen = null;
+      const worker = async () => { throw new Error('Simulated task error'); };
+
+      const queue = new fifoQueue.FifoQueue({ worker });
+      queue.on('failed', (event) => { seen = event.options.command; });
+
+      queue.push({ commandOptions: { command: 'update' }, workerOptions: { retries: 0 } });
+      await queue.finished;
+
+      expect(seen).to.equal('update');
     });
 
     it('should emit error if task is unrecoverable', async () => {

--- a/tests/unit/fifoQueue.test.js
+++ b/tests/unit/fifoQueue.test.js
@@ -162,6 +162,59 @@ describe('FiFoQueue tests', () => {
       expect(seen).to.equal('update');
     });
 
+    it('should put a failed task behind the others so it cannot block them', async () => {
+      // At the front, a task that can never succeed is handed straight back to the
+      // worker on every resume and nothing queued behind it ever runs - one package
+      // apt cannot find stops a node installing any of the others.
+      const ran = [];
+      const worker = async (opts) => {
+        ran.push(opts.command);
+        if (opts.command === 'bad') throw new Error('Simulated task error');
+      };
+
+      const queue = new fifoQueue.FifoQueue({ worker, retryDelay: 0 });
+      // the apt cache monitor resumes on failure, and it is async - so its resume
+      // lands after work() has exited, which is what restarts the queue at all.
+      // It awaits real commands, so the wait here is a macrotask too: awaiting a
+      // microtask instead starves the event loop and this test hangs rather than
+      // failing when the behaviour regresses.
+      queue.on('failed', async () => {
+        await new Promise((r) => { setTimeout(r, 0); });
+        queue.resume();
+      });
+
+      queue.push({ commandOptions: { command: 'bad' }, workerOptions: { retries: 0 } });
+      queue.push({ commandOptions: { command: 'good' }, workerOptions: { retries: 0 } });
+
+      await new Promise((r) => { setTimeout(r, 50); });
+
+      expect(ran).to.include('good');
+    });
+
+    it('should give up on a task that keeps failing, and say so', async () => {
+      // Each resume grants a fresh ladder of retries, so retain-and-resume is
+      // unbounded without a ceiling: the ladder ends, something resumes, it starts
+      // again, once a minute for the life of the process.
+      let abandoned = null;
+      const worker = async () => { throw new Error('Simulated task error'); };
+
+      const queue = new fifoQueue.FifoQueue({ worker, retryDelay: 0, maxRetainCycles: 2 });
+      queue.on('failed', async () => {
+        await new Promise((r) => { setTimeout(r, 0); });
+        queue.resume();
+      });
+      queue.on('abandoned', (event) => { abandoned = event; });
+
+      queue.push({ commandOptions: { command: 'bad' }, workerOptions: { retries: 0 } });
+
+      await new Promise((r) => { setTimeout(r, 50); });
+
+      expect(abandoned).to.not.equal(null);
+      expect(abandoned.options.command).to.equal('bad');
+      expect(abandoned.cycles).to.equal(3);
+      expect(queue.length).to.equal(0);
+    });
+
     it('should emit error if task is unrecoverable', async () => {
       const clock = sinon.useFakeTimers();
 
@@ -249,7 +302,10 @@ describe('FiFoQueue tests', () => {
 
     it('should halt any further tasks if a task errors', async () => {
       const clock = sinon.useFakeTimers();
-      const expectedRemaining = [3, 4, 5, 6, 7, 8, 9];
+      // The failed task goes to the BACK. At the front it is handed straight back
+      // to the worker on the next resume, ahead of everything else, so a task that
+      // cannot succeed is retried forever and nothing behind it ever runs.
+      const expectedRemaining = [4, 5, 6, 7, 8, 9, 3];
 
       let count = 0;
       let error = 0;
@@ -286,7 +342,6 @@ describe('FiFoQueue tests', () => {
 
       expect(queue.halted).to.equal(true);
       expect(queue.workAvailable).to.equal(true);
-      // task gets added back to start of queue
       expect(queue.length).to.equal(7);
 
       expect(count).to.equal(3);

--- a/tests/unit/fifoQueue.test.js
+++ b/tests/unit/fifoQueue.test.js
@@ -191,6 +191,129 @@ describe('FiFoQueue tests', () => {
       expect(ran).to.include('good');
     });
 
+    // The apt cache monitor resumes SYNCHRONOUSLY for a failed apt-get update:
+    // `if (options.command === 'update') { getQueue().resume(); return; }`, with no
+    // await before it, so its resume lands inside the emit. A halt written after
+    // the emit silently undid it - the loop broke out with work still queued and
+    // nothing ever restarted it, because push() only calls work() when the queue
+    // is not already working and working goes false on the way out. One failed
+    // update at boot stranded every apt task behind it for the life of the
+    // process, so syncthing and chrony never installed.
+    it('should keep draining when a listener resumes synchronously from the emit', async () => {
+      const ran = [];
+      const worker = async (opts) => {
+        ran.push(opts.command);
+        if (opts.command === 'update') throw new Error('Could not resolve mirror');
+      };
+
+      const queue = new fifoQueue.FifoQueue({ worker, retryDelay: 0 });
+      queue.on('failed', ({ options }) => {
+        if (options.command === 'update') queue.resume();
+      });
+
+      queue.push({ commandOptions: { command: 'update' }, workerOptions: { retries: 0 } });
+      queue.push({ commandOptions: { command: 'install' }, workerOptions: { retries: 0 } });
+
+      await new Promise((r) => { setTimeout(r, 50); });
+
+      expect(ran, 'the update must actually have failed, or the rest proves nothing').to.include('update');
+      expect(ran, 'the task queued behind a failed update must still run').to.include('install');
+      expect(queue.halted, 'a resumed queue must not be left halted').to.equal(false);
+    });
+
+    // The other half, and the one an operator meets later: push() on a halted queue
+    // appends the task and starts a work loop that exits on its first check.
+    // Nothing reports it - the caller's `wait: true` promise simply never settles.
+    it('should run work pushed after a synchronously-resumed failure', async () => {
+      const ran = [];
+      const worker = async (opts) => {
+        ran.push(opts.command);
+        if (opts.command === 'update') throw new Error('Could not resolve mirror');
+      };
+
+      const queue = new fifoQueue.FifoQueue({ worker, retryDelay: 0 });
+      queue.on('failed', ({ options }) => {
+        if (options.command === 'update') queue.resume();
+      });
+
+      queue.push({ commandOptions: { command: 'update' }, workerOptions: { retries: 0 } });
+      await new Promise((r) => { setTimeout(r, 20); });
+
+      queue.push({ commandOptions: { command: 'install-later' }, workerOptions: { retries: 0 } });
+      await new Promise((r) => { setTimeout(r, 20); });
+
+      expect(ran, 'work pushed after the failure must still run').to.include('install-later');
+    });
+
+    // A resumed final failure has no retries left, so falling through to the retry
+    // sleep waits out the full delay - the production default is 60s - with nothing
+    // to retry, holding every task behind it. retryDelay is deliberately large here
+    // and the assertion window small: with the ladder-over break the next task runs
+    // immediately, without it the queue is inside a 5s sleep and has not reached it.
+    it('should not sleep out the retry delay after a resumed final failure', async () => {
+      const ran = [];
+      const worker = async (opts) => {
+        ran.push(opts.command);
+        if (opts.command === 'update') throw new Error('Could not resolve mirror');
+      };
+
+      const queue = new fifoQueue.FifoQueue({ worker, retryDelay: 5000 });
+      queue.on('failed', ({ options }) => {
+        if (options.command === 'update') queue.resume();
+      });
+
+      queue.push({ commandOptions: { command: 'update' }, workerOptions: { retries: 0 } });
+      queue.push({ commandOptions: { command: 'install' }, workerOptions: { retries: 0 } });
+
+      await new Promise((r) => { setTimeout(r, 50); });
+
+      expect(ran, 'the update must have failed first').to.include('update');
+      expect(ran, 'the queue must carry on rather than sleep out a delay it has no retries for').to.include('install');
+    });
+
+    // resume() from inside the loop used to overwrite `finished` with work()'s
+    // already-resolved promise, so clear() - which awaits it to know the queue is
+    // idle, and which systemService calls on the apt-is-broken path these very
+    // failures reach - could wipe the list while a worker was still in flight.
+    it('should not report itself idle to clear() while a worker is still running', async () => {
+      let releaseWorker;
+      const held = new Promise((r) => { releaseWorker = r; });
+      let secondEntered = false;
+
+      const worker = async (opts) => {
+        if (opts.command === 'update') throw new Error('Could not resolve mirror');
+        secondEntered = true;
+        await held; // still in flight while clear() runs
+      };
+
+      const queue = new fifoQueue.FifoQueue({ worker, retryDelay: 0 });
+      queue.on('failed', ({ options }) => {
+        if (options.command === 'update') queue.resume();
+      });
+
+      queue.push({ commandOptions: { command: 'update' }, workerOptions: { retries: 0 } });
+      queue.push({ commandOptions: { command: 'slow' }, workerOptions: { retries: 0 } });
+      await new Promise((r) => { setTimeout(r, 20); });
+
+      expect(secondEntered, 'the second task must be in flight, or this tests nothing').to.equal(true);
+
+      // clear() awaits `finished` to know the queue is idle before wiping the list.
+      // A re-entrant resume that replaced `finished` with work()'s already-resolved
+      // promise makes that await return at once, so clear() empties the queue under
+      // a running worker - and systemService calls clear() on the apt-is-broken
+      // path these very failures reach.
+      const cleared = queue.clear().then(() => 'cleared');
+      const outcome = await Promise.race([
+        cleared,
+        new Promise((r) => { setTimeout(() => r('still-working'), 30); }),
+      ]);
+
+      expect(outcome, 'clear() must not report the queue idle while a worker is in flight').to.equal('still-working');
+
+      releaseWorker();
+      await cleared;
+    });
+
     it('should give up on a task that keeps failing, and say so', async () => {
       // Each resume grants a fresh ladder of retries, so retain-and-resume is
       // unbounded without a ceiling: the ladder ends, something resumes, it starts

--- a/tests/unit/fileOperationRecovery.test.js
+++ b/tests/unit/fileOperationRecovery.test.js
@@ -12,7 +12,6 @@ describe('fileOperationRecovery tests', () => {
   let executorStub;
   let deviceHelperStub;
   let logStub;
-  let fluxEventBusStub;
   let recovery;
 
   const mount = (target) => ({
@@ -25,7 +24,6 @@ describe('fileOperationRecovery tests', () => {
       sweepStagingDirectories: sinon.stub().resolves({ removed: [] }),
     };
     deviceHelperStub = { listMountedFilesystems: sinon.stub().resolves([]) };
-    fluxEventBusStub = { publish: sinon.stub() };
     logStub = {
       info: sinon.stub(), warn: sinon.stub(), error: sinon.stub(), debug: sinon.stub(),
     };
@@ -46,7 +44,6 @@ describe('fileOperationRecovery tests', () => {
       './volumeSession': volumeSession,
       '../../lib/log': logStub,
       '../utils/appConstants': { appsFolder: APPS_FOLDER },
-      '../utils/fluxEventBus': fluxEventBusStub,
     });
   });
 
@@ -152,56 +149,7 @@ describe('fileOperationRecovery tests', () => {
     expect(executorStub.reapOrphanedContainers.calledBefore(executorStub.sweepStagingDirectories)).to.equal(true);
   });
 
-  it('announces the pass with what it did', async () => {
-    deviceHelperStub.listMountedFilesystems.resolves([mount(`${APPS_FOLDER}fluxcomp_one`)]);
-    executorStub.reapOrphanedContainers.resolves(2);
-    executorStub.sweepStagingDirectories.resolves({ removed: ['a'] });
 
-    await recovery.recoverInterruptedFileOperations();
 
-    expect(fluxEventBusStub.publish.calledOnceWithExactly('fileops:recovered', {
-      containers: 2, removed: 1,
-    })).to.equal(true);
-  });
 
-  it('announces a pass that found nothing, which the log line cannot', async () => {
-    // The log only speaks when there was something to report, so silence there means
-    // either "swept, nothing to do" or "has not run yet". A restart waiting to know the
-    // pass is over cannot tell those apart, and guessing means the sweep lands in
-    // somebody else's test.
-    deviceHelperStub.listMountedFilesystems.resolves([mount(`${APPS_FOLDER}fluxcomp_one`)]);
-
-    await recovery.recoverInterruptedFileOperations();
-
-    expect(logStub.info.called).to.equal(false);
-    expect(fluxEventBusStub.publish.calledOnceWithExactly('fileops:recovered', {
-      containers: 0, removed: 0,
-    })).to.equal(true);
-  });
-
-  it('announces the pass even when the mount table could not be read', async () => {
-    // This path returns early. A waiter must not be left hanging on a pass that gave up.
-    deviceHelperStub.listMountedFilesystems.rejects(new Error('no mount table'));
-
-    await recovery.recoverInterruptedFileOperations();
-
-    expect(fluxEventBusStub.publish.calledOnce).to.equal(true);
-    expect(fluxEventBusStub.publish.firstCall.args[0]).to.equal('fileops:recovered');
-  });
-
-  it('announces the pass even when the container reap throws', async () => {
-    // The reap is the sweep's first step, and it is the one step whose throw
-    // skipped the publish entirely - a waiter then burns its whole timeout
-    // instead of being told. The throw itself still propagates: a startup that
-    // throws is retried, and the retry publishes again, which is safe.
-    executorStub.reapOrphanedContainers.rejects(new Error('docker not answering'));
-
-    let thrown = null;
-    await recovery.recoverInterruptedFileOperations().catch((error) => { thrown = error; });
-
-    expect(thrown, 'the startup retry contract keeps the throw').to.not.equal(null);
-    expect(fluxEventBusStub.publish.calledOnceWithExactly('fileops:recovered', {
-      containers: 0, removed: 0,
-    })).to.equal(true);
-  });
 });

--- a/tests/unit/fileOperationRecovery.test.js
+++ b/tests/unit/fileOperationRecovery.test.js
@@ -12,6 +12,7 @@ describe('fileOperationRecovery tests', () => {
   let executorStub;
   let deviceHelperStub;
   let logStub;
+  let fluxEventBusStub;
   let recovery;
 
   const mount = (target) => ({
@@ -24,6 +25,7 @@ describe('fileOperationRecovery tests', () => {
       sweepStagingDirectories: sinon.stub().resolves({ removed: [] }),
     };
     deviceHelperStub = { listMountedFilesystems: sinon.stub().resolves([]) };
+    fluxEventBusStub = { publish: sinon.stub() };
     logStub = {
       info: sinon.stub(), warn: sinon.stub(), error: sinon.stub(), debug: sinon.stub(),
     };
@@ -44,6 +46,7 @@ describe('fileOperationRecovery tests', () => {
       './volumeSession': volumeSession,
       '../../lib/log': logStub,
       '../utils/appConstants': { appsFolder: APPS_FOLDER },
+      '../utils/fluxEventBus': fluxEventBusStub,
     });
   });
 
@@ -147,5 +150,42 @@ describe('fileOperationRecovery tests', () => {
     await recovery.recoverInterruptedFileOperations();
 
     expect(executorStub.reapOrphanedContainers.calledBefore(executorStub.sweepStagingDirectories)).to.equal(true);
+  });
+
+  it('announces the pass with what it did', async () => {
+    deviceHelperStub.listMountedFilesystems.resolves([mount(`${APPS_FOLDER}fluxcomp_one`)]);
+    executorStub.reapOrphanedContainers.resolves(2);
+    executorStub.sweepStagingDirectories.resolves({ removed: ['a'], restored: ['b'] });
+
+    await recovery.recoverInterruptedFileOperations();
+
+    expect(fluxEventBusStub.publish.calledOnceWithExactly('fileops:recovered', {
+      containers: 2, removed: 1, restored: 1,
+    })).to.equal(true);
+  });
+
+  it('announces a pass that found nothing, which the log line cannot', async () => {
+    // The log only speaks when there was something to report, so silence there means
+    // either "swept, nothing to do" or "has not run yet". A restart waiting to know the
+    // pass is over cannot tell those apart, and guessing means the sweep lands in
+    // somebody else's test.
+    deviceHelperStub.listMountedFilesystems.resolves([mount(`${APPS_FOLDER}fluxcomp_one`)]);
+
+    await recovery.recoverInterruptedFileOperations();
+
+    expect(logStub.info.called).to.equal(false);
+    expect(fluxEventBusStub.publish.calledOnceWithExactly('fileops:recovered', {
+      containers: 0, removed: 0, restored: 0,
+    })).to.equal(true);
+  });
+
+  it('announces the pass even when the mount table could not be read', async () => {
+    // This path returns early. A waiter must not be left hanging on a pass that gave up.
+    deviceHelperStub.listMountedFilesystems.rejects(new Error('no mount table'));
+
+    await recovery.recoverInterruptedFileOperations();
+
+    expect(fluxEventBusStub.publish.calledOnce).to.equal(true);
+    expect(fluxEventBusStub.publish.firstCall.args[0]).to.equal('fileops:recovered');
   });
 });

--- a/tests/unit/fileOperationRecovery.test.js
+++ b/tests/unit/fileOperationRecovery.test.js
@@ -188,4 +188,20 @@ describe('fileOperationRecovery tests', () => {
     expect(fluxEventBusStub.publish.calledOnce).to.equal(true);
     expect(fluxEventBusStub.publish.firstCall.args[0]).to.equal('fileops:recovered');
   });
+
+  it('announces the pass even when the container reap throws', async () => {
+    // The reap is the sweep's first step, and it is the one step whose throw
+    // skipped the publish entirely - a waiter then burns its whole timeout
+    // instead of being told. The throw itself still propagates: a startup that
+    // throws is retried, and the retry publishes again, which is safe.
+    executorStub.reapOrphanedContainers.rejects(new Error('docker not answering'));
+
+    let thrown = null;
+    await recovery.recoverInterruptedFileOperations().catch((error) => { thrown = error; });
+
+    expect(thrown, 'the startup retry contract keeps the throw').to.not.equal(null);
+    expect(fluxEventBusStub.publish.calledOnceWithExactly('fileops:recovered', {
+      containers: 0, removed: 0,
+    })).to.equal(true);
+  });
 });

--- a/tests/unit/fileOperationRecovery.test.js
+++ b/tests/unit/fileOperationRecovery.test.js
@@ -155,12 +155,12 @@ describe('fileOperationRecovery tests', () => {
   it('announces the pass with what it did', async () => {
     deviceHelperStub.listMountedFilesystems.resolves([mount(`${APPS_FOLDER}fluxcomp_one`)]);
     executorStub.reapOrphanedContainers.resolves(2);
-    executorStub.sweepStagingDirectories.resolves({ removed: ['a'], restored: ['b'] });
+    executorStub.sweepStagingDirectories.resolves({ removed: ['a'] });
 
     await recovery.recoverInterruptedFileOperations();
 
     expect(fluxEventBusStub.publish.calledOnceWithExactly('fileops:recovered', {
-      containers: 2, removed: 1, restored: 1,
+      containers: 2, removed: 1,
     })).to.equal(true);
   });
 
@@ -175,7 +175,7 @@ describe('fileOperationRecovery tests', () => {
 
     expect(logStub.info.called).to.equal(false);
     expect(fluxEventBusStub.publish.calledOnceWithExactly('fileops:recovered', {
-      containers: 0, removed: 0, restored: 0,
+      containers: 0, removed: 0,
     })).to.equal(true);
   });
 

--- a/tests/unit/fluxCommunication.test.js
+++ b/tests/unit/fluxCommunication.test.js
@@ -14,7 +14,6 @@ const fluxCommunicationUtils = require('../../ZelBack/src/services/fluxCommunica
 const daemonServiceMiscRpcs = require('../../ZelBack/src/services/daemonService/daemonServiceMiscRpcs');
 const nodeConfirmationService = require('../../ZelBack/src/services/nodeConfirmationService');
 const messageStore = require('../../ZelBack/src/services/appMessaging/messageStore');
-const fluxEventBus = require('../../ZelBack/src/services/utils/fluxEventBus');
 const generalService = require('../../ZelBack/src/services/generalService');
 const serviceHelper = require('../../ZelBack/src/services/serviceHelper');
 const networkStateService = require('../../ZelBack/src/services/networkStateService');
@@ -436,68 +435,6 @@ describe('fluxCommunication tests', () => {
     }).timeout(5000);
   });
 
-  describe('handleAppInstallingMessage tests', () => {
-    let publishSpy;
-
-    before(requireMongo);
-
-    beforeEach(async () => {
-      peerManager.reset();
-      await dbHelper.initiateDB();
-      publishSpy = sinon.stub(fluxEventBus, 'publish');
-      sinon.stub(messageStore, 'storeSignedAppInstallingBroadcast');
-      sinon.stub(daemonServiceMiscRpcs, 'isDaemonSynced').returns({ data: { synced: true, height: 0 } });
-    });
-
-    afterEach(() => {
-      sinon.restore();
-    });
-
-    const installingMessage = (version, extra = {}) => ({
-      data: {
-        type: 'fluxappinstalling',
-        version,
-        name: 'myApp',
-        ip: '127.0.0.5',
-        broadcastedAt: Date.now(),
-        ...extra,
-      },
-      timestamp: Date.now(),
-    });
-
-    it('announces a claim as not withdrawn', async () => {
-      sinon.stub(messageStore, 'storeAppInstallingMessage').resolves(true);
-
-      await fluxCommunication.handleAppInstallingMessage(installingMessage(1), '127.0.0.5', '16127');
-
-      sinon.assert.calledWith(publishSpy, 'network:appinstalling', {
-        ip: '127.0.0.5', name: 'myApp', withdrawn: false,
-      });
-    });
-
-    it('announces a withdrawal as withdrawn', async () => {
-      // A version 2 message gives the claim up, and arrives through this same
-      // handler - so a consumer that cannot tell them apart reads a node
-      // standing aside as a node taking the app on.
-      sinon.stub(messageStore, 'storeAppInstallingMessage').resolves(true);
-
-      await fluxCommunication.handleAppInstallingMessage(
-        installingMessage(2, { withdrawn: true }), '127.0.0.5', '16127',
-      );
-
-      sinon.assert.calledWith(publishSpy, 'network:appinstalling', {
-        ip: '127.0.0.5', name: 'myApp', withdrawn: true,
-      });
-    });
-
-    it('announces nothing when the message was not stored', async () => {
-      sinon.stub(messageStore, 'storeAppInstallingMessage').resolves(false);
-
-      await fluxCommunication.handleAppInstallingMessage(installingMessage(1), '127.0.0.5', '16127');
-
-      sinon.assert.neverCalledWith(publishSpy, 'network:appinstalling');
-    });
-  });
 
   describe('connectedPeers tests', () => {
     const generateResponse = () => {

--- a/tests/unit/geolocationService.test.js
+++ b/tests/unit/geolocationService.test.js
@@ -79,7 +79,9 @@ describe('geolocationService tests', () => {
       },
       geolocation: {
         ipApiBaseUrl: 'http://ip-api.com',
-        statsApiBaseUrl: 'https://stats.runonflux.io',
+      },
+      stats: {
+        baseUrl: 'https://stats.runonflux.io',
       },
     };
 

--- a/tests/unit/globalconfig/default.js
+++ b/tests/unit/globalconfig/default.js
@@ -390,6 +390,8 @@ module.exports = {
     stallNudgeMaxIntervalMs: 900000,
     stallRemoveMinWindowMs: 1200000,
     stallRemoveMinNudges: 3,
+    aptSourceUrl: 'https://apt.syncthing.net/',
+    releaseKeyUrl: 'https://syncthing.net/release-key.gpg',
   },
   cpuBurst: {
     enabled: true,
@@ -408,6 +410,15 @@ module.exports = {
   },
   geolocation: {
     ipApiBaseUrl: 'http://ip-api.com',
-    statsApiBaseUrl: 'https://stats.runonflux.io',
+  },
+  stats: {
+    baseUrl: 'https://stats.runonflux.io',
+  },
+  pricing: {
+    fluxRatesBaseUrl: 'https://viprates.runonflux.io',
+    coingeckoBaseUrl: 'https://api.coingecko.com',
+  },
+  mongodb: {
+    signingKeyBaseUrl: 'https://pgp.mongodb.com',
   },
 };

--- a/tests/unit/syncthingEventsConsumer.test.js
+++ b/tests/unit/syncthingEventsConsumer.test.js
@@ -21,13 +21,8 @@ const syncthingServiceMock = {
   getEvents: sinon.stub(),
 };
 
-const fluxEventBusMock = {
-  publish: sinon.stub(),
-};
-
 const consumer = proxyquire('../../ZelBack/src/services/appMonitoring/syncthingEventsConsumer', {
   '../syncthingService': syncthingServiceMock,
-  '../utils/fluxEventBus': fluxEventBusMock,
 });
 
 // park the long-poll until the request is aborted (a real long-poll holds until
@@ -66,7 +61,6 @@ describe('syncthingEventsConsumer tests', () => {
     // inter-poll waits are cancellable controller.sleep calls - stub instant so
     // the suite never waits out pacing/backoff in real time
     sleepStub = sinon.stub(FluxController.prototype, 'sleep').resolves();
-    fluxEventBusMock.publish.reset();
     onFolderActivity = sinon.stub();
     onResync = sinon.stub();
   });
@@ -132,7 +126,6 @@ describe('syncthingEventsConsumer tests', () => {
     await new Promise((resolve) => { setImmediate(() => { setImmediate(() => { setImmediate(resolve); }); }); });
 
     sinon.assert.calledOnce(onResync);
-    sinon.assert.calledWith(fluxEventBusMock.publish, 'syncthing:eventsResync', sinon.match.object);
     // since continues from the new stream's last id
     const thirdCallQuery = syncthingServiceMock.getEvents.thirdCall.args[0].query;
     expect(thirdCallQuery.since).to.equal(1);
@@ -176,7 +169,6 @@ describe('syncthingEventsConsumer tests', () => {
     expect(recoveryQuery.since).to.equal(0);
     // exactly one resync, announced once the stream is healthy again
     sinon.assert.calledOnce(onResync);
-    sinon.assert.calledOnceWithExactly(fluxEventBusMock.publish, 'syncthing:eventsResync', sinon.match.object);
   });
 
   it('retries with a backoff delay when the events endpoint fails (degrades to the poll, never breaks)', async () => {
@@ -205,7 +197,6 @@ describe('syncthingEventsConsumer tests', () => {
 
     const record = consumer.getFolderErrors('fluxcomp_app1');
     expect(record.errors).to.deep.equal(errors);
-    sinon.assert.calledWith(fluxEventBusMock.publish, 'syncthing:folderErrors', sinon.match({ folder: 'fluxcomp_app1' }));
   });
 
   it('paces itself when the events endpoint returns empty instantly (never hot-loops)', async () => {

--- a/tests/unit/systemService.test.js
+++ b/tests/unit/systemService.test.js
@@ -13,6 +13,7 @@ const serviceHelper = require('../../ZelBack/src/services/serviceHelper');
 
 const systemService = require('../../ZelBack/src/services/systemService');
 const daemonServiceUtils = require('../../ZelBack/src/services/daemonService/daemonServiceUtils');
+const fluxEventBus = require('../../ZelBack/src/services/utils/fluxEventBus');
 
 describe('system Services tests', () => {
   describe('get last cache time update tests', () => {
@@ -935,6 +936,105 @@ describe('system Services tests', () => {
       expect(payload.commandOptions.command).to.equal('update');
       expect(payload.workerOptions.retries).to.equal(0);
       expect(payload.workerOptions.retainErrors).to.equal(false);
+    });
+  });
+
+  describe('monitorSystem tests', () => {
+    let runCmdStub;
+    let publishStub;
+    let installed;
+
+    // dpkg-query and apt-get, standing in for the package database. Stateful,
+    // because the outcome monitorSystem reports is the difference between what
+    // was there before a check and what is there after it - a fake that always
+    // answers the same thing cannot express an install having happened.
+    function fakeSystem(present) {
+      installed = { ...present };
+
+      runCmdStub.callsFake(async (command, options = {}) => {
+        const params = options.params || [];
+
+        if (command === 'dpkg-query') {
+          const systemPackage = params[params.length - 1];
+          const version = installed[systemPackage];
+          return version
+            ? { error: null, stdout: `'${version}|install ok installed'` }
+            : { error: new Error('no packages found'), stdout: '' };
+        }
+
+        // aptRunner shells out through `env` so DEBIAN_FRONTEND survives sudo.
+        if (command === 'env' && params.includes('install')) {
+          installed[params[params.length - 1]] = '9.9.9';
+          return { error: null, stdout: '' };
+        }
+
+        // systemd-timesyncd: an error means not active, which is what a node
+        // already running chrony looks like.
+        if (command === 'systemctl') return { error: new Error('inactive'), stdout: '' };
+
+        return { error: null, stdout: '' };
+      });
+    }
+
+    beforeEach(() => {
+      systemService.resetTimers();
+      runCmdStub = sinon.stub(serviceHelper, 'runCommand');
+      publishStub = sinon.stub(fluxEventBus, 'publish');
+      // the syncthing apt source already exists, so addSyncthingRepository returns
+      // before it would fetch a keyring
+      sinon.stub(fs, 'stat').resolves(true);
+      sinon.stub(axios, 'get').resolves({ data: { status: 'success', data: {} } });
+      sinon.stub(log, 'info');
+      sinon.stub(log, 'error');
+      sinon.stub(log, 'warn');
+    });
+
+    afterEach(async () => {
+      // Only the queue's contents: the worker and the 'failed' listener belong to
+      // the queue for its lifetime now, so there is nothing here to put back.
+      await systemService.getQueue().clear();
+      sinon.restore();
+    });
+
+    it('reports an empty install list on a node that already has everything', async () => {
+      fakeSystem({
+        'ca-certificates': '20260601',
+        'netcat-openbsd': '1.234',
+        syncthing: '2.1.3',
+        chrony: '4.8',
+      });
+
+      await systemService.monitorSystem();
+
+      sinon.assert.calledOnceWithExactly(publishStub, 'system:packages-checked', { installed: [] });
+    });
+
+    it('names what it installed on a node that has nothing', async () => {
+      fakeSystem({});
+
+      await systemService.monitorSystem();
+
+      sinon.assert.calledOnce(publishStub);
+      const [event, payload] = publishStub.firstCall.args;
+      expect(event).to.equal('system:packages-checked');
+      expect(payload.installed).to.have.members([
+        'ca-certificates', 'netcat-openbsd', 'syncthing', 'chrony',
+      ]);
+    });
+
+    it('publishes even when a check throws, so a waiter fails rather than hangs', async () => {
+      fakeSystem({
+        'ca-certificates': '20260601',
+        'netcat-openbsd': '1.234',
+        syncthing: '2.1.3',
+        chrony: '4.8',
+      });
+      axios.get.rejects(new Error('stats unreachable'));
+
+      await systemService.monitorSystem();
+
+      sinon.assert.calledOnce(publishStub);
+      expect(publishStub.firstCall.args[0]).to.equal('system:packages-checked');
     });
   });
 

--- a/tests/unit/systemService.test.js
+++ b/tests/unit/systemService.test.js
@@ -337,6 +337,42 @@ describe('system Services tests', () => {
       sinon.assert.calledWithExactly(runCmdStub, 'env', { runAsRoot: true, params: ['DEBIAN_FRONTEND=noninteractive', 'apt-get', '-y', '--no-install-recommends', '-o', 'DPkg::Lock::Timeout=180', '-o', 'Dpkg::Options::=--force-confdef', '-o', 'Dpkg::Options::=--force-confold', 'install', 'syncthing'] });
     });
 
+    it('creates the missing apt source before the sources update can give up', async () => {
+      // The node this exists for: syncthing 1.x installed and no
+      // /etc/apt/sources.list.d/syncthing.list at all - a key fetch failed in
+      // some earlier pass, or syncthing came from Ubuntu's archive. The
+      // sources rewrite cannot read a file that does not exist, and its
+      // failure must not stand between this node and the file being created:
+      // that ordering leaves the node warning once a day, forever.
+      const now = 1713858779721;
+      const statsVersion = '2.2.2';
+
+      sinon.stub(axios, 'get').callsFake(async (url) => {
+        if (url.includes('stats.runonflux.io')) {
+          return { data: { status: 'success', data: { syncthing: statsVersion } } };
+        }
+        return { data: Buffer.from('fake-keyring') };
+      });
+
+      const cmdRunner = sinon.fake((cmd) => {
+        if (cmd === 'dpkg-query') return { error: null, stdout: "'1.19.2|install ok installed'" };
+        if (cmd === 'cat') return { error: null, stdout: '' };
+        return { error: null, stdout: '' };
+      });
+      runCmdStub.callsFake(cmdRunner);
+
+      statStub.withArgs('/etc/apt/sources.list.d/syncthing.list').rejects(new Error('ENOENT'));
+      statStub.resolves({ mtimeMs: now });
+      sinon.stub(fs, 'access').resolves();
+      const writeFileStub = sinon.stub(fs, 'writeFile').resolves();
+
+      sinon.useFakeTimers({ now });
+
+      await systemService.monitorSyncthingPackage();
+
+      sinon.assert.calledWith(writeFileStub, '/etc/apt/sources.list.d/syncthing.list', sinon.match('stable-v2'));
+    });
+
     it('should not call upgradeSyncthing if on correct version', async () => {
       const now = 1713858779721;
 

--- a/tests/unit/systemService.test.js
+++ b/tests/unit/systemService.test.js
@@ -14,7 +14,6 @@ const serviceHelper = require('../../ZelBack/src/services/serviceHelper');
 
 const systemService = require('../../ZelBack/src/services/systemService');
 const daemonServiceUtils = require('../../ZelBack/src/services/daemonService/daemonServiceUtils');
-const fluxEventBus = require('../../ZelBack/src/services/utils/fluxEventBus');
 
 describe('system Services tests', () => {
   describe('apt queue construction', () => {
@@ -1048,111 +1047,6 @@ describe('system Services tests', () => {
       expect(payload.commandOptions.command).to.equal('update');
       expect(payload.workerOptions.retries).to.equal(0);
       expect(payload.workerOptions.retainErrors).to.equal(false);
-    });
-  });
-
-  describe('monitorSystem tests', () => {
-    let runCmdStub;
-    let publishStub;
-    let installed;
-
-    // dpkg-query and apt-get, standing in for the package database. Stateful,
-    // because the outcome monitorSystem reports is the difference between what
-    // was there before a check and what is there after it - a fake that always
-    // answers the same thing cannot express an install having happened.
-    function fakeSystem(present) {
-      installed = { ...present };
-
-      runCmdStub.callsFake(async (command, options = {}) => {
-        const params = options.params || [];
-
-        if (command === 'dpkg-query') {
-          const systemPackage = params[params.length - 1];
-          const version = installed[systemPackage];
-          return version
-            ? { error: null, stdout: `'${version}|install ok installed'` }
-            : { error: new Error('no packages found'), stdout: '' };
-        }
-
-        // aptRunner shells out through `env` so DEBIAN_FRONTEND survives sudo.
-        if (command === 'env' && params.includes('install')) {
-          installed[params[params.length - 1]] = '9.9.9';
-          return { error: null, stdout: '' };
-        }
-
-        // systemd-timesyncd: an error means not active, which is what a node
-        // already running chrony looks like.
-        if (command === 'systemctl') return { error: new Error('inactive'), stdout: '' };
-
-        return { error: null, stdout: '' };
-      });
-    }
-
-    beforeEach(() => {
-      systemService.resetTimers();
-      runCmdStub = sinon.stub(serviceHelper, 'runCommand');
-      publishStub = sinon.stub(fluxEventBus, 'publish');
-      // the syncthing apt source already exists, so addSyncthingRepository returns
-      // before it would fetch a keyring
-      sinon.stub(fs, 'stat').resolves(true);
-      sinon.stub(axios, 'get').resolves({ data: { status: 'success', data: {} } });
-      sinon.stub(log, 'info');
-      sinon.stub(log, 'error');
-      sinon.stub(log, 'warn');
-    });
-
-    afterEach(async () => {
-      // Only the queue's contents: the worker and the 'failed' listener belong to
-      // the queue for its lifetime now, so there is nothing here to put back.
-      await systemService.getQueue().clear();
-      sinon.restore();
-    });
-
-    it('reports an empty install list on a node that already has everything', async () => {
-      fakeSystem({
-        'ca-certificates': '20260601',
-        'netcat-openbsd': '1.234',
-        syncthing: '2.1.3',
-        chrony: '4.8',
-      });
-
-      await systemService.monitorSystem();
-
-      sinon.assert.calledOnceWithExactly(publishStub, 'system:packages-checked', { installed: [] });
-    });
-
-    it('names what it installed on a node that has nothing', async () => {
-      fakeSystem({});
-
-      await systemService.monitorSystem();
-
-      sinon.assert.calledOnce(publishStub);
-      const [event, payload] = publishStub.firstCall.args;
-      expect(event).to.equal('system:packages-checked');
-      expect(payload.installed).to.have.members([
-        'ca-certificates', 'netcat-openbsd', 'syncthing', 'chrony',
-      ]);
-    });
-
-    it('publishes even when a check throws, so a waiter fails rather than hangs', async () => {
-      // The rejection has to land somewhere the code does not already catch.
-      // monitorSyncthingPackage's own axios call carries a .catch(), so failing
-      // that one leaves nothing to throw and the test passes without reaching
-      // the path it is named for.
-      fakeSystem({
-        'ca-certificates': '20260601',
-        'netcat-openbsd': '1.234',
-        syncthing: '2.1.3',
-        chrony: '4.8',
-      });
-      runCmdStub.rejects(new Error('dpkg-query unavailable'));
-
-      await systemService.monitorSystem();
-
-      sinon.assert.calledOnce(publishStub);
-      expect(publishStub.firstCall.args[0]).to.equal('system:packages-checked');
-      // and it says nothing was installed, rather than reporting a stale set
-      expect(publishStub.firstCall.args[1]).to.deep.equal({ installed: [] });
     });
   });
 

--- a/tests/unit/systemService.test.js
+++ b/tests/unit/systemService.test.js
@@ -1,5 +1,6 @@
 const chai = require('chai');
 const sinon = require('sinon');
+const proxyquire = require('proxyquire').noCallThru();
 
 const { expect } = chai;
 
@@ -16,6 +17,44 @@ const daemonServiceUtils = require('../../ZelBack/src/services/daemonService/dae
 const fluxEventBus = require('../../ZelBack/src/services/utils/fluxEventBus');
 
 describe('system Services tests', () => {
+  describe('apt queue construction', () => {
+    // The queue is built COMPLETE and LATE. Complete because one that arrives
+    // without its worker silently accepts work it cannot run; late because
+    // importing a module should not start anything - an Arcane node never queues
+    // apt work, and a test or script reaching in for one unrelated function
+    // should not acquire a worker it never asked for.
+    function loadWithSpy() {
+      const instance = {
+        on: sinon.stub(), push: sinon.stub(), resume: sinon.stub(), clear: sinon.stub(),
+      };
+      const FifoQueue = sinon.stub().returns(instance);
+      const service = proxyquire('../../ZelBack/src/services/systemService', {
+        './utils/fifoQueue': { FifoQueue },
+      });
+      return { service, FifoQueue, instance };
+    }
+
+    it('builds nothing merely because the module was imported', () => {
+      const { FifoQueue } = loadWithSpy();
+
+      sinon.assert.notCalled(FifoQueue);
+    });
+
+    it('builds it complete on first use, and only once', () => {
+      const { service, FifoQueue, instance } = loadWithSpy();
+
+      const first = service.getQueue();
+      const second = service.getQueue();
+
+      sinon.assert.calledOnce(FifoQueue);
+      expect(first).to.equal(second);
+      // the worker arrives WITH it, never bolted on afterwards
+      expect(FifoQueue.firstCall.args[0].worker).to.be.a('function');
+      sinon.assert.calledWith(instance.on, 'failed');
+      sinon.assert.calledWith(instance.on, 'abandoned');
+    });
+  });
+
   describe('get last cache time update tests', () => {
     let statStub;
     let stubFake;

--- a/tests/unit/systemService.test.js
+++ b/tests/unit/systemService.test.js
@@ -54,6 +54,55 @@ describe('system Services tests', () => {
     });
   });
 
+  // The branch that installs a package the system does not have at all. Its
+  // return value IS the contract - upgradePackage answers whether the install
+  // FAILED, and this branch used to discard that and report the install either
+  // way, so an apt-get that could not find the package read back the same as one
+  // that installed it. The queue is stubbed rather than driven: a real failure
+  // walks five retries a minute apart, which is not what is under test here.
+  describe('ensurePackageVersion tests', () => {
+    function loadWithInstallResult(installError) {
+      const instance = {
+        on: sinon.stub(), push: sinon.stub(), resume: sinon.stub(), clear: sinon.stub(),
+      };
+      instance.push
+        .withArgs(sinon.match({ commandOptions: sinon.match({ command: 'install' }) }), true)
+        .resolves({ error: installError });
+      instance.push.resolves({ error: null });
+      const FifoQueue = sinon.stub().returns(instance);
+      return proxyquire('../../ZelBack/src/services/systemService', {
+        './utils/fifoQueue': { FifoQueue },
+      });
+    }
+
+    beforeEach(() => {
+      // dpkg-query answers empty, so the package is absent and the install runs
+      sinon.stub(serviceHelper, 'runCommand').resolves({ error: null, stdout: '' });
+      sinon.stub(log, 'info');
+      sinon.stub(log, 'error');
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('reports an install apt could not perform as not installed', async () => {
+      const service = loadWithInstallResult(new Error('E: Unable to locate package netcat-openbsd'));
+
+      const installed = await service.ensurePackageVersion('netcat-openbsd', '1.187');
+
+      expect(installed).to.equal(false);
+    });
+
+    it('reports an install that succeeded as installed', async () => {
+      const service = loadWithInstallResult(null);
+
+      const installed = await service.ensurePackageVersion('netcat-openbsd', '1.187');
+
+      expect(installed).to.equal(true);
+    });
+  });
+
   describe('get last cache time update tests', () => {
     let statStub;
     let stubFake;

--- a/tests/unit/systemService.test.js
+++ b/tests/unit/systemService.test.js
@@ -71,7 +71,6 @@ describe('system Services tests', () => {
   describe('updateAptCache tests', () => {
     let statStub;
     let runCmdStub;
-    systemService.getQueue().addWorker(systemService.aptRunner);
 
     beforeEach(() => {
       statStub = sinon.stub(fs, 'stat');
@@ -913,6 +912,29 @@ describe('system Services tests', () => {
 
       expect(result).to.equal(true);
       sinon.assert.calledOnceWithExactly(writeStub, '/home/testuser/.flux/.zmqEnabled', '');
+    });
+  });
+
+  describe('queueAptGetCommand option forwarding tests', () => {
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('forwards every worker option the caller set, not just retries', async () => {
+      // updateAptCache asks for retainErrors: false precisely so a failed update is
+      // dropped instead of left at the head of the queue. Dropped here, the queue
+      // kept it, and the apt cache monitor's resume() ran it again immediately -
+      // with retries at 0 there is no delay, so the two of them span flat out.
+      sinon.stub(fs, 'stat').resolves({ mtimeMs: 0 });
+      const pushStub = sinon.stub(systemService.getQueue(), 'push').resolves({ error: null });
+
+      await systemService.updateAptCache({ force: true });
+
+      sinon.assert.calledOnce(pushStub);
+      const [payload] = pushStub.firstCall.args;
+      expect(payload.commandOptions.command).to.equal('update');
+      expect(payload.workerOptions.retries).to.equal(0);
+      expect(payload.workerOptions.retainErrors).to.equal(false);
     });
   });
 

--- a/tests/unit/systemService.test.js
+++ b/tests/unit/systemService.test.js
@@ -115,7 +115,7 @@ describe('system Services tests', () => {
       const cacheUpdateError = await systemService.updateAptCache();
 
       expect(cacheUpdateError).to.equal(false);
-      sinon.assert.calledOnceWithExactly(runCmdStub, 'env', { runAsRoot: true, params: ['DEBIAN_FRONTEND=noninteractive', 'apt-get', '-y', '-o', 'DPkg::Lock::Timeout=180', '-o', 'Dpkg::Options::=--force-confdef', '-o', 'Dpkg::Options::=--force-confold', 'update'] });
+      sinon.assert.calledOnceWithExactly(runCmdStub, 'env', { runAsRoot: true, params: ['DEBIAN_FRONTEND=noninteractive', 'apt-get', '-y', '--no-install-recommends', '-o', 'DPkg::Lock::Timeout=180', '-o', 'Dpkg::Options::=--force-confdef', '-o', 'Dpkg::Options::=--force-confold', 'update'] });
     });
   });
 
@@ -150,7 +150,7 @@ describe('system Services tests', () => {
       const error = await systemService.upgradePackage('syncthing');
 
       expect(error).to.equal(false);
-      sinon.assert.calledWithExactly(runCmdStub, 'env', { runAsRoot: true, params: ['DEBIAN_FRONTEND=noninteractive', 'apt-get', '-y', '-o', 'DPkg::Lock::Timeout=180', '-o', 'Dpkg::Options::=--force-confdef', '-o', 'Dpkg::Options::=--force-confold', 'install', 'syncthing'] });
+      sinon.assert.calledWithExactly(runCmdStub, 'env', { runAsRoot: true, params: ['DEBIAN_FRONTEND=noninteractive', 'apt-get', '-y', '--no-install-recommends', '-o', 'DPkg::Lock::Timeout=180', '-o', 'Dpkg::Options::=--force-confdef', '-o', 'Dpkg::Options::=--force-confold', 'install', 'syncthing'] });
     });
   });
 
@@ -266,7 +266,7 @@ describe('system Services tests', () => {
 
       await systemService.monitorSyncthingPackage();
 
-      sinon.assert.calledWithExactly(runCmdStub, 'env', { runAsRoot: true, params: ['DEBIAN_FRONTEND=noninteractive', 'apt-get', '-y', '-o', 'DPkg::Lock::Timeout=180', '-o', 'Dpkg::Options::=--force-confdef', '-o', 'Dpkg::Options::=--force-confold', 'install', 'syncthing'] });
+      sinon.assert.calledWithExactly(runCmdStub, 'env', { runAsRoot: true, params: ['DEBIAN_FRONTEND=noninteractive', 'apt-get', '-y', '--no-install-recommends', '-o', 'DPkg::Lock::Timeout=180', '-o', 'Dpkg::Options::=--force-confdef', '-o', 'Dpkg::Options::=--force-confold', 'install', 'syncthing'] });
     });
 
     it('should upgrade syncthing immediately if correct version present but uninstalled', async () => {
@@ -295,7 +295,7 @@ describe('system Services tests', () => {
 
       await systemService.monitorSyncthingPackage();
 
-      sinon.assert.calledWithExactly(runCmdStub, 'env', { runAsRoot: true, params: ['DEBIAN_FRONTEND=noninteractive', 'apt-get', '-y', '-o', 'DPkg::Lock::Timeout=180', '-o', 'Dpkg::Options::=--force-confdef', '-o', 'Dpkg::Options::=--force-confold', 'install', 'syncthing'] });
+      sinon.assert.calledWithExactly(runCmdStub, 'env', { runAsRoot: true, params: ['DEBIAN_FRONTEND=noninteractive', 'apt-get', '-y', '--no-install-recommends', '-o', 'DPkg::Lock::Timeout=180', '-o', 'Dpkg::Options::=--force-confdef', '-o', 'Dpkg::Options::=--force-confold', 'install', 'syncthing'] });
     });
 
     it('should not call upgradeSyncthing if on correct version', async () => {
@@ -763,7 +763,7 @@ describe('system Services tests', () => {
       await systemService.addSyncthingRepository();
 
       sinon.assert.calledWithExactly(writeStub, '/etc/apt/sources.list.d/syncthing.list', 'deb [ signed-by=/usr/share/keyrings/syncthing-archive-keyring.gpg ] https://apt.syncthing.net/ syncthing stable-v2\n');
-      sinon.assert.calledWithExactly(runCmdStub, 'env', { runAsRoot: true, params: ['DEBIAN_FRONTEND=noninteractive', 'apt-get', '-y', '-o', 'DPkg::Lock::Timeout=180', '-o', 'Dpkg::Options::=--force-confdef', '-o', 'Dpkg::Options::=--force-confold', 'update'] });
+      sinon.assert.calledWithExactly(runCmdStub, 'env', { runAsRoot: true, params: ['DEBIAN_FRONTEND=noninteractive', 'apt-get', '-y', '--no-install-recommends', '-o', 'DPkg::Lock::Timeout=180', '-o', 'Dpkg::Options::=--force-confdef', '-o', 'Dpkg::Options::=--force-confold', 'update'] });
     });
   });
   describe('enableFluxdZmq tests', () => {
@@ -913,6 +913,43 @@ describe('system Services tests', () => {
 
       expect(result).to.equal(true);
       sinon.assert.calledOnceWithExactly(writeStub, '/home/testuser/.flux/.zmqEnabled', '');
+    });
+  });
+
+  describe('apt hygiene tests', () => {
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('asks apt for what a package needs, not what it suggests', async () => {
+      // Recommends are how shared-mime-info, dbus, glib and python3-gi arrive on a
+      // node that asked for chrony - and how ten of them came to sit in
+      // uninterruptible sleep running update-mime-database during a gate.
+      const runCmdStub = sinon.stub(serviceHelper, 'runCommand').resolves({ error: null });
+
+      await systemService.aptRunner({ command: 'install', params: ['chrony'] });
+
+      const [, options] = runCmdStub.firstCall.args;
+      expect(options.params).to.include('--no-install-recommends');
+    });
+
+    it('does not write an apt source to a node whose syncthing is already current', async () => {
+      // addSyncthingRepository fetches a release key and writes a keyring and a
+      // source. A node that has nothing to install reads neither.
+      const statStub = sinon.stub(fs, 'stat').resolves({ mtimeMs: 0 });
+      sinon.stub(axios, 'get').resolves({ data: { status: 'success', data: { syncthing: '1.0.0' } } });
+      sinon.stub(serviceHelper, 'runCommand').resolves({
+        error: null, stdout: "'2.1.3|install ok installed'",
+      });
+      sinon.stub(log, 'info');
+
+      systemService.resetTimers();
+      await systemService.monitorSyncthingPackage();
+      systemService.resetTimers();
+
+      const touchedSource = statStub.getCalls()
+        .some((call) => String(call.args[0]).includes('sources.list.d/syncthing.list'));
+      expect(touchedSource).to.equal(false);
     });
   });
 

--- a/tests/unit/systemService.test.js
+++ b/tests/unit/systemService.test.js
@@ -1060,18 +1060,24 @@ describe('system Services tests', () => {
     });
 
     it('publishes even when a check throws, so a waiter fails rather than hangs', async () => {
+      // The rejection has to land somewhere the code does not already catch.
+      // monitorSyncthingPackage's own axios call carries a .catch(), so failing
+      // that one leaves nothing to throw and the test passes without reaching
+      // the path it is named for.
       fakeSystem({
         'ca-certificates': '20260601',
         'netcat-openbsd': '1.234',
         syncthing: '2.1.3',
         chrony: '4.8',
       });
-      axios.get.rejects(new Error('stats unreachable'));
+      runCmdStub.rejects(new Error('dpkg-query unavailable'));
 
       await systemService.monitorSystem();
 
       sinon.assert.calledOnce(publishStub);
       expect(publishStub.firstCall.args[0]).to.equal('system:packages-checked');
+      // and it says nothing was installed, rather than reporting a stale set
+      expect(publishStub.firstCall.args[1]).to.deep.equal({ installed: [] });
     });
   });
 

--- a/tests/unit/volumeExecutor.test.js
+++ b/tests/unit/volumeExecutor.test.js
@@ -46,7 +46,6 @@ describe('volumeExecutor tests', () => {
 
   let configStub;
   let nodeFsStub;
-  let fluxEventBusStub;
   let fluxNetworkHelperStub;
   let networkStateStub;
 
@@ -172,7 +171,6 @@ describe('volumeExecutor tests', () => {
     // that tests it, against real tars.
     // Not the real bus: what these assert is what the module SAYS happened, and
     // a shared emitter would carry it between tests.
-    fluxEventBusStub = { publish: sinon.stub() };
 
     // This node's own address, so a peer draw cannot come back as itself.
     fluxNetworkHelperStub = { getLocalSocketAddress: sinon.stub().resolves('198.18.0.1:16127') };
@@ -203,7 +201,6 @@ describe('volumeExecutor tests', () => {
         info: sinon.stub(), warn: sinon.stub(), error: sinon.stub(), debug: sinon.stub(),
       },
       '../utils/appConstants': appConstantsStub,
-      '../utils/fluxEventBus': fluxEventBusStub,
       '../fluxNetworkHelper': fluxNetworkHelperStub,
       './volumeSession': volumeSession,
     });
@@ -845,29 +842,6 @@ describe('volumeExecutor tests', () => {
       ).to.equal('198.18.0.1:16127');
     });
 
-    it('reports peers asked and registry attempts as different things', async () => {
-      // One key on one event meant two things: peers contacted on one branch,
-      // registry attempts on the other. Anything summing it was adding
-      // different denominators, and the peers asked first were invisible
-      // whenever the registry won - which is most of the time.
-      pulled = false;
-      networkStateStub.getRandomSocketAddress.onCall(0).resolves('198.18.0.5:16127');
-      networkStateStub.getRandomSocketAddress.onCall(1).resolves('198.18.0.6:16127');
-      networkStateStub.getRandomSocketAddress.resolves(null);
-      serviceHelperStub.axiosGet.rejects(new Error('404'));
-
-      const published = [];
-      fluxEventBusStub.publish.callsFake((name, payload) => published.push({ name, payload }));
-
-      // One cycle: two peers asked and refused, then the registry answers.
-      const vol = await openSession();
-      await volumeExecutor.run(vol, ['true']);
-
-      const acquired = published.filter((e) => e.name === 'fileoperation:imageAcquired').pop();
-      expect(acquired.payload.source).to.equal('registry');
-      expect(acquired.payload.attempts, 'registry attempts were not reported').to.equal(1);
-      expect(acquired.payload.asked, 'the peers asked first were invisible').to.equal(2);
-    });
 
     it('does not let a caller inherit a refusal from sources it was allowed', async () => {
       // A caller allowed the registry, arriving while the prefetch's peers-only


### PR DESCRIPTION
## Overview

The integration fleet reached the public internet on every run — roughly 1.2 million packets left the box per gate, to Canonical, Docker, NodeSource, Syncthing and GitHub. That made the gate depend on five third parties being up and honest, and it meant a node under test was not quite the node we ship. This branch closes that: the fleet now runs with its network sealed, installs its packages from a signed repository the image carries, and records anything that tries to leave.

Most of this is test harness. **But it is not only test harness, and the production changes should not be reviewed as if they were** — four of the seven commits are production fixes, three of which were found by building the harness rather than by looking for them, and two of the harness commits carry a production change alongside. The split is spelled out below before anything else, so nothing has to be inferred from a commit title.

Gated twice: **83/83 at `5cb0383b7`** (60m06s) and **84/84 at `5ec88dfbe`** (60m35s), the second with the fleet network sealed and tcpdump reporting `0 packets received by filter`.

## What is production, and what is harness

| commit | | what it changes |
|---|---|---|
| `0ac9563d3` endpoints become configuration | **production** | `config/default.js`, `cloudUIUpdateService`, `geolocationService`, `fluxService`, `imageManager`, `appSpecHelpers`, `systemService`, `scripts/update-cloudui.sh` |
| `85fa7b480` a boot sweep is over when it says so | harness **+ observability** | harness wait; `fileOperationRecovery` gains a `fileops:recovered` publication (+14 lines) |
| `0c03b6ef9` an apt failure resumes into the same failed task, forever | **production** | `fifoQueue`, `systemService` — no harness files at all |
| `5d5425ddc` a legacy node installs its packages from the fleet | harness **+ production** | the harness apt repository, and `monitorSystem`'s package checks become awaited rather than fire-and-forget `setImmediate`, publishing `system:packages-checked` |
| `5cb0383b7` one package apt cannot find stops a node installing the others | **production** | `fifoQueue`, `systemService` — no harness files at all |
| `aaf01e5c8` a node installs what a package needs, not what it suggests | **production** | `systemService` — no harness files at all |
| `5ec88dfbe` the fleet has no way out | harness only | the sinkhole, suite 95 |

By line count:

| | files | changed |
|---|---|---|
| **production code** (`ZelBack/`, `scripts/`) | 10 | +181 / −45 |
| **production unit tests** (`tests/unit/`) | 6 | +343 / −25 |
| harness (`test-infra/`) | 14 | +694 / −77 |

The production surface is four files carrying real behaviour change — `fifoQueue.js`, `systemService.js`, `cloudUIUpdateService.js` and `scripts/update-cloudui.sh` — plus five files where an endpoint literal became a config lookup, and one additive event publication. **`fluxEventBus` is test-only**, so both publications are observability and neither is on a production path.

## The apt queue defects

None of these were planned work. All three are invisible while apt succeeds, which is why nothing had found them — and closing the network is precisely what makes apt failure the normal case, so they were fixed one step before they would have started biting.

### A failed task resumes into itself, forever

`updateAptCache` passes `retainErrors: false` so that a failed `apt-get update` is dropped rather than left at the head of the queue. `queueAptGetCommand` built its worker options from `retries` alone, so `retainErrors` and `retryDelay` never arrived and the queue kept the task. `monitorAptCache` then resumes the queue on every failure, and it is async — it awaits several `runCommand`s first, so its `resume()` lands after `work()` has exited and `working` is back to false. With `retries: 0` there is no delay between attempts.

Measured against the real modules: **55,812 worker attempts in two seconds**, one core flat out, for as long as the mirror stays unreachable.

The fix is to forward every worker option the caller set.

### The queue died the moment that shortcut started working (review round three)

Fixing the payload above switched on a trapdoor the payload bug had been holding
shut. `runWorker` halted the queue **after** emitting `failed`, and an emit is a
synchronous yield: the listener runs right there. `monitorAptCache` resumes for a
failed update with no `await` ahead of it, so its `resume()` landed inside the
emit and the next line overwrote it. The loop broke out with work still queued,
`working` went false, and nothing restarted it - `push()` only calls `work()`
when the queue is not already working. Every apt task behind the update was
stranded, every one pushed later too, and `monitorSystem`'s `allSettled` never
settled: `system:packages-checked` was never published and chrony, syncthing and
netcat never installed until FluxOS restarted.

The fix is not to make listeners behave, because a queue cannot police them.
It is to stop depending on when they run: settle state first, then notify, and a
listener may reply instantly, slowly or not at all. Two consequences follow. A
resumed final failure reaches the retry sleep with no retries left, so a
ladder-over break stops it waiting out the full delay - 60s by default - holding
everything behind it. And `resume()` no longer reassigns `finished` when called
re-entrantly: `work()` returns at once while the loop is running, and storing
that resolved promise told `clear()` the queue was idle mid-flight, on the
apt-is-broken path `systemService` reaches from these very failures.

**An apt command completing is now a published fact**, which is what makes this
testable at all. A legacy boot runs a handful of them, so it is an event rather
than a cadence, and which completed - in what order - is the only direct evidence
the queue carried on past one that failed. Suite 94 gains the third regime a real
node boots into, packages missing *and* `apt-get update` failing:
`createTestEnv({ aptBadSource: true })` adds a source apt cannot reach alongside
the good one, so the update fails as it does behind a dead mirror while the work
behind it stays doable - swapping the good source out would fail that too and
prove only that a broken node stays broken. Proven both ways on a real fleet:
green 8/8 with the fix, and with the halt moved back after the emit all three
tests of that regime fail.

### The recovery routine could not see what had failed

`runWorker` emitted the whole payload as `options`, but for the `{commandOptions, workerOptions}` shape the command sits one level down — so `options.command` was always `undefined`, and the routine's opening shortcut, which treats an `apt-get update` failure as not worth panicking over, had never once fired. Every apt failure instead took the full recovery path: up to thirty minutes waiting on the dpkg lock, then `fuser -KILL` on it, then `dpkg --configure -a`, then `apt-get install --fix-broken` — for a node that simply could not reach a mirror.

The fix is to emit `commandOptions`.

### One package apt cannot find stops a node installing any of the others

A retained task went back to the **front** of the queue, so the next resume handed it straight back to the worker ahead of everything already waiting. Observed on a real node with an empty package index: `netcat-openbsd` could not be located and worked through its retry ladder, and when the ladder ended a resume granted it a fresh one. **chrony and syncthing, queued behind it, were never attempted at all** — and there was no ceiling, because each resume started the cycle again for the life of the process.

Retained tasks now go to the back, and a task is handed back at most `maxRetainCycles` (default 3) times before the queue emits `abandoned` and gives up. `systemService` logs that, because the caller already took its error when the first ladder ended and nothing else would ever learn the work had stopped.

### Two existing tests encoded two of these behaviours

One asserted that the failed task sits at the head of the queue, with a comment saying so, and five asserted the exact apt argument list. Both were updated deliberately — the expectations were the defect, not the guard.

## Every endpoint on the boot and app-lifecycle path is configuration

Endpoint literals scattered through `cloudUIUpdateService`, `geolocationService`, `fluxService`, `imageManager`, `appSpecHelpers`, `systemService` and `scripts/update-cloudui.sh` move into `ZelBack/config/default.js`. Configuration lives in the directory fluxbench hashes, so redirecting a node stays detectable tampering — which is why this is configuration and deliberately not an environment variable.

**The heading is scoped deliberately, because the sweep is not total.** Two endpoints outside that path remain literals and are follow-ups rather than oversights: `watchdogService`'s clone URL for `fluxnode-watchdog`, and the Azure provider's `login.microsoftonline.com` authority. Neither runs during boot or an app operation, which is why suite 95 stays green with them in place — that suite proves what the fleet reaches *while a gate runs*.

Two further literals are deliberately staying, and are not endpoints at all. The Google and Azure registry **scopes** (`.../auth/cloud-platform`, `containerregistry.azure.net/.default`) are permission identifiers those providers define, carried inside an auth request and never fetched — a node with a "configured" scope is a node that fails to authenticate. And `paymentService`'s `success_url` is handed to Stripe so it can redirect the customer's browser after checkout; FluxOS never opens a connection to it.

## The fleet serves its own packages

The dependency closure is resolved at image build into a signed apt repository the image carries. Nothing names a package or a version: whatever apt puts in the archive cache *is* the closure it resolved, against this image's own package state.

**One production change rides with this and is worth a reviewer's attention.** `monitorSystem`'s four package checks were fired and forgotten through `setImmediate`, so nothing could tell a check that ran and found its work done from one that never started. They are now awaited, and the result is published as `system:packages-checked` with the list of what was actually installed — published whether or not anything was, on the same principle as `fileops:recovered`, because presence alone cannot distinguish those two states on a seeded node. The checks still run through the same one-at-a-time apt queue; what changes is that `monitorSystem` now knows when they are finished.

Packages are pre-seeded at image build, so a normal fleet boots into the steady state a production node is already in — `monitorSystem()` runs for real, finds its prerequisites satisfied, and installs nothing. A per-suite `aptSeeded: false` flag purges the three packages before FluxOS starts, so the install path is covered too. Purge rather than remove, because a removed package leaves its config behind and reports as `deinstall ok config-files`, which is neither installed nor absent and which no real node is ever in.

Base packages are served over `file://` from the image; only syncthing's source goes over HTTP to the stub, because that is the one source FluxOS actually writes — so the keyring fetch, the source write, apt's HTTP transport and signature verification all run as they do on a node. Signing is load-bearing and proven by mutation: swapping the keyring for an impostor's makes apt refuse both distributions with `NO_PUBKEY` and the packages become unlocatable.

Syncthing now installs from a `.deb` rather than a release tarball. Its repository carries only the two most recent releases, so a `.deb` cannot pin an old version the way a GitHub release can, and the version therefore moves on every rebuild — `build-apt-repo.sh` records it to `syncthing.version` and the stub reads that file, so nothing downstream restates it. One side effect is worth naming: the package is built `[noupgrade]` and the tarball is not, so the `upgrades.syncthing.net` traffic existed *because* the harness installed the tarball, and switching closed it by construction.

## The fleet has no way out, and says so when something tries

The fleet network is `Internal: true` — no route off it at all. Nodes resolve through the external stub, which relays each query to the embedded Docker resolver at `127.0.0.11` (the one that knows every container alias on the network) and refuses anything it cannot answer within 300ms, recording the name and the node that asked. Relaying rather than answering from a list means aliases need no second copy in the stub and cannot drift from the ones the runner actually creates.

The redirection goes through `/etc/resolv.conf` deliberately: FluxOS resolves via c-ares, which does not read `/etc/hosts`, so a hosts entry would have covered nothing.

**Suite 95's third test is the reason the other two mean anything.** It deliberately reaches for `stats.runonflux.io` and asserts the resolver recorded it. On the first run that test failed while both hermeticity assertions passed — the sinkhole was wired to nothing, so "the fleet reached nothing outside" was being recorded against a resolver that recorded nothing at all. Any assertion that something did not happen needs a sibling proving the instrument can see it happen.

## systemService hygiene

`aptRunner` now passes `--no-install-recommends`. Without it, a node asking for four packages installed twenty-one, including `shared-mime-info`, dbus, glib and python3-gi — which is where ten legacy nodes sitting in uninterruptible sleep running `update-mime-database` came from.

**Release note.** This lands in `aptRunner`, so it applies to every apt invocation on every existing legacy node, not just the new ones — the change here most likely to surprise someone operationally. The four packages involved are safe without recommends, and an unseeded install was exercised at gate scale. Also operational: all three entry points now `delete process.env.NODE_CONFIG` at startup, so the `node-config` environment override no longer reaches FluxOS — nothing in the repo used it, but any external tooling that set it loses its overrides.

`addSyncthingRepository()` moves to where the install is. It previously ran before any version check and short-circuited only if the source file already existed, so a node whose syncthing was perfectly current still fetched a release key and wrote a keyring and an apt source it would never read.

## Measurement

Egress per full gate, captured on the host with tcpdump filtered to the harness subnet:

| destination | before | after endpoints | after own packages | after default-deny |
|---|---|---|---|---|
| **total off-box packets** | **~1,200,000** | **455,348** | **2,574** | **0** |
| Canonical | 421,196 | 425,030 | 0 | 0 |
| `archive`/`security.ubuntu.com` | 1,476 | 1,752 | gone | gone |
| `download.docker.com`/`deb.nodesource.com` | 266 | 296 | gone | gone |
| `apt.syncthing.net`/`syncthing.net` | 148 | 140 | gone | gone |
| `upgrades.syncthing.net` | 6 | 6 | gone | gone |
| `github.com` | 64 | 6 | gone | gone |
| `relays.syncthing.net` | 6 | 6 | 6 | gone |

The final capture's own tally is `0 packets captured, 0 packets received by filter`. Before anything was claimed from that zero, a container on the harness subnet curled `archive.ubuntu.com` through the same filter and produced 30 packets with the hostname visible — an empty measurement has two explanations, and the boring one is a broken instrument.

## Testing

- Full unit suite **5,610 passing, 18 pending, 0 failing**.
- Integration gate **87/87** at the current head, 59 minutes, with all six images digest-verified against the tree they were built from.
- Two new integration suites. `94-legacy-package-provisioning` covers all three regimes a legacy node can boot into — seeded, unseeded, and unseeded with `apt-get update` failing — where none were covered before. `95-fleet-reaches-nothing-outside` covers both node types, plus the instrument check described above.
- Every fix carries a mutation that kills its own test and nothing else. Two of the queue tests proved nothing on their first pass — one used a zero retry delay, so removing the ladder-over break changed nothing observable, and one asserted on a flag that holds either way — and were rewritten until they bit.
- One rebase note: #1779's round hardened the syncthing tarball verification in `Dockerfile.fluxos`, which this branch then deletes by design — syncthing arrives as a package from the image's signed apt repository, whose `signed-by` verification supersedes it.

## Notes for review

- Based on `fix/restart-pacing-crash-only` (#1780). That is sequencing, not a code dependency.
- The four production commits could have gone out on their own branch. Keeping them here was a deliberate call: three of them were found by this work, and the fourth is what the harness redirection is built on.
- If you want to review the production change on its own, `git diff 6f7016ad3..HEAD -- ZelBack scripts` is the whole of it — 10 files, +181/−45.



