### PR TITLE
chore(lint): the tree lints clean, by hand

### DIFF
--- a/ZelBack/src/services/analyticsService.js
+++ b/ZelBack/src/services/analyticsService.js
@@ -176,7 +176,7 @@ function analyticsMiddleware(req, res, next) {
     return;
   }
 
-  const zelidauth = req.headers.zelidauth;
+  const { zelidauth } = req.headers;
   if (!zelidauth) {
     next();
     return;

--- a/ZelBack/src/services/explorerService.js
+++ b/ZelBack/src/services/explorerService.js
@@ -1806,53 +1806,6 @@ async function reindexExplorer(req, res) {
   }
 }
 
-async function fixExplorer(height = 1670000, rescanApps = true) {
-  try {
-    const dbopen = dbHelper.databaseConnection();
-    const blockheight = serviceHelper.ensureNumber(height);
-    const database = dbopen.db(config.database.daemon.database);
-    const query = { generalScannedHeight: { $gte: 0 } };
-    const projection = {
-      projection: {
-        _id: 0,
-        generalScannedHeight: 1,
-      },
-    };
-    const currentHeight = await dbHelper.findOneInDatabase(database, scannedHeightCollection, query, projection);
-    if (!currentHeight) {
-      throw new Error('No scanned height found');
-    }
-    if (currentHeight.generalScannedHeight <= blockheight) {
-      throw new Error('Block height shall be lower than currently scanned');
-    }
-    if (blockheight < 0) {
-      throw new Error('BlockHeight lower than 0');
-    }
-    const rescanapps = serviceHelper.ensureBoolean(rescanApps);
-    if (blockheight === 0) {
-      await dbHelper.dropCollection(database, scannedHeightCollection).catch((error) => {
-        if (error.message !== 'ns not found') {
-          log.error(error);
-        }
-      });
-    } else {
-      // stop block processing
-      const update = { $set: { generalScannedHeight: blockheight } };
-      const options = {
-        upsert: true,
-      };
-      // update scanned Height in scannedBlockHeightCollection
-      await dbHelper.updateOneInDatabase(database, scannedHeightCollection, query, update, options);
-    }
-    initiateBlockProcessor(true, false, rescanapps); // restore database and possibly do rescan of apps
-    const message = messageHelper.createSuccessMessage(`Explorer rescan from blockheight ${blockheight} initiated`);
-    log.info(message);
-  } catch (error) {
-    log.warn(error);
-    initiateBlockProcessor(true, true);
-  }
-}
-
 /**
  * To rescan Flux explorer database from a specific block height. Only accessible by admins and Flux team members.
  * @param {object} req Request.

--- a/ZelBack/src/services/fluxService.js
+++ b/ZelBack/src/services/fluxService.js
@@ -670,7 +670,7 @@ async function getFluxIP(req, res) {
  * @returns {object} Message.
  */
 function getFluxZelID(req, res) {
-  const userconfig = globalThis.userconfig;
+  const { userconfig } = globalThis;
   const zelID = userconfig.initial.zelid;
   const message = messageHelper.createDataMessage(zelID);
   return res ? res.json(message) : message;
@@ -723,7 +723,7 @@ async function getFluxGeolocation(req, res) {
  * @returns {object} Message.
  */
 function getFluxPGPidentity(req, res) {
-  const userconfig = globalThis.userconfig;
+  const { userconfig } = globalThis;
   const pgp = userconfig.initial.pgpPublicKey;
   const message = messageHelper.createDataMessage(pgp);
   return res ? res.json(message) : message;
@@ -736,7 +736,7 @@ function getFluxPGPidentity(req, res) {
  * @returns {object} Message.
  */
 function getFluxKadena(req, res) {
-  const userconfig = globalThis.userconfig;
+  const { userconfig } = globalThis;
   const kadena = userconfig.initial.kadena || null;
   const message = messageHelper.createDataMessage(kadena);
   return res ? res.json(message) : message;
@@ -749,7 +749,7 @@ function getFluxKadena(req, res) {
  * @returns {object} Message.
  */
 function getRouterIP(req, res) {
-  const userconfig = globalThis.userconfig;
+  const { userconfig } = globalThis;
   const routerIP = userconfig.initial.routerIP || '';
   const message = messageHelper.createDataMessage(routerIP);
   return res ? res.json(message) : message;
@@ -762,7 +762,7 @@ function getRouterIP(req, res) {
  * @returns {object} Message.
  */
 function getBlockedPorts(req, res) {
-  const userconfig = globalThis.userconfig;
+  const { userconfig } = globalThis;
   const blockedPorts = userconfig.initial.blockedPorts || [];
   const message = messageHelper.createDataMessage(blockedPorts);
   return res ? res.json(message) : message;
@@ -775,7 +775,7 @@ function getBlockedPorts(req, res) {
  * @returns {object} Message.
  */
 function getAPIPort(req, res) {
-  const userconfig = globalThis.userconfig;
+  const { userconfig } = globalThis;
   const routerIP = userconfig.initial.apiport || '16127';
   const message = messageHelper.createDataMessage(routerIP);
   return res ? res.json(message) : message;
@@ -788,7 +788,7 @@ function getAPIPort(req, res) {
  * @returns {object} Message.
  */
 function getBlockedRepositories(req, res) {
-  const userconfig = globalThis.userconfig;
+  const { userconfig } = globalThis;
   const blockedPorts = userconfig.initial.blockedRepositories || [];
   const message = messageHelper.createDataMessage(blockedPorts);
   return res ? res.json(message) : message;
@@ -813,7 +813,7 @@ function getEnterpriseAppOwners(req, res) {
  * @returns {object} Message.
  */
 function getMarketplaceURL(req, res) {
-  const userconfig = globalThis.userconfig;
+  const { userconfig } = globalThis;
   const development = userconfig.initial.development || false;
   let marketPlaceUrl = `${config.stats.baseUrl}/marketplace/listapps`;
   if (development) {
@@ -1282,7 +1282,7 @@ async function getFluxInfo(req, res) {
       info.flux.arcaneHumanVersion = arcaneHumanVersion;
     }
     info.flux.appsDos = dosAppsResult.data;
-    const userconfig = globalThis.userconfig;
+    const { userconfig } = globalThis;
     info.flux.development = userconfig.initial.development || false;
     const daemonInfoRes = await daemonServiceControlRpcs.getInfo();
     if (daemonInfoRes.status === 'error') {
@@ -1394,7 +1394,7 @@ async function adjustKadenaAccount(req, res) {
         throw new Error(`Invalid Chain ID ${chainid} provided.`);
       }
       const kadenaURI = `kadena:${account}?chainid=${chainid}`;
-      const userconfig = globalThis.userconfig;
+      const { userconfig } = globalThis;
       const fluxDirPath = path.join(__dirname, '../../../config/userconfig.js');
       const dataToWrite = `module.exports = {
   initial: {
@@ -1439,7 +1439,7 @@ async function adjustRouterIP(req, res) {
       let { routerip } = req.params;
       routerip = routerip || req.query.routerip || '';
 
-      const userconfig = globalThis.userconfig;
+      const { userconfig } = globalThis;
       const dataToWrite = `module.exports = {
         initial: {
           ipaddress: '${userconfig.initial.ipaddress || '127.0.0.1'}',
@@ -1495,7 +1495,7 @@ async function adjustBlockedPorts(req, res) {
     if (!Array.isArray(blockedPorts)) {
       throw new Error('Blocked Ports is not a valid array');
     }
-    const userconfig = globalThis.userconfig;
+    const { userconfig } = globalThis;
     const dataToWrite = `module.exports = {
             initial: {
               ipaddress: '${userconfig.initial.ipaddress || '127.0.0.1'}',
@@ -1545,7 +1545,7 @@ async function adjustAPIPort(req, res) {
         return;
       }
 
-      const userconfig = globalThis.userconfig;
+      const { userconfig } = globalThis;
       const dataToWrite = `module.exports = {
         initial: {
           ipaddress: '${userconfig.initial.ipaddress || '127.0.0.1'}',
@@ -1609,7 +1609,7 @@ async function adjustBlockedRepositories(req, res) {
       }
     });
 
-    const userconfig = globalThis.userconfig;
+    const { userconfig } = globalThis;
     const dataToWrite = `module.exports = {
             initial: {
               ipaddress: '${userconfig.initial.ipaddress || '127.0.0.1'}',

--- a/ZelBack/src/services/geolocationService.js
+++ b/ZelBack/src/services/geolocationService.js
@@ -250,9 +250,7 @@ async function getNodeGeolocation() {
   const dbData = await getGeolocationFromDb();
   if (dbData.geolocation) {
     storedGeolocation = dbData.geolocation;
-    staticIp = dbData.staticIp;
-    dataCenter = dbData.dataCenter;
-    lastIpChangeDate = dbData.lastIpChangeDate;
+    ({ staticIp, dataCenter, lastIpChangeDate } = dbData);
     log.info('Geolocation restored from database');
   }
   return storedGeolocation;

--- a/ZelBack/src/services/upnpService.js
+++ b/ZelBack/src/services/upnpService.js
@@ -14,7 +14,7 @@ const client = new natUpnp.Client();
 if (config.upnp.gatewayUrl) {
   // eslint-disable-next-line global-require
   const { Device } = require('@runonflux/nat-upnp/build/src/nat-upnp/device');
-  const gatewayUrl = config.upnp.gatewayUrl;
+  const { gatewayUrl } = config.upnp;
   const nodeIp = config.upnp.nodeIp || '127.0.0.1';
   client.getGateway = async () => ({
     gateway: new Device(gatewayUrl),

--- a/ZelBack/src/services/utils/globalState.js
+++ b/ZelBack/src/services/utils/globalState.js
@@ -67,7 +67,7 @@ function initializeCaches(cacheManager) {
   if (cacheManager && cacheManager.appSpawnErrorCache && cacheManager.appSpawnCache) {
     spawnErrorsLongerAppCache = cacheManager.appSpawnErrorCache;
     trySpawningGlobalAppCache = cacheManager.appSpawnCache;
-    pendingAppUpdatesCache = cacheManager.pendingAppUpdatesCache;
+    ({ pendingAppUpdatesCache } = cacheManager);
   }
 }
 

--- a/ZelBack/src/services/utils/volumeConstructor.js
+++ b/ZelBack/src/services/utils/volumeConstructor.js
@@ -8,7 +8,6 @@
 const log = require('../../lib/log');
 const { MountType } = require('./mountParser');
 const { appsFolder } = require('./appConstants');
-const config = require('../../../config/default');
 
 /**
  * Get app identifier with proper flux prefix

--- a/tests/ZelBack/daemonService.js
+++ b/tests/ZelBack/daemonService.js
@@ -11,11 +11,11 @@ const { expect } = chai;
 describe('Daemon Service calls', () => {
   it('correctly communicates with Flux and obtains data from a Daemon service', () => {
     const data = {
-      // eslint-disable-next-line vue/max-len
+      // eslint-disable-next-line max-len
       hexstring: '0400008085202f89010000000000000000000000000000000000000000000000000000000000000000ffffffff20037a4b0700324d696e6572732068747470733a2f2f326d696e6572732e636f6dffffffff04bf258e9e020000001976a91404e2699cec5f44280540fb752c7660aa3ba857cc88aca0118721000000001976a914c85ea3b8348d148b953b5c659f4f94c8998ffe2488ac601de137000000001976a914cb798afa21a56aab837459959e44ee7bc3c5691188ac80461c86000000001976a91404b74cfe29c810a5d49e8a7cdc0785e46fc4a8c588ac00000000000000000000000000000000000000',
     };
     axios.post('https://api.runonflux.io/daemon/decoderawtransaction', JSON.stringify(data)).then((res) => {
-      // eslint-disable-next-line vue/max-len
+      // eslint-disable-next-line max-len
       const expectation = '{"status":"success","data":{"txid":"01e3987803f7d74b3979799a764f1f5988c16457a800cd82e9d1cea15c17dfb1","overwintered":true,"version":4,"versiongroupid":"892f2085","locktime":0,"expiryheight":0,"vin":[{"coinbase":"037a4b0700324d696e6572732068747470733a2f2f326d696e6572732e636f6d","sequence":4294967295}],"vout":[{"value":112.50050495,"valueZat":11250050495,"n":0,"scriptPubKey":{"asm":"OP_DUP OP_HASH160 04e2699cec5f44280540fb752c7660aa3ba857cc OP_EQUALVERIFY OP_CHECKSIG","hex":"76a91404e2699cec5f44280540fb752c7660aa3ba857cc88ac","reqSigs":1,"type":"pubkeyhash","addresses":["t1JKRwXGfKTGfPV1z48rvoLyabk31z3xwHa"]}},{"value":5.625,"valueZat":562500000,"n":1,"scriptPubKey":{"asm":"OP_DUP OP_HASH160 c85ea3b8348d148b953b5c659f4f94c8998ffe24 OP_EQUALVERIFY OP_CHECKSIG","hex":"76a914c85ea3b8348d148b953b5c659f4f94c8998ffe2488ac","reqSigs":1,"type":"pubkeyhash","addresses":["t1c94XNVpBZdMEMMoGmoBhpD1EdEt1YQJDT"]}},{"value":9.375,"valueZat":937500000,"n":2,"scriptPubKey":{"asm":"OP_DUP OP_HASH160 cb798afa21a56aab837459959e44ee7bc3c56911 OP_EQUALVERIFY OP_CHECKSIG","hex":"76a914cb798afa21a56aab837459959e44ee7bc3c5691188ac","reqSigs":1,"type":"pubkeyhash","addresses":["t1cRUnDyJaUJujuyss5DgdfYwR4jAk7hp99"]}},{"value":22.5,"valueZat":2250000000,"n":3,"scriptPubKey":{"asm":"OP_DUP OP_HASH160 04b74cfe29c810a5d49e8a7cdc0785e46fc4a8c5 OP_EQUALVERIFY OP_CHECKSIG","hex":"76a91404b74cfe29c810a5d49e8a7cdc0785e46fc4a8c588ac","reqSigs":1,"type":"pubkeyhash","addresses":["t1JJYJ4aY83DR1kw9HwrxspB2gpfQRb4VtK"]}}],"vjoinsplit":[],"valueBalance":0,"vShieldedSpend":[],"vShieldedOutput":[]}}';
       expect(JSON.stringify(res.data)).to.equal(expectation);
     });

--- a/tests/unit/appHashSyncService.test.js
+++ b/tests/unit/appHashSyncService.test.js
@@ -314,7 +314,7 @@ describe('appHashSyncService tests', () => {
 
       dbHelperStub.findOneInDatabase.resolves({ generalScannedHeight: 2555000 });
 
-      const result = await appHashSyncService.syncMissingHashes();
+      await appHashSyncService.syncMissingHashes();
 
       // Should have attempted bulk fetch (axiosGet called for explorer sync check + permanent messages)
       expect(serviceHelperStub.axiosGet.called).to.be.true;
@@ -638,7 +638,7 @@ describe('appHashSyncService tests', () => {
       dbHelperStub.findInDatabase.resolves(missing);
       // getMissingHashes adds $or filter for nextRetryHeight, but since we stub findInDatabase
       // the filter is applied by the DB. For this test, verify the query includes the filter.
-      const result = await appHashSyncService.getMissingHashes();
+      await appHashSyncService.getMissingHashes();
       // All 3 returned because findInDatabase stub ignores the query — but verify the query was correct
       const query = dbHelperStub.findInDatabase.firstCall.args[2];
       expect(query.message).to.equal(false);

--- a/tests/unit/appSyncOrchestrator.test.js
+++ b/tests/unit/appSyncOrchestrator.test.js
@@ -87,8 +87,7 @@ describe('AppSyncOrchestrator', () => {
     signMessageStub = sinon.stub().returns('fakesig==');
 
     const appSyncEventsModule = require('../../ZelBack/src/services/utils/appSyncEvents');
-    appSyncEvents = appSyncEventsModule.appSyncEvents;
-    EVENTS = appSyncEventsModule.EVENTS;
+    ({ appSyncEvents, EVENTS } = appSyncEventsModule);
     appSyncEvents.removeAllListeners();
 
     const mod = proxyquire('../../ZelBack/src/services/appMessaging/appSyncOrchestrator', {
@@ -118,8 +117,7 @@ describe('AppSyncOrchestrator', () => {
       },
       '../utils/appSyncEvents': appSyncEventsModule,
     });
-    AppSyncOrchestrator = mod.AppSyncOrchestrator;
-    STATES = mod.STATES;
+    ({ AppSyncOrchestrator, STATES } = mod);
   });
 
   afterEach(() => {

--- a/tests/unit/arcaneAuthService.test.js
+++ b/tests/unit/arcaneAuthService.test.js
@@ -4,7 +4,6 @@ const sinon = require('sinon');
 const { expect } = chai;
 
 const log = require('../../ZelBack/src/lib/log');
-const messageHelper = require('../../ZelBack/src/services/messageHelper');
 const arcaneAuthService = require('../../ZelBack/src/services/arcaneAuthService');
 const fluxConfigdClient = require('../../ZelBack/src/services/utils/fluxConfigdClient');
 

--- a/tests/unit/cpuBurstHelper.test.js
+++ b/tests/unit/cpuBurstHelper.test.js
@@ -5,7 +5,6 @@ const sinon = require('sinon');
 const os = require('os');
 const fs = require('fs');
 const proxyquire = require('proxyquire');
-const config = require('config');
 
 const { expect } = chai;
 

--- a/tests/unit/daemonServiceMiscRpcs.test.js
+++ b/tests/unit/daemonServiceMiscRpcs.test.js
@@ -1,7 +1,6 @@
 const sinon = require('sinon');
 const { expect } = require('chai');
 const daemonServiceUtils = require('../../ZelBack/src/services/daemonService/daemonServiceUtils');
-const daemonServiceBlockchainRpcs = require('../../ZelBack/src/services/daemonService/daemonServiceBlockchainRpcs');
 const daemonServiceMiscRpcs = require('../../ZelBack/src/services/daemonService/daemonServiceMiscRpcs');
 const log = require('../../ZelBack/src/lib/log');
 

--- a/tests/unit/fluxPeerManager.test.js
+++ b/tests/unit/fluxPeerManager.test.js
@@ -485,7 +485,7 @@ describe('FluxPeerSocket tests', () => {
       const ws = createMockWs();
       sinon.spy(manager, 'remove');
       // Add via manager so peer is in the map
-      const peer = manager.add(ws, '10.0.0.1', '16127', { source: PEER_SOURCE.RANDOM });
+      manager.add(ws, '10.0.0.1', '16127', { source: PEER_SOURCE.RANDOM });
 
       expect(ws.onclose).to.be.a('function');
       ws.onclose({ code: 1000 });

--- a/tests/unit/networkHealthMonitor.test.js
+++ b/tests/unit/networkHealthMonitor.test.js
@@ -9,12 +9,8 @@ const {
   NetworkHealthMonitor,
   HEALTH_STATUS,
   isUnexpectedDisconnect,
-  VELOCITY_BUFFER_SIZE,
   VELOCITY_THRESHOLD_COUNT,
-  VELOCITY_WINDOW_MS,
-  MIN_CONNECTION_AGE_MS,
   STEADY_STATE_DELAY_MS,
-  DIAGNOSIS_COOLDOWN_MS,
 } = require('../../ZelBack/src/services/utils/NetworkHealthMonitor');
 const { CLOSE_CODES } = require('../../ZelBack/src/services/utils/FluxPeerSocket');
 const { FluxPeerManager } = require('../../ZelBack/src/services/utils/FluxPeerManager');

--- a/tests/unit/systemService.test.js
+++ b/tests/unit/systemService.test.js
@@ -237,7 +237,16 @@ describe('system Services tests', () => {
       const error = await systemService.upgradePackage('syncthing');
 
       expect(error).to.equal(false);
-      sinon.assert.calledWithExactly(runCmdStub, 'env', { runAsRoot: true, params: ['DEBIAN_FRONTEND=noninteractive', 'apt-get', '-y', '--no-install-recommends', '-o', 'DPkg::Lock::Timeout=180', '-o', 'Dpkg::Options::=--force-confdef', '-o', 'Dpkg::Options::=--force-confold', 'install', 'syncthing'] });
+      sinon.assert.calledWithExactly(runCmdStub, 'env', {
+        runAsRoot: true,
+        params: [
+          'DEBIAN_FRONTEND=noninteractive', 'apt-get', '-y', '--no-install-recommends',
+          '-o', 'DPkg::Lock::Timeout=180',
+          '-o', 'Dpkg::Options::=--force-confdef',
+          '-o', 'Dpkg::Options::=--force-confold',
+          'install', 'syncthing',
+        ],
+      });
     });
   });
 
@@ -353,7 +362,16 @@ describe('system Services tests', () => {
 
       await systemService.monitorSyncthingPackage();
 
-      sinon.assert.calledWithExactly(runCmdStub, 'env', { runAsRoot: true, params: ['DEBIAN_FRONTEND=noninteractive', 'apt-get', '-y', '--no-install-recommends', '-o', 'DPkg::Lock::Timeout=180', '-o', 'Dpkg::Options::=--force-confdef', '-o', 'Dpkg::Options::=--force-confold', 'install', 'syncthing'] });
+      sinon.assert.calledWithExactly(runCmdStub, 'env', {
+        runAsRoot: true,
+        params: [
+          'DEBIAN_FRONTEND=noninteractive', 'apt-get', '-y', '--no-install-recommends',
+          '-o', 'DPkg::Lock::Timeout=180',
+          '-o', 'Dpkg::Options::=--force-confdef',
+          '-o', 'Dpkg::Options::=--force-confold',
+          'install', 'syncthing',
+        ],
+      });
     });
 
     it('should upgrade syncthing immediately if correct version present but uninstalled', async () => {
@@ -382,7 +400,16 @@ describe('system Services tests', () => {
 
       await systemService.monitorSyncthingPackage();
 
-      sinon.assert.calledWithExactly(runCmdStub, 'env', { runAsRoot: true, params: ['DEBIAN_FRONTEND=noninteractive', 'apt-get', '-y', '--no-install-recommends', '-o', 'DPkg::Lock::Timeout=180', '-o', 'Dpkg::Options::=--force-confdef', '-o', 'Dpkg::Options::=--force-confold', 'install', 'syncthing'] });
+      sinon.assert.calledWithExactly(runCmdStub, 'env', {
+        runAsRoot: true,
+        params: [
+          'DEBIAN_FRONTEND=noninteractive', 'apt-get', '-y', '--no-install-recommends',
+          '-o', 'DPkg::Lock::Timeout=180',
+          '-o', 'Dpkg::Options::=--force-confdef',
+          '-o', 'Dpkg::Options::=--force-confold',
+          'install', 'syncthing',
+        ],
+      });
     });
 
     it('creates the missing apt source before the sources update can give up', async () => {

--- a/tests/unit/watchdogService.test.js
+++ b/tests/unit/watchdogService.test.js
@@ -1,6 +1,5 @@
 const fs = require('node:fs/promises');
 const os = require('node:os');
-const path = require('node:path');
 
 const chai = require('chai');
 const sinon = require('sinon');
@@ -14,16 +13,14 @@ const log = require('../../ZelBack/src/lib/log');
 describe('watchdogService tests', () => {
   let watchdogService;
   let runCommandStub;
-  let homedirStub;
   let logInfoStub;
-  let logWarnStub;
   let logErrorStub;
 
   beforeEach(() => {
     runCommandStub = sinon.stub(serviceHelper, 'runCommand');
-    homedirStub = sinon.stub(os, 'homedir').returns('/home/testuser');
+    sinon.stub(os, 'homedir').returns('/home/testuser');
     logInfoStub = sinon.stub(log, 'info');
-    logWarnStub = sinon.stub(log, 'warn');
+    sinon.stub(log, 'warn');
     logErrorStub = sinon.stub(log, 'error');
   });
 
@@ -410,7 +407,7 @@ describe('watchdogService tests', () => {
         // createDefaultConfig - config doesn't exist
         statStub.withArgs('/home/testuser/watchdog/config.js').rejects(new Error('ENOENT'));
 
-        const writeFileStub = sinon.stub(fs, 'writeFile').resolves();
+        sinon.stub(fs, 'writeFile').resolves();
         runCommandStub.resolves({ error: null, stdout: '[]' });
 
         await watchdogService.ensureWatchdogRunning();


### PR DESCRIPTION
Eighth and last in the stack: `development ← #1774 ← #1775 ← #1778 ← #1777 ← #1779 ← #1780 ← #1781 ← this`. Based on `fix/external-endpoints-configurable` (#1781).

`npm run lint` reported **45 errors across 17 files**. None were introduced by the seven PRs beneath this one — this is pre-existing debt, separated out so it cannot hide a review of anything else.

Fixed **by hand, not with `--fix`**, because three of the categories needed a decision rather than a rewrite.

## What they were

**24 × `prefer-destructuring`.** Fourteen were the same line repeated in `fluxService.js`: `const userconfig = globalThis.userconfig`. The rest are individual. The reassignment cases take the parenthesised form, and only properties whose names already matched could be folded in — neighbouring lines assign under different names (`storedGeolocation = dbData.geolocation`) and are untouched.

**16 × `no-unused-vars`, and they are not all the same thing.** A `const x = sinon.stub(...)` still installs the stub, so only the binding is removed and the call stays. Deleting those lines outright would have quietly changed what the tests exercise — the point of not running `--fix`. Unused `require`s and unused named imports are removed entirely.

**2 × a rule that does not exist.** `// eslint-disable-next-line vue/max-len` on lines of 496 and 1612 characters — eslint reports an unknown rule as an error, so both the disable and the long line were failing. The intent was right and the rule name was wrong; they now name `max-len` and still apply.

**3 × `max-len`.** The same 304-character `sinon.assert.calledWithExactly` repeated verbatim in `systemService.test.js`, now wrapped.

**1 × a dead function.** `fixExplorer` in `explorerService.js` — 46 lines, neither exported nor called anywhere in the tree. Unreachable rather than merely uncalled, so removed; it is in the history if it is ever wanted.

## Verification

`npx eslint --ext .js ./` → **0 errors**.

Every test file touched, plus the tests covering every production file touched, run green: **793 passing** (`appSyncOrchestrator`, `appHashSyncService`, `arcaneAuthService`, `cpuBurstHelper`, `daemonServiceMiscRpcs`, `fluxPeerManager`, `watchdogService`, `networkHealthMonitor`, `systemService`, `fluxService`, `geolocationService`, `geolocationRule`, `globalState`, `upnpService`, `volumeConstructor`, `explorerService`).

One correction caught during the work and worth stating, because it is the argument against `--fix`: an early edit removed `const result = ` from the wrong occurrence — the text was not unique, and the earlier match's `result` was in use. eslint caught it as five `no-undef` errors. It was redone by line number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
