### PR TITLE
feat(dos): a residential node holds, evacuates, and only then goes to DOS

### DIFF
--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -430,6 +430,12 @@ module.exports = {
     // index is expireAt/expireAfterSeconds:0, so changing one of these takes
     // effect on records written after it, not on the ones already stored.
     locationTtlS: 7500, // a running-app location record: 125 minutes
+    // Grace after a node announces its own shutdown, before peers drop its
+    // locations. MUST stay below locationTtlS: appStartupManager expires on
+    // `(cleanShutdown && downtime > sigterm) || downtime > running`, so a value
+    // above the running expiry makes this window unreachable and a clean
+    // shutdown gets no grace at all.
+    sigtermExpiryS: 420,
     installingTtlS: 900, // an in-progress install: 15 minutes
     // 24 hours. This was 3600 while a collection-level TTL index on `cachedAt`
     // drove it; that index was dropped when expiry moved per-document, and the

--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -465,6 +465,13 @@ module.exports = {
     connectionBackoffMs: [120000, 300000, 600000, 900000],
     nodeMonitorIntervalMs: 1200000,
     nodeMonitorRemovalDelayMs: 60000,
+    // Residential-node staging. The placement hold is immediate and is not
+    // tunable; these pace only the part that moves customer data.
+    residentialCheckIntervalMs: 6 * 60 * 60 * 1000, // re-evaluate the verdict
+    residentialSettleMs: 24 * 60 * 60 * 1000, // verdict must hold before any app moves
+    residentialEvacuationIntervalMs: 6 * 60 * 60 * 1000, // minimum gap between departures
+    residentialQueueBaseMs: 30 * 60 * 1000, // every node waits at least this
+    residentialQueueStepMs: 15 * 60 * 1000, // per position in the instance order
     nodeMonitorDosRecoveryDelayMs: 600000,
     nodeMonitorConfirmationLossDelayMs: 1200000,
     nodeMonitorErrorRecoveryDelayMs: 120000,
@@ -625,13 +632,6 @@ module.exports = {
     // Where a replacement server signing key is fetched from when the installed one
     // has expired. The version is appended: /server-<major.minor>.asc
     signingKeyBaseUrl: 'https://pgp.mongodb.com',
-  },
-  residentialDos: {
-    // A node on a residential connection is only fit to serve the network when it
-    // runs ArcaneOS; without it, the host is unattested and the connection has no
-    // datacenter uptime behind it. Such a node is put into DOS until it migrates.
-    // Set false to disable enforcement fleet-wide from a config change alone.
-    enabled: true,
   },
   analytics: {
     url: 'https://cloudaudit.runonflux.io', // analytics server URL (e.g. 'https://analytics.runonflux.io'). Empty = disabled.

--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -425,10 +425,18 @@ module.exports = {
     bootDelayMultiplier: 1,
     spawnDelayMs: 0,
     removalSpacingMs: 60000,
-    locationTtlS: 7500,
-    installingTtlS: 900,
-    installErrorTtlS: 3600,
-    tempMsgTtlS: 3600,
+    // Per-document expiry for the ephemeral app collections, in seconds, read by
+    // appConstants.js. Each record carries its own deadline and the collection
+    // index is expireAt/expireAfterSeconds:0, so changing one of these takes
+    // effect on records written after it, not on the ones already stored.
+    locationTtlS: 7500, // a running-app location record: 125 minutes
+    installingTtlS: 900, // an in-progress install: 15 minutes
+    // 24 hours. This was 3600 while a collection-level TTL index on `cachedAt`
+    // drove it; that index was dropped when expiry moved per-document, and the
+    // key kept the old mechanism's number for three months while nothing read
+    // it. The 24h the code has actually run since is the value.
+    installErrorTtlS: 86400,
+    tempMsgTtlS: 3600, // collection-level index, serviceManager.js
     hashSyncIntervalMs: 1800000,
     peerNotifyIntervalMs: 3600000,
     cpuCheckIntervalMs: 900000,
@@ -471,7 +479,19 @@ module.exports = {
     residentialSettleMs: 24 * 60 * 60 * 1000, // verdict must hold before any app moves
     residentialEvacuationIntervalMs: 6 * 60 * 60 * 1000, // minimum gap between departures
     residentialQueueBaseMs: 30 * 60 * 1000, // every node waits at least this
-    residentialQueueStepMs: 15 * 60 * 1000, // per position in the instance order
+    // Per position in the instance order, and it MUST stay longer than the pass
+    // that reads it. mayEvacuateApp is reached only from the give-up pass at
+    // explorerService.js:651, which runs every removeFluxAppsPeriod (11) x
+    // speedMultiplier (4 post-PON) = 44 blocks = 22 minutes at 30s blocks, and
+    // wholeSince is stamped inside that pass - so maturity is quantised to a
+    // 22-minute grid and a shorter step cannot separate two points on it.
+    // Adjacent positions would mature on the same pass, and the pass is keyed on
+    // block height so every node evaluates in the same instant. Both holders
+    // then read the app at full strength, because fluxappremoved is broadcast
+    // after the volume is already deleted. 40 minutes is 1.8x the pass, so the
+    // chain would have to slow to ~55s blocks before adjacent positions could
+    // meet. Asserted against production's own config in the unit tests.
+    residentialQueueStepMs: 40 * 60 * 1000,
     nodeMonitorDosRecoveryDelayMs: 600000,
     nodeMonitorConfirmationLossDelayMs: 1200000,
     nodeMonitorErrorRecoveryDelayMs: 120000,

--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -626,6 +626,13 @@ module.exports = {
     // has expired. The version is appended: /server-<major.minor>.asc
     signingKeyBaseUrl: 'https://pgp.mongodb.com',
   },
+  residentialDos: {
+    // A node on a residential connection is only fit to serve the network when it
+    // runs ArcaneOS; without it, the host is unattested and the connection has no
+    // datacenter uptime behind it. Such a node is put into DOS until it migrates.
+    // Set false to disable enforcement fleet-wide from a config change alone.
+    enabled: true,
+  },
   analytics: {
     url: 'https://cloudaudit.runonflux.io', // analytics server URL (e.g. 'https://analytics.runonflux.io'). Empty = disabled.
   },

--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -509,7 +509,13 @@ module.exports = {
     },
     spawnDelayMultiplier: 1,
     daemonInfoIntervalMs: 30000,
-    explorerPollIntervalMs: 5000, // how often the explorer asks whether the chain moved - the floor on block-driven work
+    // NOT how often the chain is asked. pollForNewBlocks reads a height cached
+    // by daemonServiceMiscRpcs and refreshed on the daemonInfoIntervalMs timer
+    // above, so this is the rate at which the node works THROUGH blocks once it
+    // knows it is behind. Its share of that refresh window - 5000/30000, 16.7% -
+    // is what decides whether a block is still the tip when it is processed,
+    // and everything hung off block processing inherits that.
+    explorerPollIntervalMs: 5000,
     explorerSyncRetryMs: 120000,
     explorerDeepRestoreBlocks: 100,
     syncTimeoutMs: 120000,

--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -489,6 +489,7 @@ module.exports = {
     },
     spawnDelayMultiplier: 1,
     daemonInfoIntervalMs: 30000,
+    explorerPollIntervalMs: 5000, // how often the explorer asks whether the chain moved - the floor on block-driven work
     explorerSyncRetryMs: 120000,
     explorerDeepRestoreBlocks: 100,
     syncTimeoutMs: 120000,

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -3604,9 +3604,14 @@ async function reasonToGiveUpApp(installedApp, runningAppList, localSocketAddr, 
       const runsWriter = Boolean(writer) && Boolean(deps.isComponentRunningLocally)
         && await deps.isComponentRunningLocally(writer);
       if (!runsWriter) return { giveUp: true, reason: 'SURPLUS', detail };
-      return {
-        giveUp: false,
-        reason: 'SURPLUS',
+      // Carried out to the evacuation gate rather than returned past it, for the
+      // reason the second-newest branch below is: a node that is also draining
+      // must still be asked whether it should hand this app back. Returned here,
+      // an evacuating node that is the newest copy AND runs the writer answers
+      // "staying" forever - when the gate would have stood it down, let a peer
+      // take the writer, and released it on the next pass.
+      surplusDeclined = {
+        code: 'NEWEST_HOLDS_WRITER',
         detail: `this node is the newest but holds ${writer}; the next copy trims instead`,
       };
     }

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -54,6 +54,23 @@ const isArcane = Boolean(process.env.FLUXOS_PATH);
 
 // Master/slave app tracking
 const mastersRunningGSyncthingApps = new Map();
+// When the election last reached a CONCLUSIVE verdict for an identifier: FDM
+// answered, and either named a primary or named none. An absent or stale entry
+// means the election is not running - it returns early before it reaches any
+// app while syncthing's first-run mount-safety is outstanding, while syncthing
+// is unhealthy, and per app whenever FDM cannot be reached - and "the election
+// is not running" must not be readable as "there is no primary here".
+//
+// Without this the presence of an entry in mastersRunningGSyncthingApps is the
+// only evidence there is, and its absence carries two opposite meanings at
+// once.
+const primaryElectionCheckedAt = new Map();
+// Ten election cycles. Derived from the election's own cadence rather than
+// written as its own number, so it stays in the same proportion to the pass
+// that refreshes it at every scale - the harness compresses masterSlaveApps by
+// 10x and this follows exactly, instead of being a constant that silently
+// becomes hundreds of cycles under compression.
+const PRIMARY_ELECTION_STALE_MS = (config.fluxapps.masterSlaveIntervalMs ?? 30 * 1000) * 10;
 const timeTostartNewMasterApp = new Map();
 // Components already reported as operator-stopped, so the exclusion is announced
 // on entry (and again after a restart) instead of every 30s cycle. An operator
@@ -245,6 +262,11 @@ async function getMasterIpFromFdm(appName, axiosOptions) {
       const url = `${region.baseUrl}/appips/${appName}`;
       // eslint-disable-next-line no-await-in-loop
       const response = await serviceHelper.axiosGet(url, axiosOptions);
+      // axiosGet is bare axios.get and rejects on any non-2xx, so reaching here
+      // at all means the service replied. Whether the body names a primary is a
+      // separate question, answered below: an unparseable 2xx is FDM being
+      // reachable and telling us nothing, not FDM being down.
+      answered = true;
 
       if (response.data && response.data.status === 'success' && response.data.data) {
         answered = true;
@@ -265,6 +287,7 @@ async function getMasterIpFromFdm(appName, axiosOptions) {
         answered = true;
         log.debug(`getMasterIpFromFdm: App ${appName} not found in ${region.name} FDM`);
       } else if (error.response && error.response.status === 503) {
+        // Starting up - it is not answering yet, so it has told us nothing.
         log.debug(`getMasterIpFromFdm: ${region.name} FDM service starting up for app ${appName}`);
       } else {
         log.error(`getMasterIpFromFdm: Failed to reach ${region.name} FDM for app ${appName}: ${error.message}`);
@@ -3418,6 +3441,17 @@ async function updateAppGlobalyApi(req, res) {
 }
 
 /**
+ * The app/component identifier a docker container name carries, with the
+ * runtime prefix removed. Containers are named `/flux<identifier>`, and
+ * `/zel<identifier>` for anything installed before the rename.
+ * @param {string} containerName Docker's name, leading slash included.
+ * @returns {string} The identifier the election and the specs both use.
+ */
+function identifierFromContainerName(containerName) {
+  return containerName.startsWith('/zel') ? containerName.slice(4) : containerName.slice(5);
+}
+
+/**
  * Whether this node is the primary currently elected to run an app's `g:`
  * component.
  *
@@ -3428,17 +3462,42 @@ async function updateAppGlobalyApi(req, res) {
  *
  * The election keys one identifier per app - the app name below v4, and
  * `<component>_<app>` above it - so both forms are matched.
+ *
+ * Three states, because two cannot express what is known here. An empty
+ * election table means either "no node is primary" or "the election has not
+ * run", and the caller destroys a volume on the difference. Every other
+ * unavailable input in canSafelyRemoveApp refuses; so does this one.
+ *
+ * Only a fresh verdict that NAMES a primary answers false. "FDM named nobody"
+ * is null rather than false, because FDM registration lags a node actually
+ * starting the component by ~110s (see the note at the `all` peer check below),
+ * and throughout that window it reports no primary while an instance is live -
+ * so on a node running the component it is the likeliest single reading of "no
+ * primary" that this node is the one just promoted.
+ *
+ * Null is also returned when no verdict has been recorded for the app, or when
+ * the one on record has gone stale: the election refreshes every
+ * masterSlaveIntervalMs, so an entry older than PRIMARY_ELECTION_STALE_MS means
+ * it has stopped running rather than that nothing has changed.
  * @param {string} appName Global app name.
  * @param {string} localSocketAddr This node's socket address.
- * @returns {boolean}
+ * @param {number} [now] Epoch ms, injectable for tests.
+ * @returns {boolean|null} True if this node is the elected primary, false if
+ *   another node provably is, null if the election cannot say.
  */
-function isElectedPrimaryHere(appName, localSocketAddr) {
+function isElectedPrimaryHere(appName, localSocketAddr, now = Date.now()) {
+  let namesAPrimary = false;
   // eslint-disable-next-line no-restricted-syntax
-  for (const [identifier, masterIp] of mastersRunningGSyncthingApps) {
+  for (const [identifier, checkedAt] of primaryElectionCheckedAt) {
     const namesThisApp = identifier === appName || identifier.endsWith(`_${appName}`);
-    if (namesThisApp && ipsMatch(masterIp, localSocketAddr)) return true;
+    if (!namesThisApp) continue;
+    if (now - checkedAt > PRIMARY_ELECTION_STALE_MS) continue;
+    const masterIp = mastersRunningGSyncthingApps.get(identifier);
+    if (!masterIp) continue;
+    namesAPrimary = true;
+    if (ipsMatch(masterIp, localSocketAddr)) return true;
   }
-  return false;
+  return namesAPrimary ? false : null;
 }
 
 /**
@@ -3530,6 +3589,27 @@ async function checkAndRemoveApplicationInstance() {
       return;
     }
 
+    // Which components this node is actually running, read once for the pass
+    // rather than once per app. Only the g: ones matter downstream: a node not
+    // running the writer component cannot be the writer, which is what lets the
+    // safety gate answer without FDM on every node that is merely holding a
+    // synced copy.
+    // eslint-disable-next-line global-require
+    const appQueryService = require('../appQuery/appQueryService');
+    const runningRes = await appQueryService.listRunningApps();
+    const runningIdentifiers = runningRes && runningRes.status === 'success' && Array.isArray(runningRes.data)
+      ? new Set(runningRes.data.map((app) => identifierFromContainerName(app.Names[0])))
+      : null;
+    if (!runningIdentifiers) {
+      log.warn('Give-up-an-app pass: running container list unreadable; every g: component is treated as running here');
+    }
+    // Unreadable is not "not running". A container list this node cannot read
+    // says nothing about what is on its disk, and answering "not running" would
+    // route every app straight past the primary check.
+    const isComponentRunningLocally = async (identifier) => (
+      runningIdentifiers ? runningIdentifiers.has(identifier) : true
+    );
+
     // eslint-disable-next-line no-restricted-syntax
     for (const installedApp of appsInstalled) {
       // eslint-disable-next-line no-await-in-loop
@@ -3559,11 +3639,13 @@ async function checkAndRemoveApplicationInstance() {
         getApplicationGlobalSpecifications: registryManager.getApplicationGlobalSpecifications,
         findSyncedPeer,
         isElectedPrimary: (name) => isElectedPrimaryHere(name, localSocketAddr),
+        isComponentRunningLocally,
       });
       fluxEventBus.publish('giveUp:safety', {
         appName: installedApp.name,
         reason: decision.reason,
         safe: safety.safe,
+        code: safety.code,
         detail: safety.reason,
       });
       if (!safety.safe) {
@@ -3571,7 +3653,15 @@ async function checkAndRemoveApplicationInstance() {
         // uninterrupted period of the app being whole rather than accumulated
         // across a gap.
         residentialNodeDosService.forgetAppObservation(installedApp.name);
-        log.info(`${installedApp.name} would be given up (${decision.reason}) but it is not safe: ${safety.reason}`);
+        if (safety.code === 'ELECTION_UNKNOWN') {
+          // Louder than the rest: every other refusal here is the gate working,
+          // and this one means the node cannot establish something it needs. A
+          // node in this state indefinitely is not idle, it is stuck, and the
+          // two read identically at info level.
+          log.warn(`${installedApp.name} cannot be given up (${decision.reason}): ${safety.reason}`);
+        } else {
+          log.info(`${installedApp.name} would be given up (${decision.reason}) but it is not safe: ${safety.reason}`);
+        }
         // eslint-disable-next-line no-continue
         continue;
       }
@@ -4257,12 +4347,7 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
 
     // Decrypt enterprise apps (version 8 with encrypted content)
     ({ inPlace: appsInstalled.data } = await decryptEnterpriseApps(appsInstalled.data));
-    const runningAppsNames = runningApps.map((app) => {
-      if (app.Names[0].startsWith('/zel')) {
-        return app.Names[0].slice(4);
-      }
-      return app.Names[0].slice(5);
-    });
+    const runningAppsNames = runningApps.map((app) => identifierFromContainerName(app.Names[0]));
     const agent = new https.Agent({
       rejectUnauthorized: false,
     });
@@ -4302,6 +4387,15 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
       if (!validIdentifiers.has(identifier)) {
         mastersRunningGSyncthingApps.delete(identifier);
         log.info(`masterSlaveApps: Cleaned up stale entry from mastersRunningGSyncthingApps: ${identifier}`);
+      }
+    }
+
+    // And the verdict record beside it. An identifier the node no longer holds
+    // must not keep answering for the app it names.
+    // eslint-disable-next-line no-restricted-syntax
+    for (const identifier of primaryElectionCheckedAt.keys()) {
+      if (!validIdentifiers.has(identifier)) {
+        primaryElectionCheckedAt.delete(identifier);
       }
     }
 
@@ -4400,6 +4494,12 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
               // eslint-disable-next-line no-continue
               continue;
             }
+            // FDM answered and `ip` is either a primary's address or null for
+            // none. Both are verdicts, and it is the verdict rather than the
+            // table entry that isElectedPrimaryHere reads - a null ip writes
+            // nothing to mastersRunningGSyncthingApps, so without this line the
+            // two ways of having no entry stay indistinguishable.
+            primaryElectionCheckedAt.set(identifier, Date.now());
             if ((!ip)) {
               log.info(`masterSlaveApps: app:${installedApp.name} has currently no primary set`);
               if (!runningAppsNames.includes(identifier)) {

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -3604,6 +3604,31 @@ async function checkAndRemoveApplicationInstance() {
       return;
     }
 
+    // removeAppLocally refuses when another removal or install holds the lock,
+    // and it refuses by returning - no throw, no status, nothing the caller can
+    // read. So a pass that ran into one logged "locally removed", called
+    // noteEvacuated, burned the whole departure interval and discarded the
+    // app's queue wait, for a removal that never happened.
+    //
+    // They do collide: explorerService invokes this pass WITHOUT awaiting it,
+    // so it outlives the block that started it, and two blocks later the same
+    // scanner awaits expireGlobalApplications, which holds removalInProgress
+    // through a real uninstall.
+    //
+    // Checked here rather than by making removeAppLocally report back: the file
+    // it lives in is untouched by this branch, every force=false caller shares
+    // the same refusal, and a pass that knows it would be refused has no reason
+    // to start. The same guard reinstallOldApplications and softRemoveAppLocally
+    // already use.
+    if (globalState.removalInProgress) {
+      log.info('Give-up-an-app pass skipped: another removal is in progress');
+      return;
+    }
+    if (globalState.installationInProgress) {
+      log.info('Give-up-an-app pass skipped: an installation is in progress');
+      return;
+    }
+
     // Which components this node is actually running, read once for the pass
     // rather than once per app. Only the g: ones matter downstream: a node not
     // running the writer component cannot be the writer, which is what lets the

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -3650,7 +3650,9 @@ async function reasonToGiveUpApp(installedApp, runningAppList, localSocketAddr, 
         detail: 'node is not fit to serve and is handing its apps back',
       };
     }
-    return { giveUp: false, reason: 'EVACUATION', detail: verdict.reason };
+    return {
+      giveUp: false, reason: 'EVACUATION', code: verdict.code, detail: verdict.reason,
+    };
   }
 
   return { giveUp: false, reason: 'NONE', detail: '' };
@@ -3802,11 +3804,32 @@ async function checkAndRemoveApplicationInstance() {
         appName: installedApp.name,
         giveUp: decision.giveUp,
         reason: decision.reason,
+        code: decision.code,
         detail: decision.detail,
       });
       if (!decision.giveUp) {
         if (decision.reason === 'EVACUATION') {
-          log.info(`${installedApp.name} not handed back yet: ${decision.detail}`);
+          // A node held below the instance count WANTS to leave and cannot, and
+          // it is counted and escalated exactly as a safety refusal is - because
+          // until the strength test moved into the pacing gate, that is where
+          // this was answered and what it did. Left uncounted, a node stuck on
+          // an app the fleet can never bring back to strength says nothing
+          // louder than an info line, forever.
+          //
+          // Only this code. Waiting a turn, and pausing between departures, are
+          // this working: counting those would escalate every evacuating node on
+          // its twelfth pass and teach everyone to ignore the warning.
+          if (decision.code === 'BELOW_INSTANCE_COUNT') {
+            const shortRefusals = (giveUpRefusals.get(installedApp.name) ?? 0) + 1;
+            giveUpRefusals.set(installedApp.name, shortRefusals);
+            if (shortRefusals % REFUSALS_BEFORE_ESCALATING === 0) {
+              log.warn(`${installedApp.name} has been refused ${shortRefusals} passes running (EVACUATION, ${decision.code}): ${decision.detail}`);
+            } else {
+              log.info(`${installedApp.name} not handed back yet: ${decision.detail}`);
+            }
+          } else {
+            log.info(`${installedApp.name} not handed back yet: ${decision.detail}`);
+          }
         }
         // eslint-disable-next-line no-continue
         continue;

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -80,6 +80,28 @@ const giveUpRefusals = new Map();
 // a folder mid-resync, a peer rebooting or a load balancer blipping has been
 // and gone, short enough to still be the same day.
 const REFUSALS_BEFORE_ESCALATING = 12;
+
+// Components this node has stopped in order to hand their app back, mapped to
+// the number of give-up passes since. An evacuating node that is the elected
+// primary cannot leave while it is the one writing to the volume, so it stops
+// writing and asks again next pass, by which time the ordinary election has
+// given the role to a peer.
+//
+// THIS IS ALSO WHAT KEEPS THE COMPONENT STOPPED. masterSlaveApps runs every
+// 30s and would otherwise see the component not running here, clear this node's
+// own stale primary record, find no peer running it yet, and start it straight
+// back up - undoing the stand-down within one election cycle, every cycle. It
+// is read there as a "not a candidate right now" filter, which is the whole
+// mechanism: no new wire state, no negotiation, just this node declining to
+// stand for an office it is trying to leave.
+const standingDown = new Map();
+// Give-up passes a stood-down component may wait before this node gives up on
+// leaving and becomes electable again. The alternative to a cap is an app that
+// is stopped here AND not running anywhere else, which is worse than the
+// stuck-but-serving state the stand-down exists to fix. On expiry the entry is
+// simply dropped: masterSlaveApps then clears this node's stale primary record
+// and the normal paths restart the component wherever it belongs.
+const STAND_DOWN_PASSES_BEFORE_GIVING_UP = 6;
 // Ten election cycles. Derived from the election's own cadence rather than
 // written as its own number, so it stays in the same proportion to the pass
 // that refreshes it at every scale - the harness compresses masterSlaveApps by
@@ -3657,6 +3679,29 @@ async function checkAndRemoveApplicationInstance() {
     for (const name of giveUpRefusals.keys()) {
       if (!heldNames.has(name)) giveUpRefusals.delete(name);
     }
+    // Stood-down components age on the pass that would have removed them, so the
+    // cap is counted in the thing that re-asks the question. Two ways out: the
+    // app left by any route, or this node waited out the cap without being able
+    // to leave. The second matters more than it looks - a component stopped here
+    // and running nowhere is a worse state than the one the stand-down exists to
+    // fix, so the node gives up leaving and stands for election again rather
+    // than holding a stopped app indefinitely.
+    // eslint-disable-next-line no-restricted-syntax
+    for (const [identifier, passes] of standingDown) {
+      const owner = identifier.includes('_') ? identifier.slice(identifier.indexOf('_') + 1) : identifier;
+      if (!heldNames.has(owner)) {
+        standingDown.delete(identifier);
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+      if (passes >= STAND_DOWN_PASSES_BEFORE_GIVING_UP) {
+        standingDown.delete(identifier);
+        log.warn(`${identifier} stood down ${passes} passes without being able to leave; standing for election again`);
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+      standingDown.set(identifier, passes + 1);
+    }
 
     // eslint-disable-next-line no-restricted-syntax
     for (const installedApp of appsInstalled) {
@@ -3696,6 +3741,38 @@ async function checkAndRemoveApplicationInstance() {
         code: safety.code,
         detail: safety.reason,
       });
+      if (safety.code === 'STAND_DOWN_REQUIRED' && decision.reason === 'EVACUATION') {
+        // Every other condition has already passed - a connected peer holds each
+        // synced folder in full, and the app is at strength - so the only thing
+        // between this node and leaving is that it is the one writing. Stop
+        // writing. The election hands the role to a peer within a cycle or two,
+        // and the next pass finds the component not running here, re-proves the
+        // peer is complete with nothing left to write, and removes.
+        //
+        // EVACUATION only. SURPLUS picks the JUNIOR instance and the primary is
+        // the senior one, so a surplus giver-up is never the primary; wiring
+        // this there would stop a container for a case that cannot arise.
+        // eslint-disable-next-line no-restricted-syntax
+        for (const identifier of safety.standDown) {
+          try {
+            // eslint-disable-next-line no-await-in-loop
+            await appDockerStop(identifier);
+            standingDown.set(identifier, 0);
+            log.warn(`${installedApp.name}: standing down as ${identifier}'s primary so the app can be handed back`);
+          } catch (error) {
+            // Left unmarked deliberately: a component this node failed to stop
+            // is one it is still writing to, and marking it would make the node
+            // unelectable for a component it is running. The next pass retries.
+            log.error(`${installedApp.name}: could not stand down ${identifier}: ${error.message}`);
+          }
+        }
+        fluxEventBus.publish('giveUp:standDown', {
+          appName: installedApp.name,
+          components: safety.standDown,
+        });
+        // One action per pass, exactly as a removal is.
+        return;
+      }
       if (!safety.safe) {
         if (decision.reason === 'EVACUATION') {
           // The observation window restarts, so the queue wait is served against
@@ -4507,6 +4584,18 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
         }
       }
       if (needsToBeChecked) {
+        // This node stopped the component in order to hand the app back, so it
+        // is not a candidate. Without this the election restores it within one
+        // cycle: the component is not running here, this node's own stale
+        // primary record is cleared below, no peer has picked it up yet, and the
+        // index-0 branch starts it again - every 30s, forever. Checked in the
+        // same place and for the same reason as operator-stopped, which is the
+        // other way a component this node holds is deliberately not running.
+        if (standingDown.has(identifier)) {
+          log.info(`masterSlaveApps: ${identifier} is standing down to be handed back - excluded from primary election`);
+          // eslint-disable-next-line no-continue
+          continue;
+        }
         // operator explicitly stopped this g: component; don't elect or act on it
         // eslint-disable-next-line no-await-in-loop
         if (await appsRuntimeState.isOperatorStopped(identifier)) {

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -299,11 +299,6 @@ async function getMasterIpFromFdm(appName, axiosOptions) {
       const url = `${region.baseUrl}/appips/${appName}`;
       // eslint-disable-next-line no-await-in-loop
       const response = await serviceHelper.axiosGet(url, axiosOptions);
-      // axiosGet is bare axios.get and rejects on any non-2xx, so reaching here
-      // at all means the service replied. Whether the body names a primary is a
-      // separate question, answered below: an unparseable 2xx is FDM being
-      // reachable and telling us nothing, not FDM being down.
-      answered = true;
 
       if (response.data && response.data.status === 'success' && response.data.data) {
         answered = true;

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -3896,9 +3896,28 @@ async function checkAndRemoveApplicationInstance() {
             // a node into standby, which is what standing down makes this one.
             appReconciler.setControllerDesired(identifier, 'stopped', 'standing down to hand the app back');
             // eslint-disable-next-line no-await-in-loop
-            await appDockerStop(identifier);
-            standingDown.set(identifier, 0);
-            log.warn(`${installedApp.name}: standing down as ${identifier}'s primary so the app can be handed back`);
+            const stop = await appDockerStop(identifier);
+            // THE VERDICT, not the fact that the call returned. appDockerStop
+            // REPORTS a refusal rather than throwing one - it catches internally
+            // and answers { stopped, running, unavailable, errors }, where
+            // `stopped` is read back from docker rather than taken from the stop
+            // call. So the catch below can only fire on an unexpected throw, and
+            // marking here on the strength of having CALLED the stop marked a
+            // component that may still be up: docker refusing, or never becoming
+            // able to answer, both come back as stopped:false with no throw.
+            if (!stop || !stop.stopped) {
+              // Same reasoning as the catch, for the case that actually happens
+              // on a node. Unmarked, so the next pass tries again rather than
+              // this node excluding itself from the election for a component it
+              // is still running.
+              log.error(`${installedApp.name}: could not stand down ${identifier}: `
+                + `running=[${(stop?.running ?? []).join(', ')}] `
+                + `unavailable=${stop?.unavailable ?? 'unknown'} `
+                + `errors=[${(stop?.errors ?? []).join('; ')}]`);
+            } else {
+              standingDown.set(identifier, 0);
+              log.warn(`${installedApp.name}: standing down as ${identifier}'s primary so the app can be handed back`);
+            }
           } catch (error) {
             // Left unmarked deliberately: a component this node failed to stop
             // is one it is still writing to, and marking it would make the node

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -65,6 +65,21 @@ const mastersRunningGSyncthingApps = new Map();
 // only evidence there is, and its absence carries two opposite meanings at
 // once.
 const primaryElectionCheckedAt = new Map();
+// Consecutive passes on which the safety gate has refused to give up an app,
+// keyed by name. A first refusal is the gate working and says nothing; the
+// twentieth is a node that cannot establish something it needs and has not been
+// able to for hours. Those two are indistinguishable at info level, and the
+// giveUp:safety event does not close the gap - fluxEventBus is disabled on a
+// real node (config.testEventStream is false), so the event exists for the
+// harness and nothing reads it in production.
+//
+// Counted rather than timed because the pass is the unit: it is what re-asks
+// the question, and how long it has been stuck is only meaningful in passes.
+const giveUpRefusals = new Map();
+// About four hours of block passes at the production cadence - long enough that
+// a folder mid-resync, a peer rebooting or a load balancer blipping has been
+// and gone, short enough to still be the same day.
+const REFUSALS_BEFORE_ESCALATING = 12;
 // Ten election cycles. Derived from the election's own cadence rather than
 // written as its own number, so it stays in the same proportion to the pass
 // that refreshes it at every scale - the harness compresses masterSlaveApps by
@@ -3610,6 +3625,14 @@ async function checkAndRemoveApplicationInstance() {
       runningIdentifiers ? runningIdentifiers.has(identifier) : true
     );
 
+    // An app can leave by routes this pass never sees - an operator removal, a
+    // redeploy - and a counter for one this node no longer holds is a leak.
+    const heldNames = new Set(appsInstalled.map((app) => app.name));
+    // eslint-disable-next-line no-restricted-syntax
+    for (const name of giveUpRefusals.keys()) {
+      if (!heldNames.has(name)) giveUpRefusals.delete(name);
+    }
+
     // eslint-disable-next-line no-restricted-syntax
     for (const installedApp of appsInstalled) {
       // eslint-disable-next-line no-await-in-loop
@@ -3649,22 +3672,33 @@ async function checkAndRemoveApplicationInstance() {
         detail: safety.reason,
       });
       if (!safety.safe) {
-        // The observation window restarts, so the queue wait is served against an
-        // uninterrupted period of the app being whole rather than accumulated
-        // across a gap.
-        residentialNodeDosService.forgetAppObservation(installedApp.name);
-        if (safety.code === 'ELECTION_UNKNOWN') {
-          // Louder than the rest: every other refusal here is the gate working,
-          // and this one means the node cannot establish something it needs. A
-          // node in this state indefinitely is not idle, it is stuck, and the
-          // two read identically at info level.
-          log.warn(`${installedApp.name} cannot be given up (${decision.reason}): ${safety.reason}`);
-        } else {
+        if (decision.reason === 'EVACUATION') {
+          // The observation window restarts, so the queue wait is served against
+          // an uninterrupted period of the app being whole rather than
+          // accumulated across a gap. Only the evacuation path has a window;
+          // calling this on a surplus refusal cleared a mark nothing had set.
+          residentialNodeDosService.forgetAppObservation(installedApp.name);
+        }
+        const refusals = (giveUpRefusals.get(installedApp.name) ?? 0) + 1;
+        giveUpRefusals.set(installedApp.name, refusals);
+        // No removal follows from this, however long it lasts, and that is
+        // deliberate. Every reason the gate refuses is a reason removing would
+        // be wrong: the peers really are incomplete, so this copy is one of the
+        // few that is not; or this node cannot see them, which is not evidence
+        // about them. Deleting after a timeout does not fix a wedged folder, it
+        // just loses the data more slowly. What a node stuck here needs is to
+        // be VISIBLE - the app is over-served, not down, so nothing about it is
+        // urgent, and the node being unable to establish anything is the part
+        // worth acting on.
+        if (refusals % REFUSALS_BEFORE_ESCALATING !== 0) {
           log.info(`${installedApp.name} would be given up (${decision.reason}) but it is not safe: ${safety.reason}`);
+        } else {
+          log.warn(`${installedApp.name} has been refused ${refusals} passes running (${decision.reason}, ${safety.code}): ${safety.reason}`);
         }
         // eslint-disable-next-line no-continue
         continue;
       }
+      giveUpRefusals.delete(installedApp.name);
 
       log.warn(`REMOVAL REASON: ${decision.reason} - ${installedApp.name} ${decision.detail}. Safe: ${safety.reason}`);
       // eslint-disable-next-line no-await-in-loop

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -3755,6 +3755,16 @@ async function checkAndRemoveApplicationInstance() {
         // eslint-disable-next-line no-restricted-syntax
         for (const identifier of safety.standDown) {
           try {
+            // The controller's opinion FIRST, and it is not optional. For a g:
+            // component appReconciler reads its desired state from
+            // controllerDesired, so a container stopped while that still says
+            // 'running' is one the reconciler starts again on its next sweep:
+            // the stand-down reports success, the component keeps running, the
+            // election entry goes stale because this node has excluded itself,
+            // and every later pass refuses with ELECTION_UNKNOWN while the node
+            // never leaves. This is the same lever masterSlaveApps pulls to put
+            // a node into standby, which is what standing down makes this one.
+            appReconciler.setControllerDesired(identifier, 'stopped', 'standing down to hand the app back');
             // eslint-disable-next-line no-await-in-loop
             await appDockerStop(identifier);
             standingDown.set(identifier, 0);

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -3573,7 +3573,7 @@ function reasonToGiveUpApp(installedApp, runningAppList, localSocketAddr) {
   }
 
   if (residentialNodeDosService.isEvacuating()) {
-    const verdict = residentialNodeDosService.mayEvacuateApp(installedApp.name, runningAppList, localSocketAddr);
+    const verdict = residentialNodeDosService.mayEvacuateApp(installedApp.name, runningAppList, localSocketAddr, minInstances);
     if (verdict.ok) {
       return {
         giveUp: true,

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -3538,6 +3538,23 @@ function isElectedPrimaryHere(appName, localSocketAddr, now = Date.now()) {
 }
 
 /**
+ * The identifier of an app's `g:` component, or null when it has none.
+ *
+ * Derived the same way masterSlaveApps derives it - the app name below v4, and
+ * `<component>_<app>` above it - because it names the same thing: the one
+ * component that runs on a single node at a time and writes to the volume.
+ * @param {object} installedApp Locally installed app record.
+ * @returns {string|null}
+ */
+function gComponentIdentifier(installedApp) {
+  if (installedApp.version <= 3) {
+    return mountParser.isGComponent(installedApp.containerData) ? installedApp.name : null;
+  }
+  const component = (installedApp.compose || []).find((c) => mountParser.isGComponent(c.containerData));
+  return component ? `${component.name}_${installedApp.name}` : null;
+}
+
+/**
  * Whether this node should give up an app, and why.
  *
  * Two reasons, one answer. SURPLUS: the app runs on more nodes than it needs and
@@ -3550,9 +3567,13 @@ function isElectedPrimaryHere(appName, localSocketAddr, now = Date.now()) {
  * @param {object} installedApp Locally installed app record.
  * @param {object[]} runningAppList Instance locations for the app.
  * @param {string} localSocketAddr This node's socket address.
- * @returns {{giveUp: boolean, reason: string, detail: string}}
+ * @param {object} [deps] Injected collaborators for the surplus probe.
+ * @param {Function} [deps.isComponentRunningLocally] Whether a component
+ *   identifier is running on this node right now.
+ * @param {object} [deps.liveness] Peer folder liveness, for judging a silent peer.
+ * @returns {Promise<{giveUp: boolean, reason: string, detail: string}>}
  */
-function reasonToGiveUpApp(installedApp, runningAppList, localSocketAddr) {
+async function reasonToGiveUpApp(installedApp, runningAppList, localSocketAddr, deps = {}) {
   // lazy load to avoid circular dependency
   // eslint-disable-next-line global-require
   const residentialNodeDosService = require('../residentialNodeDosService');
@@ -3563,12 +3584,60 @@ function reasonToGiveUpApp(installedApp, runningAppList, localSocketAddr) {
     // by the shared ordering so every node names the same surplus
     const ordered = [...runningAppList].sort((a, b) => compareInstanceSeniority(b, a));
     const index = ordered.findIndex((x) => socketAddressesMatch(x.ip, localSocketAddr));
+    const writer = gComponentIdentifier(installedApp);
+    const detail = `running on ${runningAppList.length} instances (max: ${minInstances}) and this node is the newest`;
+
+    // "THE NEWEST STANDS ASIDE" IS A STAND-IN FOR "THE LEAST VALUABLE COPY
+    // STANDS ASIDE", and when the newest copy is the one WRITING the stand-in
+    // is backwards - that is the most valuable copy on the network, not the
+    // least. The election is allowed to seat the writer anywhere in the order:
+    // it skips instances whose data has not finished syncing and starts
+    // whichever one is ready, and the designated-leader branch leaves the order
+    // outright. So the two rules can land on the same node.
+    //
+    // The node stays, and the next copy trims instead. What it does NOT do is
+    // stop the writer to make the ordering come true: an app is over-served,
+    // not down, and interrupting the one node serving it to tidy up the count
+    // is a worse outcome than the count being wrong for another pass.
     if (index === 0) {
+      // eslint-disable-next-line no-await-in-loop
+      const runsWriter = Boolean(writer) && Boolean(deps.isComponentRunningLocally)
+        && await deps.isComponentRunningLocally(writer);
+      if (!runsWriter) return { giveUp: true, reason: 'SURPLUS', detail };
       return {
-        giveUp: true,
+        giveUp: false,
         reason: 'SURPLUS',
-        detail: `running on ${runningAppList.length} instances (max: ${minInstances}) and this node is the newest`,
+        detail: `this node is the newest but holds ${writer}; the next copy trims instead`,
       };
+    }
+
+    // The next copy, and it steps in ONLY on a positive confirmation that the
+    // newest is running the writer. Every node ranks the same shared order, but
+    // "who is writing" is each node's own reading and FDM's registration lags
+    // it by ~110s - so a second node acting on a guess is how two copies leave
+    // at once, which is the failure the shared order exists to prevent.
+    //
+    // Silence, a timeout, a refusal, "not running": all mean this node does
+    // nothing, and nothing is exactly today's behaviour. The rule can only ever
+    // fail towards no trim, never towards two.
+    if (index === 1 && writer && deps.liveness) {
+      const appId = dockerService.getAppIdentifier(writer);
+      // eslint-disable-next-line no-await-in-loop
+      const newestState = await peerComponentState(ordered[0].ip, {
+        appId,
+        identifier: writer,
+        appName: installedApp.name,
+        liveness: deps.liveness,
+        label: 'the newest copy',
+        logPrefix: 'giveUpApp',
+      });
+      if (newestState === PeerComponent.RUNNING) {
+        return {
+          giveUp: true,
+          reason: 'SURPLUS',
+          detail: `${detail.replace('this node is the newest', `the newest copy holds ${writer}, so this node trims`)}`,
+        };
+      }
     }
   }
 
@@ -3681,6 +3750,10 @@ async function checkAndRemoveApplicationInstance() {
       runningIdentifiers ? runningIdentifiers.has(identifier) : true
     );
 
+    // One per pass, so a peer asked about twice is asked once. Lazy - it does no
+    // work at all unless a probe below actually goes silent.
+    const liveness = createPeerFolderLiveness();
+
     // An app can leave by routes this pass never sees - an operator removal, a
     // redeploy - and a counter for one this node no longer holds is a leak.
     const heldNames = new Set(appsInstalled.map((app) => app.name));
@@ -3716,7 +3789,11 @@ async function checkAndRemoveApplicationInstance() {
     for (const installedApp of appsInstalled) {
       // eslint-disable-next-line no-await-in-loop
       const runningAppList = await registryManager.appLocation(installedApp.name);
-      const decision = reasonToGiveUpApp(installedApp, runningAppList, localSocketAddr);
+      // eslint-disable-next-line no-await-in-loop
+      const decision = await reasonToGiveUpApp(installedApp, runningAppList, localSocketAddr, {
+        isComponentRunningLocally,
+        liveness,
+      });
       // Every pass reports what it decided about every app it holds. Without
       // this the pass is invisible: it logs nothing at all when it has nothing
       // to give up, so "never ran" and "ran and declined" read identically, and
@@ -4443,6 +4520,118 @@ const SILENCE_REASONS = Object.freeze({
 });
 
 /**
+ * What this node can show one peer to be doing with a component.
+ *
+ * Lifted out of masterSlaveApps so the election and the surplus rule ask this
+ * question through the same code. Two implementations of "is that peer running
+ * it" drift, and they drift towards whatever answer each caller finds
+ * convenient - which for one of them is a removal.
+ *
+ * `label` names the peer the way its caller knows it, so a log line reads the
+ * same whether the peer came from the election order, from the remembered
+ * primary, or from the instance order the surplus rule ranks.
+ * @param {string} peerSocketAddr The peer's socket address.
+ * @param {object} ctx Everything the probe needs that is not the peer.
+ * @param {string} ctx.appId Container name for the component.
+ * @param {string} ctx.identifier `<component>_<app>` the election keys on.
+ * @param {string} ctx.appName Global app name, for the log lines.
+ * @param {object} ctx.liveness Peer folder liveness, for judging silence.
+ * @param {string} ctx.label How the caller knows this peer.
+ * @param {string} ctx.logPrefix Which caller is asking.
+ * @returns {Promise<string>} A PeerComponent state.
+ */
+async function peerComponentState(peerSocketAddr, {
+  appId, identifier, appName, liveness, label, logPrefix,
+}) {
+  // Docker reports names with a leading slash, and getAppIdentifier yields
+  // exactly the container name for this component. Compare whole names: a
+  // substring test also matches a longer app whose name merely begins the same
+  // way - myapp against myapp2, or simplexsmp against simplexsmp1 - and a false
+  // positive here means the component is never started at all.
+  const peerRunsThisComponent = (appsRunning) => appsRunning.some(
+    (app) => (app.Names || []).some((name) => name.replace(/^\//, '') === appId),
+  );
+  const ipToCheck = extractIp(peerSocketAddr);
+  const portToCheck = extractPort(peerSocketAddr);
+  const { CancelToken } = axios;
+  const source = CancelToken.source();
+  // Cleared once the request settles: every probe otherwise leaves a
+  // live 10s timer behind, and this runs for each peer on every pass
+  // until the component is running locally.
+  const cancelTimer = setTimeout(() => source.cancel('Operation canceled by timeout.'), PEER_PROBE_TIMEOUT_MS);
+
+  try {
+    // heldcomponents, not listrunningapps: a peer part-way through
+    // its own pre-start ownership fix has committed but has no
+    // container, and answering from containers alone reports the
+    // component free. A peer too old to serve it falls back below.
+    const heldResponse = await axios.get(`http://${ipToCheck}:${portToCheck}/apps/heldcomponents`, { timeout: PEER_PROBE_TIMEOUT_MS, cancelToken: source.token })
+      .catch((error) => {
+        // A status is an answer: the peer is alive and merely too old
+        // for this endpoint, so fall through to the container list. No
+        // reply at all is the case this function exists to judge, and
+        // it belongs to the handler below.
+        if (!error.response) throw error;
+        return null;
+      });
+    const held = heldResponse?.data?.data;
+    if (Array.isArray(held)) {
+      if (held.includes(appId)) {
+        fluxEventBus.count('masterSlave:decision', identifier, 'heldOnPeer');
+        log.info(`${logPrefix}: component:${identifier} is held on peer node (${label}) at ${ipToCheck}, will not start`);
+        return PeerComponent.RUNNING;
+      }
+      return PeerComponent.NOT_RUNNING;
+    }
+
+    // The peer HAS the endpoint and it failed. FluxOS answers
+    // errors in band, so this arrives as a 200 carrying an error
+    // object rather than a list - indistinguishable from a peer
+    // too old for the route by shape alone, which is why it is
+    // separated here.
+    // Falling through would answer from the container list a
+    // question the peer has just said it cannot answer, and that
+    // list cannot see the durable stop lock at all: a primary its
+    // owner stopped to work on reads as free, and this node
+    // elects itself over them. Alive and unreadable is UNKNOWN.
+    if (heldResponse?.data?.status === 'error') {
+      log.info(`${logPrefix}: peer node (${label}) at ${ipToCheck} could not answer what it holds for app:${appName} - alive, and cannot be ruled out, will not start`);
+      return PeerComponent.UNKNOWN;
+    }
+
+    const response = await axios.get(`http://${ipToCheck}:${portToCheck}/apps/listrunningapps`, { timeout: PEER_PROBE_TIMEOUT_MS, cancelToken: source.token });
+    const appsRunning = response.data?.data;
+    // A reply this node cannot read is not a clearance. The peer
+    // answered, so it is alive; what it is running is simply unknown.
+    if (!Array.isArray(appsRunning)) {
+      log.info(`${logPrefix}: peer node (${label}) at ${ipToCheck} is alive but did not list what it runs for app:${appName}, will not start`);
+      return PeerComponent.UNKNOWN;
+    }
+    // Match on the g: component identifier, not the app name: non-g siblings
+    // (e.g. a DB cluster component) run on every node and must not be mistaken
+    // for the master/slave component being active there.
+    if (peerRunsThisComponent(appsRunning)) {
+      log.info(`${logPrefix}: component:${identifier} is running on peer node (${label}) at ${ipToCheck}, will not start`);
+      return PeerComponent.RUNNING;
+    }
+    return PeerComponent.NOT_RUNNING;
+  } catch (error) {
+    if (error.response) {
+      log.info(`${logPrefix}: peer node (${label}) at ${ipToCheck} answered ${error.response.status} for app:${appName} - alive, and cannot be ruled out, will not start`);
+      return PeerComponent.UNKNOWN;
+    }
+    const verdict = await silenceVerdict(appId, peerSocketAddr, liveness);
+    if (verdict === SilenceVerdict.GONE) {
+      log.info(`${logPrefix}: peer node (${label}) at ${ipToCheck} is silent and this node's syncthing shows its connection for ${appId} gone - the component is free there`);
+      return PeerComponent.NOT_RUNNING;
+    }
+    log.info(`${logPrefix}: peer node (${label}) at ${ipToCheck} is silent for app:${appName} and ${SILENCE_REASONS[verdict]}, will not start`);
+    return PeerComponent.UNKNOWN;
+  } finally {
+    clearTimeout(cancelTimer);
+  }
+}
+/**
  * Manages syncthing master/slave application coordination using FDM services.
  * State (the busy lists, the receive-only cache) is read off globalStateParam at
  * the point of each decision, never taken as separate parameters: the getters
@@ -4762,99 +4951,8 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                 // here), and ahead of every later g: app in the same pass. Running
                 // them together bounds the wait at one timeout regardless of peer
                 // count.
-                // Docker reports names with a leading slash, and getAppIdentifier
-                // yields exactly the container name for this component. Compare whole
-                // names: a substring test also matches a longer app whose name merely
-                // begins the same way - myapp against myapp2, or simplexsmp against
-                // simplexsmp1 - and a false positive here means the component is never
-                // started at all.
-                const peerRunsThisComponent = (appsRunning) => appsRunning.some(
-                  (app) => (app.Names || []).some((name) => name.replace(/^\//, '') === appId),
-                );
-                // What this node can show one peer to be doing with the component.
-                // `label` names that peer the way its caller knows it, so a log line
-                // reads the same whether the peer came from the election order or
-                // from the remembered primary.
-                const peerComponentState = async (peerSocketAddr, label) => {
-                  const ipToCheck = extractIp(peerSocketAddr);
-                  const portToCheck = extractPort(peerSocketAddr);
-                  const { CancelToken } = axios;
-                  const source = CancelToken.source();
-                  // Cleared once the request settles: every probe otherwise leaves a
-                  // live 10s timer behind, and this runs for each peer on every pass
-                  // until the component is running locally.
-                  const cancelTimer = setTimeout(() => source.cancel('Operation canceled by timeout.'), PEER_PROBE_TIMEOUT_MS);
-
-                  try {
-                    // heldcomponents, not listrunningapps: a peer part-way through
-                    // its own pre-start ownership fix has committed but has no
-                    // container, and answering from containers alone reports the
-                    // component free. A peer too old to serve it falls back below.
-                    const heldResponse = await axios.get(`http://${ipToCheck}:${portToCheck}/apps/heldcomponents`, { timeout: PEER_PROBE_TIMEOUT_MS, cancelToken: source.token })
-                      .catch((error) => {
-                        // A status is an answer: the peer is alive and merely too old
-                        // for this endpoint, so fall through to the container list. No
-                        // reply at all is the case this function exists to judge, and
-                        // it belongs to the handler below.
-                        if (!error.response) throw error;
-                        return null;
-                      });
-                    const held = heldResponse?.data?.data;
-                    if (Array.isArray(held)) {
-                      if (held.includes(appId)) {
-                        fluxEventBus.count('masterSlave:decision', identifier, 'heldOnPeer');
-                        log.info(`masterSlaveApps: component:${identifier} is held on peer node (${label}) at ${ipToCheck}, will not start`);
-                        return PeerComponent.RUNNING;
-                      }
-                      return PeerComponent.NOT_RUNNING;
-                    }
-
-                    // The peer HAS the endpoint and it failed. FluxOS answers
-                    // errors in band, so this arrives as a 200 carrying an error
-                    // object rather than a list - indistinguishable from a peer
-                    // too old for the route by shape alone, which is why it is
-                    // separated here.
-                    // Falling through would answer from the container list a
-                    // question the peer has just said it cannot answer, and that
-                    // list cannot see the durable stop lock at all: a primary its
-                    // owner stopped to work on reads as free, and this node
-                    // elects itself over them. Alive and unreadable is UNKNOWN.
-                    if (heldResponse?.data?.status === 'error') {
-                      log.info(`masterSlaveApps: peer node (${label}) at ${ipToCheck} could not answer what it holds for app:${installedApp.name} - alive, and cannot be ruled out, will not start`);
-                      return PeerComponent.UNKNOWN;
-                    }
-
-                    const response = await axios.get(`http://${ipToCheck}:${portToCheck}/apps/listrunningapps`, { timeout: PEER_PROBE_TIMEOUT_MS, cancelToken: source.token });
-                    const appsRunning = response.data?.data;
-                    // A reply this node cannot read is not a clearance. The peer
-                    // answered, so it is alive; what it is running is simply unknown.
-                    if (!Array.isArray(appsRunning)) {
-                      log.info(`masterSlaveApps: peer node (${label}) at ${ipToCheck} is alive but did not list what it runs for app:${installedApp.name}, will not start`);
-                      return PeerComponent.UNKNOWN;
-                    }
-                    // Match on the g: component identifier, not the app name: non-g siblings
-                    // (e.g. a DB cluster component) run on every node and must not be mistaken
-                    // for the master/slave component being active there.
-                    if (peerRunsThisComponent(appsRunning)) {
-                      log.info(`masterSlaveApps: component:${identifier} is running on peer node (${label}) at ${ipToCheck}, will not start`);
-                      return PeerComponent.RUNNING;
-                    }
-                    return PeerComponent.NOT_RUNNING;
-                  } catch (error) {
-                    if (error.response) {
-                      log.info(`masterSlaveApps: peer node (${label}) at ${ipToCheck} answered ${error.response.status} for app:${installedApp.name} - alive, and cannot be ruled out, will not start`);
-                      return PeerComponent.UNKNOWN;
-                    }
-                    const verdict = await silenceVerdict(appId, peerSocketAddr, liveness);
-                    if (verdict === SilenceVerdict.GONE) {
-                      log.info(`masterSlaveApps: peer node (${label}) at ${ipToCheck} is silent and this node's syncthing shows its connection for ${appId} gone - the component is free there`);
-                      return PeerComponent.NOT_RUNNING;
-                    }
-                    log.info(`masterSlaveApps: peer node (${label}) at ${ipToCheck} is silent for app:${installedApp.name} and ${SILENCE_REASONS[verdict]}, will not start`);
-                    return PeerComponent.UNKNOWN;
-                  } finally {
-                    clearTimeout(cancelTimer);
-                  }
+                const probeCtx = {
+                  appId, identifier, appName: installedApp.name, liveness, logPrefix: 'masterSlaveApps',
                 };
 
                 const checkPeersRunning = async (scope) => {
@@ -4889,7 +4987,7 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                   if (!peers.length) return PeerComponent.NOT_RUNNING;
 
                   const states = await Promise.all(
-                    peers.map(({ i, node }) => peerComponentState(node.ip, `index ${i}`)),
+                    peers.map(({ i, node }) => peerComponentState(node.ip, { ...probeCtx, label: `index ${i}` })),
                   );
                   // One peer that cannot be ruled out holds the start on its own:
                   // every other peer answering "not me" says nothing about that one.
@@ -4925,7 +5023,7 @@ async function masterSlaveApps(globalStateParam, installedApps, listRunningApps,
                   // instance most likely to still hold the volume, and electing over
                   // it is exactly the split-brain this branch is reached to avoid.
                   // eslint-disable-next-line no-await-in-loop
-                  const previousMasterState = await peerComponentState(previousMasterAddr, 'previous primary');
+                  const previousMasterState = await peerComponentState(previousMasterAddr, { ...probeCtx, label: 'previous primary' });
                   if (previousMasterState !== PeerComponent.NOT_RUNNING) {
                     // Only THIS app is settled - the previous master still holds it,
                     // so there is nothing to elect. Returning here would abandon the

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -3589,7 +3589,16 @@ function reasonToGiveUpApp(installedApp, runningAppList, localSocketAddr) {
 
 /**
  * The single pass that decides whether this node should stop holding an app.
- * At most one app goes per pass, spaced by config.fluxapps.removal.delay.
+ *
+ * At most one app goes per pass, and the PASS is the spacing: this returns as
+ * soon as one app has gone, and explorerService runs it again every
+ * removeFluxAppsPeriod * speedMultiplier blocks. config.fluxapps.removal.delay
+ * is not read here, or anywhere else - it paced a serviceHelper.delay() inside
+ * a loop that removed several apps in one pass, and that sleep held the whole
+ * pass open: everything behind it waited, and every decision after it was made
+ * against an installed-app list read minutes earlier. The pass is fired
+ * unawaited from the block handler and guards nothing itself, so a pass long
+ * enough to outlive its own interval could also overlap the next one.
  * @returns {void} Return statement is only used here to interrupt the function and nothing is returned.
  */
 async function checkAndRemoveApplicationInstance() {

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -3579,6 +3579,11 @@ async function reasonToGiveUpApp(installedApp, runningAppList, localSocketAddr, 
   const residentialNodeDosService = require('../residentialNodeDosService');
   const minInstances = installedApp.instances || config.fluxapps.minimumInstances;
 
+  // A surplus this node declined to act on, carried out of the block so the
+  // decision can be reported without returning here - a node that is also
+  // evacuating must still reach the evacuation gate below.
+  let surplusDeclined = null;
+
   if (runningAppList.length > minInstances) {
     // junior end first: the newest instance stands aside, ties broken
     // by the shared ordering so every node names the same surplus
@@ -3638,6 +3643,17 @@ async function reasonToGiveUpApp(installedApp, runningAppList, localSocketAddr, 
           detail: `${detail.replace('this node is the newest', `the newest copy holds ${writer}, so this node trims`)}`,
         };
       }
+      // DECLINING IS A DECISION, and it is reported as one. The newest copy's
+      // own refusal already reports SURPLUS with giveUp false; this one fell
+      // through to NONE - which is what the pass reports when the app has no
+      // surplus at all. So "there is a surplus and I will not act on a guess"
+      // and "there is nothing here to trim" reached the event stream
+      // identically, and the single observation that would catch this rule
+      // failing open was not available to anything watching it.
+      surplusDeclined = {
+        code: 'WRITER_UNCONFIRMED',
+        detail: `${detail} but the newest copy could not be confirmed to hold ${writer} (${newestState}); nothing is trimmed`,
+      };
     }
   }
 
@@ -3655,6 +3671,11 @@ async function reasonToGiveUpApp(installedApp, runningAppList, localSocketAddr, 
     };
   }
 
+  if (surplusDeclined) {
+    return {
+      giveUp: false, reason: 'SURPLUS', code: surplusDeclined.code, detail: surplusDeclined.detail,
+    };
+  }
   return { giveUp: false, reason: 'NONE', detail: '' };
 }
 

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -3418,7 +3418,82 @@ async function updateAppGlobalyApi(req, res) {
 }
 
 /**
- * To find and remove apps that are spawned more than maximum number of instances allowed locally.
+ * Whether this node is the primary currently elected to run an app's `g:`
+ * component.
+ *
+ * A `g:` component runs on one node at a time, and that node is the one writing
+ * to the volume. Handing the app back from under it drops whatever it has
+ * written since the peer last reported the folder complete, so the primary
+ * stands down and lets masterSlaveApps elect a successor before it may leave.
+ *
+ * The election keys one identifier per app - the app name below v4, and
+ * `<component>_<app>` above it - so both forms are matched.
+ * @param {string} appName Global app name.
+ * @param {string} localSocketAddr This node's socket address.
+ * @returns {boolean}
+ */
+function isElectedPrimaryHere(appName, localSocketAddr) {
+  // eslint-disable-next-line no-restricted-syntax
+  for (const [identifier, masterIp] of mastersRunningGSyncthingApps) {
+    const namesThisApp = identifier === appName || identifier.endsWith(`_${appName}`);
+    if (namesThisApp && ipsMatch(masterIp, localSocketAddr)) return true;
+  }
+  return false;
+}
+
+/**
+ * Whether this node should give up an app, and why.
+ *
+ * Two reasons, one answer. SURPLUS: the app runs on more nodes than it needs and
+ * this node holds the junior instance. EVACUATION: the node is shedding what it
+ * holds because it is no longer fit to serve, and this app's turn has come.
+ *
+ * Only the reason is decided here. Whether it is SAFE to act on it is
+ * appEvacuationSafety's question, and both must agree - a count has never been
+ * able to tell a redundant copy from the last one that holds the data.
+ * @param {object} installedApp Locally installed app record.
+ * @param {object[]} runningAppList Instance locations for the app.
+ * @param {string} localSocketAddr This node's socket address.
+ * @returns {{giveUp: boolean, reason: string, detail: string}}
+ */
+function reasonToGiveUpApp(installedApp, runningAppList, localSocketAddr) {
+  // lazy load to avoid circular dependency
+  // eslint-disable-next-line global-require
+  const residentialNodeDosService = require('../residentialNodeDosService');
+  const minInstances = installedApp.instances || config.fluxapps.minimumInstances;
+
+  if (runningAppList.length > minInstances) {
+    // junior end first: the newest instance stands aside, ties broken
+    // by the shared ordering so every node names the same surplus
+    const ordered = [...runningAppList].sort((a, b) => compareInstanceSeniority(b, a));
+    const index = ordered.findIndex((x) => socketAddressesMatch(x.ip, localSocketAddr));
+    if (index === 0) {
+      return {
+        giveUp: true,
+        reason: 'SURPLUS',
+        detail: `running on ${runningAppList.length} instances (max: ${minInstances}) and this node is the newest`,
+      };
+    }
+  }
+
+  if (residentialNodeDosService.isEvacuating()) {
+    const verdict = residentialNodeDosService.mayEvacuateApp(installedApp.name, runningAppList, localSocketAddr);
+    if (verdict.ok) {
+      return {
+        giveUp: true,
+        reason: 'EVACUATION',
+        detail: 'node is not fit to serve and is handing its apps back',
+      };
+    }
+    return { giveUp: false, reason: 'EVACUATION', detail: verdict.reason };
+  }
+
+  return { giveUp: false, reason: 'NONE', detail: '' };
+}
+
+/**
+ * The single pass that decides whether this node should stop holding an app.
+ * At most one app goes per pass, spaced by config.fluxapps.removal.delay.
  * @returns {void} Return statement is only used here to interrupt the function and nothing is returned.
  */
 async function checkAndRemoveApplicationInstance() {
@@ -3442,36 +3517,59 @@ async function checkAndRemoveApplicationInstance() {
     const appUninstaller = require('./appUninstaller');
     // eslint-disable-next-line global-require
     const registryManager = require('../appDatabase/registryManager');
+    // eslint-disable-next-line global-require
+    const evacuationSafety = require('./appEvacuationSafety');
+    // eslint-disable-next-line global-require
+    const residentialNodeDosService = require('../residentialNodeDosService');
+    // eslint-disable-next-line global-require
+    const { findSyncedPeer } = require('../appMonitoring/syncthingFolderStateMachine');
+
+    const localSocketAddr = await fluxNetworkHelper.getLocalSocketAddress();
+    if (!localSocketAddr) {
+      log.info('Give-up-an-app pass skipped: local socket address unknown');
+      return;
+    }
+
     // eslint-disable-next-line no-restricted-syntax
     for (const installedApp of appsInstalled) {
       // eslint-disable-next-line no-await-in-loop
       const runningAppList = await registryManager.appLocation(installedApp.name);
-      const minInstances = installedApp.instances || config.fluxapps.minimumInstances; // introduced in v3 of apps specs
-      if (runningAppList.length > minInstances) {
-        // eslint-disable-next-line no-await-in-loop
-        const appDetails = await registryManager.getApplicationGlobalSpecifications(installedApp.name);
-        if (appDetails) {
-          log.info(`Application ${installedApp.name} is already spawned on ${runningAppList.length} instances. Checking if should be unninstalled from the FluxNode..`);
-          // junior end first: the newest instance stands aside, ties broken
-          // by the shared ordering so every node names the same surplus
-          runningAppList.sort((a, b) => compareInstanceSeniority(b, a));
-          // eslint-disable-next-line no-await-in-loop
-          const localSocketAddr = await fluxNetworkHelper.getLocalSocketAddress();
-          if (localSocketAddr) {
-            const index = runningAppList.findIndex((x) => socketAddressesMatch(x.ip, localSocketAddr));
-            if (index === 0) {
-              log.info(`Application ${installedApp.name} going to be removed from node as it was the latest one running it to install it..`);
-              log.warn(`REMOVAL REASON: Too many instances - ${installedApp.name} running on ${runningAppList.length} instances (max: ${minInstances}) - This node is the newest instance`);
-              log.warn(`Removing application ${installedApp.name} locally`);
-              // eslint-disable-next-line no-await-in-loop
-              await appUninstaller.removeAppLocally(installedApp.name, null, false, true, true);
-              log.warn(`Application ${installedApp.name} locally removed`);
-              // eslint-disable-next-line no-await-in-loop
-              await serviceHelper.delay(config.fluxapps.removal.delay * 1000); // wait for 6 mins so we don't have more removals at the same time
-            }
-          }
+      const decision = reasonToGiveUpApp(installedApp, runningAppList, localSocketAddr);
+      if (!decision.giveUp) {
+        if (decision.reason === 'EVACUATION') {
+          log.info(`${installedApp.name} not handed back yet: ${decision.detail}`);
         }
+        // eslint-disable-next-line no-continue
+        continue;
       }
+
+      // eslint-disable-next-line no-await-in-loop
+      const safety = await evacuationSafety.canSafelyRemoveApp(installedApp.name, {
+        appLocation: registryManager.appLocation,
+        getApplicationGlobalSpecifications: registryManager.getApplicationGlobalSpecifications,
+        findSyncedPeer,
+        isElectedPrimary: (name) => isElectedPrimaryHere(name, localSocketAddr),
+      });
+      if (!safety.safe) {
+        // The observation window restarts, so the queue wait is served against an
+        // uninterrupted period of the app being whole rather than accumulated
+        // across a gap.
+        residentialNodeDosService.forgetAppObservation(installedApp.name);
+        log.info(`${installedApp.name} would be given up (${decision.reason}) but it is not safe: ${safety.reason}`);
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+
+      log.warn(`REMOVAL REASON: ${decision.reason} - ${installedApp.name} ${decision.detail}. Safe: ${safety.reason}`);
+      // eslint-disable-next-line no-await-in-loop
+      await appUninstaller.removeAppLocally(installedApp.name, null, false, true, true);
+      log.warn(`Application ${installedApp.name} locally removed`);
+      if (decision.reason === 'EVACUATION') {
+        residentialNodeDosService.noteEvacuated(installedApp.name);
+      }
+      // One per pass. Removing a second here would take two instances off the
+      // network before the spawner has replaced either.
+      return;
     }
   } catch (error) {
     log.error(error);
@@ -4752,6 +4850,8 @@ module.exports = {
   installationInProgressReset,
   setInstallationInProgressTrue,
   checkAndRemoveApplicationInstance,
+  reasonToGiveUpApp,
+  isElectedPrimaryHere,
   reinstallOldApplications,
   checkAndRemoveEnterpriseAppsOnNonArcane,
   forceAppRemovals,

--- a/ZelBack/src/services/appLifecycle/advancedWorkflows.js
+++ b/ZelBack/src/services/appLifecycle/advancedWorkflows.js
@@ -3535,6 +3535,16 @@ async function checkAndRemoveApplicationInstance() {
       // eslint-disable-next-line no-await-in-loop
       const runningAppList = await registryManager.appLocation(installedApp.name);
       const decision = reasonToGiveUpApp(installedApp, runningAppList, localSocketAddr);
+      // Every pass reports what it decided about every app it holds. Without
+      // this the pass is invisible: it logs nothing at all when it has nothing
+      // to give up, so "never ran" and "ran and declined" read identically, and
+      // a suite can only tell them apart by scraping logs.
+      fluxEventBus.publish('giveUp:considered', {
+        appName: installedApp.name,
+        giveUp: decision.giveUp,
+        reason: decision.reason,
+        detail: decision.detail,
+      });
       if (!decision.giveUp) {
         if (decision.reason === 'EVACUATION') {
           log.info(`${installedApp.name} not handed back yet: ${decision.detail}`);
@@ -3549,6 +3559,12 @@ async function checkAndRemoveApplicationInstance() {
         getApplicationGlobalSpecifications: registryManager.getApplicationGlobalSpecifications,
         findSyncedPeer,
         isElectedPrimary: (name) => isElectedPrimaryHere(name, localSocketAddr),
+      });
+      fluxEventBus.publish('giveUp:safety', {
+        appName: installedApp.name,
+        reason: decision.reason,
+        safe: safety.safe,
+        detail: safety.reason,
       });
       if (!safety.safe) {
         // The observation window restarts, so the queue wait is served against an

--- a/ZelBack/src/services/appLifecycle/appEvacuationSafety.js
+++ b/ZelBack/src/services/appLifecycle/appEvacuationSafety.js
@@ -1,0 +1,186 @@
+// Whether this node may give up an app right now.
+//
+// "Evacuation" is a node shedding the apps it holds. Deliberately not called
+// draining: that word already means a socket or buffer emptying in this codebase,
+// and in v9 it means an app shedding traffic.
+//
+// Every existing removal path decides on an instance count alone, and a count
+// cannot tell a redundant copy from the last one that holds the data. Two of the
+// paths that do it - surplus removal and the geolocation-change redeploy - have
+// already destroyed customer volumes. This is the predicate they should all ask.
+//
+// The answer is deliberately conservative: anything it cannot establish is a
+// refusal, because the cost of waiting is a delay and the cost of being wrong is
+// an unrecoverable `rm -rf`.
+
+const config = require('config');
+const log = require('../../lib/log');
+const dockerService = require('../dockerService');
+const globalState = require('../utils/globalState');
+const mountParser = require('../utils/mountParser');
+const fluxNetworkHelper = require('../fluxNetworkHelper');
+const { socketAddressesMatch, extractIp } = require('../utils/socketAddressUtils');
+
+/**
+ * How many running instances the network insists this app keeps. Mirrors the
+ * spawner's deficit test (`$lt: [actual, {$ifNull: [instances, 3]}]`) exactly:
+ * the drain works by creating a deficit the spawner then fills, so a different
+ * idea of "enough" here would either stall the drain or leave the app short.
+ * @param {object} spec Global app specification.
+ * @returns {number}
+ */
+function requiredInstances(spec) {
+  return spec.instances ?? config.fluxapps.minimumInstances;
+}
+
+/**
+ * The components of an app that keep synced state, with the syncthing folder id
+ * each one owns. Folder ids ARE app identifiers.
+ * @param {object} spec Global app specification.
+ * @returns {Array<{name: string, syncMode: string, folderId: string}>}
+ */
+function syncedComponents(spec) {
+  const components = spec.version >= 4 && Array.isArray(spec.compose) ? spec.compose : [spec];
+  return components.reduce((acc, component) => {
+    const syncMode = mountParser.getComponentSyncMode(component.containerData || '');
+    if (!syncMode) return acc;
+    const identifier = spec.version >= 4 && Array.isArray(spec.compose)
+      ? `${component.name}_${spec.name}`
+      : spec.name;
+    acc.push({
+      name: component.name || spec.name,
+      syncMode,
+      folderId: dockerService.getAppIdentifier(identifier),
+    });
+    return acc;
+  }, []);
+}
+
+/**
+ * Instances that are not this node, counted one per physical host.
+ *
+ * Several FluxNode registrations routinely share one machine and one connection,
+ * so two locations at the same address were never two copies: they fail together,
+ * and on a residential line they are being drained together. Counting them
+ * separately is how an app with "two instances" loses both.
+ * @param {Array<{ip: string}>} locations Instance locations for the app.
+ * @param {string} localSocketAddr This node's socket address.
+ * @returns {number} Distinct other hosts holding the app.
+ */
+function otherHostCount(locations, localSocketAddr) {
+  const localIp = extractIp(localSocketAddr);
+  const hosts = new Set();
+  locations.forEach((location) => {
+    if (socketAddressesMatch(location.ip, localSocketAddr)) return;
+    const ip = extractIp(location.ip);
+    if (ip && ip !== localIp) hosts.add(ip);
+  });
+  return hosts.size;
+}
+
+/**
+ * May this node remove this app right now?
+ *
+ * @param {string} appName Global app name.
+ * @param {object} deps Injected collaborators, so this is testable without a
+ *   database, a docker daemon or a syncthing process.
+ * @param {Function} deps.appLocation Instance locations for an app name.
+ * @param {Function} deps.getApplicationGlobalSpecifications Global spec for an app name.
+ * @param {Function} deps.findSyncedPeer Connected peer that holds a folder, or null.
+ * @param {Function} [deps.isElectedPrimary] Whether this node currently runs the
+ *   `g:` component as primary.
+ * @returns {Promise<{safe: boolean, reason: string}>}
+ */
+async function canSafelyRemoveApp(appName, deps) {
+  const {
+    appLocation,
+    getApplicationGlobalSpecifications,
+    findSyncedPeer,
+    isElectedPrimary = async () => false,
+  } = deps;
+
+  try {
+    if (globalState.backupInProgress.includes(appName)) {
+      return { safe: false, reason: 'backup in progress' };
+    }
+    if (globalState.restoreInProgress.includes(appName)) {
+      return { safe: false, reason: 'restore in progress' };
+    }
+
+    const spec = await getApplicationGlobalSpecifications(appName);
+    if (!spec) {
+      // No spec means we cannot tell how many instances the app needs, nor
+      // whether it keeps state. Both are required to answer safely.
+      return { safe: false, reason: 'no global specification available' };
+    }
+
+    const localSocketAddr = await fluxNetworkHelper.getLocalSocketAddress();
+    if (!localSocketAddr) {
+      return { safe: false, reason: 'local socket address unknown' };
+    }
+
+    const locations = await appLocation(appName);
+    if (!Array.isArray(locations) || !locations.length) {
+      // An empty list is far more likely to mean the location view has not
+      // populated than that the app runs nowhere while installed here.
+      return { safe: false, reason: 'no instance locations known' };
+    }
+
+    // The serialisation gate. Removing takes the app to N-1, so every other
+    // draining holder sees it short and waits; the spawner fills the gap and
+    // releases the next one. Acting while it is ALREADY short would take a
+    // second copy off an app that is mid-replacement.
+    const required = requiredInstances(spec);
+    if (locations.length < required) {
+      return {
+        safe: false,
+        reason: `app is below its instance count (${locations.length}/${required}), another move is in flight`,
+      };
+    }
+
+    const synced = syncedComponents(spec);
+    const otherHosts = otherHostCount(locations, localSocketAddr);
+
+    if (!synced.length) {
+      // Nothing to lose but the container, which the spawner rebuilds from the
+      // specification. Removing the only instance is a gap, not a loss.
+      return { safe: true, reason: `stateless app, ${otherHosts} other host(s) hold it` };
+    }
+
+    // Past here the volume IS the product.
+    if (otherHosts < 1) {
+      return { safe: false, reason: 'stateful app and this is the only host holding it' };
+    }
+
+    if (await isElectedPrimary(appName)) {
+      return { safe: false, reason: 'this node is the elected primary; stand down first' };
+    }
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const component of synced) {
+      // eslint-disable-next-line no-await-in-loop
+      const peer = await findSyncedPeer(component.folderId);
+      if (!peer) {
+        return {
+          safe: false,
+          reason: `no connected peer holds ${component.folderId} in full`,
+        };
+      }
+    }
+
+    return {
+      safe: true,
+      reason: `${synced.length} synced component(s) held in full by a connected peer, ${otherHosts} other host(s)`,
+    };
+  } catch (error) {
+    log.warn(`appEvacuationSafety - ${appName}: ${error.message}`);
+    return { safe: false, reason: `safety check failed: ${error.message}` };
+  }
+}
+
+module.exports = {
+  canSafelyRemoveApp,
+  requiredInstances,
+  syncedComponents,
+  otherHostCount,
+};

--- a/ZelBack/src/services/appLifecycle/appEvacuationSafety.js
+++ b/ZelBack/src/services/appLifecycle/appEvacuationSafety.js
@@ -50,6 +50,10 @@ function syncedComponents(spec) {
     acc.push({
       name: component.name || spec.name,
       syncMode,
+      // The key masterSlaveApps elects on, and the name the container carries
+      // once the prefix is stripped - so a caller can ask whether THIS node is
+      // running the component without reconstructing either.
+      identifier,
       folderId: dockerService.getAppIdentifier(identifier),
     });
     return acc;
@@ -87,43 +91,59 @@ function otherHostCount(locations, localSocketAddr) {
  * @param {Function} deps.appLocation Instance locations for an app name.
  * @param {Function} deps.getApplicationGlobalSpecifications Global spec for an app name.
  * @param {Function} deps.findSyncedPeer Connected peer that holds a folder, or null.
- * @param {Function} [deps.isElectedPrimary] Whether this node currently runs the
- *   `g:` component as primary.
- * @returns {Promise<{safe: boolean, reason: string}>}
+ * @param {Function} deps.isElectedPrimary Three-state: true if this node is the
+ *   elected `g:` primary, false if another node provably is, null if the
+ *   election cannot say. Required - null and false are not interchangeable here.
+ * @param {Function} deps.isComponentRunningLocally Whether a component
+ *   identifier is running on this node right now. Required.
+ * @returns {Promise<{safe: boolean, code: string, reason: string}>} `code` is
+ *   the machine-readable verdict - a refusal because the election cannot answer
+ *   reads identically to an idle pass without it, and a node stuck that way
+ *   should be visible rather than silent.
  */
 async function canSafelyRemoveApp(appName, deps) {
   const {
     appLocation,
     getApplicationGlobalSpecifications,
     findSyncedPeer,
-    isElectedPrimary = async () => false,
+    isElectedPrimary,
+    isComponentRunningLocally,
   } = deps;
 
   try {
+    // No default. These used to default to `async () => false`, which answered
+    // "no, you are not the primary" to a caller that had not asked anyone - the
+    // one unavailable input in this function that proceeded rather than
+    // refused. A caller that cannot answer must not be told the removal is
+    // safe, so the omission throws and the catch below turns it into a refusal
+    // that says so.
+    if (typeof isElectedPrimary !== 'function' || typeof isComponentRunningLocally !== 'function') {
+      throw new Error('isElectedPrimary and isComponentRunningLocally are required');
+    }
     if (globalState.backupInProgress.includes(appName)) {
-      return { safe: false, reason: 'backup in progress' };
+      return { safe: false, code: 'BACKUP_IN_PROGRESS', reason: 'backup in progress' };
     }
     if (globalState.restoreInProgress.includes(appName)) {
-      return { safe: false, reason: 'restore in progress' };
+      return { safe: false, code: 'RESTORE_IN_PROGRESS', reason: 'restore in progress' };
     }
 
     const spec = await getApplicationGlobalSpecifications(appName);
     if (!spec) {
       // No spec means we cannot tell how many instances the app needs, nor
       // whether it keeps state. Both are required to answer safely.
-      return { safe: false, reason: 'no global specification available' };
+      return { safe: false, code: 'NO_SPEC', reason: 'no global specification available' };
     }
 
     const localSocketAddr = await fluxNetworkHelper.getLocalSocketAddress();
     if (!localSocketAddr) {
-      return { safe: false, reason: 'local socket address unknown' };
+      return { safe: false, code: 'NO_LOCAL_ADDRESS', reason: 'local socket address unknown' };
     }
 
     const locations = await appLocation(appName);
     if (!Array.isArray(locations) || !locations.length) {
       // An empty list is far more likely to mean the location view has not
       // populated than that the app runs nowhere while installed here.
-      return { safe: false, reason: 'no instance locations known' };
+      return { safe: false, code: 'NO_LOCATIONS', reason: 'no instance locations known' };
     }
 
     // The serialisation gate. Removing takes the app to N-1, so every other
@@ -134,6 +154,7 @@ async function canSafelyRemoveApp(appName, deps) {
     if (locations.length < required) {
       return {
         safe: false,
+        code: 'BELOW_INSTANCE_COUNT',
         reason: `app is below its instance count (${locations.length}/${required}), another move is in flight`,
       };
     }
@@ -144,16 +165,41 @@ async function canSafelyRemoveApp(appName, deps) {
     if (!synced.length) {
       // Nothing to lose but the container, which the spawner rebuilds from the
       // specification. Removing the only instance is a gap, not a loss.
-      return { safe: true, reason: `stateless app, ${otherHosts} other host(s) hold it` };
+      return { safe: true, code: 'STATELESS', reason: `stateless app, ${otherHosts} other host(s) hold it` };
     }
 
     // Past here the volume IS the product.
     if (otherHosts < 1) {
-      return { safe: false, reason: 'stateful app and this is the only host holding it' };
+      return { safe: false, code: 'ONLY_HOST', reason: 'stateful app and this is the only host holding it' };
     }
 
-    if (await isElectedPrimary(appName)) {
-      return { safe: false, reason: 'this node is the elected primary; stand down first' };
+    // A g: component runs on one node at a time and that node is the one
+    // writing to the volume; the rest hold synced copies with the component
+    // stopped. So a node not running it cannot be the writer - a local fact,
+    // needing neither FDM nor the election, and the reason a load-balancer
+    // outage stalls the trim only on the nodes actually holding a writer
+    // instead of on all of them.
+    const gComponents = synced.filter((component) => component.syncMode === 'g');
+    const runningHere = await Promise.all(
+      gComponents.map((component) => isComponentRunningLocally(component.identifier)),
+    );
+    if (runningHere.some(Boolean)) {
+      const primary = await isElectedPrimary(appName);
+      if (primary === null) {
+        // Not "there is no primary" - "nobody can tell me who it is". This node
+        // is running the writer, so the likeliest reading is that it is the one
+        // just promoted and FDM has not caught up. Handing the app back from
+        // under it drops whatever it has written since the peer last reported
+        // the folder complete.
+        return {
+          safe: false,
+          code: 'ELECTION_UNKNOWN',
+          reason: 'this node runs the g: component and the election cannot say who is primary',
+        };
+      }
+      if (primary === true) {
+        return { safe: false, code: 'ELECTED_PRIMARY', reason: 'this node is the elected primary; stand down first' };
+      }
     }
 
     // eslint-disable-next-line no-restricted-syntax
@@ -163,6 +209,7 @@ async function canSafelyRemoveApp(appName, deps) {
       if (!peer) {
         return {
           safe: false,
+          code: 'NO_SYNCED_PEER',
           reason: `no connected peer holds ${component.folderId} in full`,
         };
       }
@@ -170,11 +217,12 @@ async function canSafelyRemoveApp(appName, deps) {
 
     return {
       safe: true,
+      code: 'SYNCED_ELSEWHERE',
       reason: `${synced.length} synced component(s) held in full by a connected peer, ${otherHosts} other host(s)`,
     };
   } catch (error) {
     log.warn(`appEvacuationSafety - ${appName}: ${error.message}`);
-    return { safe: false, reason: `safety check failed: ${error.message}` };
+    return { safe: false, code: 'CHECK_FAILED', reason: `safety check failed: ${error.message}` };
   }
 }
 

--- a/ZelBack/src/services/appLifecycle/appEvacuationSafety.js
+++ b/ZelBack/src/services/appLifecycle/appEvacuationSafety.js
@@ -173,6 +173,28 @@ async function canSafelyRemoveApp(appName, deps) {
       return { safe: false, code: 'ONLY_HOST', reason: 'stateful app and this is the only host holding it' };
     }
 
+    // ASKED BEFORE THE ELECTION, and that order is the whole of what makes a
+    // stand-down safe. A node that holds the only good copy refuses here and
+    // never reaches the question below, so standing down can never be the thing
+    // that strands an app.
+    //
+    // On the pass that removes, this is also the proof that everything this node
+    // ever wrote has landed elsewhere: by then the component is stopped, so a
+    // peer at 100% is a peer holding the final state rather than the state as of
+    // a moment before the next write.
+    // eslint-disable-next-line no-restricted-syntax
+    for (const component of synced) {
+      // eslint-disable-next-line no-await-in-loop
+      const peer = await findSyncedPeer(component.folderId);
+      if (!peer) {
+        return {
+          safe: false,
+          code: 'NO_SYNCED_PEER',
+          reason: `no connected peer holds ${component.folderId} in full`,
+        };
+      }
+    }
+
     // A g: component runs on one node at a time and that node is the one
     // writing to the volume; the rest hold synced copies with the component
     // stopped. So a node not running it cannot be the writer - a local fact,
@@ -183,7 +205,10 @@ async function canSafelyRemoveApp(appName, deps) {
     const runningHere = await Promise.all(
       gComponents.map((component) => isComponentRunningLocally(component.identifier)),
     );
-    if (runningHere.some(Boolean)) {
+    const runningIdentifiers = gComponents
+      .filter((_component, index) => runningHere[index])
+      .map((component) => component.identifier);
+    if (runningIdentifiers.length) {
       const primary = await isElectedPrimary(appName);
       if (primary === null) {
         // Not "there is no primary" - "nobody can tell me who it is". This node
@@ -198,19 +223,16 @@ async function canSafelyRemoveApp(appName, deps) {
         };
       }
       if (primary === true) {
-        return { safe: false, code: 'ELECTED_PRIMARY', reason: 'this node is the elected primary; stand down first' };
-      }
-    }
-
-    // eslint-disable-next-line no-restricted-syntax
-    for (const component of synced) {
-      // eslint-disable-next-line no-await-in-loop
-      const peer = await findSyncedPeer(component.folderId);
-      if (!peer) {
+        // Not a removal, and not a refusal to leave - an instruction to stop
+        // writing first. The caller stops these components and asks again next
+        // pass, by which time the election has given the role to a peer and the
+        // check above means something stronger. `standDown` names what to stop,
+        // so the caller does not re-derive it from the spec.
         return {
           safe: false,
-          code: 'NO_SYNCED_PEER',
-          reason: `no connected peer holds ${component.folderId} in full`,
+          code: 'STAND_DOWN_REQUIRED',
+          reason: 'this node is the elected primary; stop the component before handing the app back',
+          standDown: runningIdentifiers,
         };
       }
     }

--- a/ZelBack/src/services/appLifecycle/appSpawner.js
+++ b/ZelBack/src/services/appLifecycle/appSpawner.js
@@ -295,11 +295,21 @@ async function trySpawningGlobalApplication() {
     } else {
       const myNodeLocation = await systemIntegration.nodeFullGeolocation();
 
+      // Where the candidates went. Every filter below removes apps for a
+      // different and entirely reasonable reason, and none of them says so - the
+      // pass ends with "No app currently to be processed" whether one filter
+      // dropped everything or five each took a share. From outside the process
+      // that is indistinguishable from an app nobody wanted, which is how a port
+      // collision looked like a placement failure for a whole day.
+      const survivors = { found: globalAppNamesLocation.length };
+
       // filter apps that failed to install before
       globalAppNamesLocation = globalAppNamesLocation.filter((app) => !runningApps.data.find((appsRunning) => appsRunning.Names[0].slice(5) === app.name)
         && !globalState.spawnErrorsLongerAppCache.has(app.hash)
         && !globalState.trySpawningGlobalAppCache.has(app.hash)
         && !appsToBeCheckedLater.some((appAux) => appAux.appName === app.name));
+      survivors.afterAlreadyHeldOrTried = globalAppNamesLocation.length;
+
       // filter apps that are non enterprise or are marked to install on my node.
       // Enterprise-owned apps that target specific node IPs are strict: only a node
       // whose IP is listed may install them, regardless of version (the version>=8
@@ -346,10 +356,13 @@ async function trySpawningGlobalApplication() {
         // installer arbitrates
       }
       const myLocation = { continentCode: myContinentCode, countryCode: myCountryCode, region: myTableRegion };
+      survivors.afterNodePin = globalAppNamesLocation.length;
       globalAppNamesLocation = globalAppNamesLocation.filter(
         (app) => placementFeasibility.nodeLocationMatchesGeolocation(myLocation, app.geolocation),
       );
+      survivors.afterGeolocation = globalAppNamesLocation.length;
       globalAppNamesLocation = enterpriseNetwork.filterAppsByOwnership(globalAppNamesLocation, isEnterprise);
+      survivors.afterOwnership = globalAppNamesLocation.length;
 
       // Drop candidates whose remaining slots are already claimed, before one is
       // picked at random. The pool counts running instances only, so an app that
@@ -368,8 +381,11 @@ async function trySpawningGlobalApplication() {
       appsCountAvailableToInstallOnMyNode = globalAppNamesLocation.length + appsSyncthingToBeCheckedLater.length + appsToBeCheckedLater.length;
       ({ shortDelayTime, delayTime } = enterpriseNetwork.getSpawnDelays(isEnterprise, appsCountAvailableToInstallOnMyNode));
 
+      survivors.afterClaims = globalAppNamesLocation.length;
+
       if (globalAppNamesLocation.length === 0) {
-        log.info('trySpawningGlobalApplication - No app currently to be processed');
+        log.info(`trySpawningGlobalApplication - No app currently to be processed (${JSON.stringify(survivors)})`);
+        fluxEventBus.publish('spawner:noCandidates', survivors);
         return delayTime;
       }
       log.info(`trySpawningGlobalApplication - Found ${globalAppNamesLocation.length} apps that are missing instances on the network and can be selected to try to spawn on my node.`);
@@ -932,16 +948,23 @@ async function trySpawningGlobalApplication() {
 
     // install the app
     let registerOk = false;
+    // The installer signals failure two ways - a false return and a throw - and
+    // only the reason it throws with says WHICH check refused. A port already
+    // held by another app is raised that way, and reporting the failure without
+    // it leaves a suite unable to tell a refusal from an app that was simply
+    // never selected.
+    let installError = null;
     try {
       registerOk = await appInstaller.registerAppLocally(appSpecifications, null, null, false); // can throw
     } catch (error) {
       log.error(error);
+      installError = error.message ?? String(error);
       registerOk = false;
     }
     if (!registerOk) {
       log.info(`trySpawningGlobalApplication - Install failed for ${appToRun}, adding to local error cache`);
       globalState.spawnErrorsLongerAppCache.set(appHash, '');
-      fluxEventBus.publish('spawner:installFailed', { appName: appToRun, hash: appHash });
+      fluxEventBus.publish('spawner:installFailed', { appName: appToRun, hash: appHash, error: installError });
       return shortDelayTime;
     }
 

--- a/ZelBack/src/services/appLifecycle/appSpawner.js
+++ b/ZelBack/src/services/appLifecycle/appSpawner.js
@@ -583,6 +583,15 @@ async function trySpawningGlobalApplication() {
     runningAppList = await registryManager.appLocation(appToRun);
     installingAppList = await registryManager.appInstallingLocation(appToRun);
     if (runningAppList.length + installingAppList.length >= minInstances) {
+      // Cleared, because this count is not a durable fact. It includes nodes that
+      // have only CLAIMED to be installing, and a claim is withdrawn as soon as
+      // its node finds the share already filled - seconds later, routinely. Left
+      // set, a node that looked inside that window remembers "enough copies
+      // exist" for the cache's twelve hours and never reconsiders, so an app that
+      // falls back below its instance count waits out the day on every node that
+      // happened to glance at the wrong moment. The claimed-instance path below
+      // already does this; these two counted the same claims and did not.
+      globalState.trySpawningGlobalAppCache.delete(appHash);
       log.info(`trySpawningGlobalApplication - Application ${appToRun} is already spawned or being installed on ${runningAppList.length + installingAppList.length} instances.`);
       return shortDelayTime;
     }
@@ -833,6 +842,15 @@ async function trySpawningGlobalApplication() {
     runningAppList = await registryManager.appLocation(appToRun);
     installingAppList = await registryManager.appInstallingLocation(appToRun);
     if (runningAppList.length + installingAppList.length >= minInstances) {
+      // Cleared, because this count is not a durable fact. It includes nodes that
+      // have only CLAIMED to be installing, and a claim is withdrawn as soon as
+      // its node finds the share already filled - seconds later, routinely. Left
+      // set, a node that looked inside that window remembers "enough copies
+      // exist" for the cache's twelve hours and never reconsiders, so an app that
+      // falls back below its instance count waits out the day on every node that
+      // happened to glance at the wrong moment. The claimed-instance path below
+      // already does this; these two counted the same claims and did not.
+      globalState.trySpawningGlobalAppCache.delete(appHash);
       log.info(`trySpawningGlobalApplication - Application ${appToRun} is already spawned or being installed on ${runningAppList.length + installingAppList.length} instances.`);
       return shortDelayTime;
     }

--- a/ZelBack/src/services/appLifecycle/appSpawner.js
+++ b/ZelBack/src/services/appLifecycle/appSpawner.js
@@ -13,6 +13,44 @@ const { compareInstallingClaims, compareInstanceSeniority, describeRanking } = r
 
 // Import modular services
 const appQueryService = require('../appQuery/appQueryService');
+
+// What this node last concluded about each app: the stage that removed it from
+// the candidate list, or 'candidate' when it survived to the draw.
+//
+// Kept so the verdict can be published on CHANGE ONLY. "This pass passed over
+// that app" is true every pass for every app the fleet already covers - it is a
+// fact about the clock, and fluxEventBus says plainly that a cadence is a
+// counter, not an event. What actually happens, rarely, is a verdict FLIPPING:
+// an app this node was excluded from becoming one it may take again, which is
+// the thing a caller wants to know and the thing no log line makes assertable.
+const lastCandidacy = new Map();
+
+/**
+ * Which stage removed each app, from the survivor snapshots taken through the
+ * filter chain, and publish only the ones whose answer changed since last pass.
+ *
+ * @param {Array<[string, Set<string>]>} stages Ordered [stageName, names still in].
+ */
+function publishCandidacyChanges(stages) {
+  if (!stages.length) return;
+  const [, initial] = stages[0];
+  const verdicts = new Map();
+  for (const name of initial) {
+    let stage = 'candidate';
+    for (let i = 1; i < stages.length; i += 1) {
+      if (!stages[i][1].has(name)) { stage = stages[i][0]; break; }
+    }
+    verdicts.set(name, stage);
+  }
+  for (const [name, stage] of verdicts) {
+    if (lastCandidacy.get(name) === stage) continue;
+    lastCandidacy.set(name, stage);
+    fluxEventBus.publish('spawner:candidacy', { name, stage, candidate: stage === 'candidate' });
+  }
+  for (const name of [...lastCandidacy.keys()]) {
+    if (!verdicts.has(name)) lastCandidacy.delete(name);
+  }
+}
 const resourceQueryService = require('../appQuery/resourceQueryService');
 const messageStore = require('../appMessaging/messageStore');
 const registryManager = require('../appDatabase/registryManager');
@@ -302,6 +340,8 @@ async function trySpawningGlobalApplication() {
       // that is indistinguishable from an app nobody wanted, which is how a port
       // collision looked like a placement failure for a whole day.
       const survivors = { found: globalAppNamesLocation.length };
+      const nameSet = () => new Set(globalAppNamesLocation.map((app) => app.name));
+      const stages = [['found', nameSet()]];
 
       // filter apps that failed to install before
       globalAppNamesLocation = globalAppNamesLocation.filter((app) => !runningApps.data.find((appsRunning) => appsRunning.Names[0].slice(5) === app.name)
@@ -309,6 +349,7 @@ async function trySpawningGlobalApplication() {
         && !globalState.trySpawningGlobalAppCache.has(app.hash)
         && !appsToBeCheckedLater.some((appAux) => appAux.appName === app.name));
       survivors.afterAlreadyHeldOrTried = globalAppNamesLocation.length;
+      stages.push(['afterAlreadyHeldOrTried', nameSet()]);
 
       // filter apps that are non enterprise or are marked to install on my node.
       // Enterprise-owned apps that target specific node IPs are strict: only a node
@@ -357,12 +398,15 @@ async function trySpawningGlobalApplication() {
       }
       const myLocation = { continentCode: myContinentCode, countryCode: myCountryCode, region: myTableRegion };
       survivors.afterNodePin = globalAppNamesLocation.length;
+      stages.push(['afterNodePin', nameSet()]);
       globalAppNamesLocation = globalAppNamesLocation.filter(
         (app) => placementFeasibility.nodeLocationMatchesGeolocation(myLocation, app.geolocation),
       );
       survivors.afterGeolocation = globalAppNamesLocation.length;
+      stages.push(['afterGeolocation', nameSet()]);
       globalAppNamesLocation = enterpriseNetwork.filterAppsByOwnership(globalAppNamesLocation, isEnterprise);
       survivors.afterOwnership = globalAppNamesLocation.length;
+      stages.push(['afterOwnership', nameSet()]);
 
       // Drop candidates whose remaining slots are already claimed, before one is
       // picked at random. The pool counts running instances only, so an app that
@@ -382,10 +426,19 @@ async function trySpawningGlobalApplication() {
       ({ shortDelayTime, delayTime } = enterpriseNetwork.getSpawnDelays(isEnterprise, appsCountAvailableToInstallOnMyNode));
 
       survivors.afterClaims = globalAppNamesLocation.length;
+      stages.push(['afterClaims', nameSet()]);
+
+      publishCandidacyChanges(stages);
 
       if (globalAppNamesLocation.length === 0) {
         log.info(`trySpawningGlobalApplication - No app currently to be processed (${JSON.stringify(survivors)})`);
-        fluxEventBus.publish('spawner:noCandidates', survivors);
+        // A TALLY, not a stream. This is true on every pass of a fleet whose apps
+        // are all at their instance count - roughly every 240ms per node under
+        // the harness multiplier - and as an event it spent a ring every other
+        // consumer shares, which is why nothing could afford to subscribe to it.
+        // The breakdown stays in the log line above, and what CHANGED went out as
+        // spawner:candidacy.
+        fluxEventBus.count('spawner:noCandidates');
         return delayTime;
       }
       log.info(`trySpawningGlobalApplication - Found ${globalAppNamesLocation.length} apps that are missing instances on the network and can be selected to try to spawn on my node.`);

--- a/ZelBack/src/services/appLifecycle/appSpawner.js
+++ b/ZelBack/src/services/appLifecycle/appSpawner.js
@@ -109,6 +109,12 @@ async function trySpawningGlobalApplication() {
       return installDelay;
     }
 
+    if (fluxNetworkHelper.isPlacementHeld()) {
+      log.info(`Node held back from new placements (${fluxNetworkHelper.getPlacementHold()}). Global applications will not be installed`);
+      fluxEventBus.publish('spawner:blocked', { reason: 'placement_hold' });
+      return installDelay;
+    }
+
     let isNodeConfirmed = false;
     isNodeConfirmed = await generalService.isNodeStatusConfirmed().catch(() => null);
     if (!isNodeConfirmed) {

--- a/ZelBack/src/services/appLifecycle/appSpawner.js
+++ b/ZelBack/src/services/appLifecycle/appSpawner.js
@@ -583,15 +583,25 @@ async function trySpawningGlobalApplication() {
     runningAppList = await registryManager.appLocation(appToRun);
     installingAppList = await registryManager.appInstallingLocation(appToRun);
     if (runningAppList.length + installingAppList.length >= minInstances) {
-      // Cleared, because this count is not a durable fact. It includes nodes that
-      // have only CLAIMED to be installing, and a claim is withdrawn as soon as
-      // its node finds the share already filled - seconds later, routinely. Left
-      // set, a node that looked inside that window remembers "enough copies
-      // exist" for the cache's twelve hours and never reconsiders, so an app that
-      // falls back below its instance count waits out the day on every node that
-      // happened to glance at the wrong moment. The claimed-instance path below
-      // already does this; these two counted the same claims and did not.
-      globalState.trySpawningGlobalAppCache.delete(appHash);
+      // KEPT when the running copies alone meet the count, CLEARED when the
+      // claims were needed to reach it.
+      //
+      // A running copy is a durable fact and caching it is the point of the
+      // cache - the app is covered, and re-deciding that every pass is waste.
+      // A claim is not: it is withdrawn as soon as its node finds the share
+      // already filled, seconds later and by design, because the share is
+      // checked after the claim goes out. Cached on a count that needed those
+      // claims, this node remembers "covered" for the cache's twelve hours and
+      // never reconsiders, so an app that falls back below its instance count
+      // waits out the day on every node that glanced inside that window.
+      //
+      // Clearing unconditionally is the other way to be wrong: an app whose
+      // count is genuinely met would re-enter the candidate pool on every pass
+      // and be declined again forever, never cached because it was never
+      // installed.
+      if (runningAppList.length < minInstances) {
+        globalState.trySpawningGlobalAppCache.delete(appHash);
+      }
       log.info(`trySpawningGlobalApplication - Application ${appToRun} is already spawned or being installed on ${runningAppList.length + installingAppList.length} instances.`);
       return shortDelayTime;
     }
@@ -842,15 +852,25 @@ async function trySpawningGlobalApplication() {
     runningAppList = await registryManager.appLocation(appToRun);
     installingAppList = await registryManager.appInstallingLocation(appToRun);
     if (runningAppList.length + installingAppList.length >= minInstances) {
-      // Cleared, because this count is not a durable fact. It includes nodes that
-      // have only CLAIMED to be installing, and a claim is withdrawn as soon as
-      // its node finds the share already filled - seconds later, routinely. Left
-      // set, a node that looked inside that window remembers "enough copies
-      // exist" for the cache's twelve hours and never reconsiders, so an app that
-      // falls back below its instance count waits out the day on every node that
-      // happened to glance at the wrong moment. The claimed-instance path below
-      // already does this; these two counted the same claims and did not.
-      globalState.trySpawningGlobalAppCache.delete(appHash);
+      // KEPT when the running copies alone meet the count, CLEARED when the
+      // claims were needed to reach it.
+      //
+      // A running copy is a durable fact and caching it is the point of the
+      // cache - the app is covered, and re-deciding that every pass is waste.
+      // A claim is not: it is withdrawn as soon as its node finds the share
+      // already filled, seconds later and by design, because the share is
+      // checked after the claim goes out. Cached on a count that needed those
+      // claims, this node remembers "covered" for the cache's twelve hours and
+      // never reconsiders, so an app that falls back below its instance count
+      // waits out the day on every node that glanced inside that window.
+      //
+      // Clearing unconditionally is the other way to be wrong: an app whose
+      // count is genuinely met would re-enter the candidate pool on every pass
+      // and be declined again forever, never cached because it was never
+      // installed.
+      if (runningAppList.length < minInstances) {
+        globalState.trySpawningGlobalAppCache.delete(appHash);
+      }
       log.info(`trySpawningGlobalApplication - Application ${appToRun} is already spawned or being installed on ${runningAppList.length + installingAppList.length} instances.`);
       return shortDelayTime;
     }

--- a/ZelBack/src/services/appMonitoring/syncthingFolderStateMachine.js
+++ b/ZelBack/src/services/appMonitoring/syncthingFolderStateMachine.js
@@ -679,10 +679,38 @@ async function checkIfPeersAreSynced(folderId) {
       return true;
     }
 
-    // Check remote devices for this folder
+    return Boolean(await findSyncedPeer(folderId));
+  } catch (error) {
+    log.error(`checkIfPeersAreSynced - Error checking peers for ${folderId}: ${error.message}`);
+    return false;
+  }
+}
+
+/**
+ * The first connected peer that demonstrably holds everything in this folder.
+ *
+ * Unlike checkIfPeersAreSynced this never answers from our OWN folder mode: a
+ * caller about to delete its local copy needs a peer that holds the data, and
+ * "we are sendreceive" says nothing about where else the data lives.
+ * @param {string} folderId - Syncthing folder ID
+ * @returns {Promise<{deviceID: string, globalBytes: number}|null>} The peer, or
+ *   null when no peer can be shown to hold this folder.
+ */
+async function findSyncedPeer(folderId) {
+  try {
+    const configResponse = await syncthingService.getConfig({}, null);
+    if (!configResponse || configResponse.status !== 'success') {
+      return null;
+    }
+
+    const folder = configResponse.data.folders?.find((f) => f.id === folderId);
+    if (!folder) {
+      return null;
+    }
+
     const { devices = [] } = folder;
     if (devices.length === 0) {
-      return false;
+      return null;
     }
 
     // Get device completion status for each remote device
@@ -706,25 +734,25 @@ async function checkIfPeersAreSynced(folderId) {
         //   a bad seed would falsely satisfy "peers are synced" and we would remove
         //   the good local copy in favour of an empty one (data loss).
         if (remoteState === 'valid' && completion === 100 && globalBytes > 0) {
-          log.info(`checkIfPeersAreSynced - Found synced peer for ${folderId}: device ${device.deviceID.substring(0, 7)}... at ${completion}% (${globalBytes} bytes, connected)`);
-          return true;
+          log.info(`findSyncedPeer - Found synced peer for ${folderId}: device ${device.deviceID.substring(0, 7)}... at ${completion}% (${globalBytes} bytes, connected)`);
+          return { deviceID: device.deviceID, globalBytes };
         }
         if (completion === 100 && remoteState !== 'valid') {
-          log.warn(`checkIfPeersAreSynced - ${folderId}: device ${device.deviceID.substring(0, 7)}... reports 100% but is not connected (remoteState ${remoteState}); stale index, not a synced source`);
+          log.warn(`findSyncedPeer - ${folderId}: device ${device.deviceID.substring(0, 7)}... reports 100% but is not connected (remoteState ${remoteState}); stale index, not a synced source`);
         } else if (completion === 100) {
-          log.warn(`checkIfPeersAreSynced - ${folderId}: device ${device.deviceID.substring(0, 7)}... reports 100% but 0 bytes (empty); not treating it as a synced source`);
+          log.warn(`findSyncedPeer - ${folderId}: device ${device.deviceID.substring(0, 7)}... reports 100% but 0 bytes (empty); not treating it as a synced source`);
         }
       } catch (deviceError) {
         // a failed completion read silently skipping the device would read as
         // "peer not synced" with zero diagnostics - fail-safe, but loud
-        log.warn(`checkIfPeersAreSynced - ${folderId}: completion read for device ${device.deviceID.substring(0, 7)}... failed: ${deviceError.message}`);
+        log.warn(`findSyncedPeer - ${folderId}: completion read for device ${device.deviceID.substring(0, 7)}... failed: ${deviceError.message}`);
       }
     }
 
-    return false;
+    return null;
   } catch (error) {
-    log.error(`checkIfPeersAreSynced - Error checking peers for ${folderId}: ${error.message}`);
-    return false;
+    log.error(`findSyncedPeer - Error checking peers for ${folderId}: ${error.message}`);
+    return null;
   }
 }
 
@@ -1213,6 +1241,7 @@ module.exports = {
   isDesignatedLeader,
   verifyFolderMountSafety,
   verifySendReceiveFolderSafety,
+  findSyncedPeer,
   isPathMounted,
   checkDirectoryHasContent,
   checkDirectoryHasSyncScopedContent,

--- a/ZelBack/src/services/appMonitoring/syncthingFolderStateMachine.js
+++ b/ZelBack/src/services/appMonitoring/syncthingFolderStateMachine.js
@@ -698,12 +698,16 @@ async function checkIfPeersAreSynced(folderId) {
  */
 async function findSyncedPeer(folderId) {
   try {
-    const configResponse = await syncthingService.getConfig({}, null);
-    if (!configResponse || configResponse.status !== 'success') {
-      return null;
-    }
+    // getConfig takes no request and answers with the config itself, not a
+    // {status, data} envelope - the same call its sibling checkIfPeersAreSynced
+    // makes twenty lines up. Called the old way, this returned early on every
+    // invocation and findSyncedPeer answered null without ever asking a device,
+    // which reads as "no peer holds this data" and is the answer that keeps an
+    // app rather than removing it. Six unit tests caught it; nothing in the
+    // stacking rebase did, because both spellings parse.
+    const config = await syncthingService.getConfig();
 
-    const folder = configResponse.data.folders?.find((f) => f.id === folderId);
+    const folder = config?.folders?.find((f) => f.id === folderId);
     if (!folder) {
       return null;
     }

--- a/ZelBack/src/services/appMonitoring/syncthingFolderStateMachine.js
+++ b/ZelBack/src/services/appMonitoring/syncthingFolderStateMachine.js
@@ -713,9 +713,30 @@ async function findSyncedPeer(folderId) {
       return null;
     }
 
+    // Every folder's device list BEGINS with this node's own device - see
+    // syncthingMonitorHelpers, `const devices = [{ deviceID: myDeviceId }]` -
+    // and this walk had no self-exclusion, so it asked /rest/db/completion
+    // about the local device first. Our own copy trivially reports completion
+    // 100 with globalBytes > 0.
+    //
+    // What separates "a peer holds it" from "I hold it" today is only that
+    // syncthing does not report remoteState 'valid' for the local device: an
+    // incidental property of a field read defensively below, with a default,
+    // rather than an intention. Every other device walk in this codebase
+    // excludes local explicitly. If that assumption were ever wrong,
+    // canSafelyRemoveApp would return safe for a single-copy stateful app on
+    // the strength of the copy it is about to delete.
+    const localDeviceId = await syncthingService.getDeviceId().catch(() => null);
+
     // Get device completion status for each remote device
     // eslint-disable-next-line no-restricted-syntax
     for (const device of devices) {
+      // A device id this node could not establish excludes nothing, which is
+      // the safe direction: the completion checks below still have to pass.
+      if (localDeviceId && device.deviceID === localDeviceId) {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
       try {
         // eslint-disable-next-line no-await-in-loop
         const { completion = 0, globalBytes = 0, remoteState = 'unknown' } = await syncthingService.getDbCompletion({

--- a/ZelBack/src/services/appPlacement/ipLocationStore.js
+++ b/ZelBack/src/services/appPlacement/ipLocationStore.js
@@ -94,6 +94,22 @@ let regionCodeByName = new Map();
 // gather for itself (the registries' own record of what a block was assigned
 // for) is available; here it is only read.
 const NETWORK_CLASS_BY_CODE = Object.freeze({ 1: 'RESIDENTIAL', 2: 'DATACENTER' });
+
+/**
+ * The class a wire code names, or null when this build does not know it.
+ *
+ * An explicit comparison rather than a property lookup: `NETWORK_CLASS_BY_CODE[code]`
+ * answers for every member of Object.prototype, so a header carrying
+ * `{"<token>": "toString"}` would pass a truthiness check and store an inherited
+ * function as an organisation's network class.
+ * @param {*} code The code as it appears in the header.
+ * @returns {string|null} The class name, or null.
+ */
+function classForCode(code) {
+  if (code === 1) return NETWORK_CLASS_BY_CODE[1];
+  if (code === 2) return NETWORK_CLASS_BY_CODE[2];
+  return null;
+}
 let networkClassByOrg = new Map();
 let minimumRowCount = MIN_ROW_COUNT;
 // The per-node view, resident. It is a decoration on the node list - one small
@@ -250,10 +266,32 @@ function parseHeader(buf) {
   }
   const orgClasses = new Map();
   orgClassEntries.forEach(([token, code]) => {
-    if (!NETWORK_CLASS_BY_CODE[code]) {
-      throw malformed(`header orgClasses.${token} is not a known class code`);
+    // SKIPPED, not rejected. This vocabulary is a closed two-value enum here and
+    // a separate closed enum in the publisher's repo, and the artifact carries
+    // codes rather than names, so nothing binds them: adding a third class there
+    // and merging IS publishing - config.policy.baseUrl reads the branch head,
+    // with no FluxOS release in the loop. Throwing would take the next fetch on
+    // every node down with it, so a node holding no baseline yet would get none
+    // and every other node would silently stop updating - country, continent,
+    // region and organisation for two million rows, over one value in an
+    // optional section.
+    //
+    // That is the trade this file already refuses forty lines above, for
+    // regionNames: "the worse failure, not the stricter one". An organisation
+    // this build has no verdict for is a state lookup already returns
+    // (networkClass: null) and which enforces nothing, so an unreadable code
+    // costs exactly the enforcement it should and nothing else.
+    //
+    // Compared against the values rather than looked up, so a header saying
+    // "toString" cannot pass on an inherited function and store it as a class -
+    // the same hazard the Maps below are built to avoid, three lines away.
+    const known = classForCode(code);
+    if (!known) {
+      log.warn(`ipLocationStore - orgClasses.${token} carries class code ${JSON.stringify(code)},`
+        + ' which this build does not know; that organisation is left unclassified');
+      return;
     }
-    orgClasses.set(token, NETWORK_CLASS_BY_CODE[code]);
+    orgClasses.set(token, known);
   });
 
   return {

--- a/ZelBack/src/services/appPlacement/ipLocationStore.js
+++ b/ZelBack/src/services/appPlacement/ipLocationStore.js
@@ -88,6 +88,13 @@ let continentByCountry = new Map();
 // codes, while an app's geolocation may name a region the way ip-api does, and
 // this is what connects the two.
 let regionCodeByName = new Map();
+
+// Organisation token -> network class, from the header's optional orgClasses.
+// The classification is decided in the policy repo, where evidence a node cannot
+// gather for itself (the registries' own record of what a block was assigned
+// for) is available; here it is only read.
+const NETWORK_CLASS_BY_CODE = Object.freeze({ 1: 'RESIDENTIAL', 2: 'DATACENTER' });
+let networkClassByOrg = new Map();
 let minimumRowCount = MIN_ROW_COUNT;
 // The per-node view, resident. It is a decoration on the node list - one small
 // fact per listed address - and the node list lives in this process, so keeping
@@ -217,10 +224,12 @@ function parseHeader(buf) {
       throw malformed(`header continents.${country} is not a token`);
     }
   });
-  // The region-name vocabulary, keyed '<CC>|<name>'. Optional: a baseline built
-  // before it existed carries none, and without it a spec that names a region
-  // the way ip-api does is answered at country granularity - the same place a
-  // name this vocabulary cannot resolve lands, and the safe direction.
+  // The region-name vocabulary, keyed '<CC>|<name>'. Optional because its
+  // absence degrades safely: a spec naming a region the way ip-api does is then
+  // answered at country granularity, the same place a name this vocabulary
+  // cannot resolve lands. Requiring it would trade that conservative fallback
+  // for rejecting the whole table - losing country, region and organisation with
+  // it - which is the worse failure, not the stricter one.
   const regionNameEntries = Object.entries(header.regionNames ?? {});
   if (typeof (header.regionNames ?? {}) !== 'object' || Array.isArray(header.regionNames)) {
     throw malformed('header section regionNames is not an object');
@@ -231,11 +240,28 @@ function parseHeader(buf) {
       throw malformed(`header regionNames.${key} is not a token`);
     }
   });
+  // Which organisations run access networks and which sell hosting. Optional for
+  // the same reason regionNames is: an organisation absent from the map has no
+  // verdict, and a consumer that acts against nodes must do nothing without one,
+  // so its absence costs enforcement rather than misdirecting it.
+  const orgClassEntries = Object.entries(header.orgClasses ?? {});
+  if (typeof (header.orgClasses ?? {}) !== 'object' || Array.isArray(header.orgClasses)) {
+    throw malformed('header section orgClasses is not an object');
+  }
+  const orgClasses = new Map();
+  orgClassEntries.forEach(([token, code]) => {
+    if (!NETWORK_CLASS_BY_CODE[code]) {
+      throw malformed(`header orgClasses.${token} is not a known class code`);
+    }
+    orgClasses.set(token, NETWORK_CLASS_BY_CODE[code]);
+  });
+
   return {
     header,
     // Maps, so a country named after an Object.prototype member reads as itself
     continents: new Map(continentEntries),
     regionNames: new Map(regionNameEntries),
+    orgClasses,
     rowCount: buf.readUInt32LE(rowCountOffset),
     rowsOffset: rowCountOffset + 4,
   };
@@ -391,6 +417,7 @@ async function writeIngestMarker(database, parsed) {
         // the artifact
         continents: Object.fromEntries(parsed.continents),
         regionNames: Object.fromEntries(parsed.regionNames),
+        orgClasses: Object.fromEntries(parsed.orgClasses),
         ingestedAt: Date.now(),
       },
     },
@@ -429,6 +456,7 @@ async function setArtifact(bytes) {
   status = { ready: true, generated: parsed.header.generated, rowCount: parsed.rowCount };
   continentByCountry = parsed.continents;
   regionCodeByName = parsed.regionNames;
+  networkClassByOrg = parsed.orgClasses;
   await writeIngestMarker(database, parsed);
   log.info(`ipLocationStore - baseline installed: ${parsed.rowCount} ranges, generated ${parsed.header.generated}`);
   return { generated: status.generated, rowCount: status.rowCount };
@@ -456,6 +484,7 @@ async function adoptPersistedStatus() {
   status = { ready: true, generated: marker.generated, rowCount: marker.rowCount ?? 0 };
   continentByCountry = new Map(Object.entries(marker.continents ?? {}));
   regionCodeByName = new Map(Object.entries(marker.regionNames ?? {}));
+  networkClassByOrg = new Map(Object.entries(marker.orgClasses ?? {}));
   log.info(`ipLocationStore - adopted the stored baseline: ${status.rowCount} ranges, generated ${status.generated}`);
   return true;
 }
@@ -602,6 +631,9 @@ async function lookup(ip) {
     countryCode: row.c ?? null,
     continentCode: row.n ?? null,
     region: row.r ?? null,
+    // null, never a third class value: an organisation with no published verdict
+    // is one nothing may act on, and that must not be confusable with a verdict.
+    networkClass: (row.o && networkClassByOrg.get(row.o)) || null,
   };
 }
 
@@ -732,6 +764,7 @@ function clear() {
   status = { ready: false, generated: null, rowCount: 0 };
   continentByCountry = new Map();
   regionCodeByName = new Map();
+  networkClassByOrg = new Map();
   minimumRowCount = MIN_ROW_COUNT;
   nodeView = new Map();
   nodeViewLoaded = false;

--- a/ZelBack/src/services/appPlacement/ipLocationSync.js
+++ b/ZelBack/src/services/appPlacement/ipLocationSync.js
@@ -34,6 +34,7 @@ let refreshInterval = null;
 let retryTimer = null;
 let retryAttempt = 0;
 let started = false;
+let restored = false;
 let nodeLocationPass = null;
 
 /**
@@ -134,17 +135,23 @@ function scheduleRefresh() {
 }
 
 /**
- * Adopt the stored baseline - or restore the last-good artifact from GridFS -
- * then refresh in the background and daily thereafter. Placement needs no table
- * to run - it degrades to status-quo /16 arithmetic - so nothing here ever
- * gates boot. Idempotent. Call after mongo is up.
+ * Bring back the table this node already holds: adopt the stored baseline, or
+ * restore the last-good artifact from GridFS.
+ *
+ * Separate from startSync, and started separately, because the two halves need
+ * different things and cost different amounts. This half needs MONGO ONLY - on a
+ * node that has run before it is a single marker read, and the two million rows
+ * are already in the collection - so it belongs as early as the database is up.
+ * Every consumer of the table then has it within milliseconds of boot instead of
+ * waiting on work it does not depend on. Idempotent.
+ * @returns {Promise<void>}
  */
-async function startSync() {
-  if (started) return;
-  started = true;
-  // The restore is best-effort: a database that is briefly unavailable at this
-  // moment must not cost this process its table for the rest of its life, so a
-  // failure here still leaves the fetch and the refresh loop armed.
+async function restoreCachedTable() {
+  if (restored) return;
+  restored = true;
+  // Best-effort: a database briefly unavailable at this moment must not cost
+  // this process its table for the rest of its life, so a failure here still
+  // leaves the fetch and the refresh loop armed.
   try {
     const adopted = await ipLocationStore.adoptPersistedStatus();
     await policyArtifactRepository.sweepOrphanedArtifacts(ARTIFACT_NAME);
@@ -179,6 +186,24 @@ async function startSync() {
   } catch (error) {
     log.warn(`ipLocationSync - could not restore the cached table, fetching instead: ${error.message}`);
   }
+}
+
+/**
+ * Fetch the artifact if it has changed, and keep it fresh daily.
+ *
+ * The expensive half: a 4.2 MB download and, when the published baseline has
+ * moved, an ingest of two million rows. It is deliberately NOT started with the
+ * restore above - a node with no cache would otherwise run that ingest
+ * concurrently with the app-database rebuild, which is the busiest the database
+ * ever is. Placement needs no table to run - it degrades to status-quo /16
+ * arithmetic - so nothing here gates boot either way. Restores first if that has
+ * not happened. Idempotent.
+ * @returns {Promise<void>}
+ */
+async function startSync() {
+  if (started) return;
+  started = true;
+  await restoreCachedTable();
   scheduleRefresh();
   refreshInterval = setInterval(scheduleRefresh, REFRESH_INTERVAL_MS);
   if (refreshInterval.unref) refreshInterval.unref();
@@ -194,10 +219,12 @@ function stopSync() {
   retryTimer = null;
   retryAttempt = 0;
   started = false;
+  restored = false;
   etag = null;
 }
 
 module.exports = {
+  restoreCachedTable,
   startSync,
   stopSync,
   refresh,

--- a/ZelBack/src/services/appRequirements/hwRequirements.js
+++ b/ZelBack/src/services/appRequirements/hwRequirements.js
@@ -124,7 +124,15 @@ async function nodeFullGeolocation() {
 }
 
 /**
- * To check app requirements of staticip restrictions for a node
+ * To check app requirements of staticip restrictions for a node.
+ *
+ * `staticip` means the node is directly connected - a public address on its own
+ * interface - and has not been seen to move. Both halves are required: an app
+ * asking for this needs a fixed ip:port that stays REACHABLE, and a node
+ * reaching the world through a NAT port mapping promises neither, however
+ * stable its upstream address is. A range-level "this is a hosting network"
+ * verdict answers neither half, so it confers nothing here. The full rule, and
+ * the fleet census behind it, are in geolocationService's decision table.
  * @param {object} appSpecs App specifications.
  * @returns {boolean} True if all checks passed.
  */

--- a/ZelBack/src/services/appTamperingBlocklistService.js
+++ b/ZelBack/src/services/appTamperingBlocklistService.js
@@ -31,6 +31,27 @@ function isOurStickyDos() {
 }
 
 /**
+ * Give up the DOS this service is holding. The slot is only cleared when the
+ * message in it is still ours: the slot holds one message and has more than one
+ * enforcer writing to it, so clearing on our own `ourDosActive` alone would drop
+ * another owner's DOS on the floor. Dropping our claim is all we are entitled to
+ * do once the slot has changed hands.
+ * @param {string} reason Logged context for the release.
+ */
+function releaseOurDos(reason) {
+  if (isOurStickyDos()) {
+    log.info(`appTamperingBlocklist - clearing sticky DOS (${reason})`);
+    fluxNetworkHelper.clearStickyDosMessage();
+    ourDosActive = false;
+    return;
+  }
+  if (ourDosActive) {
+    log.info(`appTamperingBlocklist - our DOS was replaced by another owner, releasing our claim only (${reason})`);
+    ourDosActive = false;
+  }
+}
+
+/**
  * Fetch the manually-curated txhash blocklist from the policy repo.
  * Returns null on any failure - could-not-fetch is not an empty list, and the
  * enforcer must distinguish them or an outage clears an active DOS.
@@ -191,6 +212,15 @@ async function enforceBlocklist() {
   log.info(`appTamperingBlocklist - txhash=${myTxhash} listed=${listed} score=${tamperScore} shouldDos=${shouldDos}`);
 
   if (shouldDos) {
+    // Another owner's DOS already has this node out of service for its own
+    // reason. Taking the single slot from it would leave that owner unable to
+    // recognise or release its own state, and the node is DOSed either way -
+    // so leave it and re-check next tick.
+    const sticky = fluxNetworkHelper.getStickyDosMessage();
+    if (sticky && !isOurStickyDos()) {
+      log.info('appTamperingBlocklist - another sticky DOS is active, not overwriting it');
+      return;
+    }
     const message = `${DOS_MESSAGE_PREFIX}: tamper score ${tamperScore}, txhash ${myTxhash}`;
     fluxNetworkHelper.setStickyDosMessage(message);
     fluxNetworkHelper.setStickyDosStateValue(100);
@@ -199,11 +229,7 @@ async function enforceBlocklist() {
     return;
   }
 
-  if (ourDosActive || isOurStickyDos()) {
-    log.info(`appTamperingBlocklist - clearing sticky DOS (listed=${listed}, score=${tamperScore})`);
-    fluxNetworkHelper.clearStickyDosMessage();
-    ourDosActive = false;
-  }
+  releaseOurDos(`listed=${listed}, score=${tamperScore}`);
 }
 
 /**

--- a/ZelBack/src/services/appTamperingBlocklistService.js
+++ b/ZelBack/src/services/appTamperingBlocklistService.js
@@ -9,6 +9,11 @@ const benchmarkService = require('./benchmarkService');
 
 const BLOCKLIST_URL = `${config.policy.baseUrl}/tamperingblockednodes.json`;
 const CHECK_INTERVAL_MS = 12 * 60 * 60 * 1000; // 12 hours
+// How often to look at the DOS slot while waiting for another owner to let go
+// of it. Purely local - it reads the slot and nothing else, so it costs no
+// blocklist fetch and no benchmark call, which is why it can run this often
+// against a 12-hourly enforcement cadence.
+const SLOT_WATCH_MS = 60 * 1000; // 60s
 const SYNC_POLL_MS = 60 * 1000; // 60s while waiting for daemon sync
 const TAMPER_SCORE_THRESHOLD = 10;
 const DOS_MESSAGE_PREFIX = 'Node flagged via tampering blocklist';
@@ -16,6 +21,14 @@ const DOS_MESSAGE_PREFIX = 'Node flagged via tampering blocklist';
 const tamperingEventsCollection = config.database.local.collections.appTamperingEvents;
 
 let intervalHandle = null;
+let slotWatchHandle = null;
+// The DOS this node should be under, held here while another owner has the
+// single sticky slot. Enforcement runs every 12 hours, so without this a
+// blocklisted node that the other owner later RELEASES - a residential verdict
+// flipping to datacenter clears its own sticky - sits at DOS 0 taking apps
+// until the next 12-hourly tick. The slot is watched instead, and claimed
+// within a minute of it coming free.
+let deferredDosMessage = null;
 let ourDosActive = false;
 let stopping = false;
 let syncWaitTimer = null;
@@ -216,12 +229,19 @@ async function enforceBlocklist() {
     // reason. Taking the single slot from it would leave that owner unable to
     // recognise or release its own state, and the node is DOSed either way -
     // so leave it and re-check next tick.
+    const message = `${DOS_MESSAGE_PREFIX}: tamper score ${tamperScore}, txhash ${myTxhash}`;
     const sticky = fluxNetworkHelper.getStickyDosMessage();
     if (sticky && !isOurStickyDos()) {
-      log.info('appTamperingBlocklist - another sticky DOS is active, not overwriting it');
+      log.info('appTamperingBlocklist - another sticky DOS is active, not overwriting it; watching for the slot');
+      // Remembered, and the slot watched. The score in it can be a few hours
+      // stale by the time the slot frees, which is the right trade: the next
+      // full tick refreshes the message, and the node is one this build has
+      // already determined should be out of service.
+      deferredDosMessage = message;
+      startSlotWatch();
       return;
     }
-    const message = `${DOS_MESSAGE_PREFIX}: tamper score ${tamperScore}, txhash ${myTxhash}`;
+    stopSlotWatch();
     fluxNetworkHelper.setStickyDosMessage(message);
     fluxNetworkHelper.setStickyDosStateValue(100);
     ourDosActive = true;
@@ -229,7 +249,43 @@ async function enforceBlocklist() {
     return;
   }
 
+  stopSlotWatch();
   releaseOurDos(`listed=${listed}, score=${tamperScore}`);
+}
+
+/**
+ * Claim the DOS slot the moment the owner holding it lets go.
+ *
+ * Local only: it reads the sticky message and nothing else, so it costs no
+ * blocklist fetch, no benchmark call and no RPC.
+ */
+function claimSlotIfFree() {
+  if (!deferredDosMessage) {
+    stopSlotWatch();
+    return;
+  }
+  const sticky = fluxNetworkHelper.getStickyDosMessage();
+  if (sticky && !isOurStickyDos()) return;
+  fluxNetworkHelper.setStickyDosMessage(deferredDosMessage);
+  fluxNetworkHelper.setStickyDosStateValue(100);
+  ourDosActive = true;
+  log.error(`${deferredDosMessage} (claimed after another owner released the slot)`);
+  deferredDosMessage = null;
+  stopSlotWatch();
+}
+
+function startSlotWatch() {
+  if (slotWatchHandle || stopping) return;
+  slotWatchHandle = setInterval(claimSlotIfFree, SLOT_WATCH_MS);
+  if (slotWatchHandle.unref) slotWatchHandle.unref();
+}
+
+function stopSlotWatch() {
+  deferredDosMessage = null;
+  if (slotWatchHandle) {
+    clearInterval(slotWatchHandle);
+    slotWatchHandle = null;
+  }
 }
 
 /**
@@ -270,6 +326,7 @@ async function start() {
 
 function stop() {
   stopping = true;
+  stopSlotWatch();
   if (syncWaitTimer) {
     clearTimeout(syncWaitTimer);
     syncWaitTimer = null;
@@ -293,6 +350,8 @@ module.exports = {
   start,
   stop,
   enforceBlocklist,
+  // Test seam: the slot watch is otherwise only driven by its own timer.
+  claimSlotIfFree,
   fetchBlocklist,
   computeTamperScore,
   getMyTxhash,

--- a/ZelBack/src/services/explorerService.js
+++ b/ZelBack/src/services/explorerService.js
@@ -1118,12 +1118,22 @@ async function checkAndHandleReorgs(database, scannedBlockHeight) {
   return height;
 }
 
+// How long the explorer waits before asking again whether the chain has moved.
+//
+// This is the floor on how fast a node can process blocks: a block is not looked
+// at until the next poll, so nothing downstream of block processing - expiring
+// app records, trimming surplus instances, the give-up pass - can run more often
+// than this however fast blocks are produced. Production wants 5s against a 30s
+// block; a harness driving its own chain wants it far shorter, and had no way to
+// say so.
+const POLL_INTERVAL_MS = config.fluxapps.explorerPollIntervalMs ?? 5000;
+
 async function pollForNewBlocks() {
   if (!blockProccessingCanContinue) return;
   try {
     const syncStatus = daemonServiceMiscRpcs.isDaemonSynced();
     if (!syncStatus.data.synced) {
-      pollTimeout = setTimeout(pollForNewBlocks, 5000);
+      pollTimeout = setTimeout(pollForNewBlocks, POLL_INTERVAL_MS);
       return;
     }
 
@@ -1145,10 +1155,10 @@ async function pollForNewBlocks() {
       return;
     }
 
-    pollTimeout = setTimeout(pollForNewBlocks, 5000);
+    pollTimeout = setTimeout(pollForNewBlocks, POLL_INTERVAL_MS);
   } catch (error) {
     log.error(`Explorer poll error: ${error.message}`);
-    pollTimeout = setTimeout(pollForNewBlocks, 5000);
+    pollTimeout = setTimeout(pollForNewBlocks, POLL_INTERVAL_MS);
   }
 }
 

--- a/ZelBack/src/services/explorerService.js
+++ b/ZelBack/src/services/explorerService.js
@@ -627,7 +627,20 @@ async function processBlock(blockHeight, isInsightExplorer) {
     const options = {
       upsert: true,
     };
-    // this should run only when node is synced
+    // True when this block was still the chain tip at the moment it was fetched,
+    // which is NOT the same as "the node is synced". The tip is read from a
+    // cache refreshed every daemonInfoIntervalMs, and the branch at the end of
+    // this function chains straight into the next block whenever it is behind -
+    // so a burst of blocks arriving between two refreshes is processed back to
+    // back and only the LAST of them qualifies. Everything gated below is
+    // skipped for the others, and skipped silently: expiring global app
+    // records, trimming surplus instances, reinstalling outdated apps.
+    //
+    // Post-PON that is a 30s block against a 30s refresh, and the refresh
+    // reschedules only after awaiting its RPC, so it drifts behind the chain and
+    // the bursts recur. v9 removes the race rather than tuning it - fluxd pushes
+    // hashblockheight to chainTipSource, which drives both the cached tip and
+    // this scan, so a block is processed while it is still the tip.
     isSynced = !(blockDataVerbose.confirmations >= 2);
     if (isSynced) {
       blockEmitter.emit('blocksProcessed', scannedHeight);

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -54,6 +54,13 @@ let dosMessage = null;
 let stickyDosState = 0;
 let stickyDosMessage = null;
 
+// Stops the node taking on NEW apps without declaring it unfit for the ones it
+// already runs. DOS conflates those: isNodeDos() makes appSpawner refuse
+// installs AND makes nodeStatusMonitor and appStartupManager delete every app on
+// the box. A node that must stop growing but keep its customer volumes needs
+// only the first, so this is a separate flag whose only consumer is the spawner.
+let placementHold = null;
+
 let storedFluxBenchAllowed = null;
 let ipChangeData = null;
 let dosTooManyIpChanges = false;
@@ -901,6 +908,39 @@ function getDosStateValue() {
 function isNodeDos() {
   const effectiveState = stickyDosMessage ? stickyDosState : dosState;
   return effectiveState >= 100;
+}
+
+/**
+ * Hold this node back from new placements. Idempotent.
+ * @param {string} reason Identifies the owner; logged and reported.
+ */
+function setPlacementHold(reason) {
+  if (placementHold === reason) return;
+  placementHold = reason;
+  log.info(`Placement hold set: ${reason}`);
+}
+
+/**
+ * Release the hold. The owner clears it when the condition that set it lifts.
+ */
+function clearPlacementHold() {
+  if (placementHold === null) return;
+  log.info(`Placement hold cleared (was: ${placementHold})`);
+  placementHold = null;
+}
+
+/**
+ * @returns {string|null} Why the node is held, or null when it is not.
+ */
+function getPlacementHold() {
+  return placementHold;
+}
+
+/**
+ * @returns {boolean} True when this node must not take on new apps.
+ */
+function isPlacementHeld() {
+  return placementHold !== null;
 }
 
 /**
@@ -2580,6 +2620,10 @@ module.exports = {
   setDosStateValue,
   getDosStateValue,
   isNodeDos,
+  setPlacementHold,
+  clearPlacementHold,
+  getPlacementHold,
+  isPlacementHeld,
   setStickyDosMessage,
   getStickyDosMessage,
   clearStickyDosMessage,

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -54,12 +54,28 @@ let dosMessage = null;
 let stickyDosState = 0;
 let stickyDosMessage = null;
 
+// Who may hold this node back from placement. An owner is an IDENTITY, not a
+// message: the reason is what an operator reads, and the owner is what a release
+// is checked against. Adding a feature that holds placement means adding a value
+// here, which is the point - an unknown owner is refused rather than accepted as
+// a new one.
+const PlacementHoldOwner = Object.freeze({
+  RESIDENTIAL_DOS: 'residentialDos',
+});
+
 // Stops the node taking on NEW apps without declaring it unfit for the ones it
 // already runs. DOS conflates those: isNodeDos() makes appSpawner refuse
 // installs AND makes nodeStatusMonitor and appStartupManager delete every app on
 // the box. A node that must stop growing but keep its customer volumes needs
 // only the first, so this is a separate flag whose only consumer is the spawner.
-let placementHold = null;
+//
+// owner -> reason, rather than one slot. A single slot cannot express two
+// owners: a second hold OVERWROTE the first, and whoever cleared next released
+// both - so the node resumed taking apps for a condition that had not lifted.
+// Checking ownership on a single slot only moves the failure, because the
+// overwritten owner can then never clear and the node stays held forever. The
+// node is held while any owner holds it.
+const placementHolds = new Map();
 
 let storedFluxBenchAllowed = null;
 let ipChangeData = null;
@@ -947,36 +963,50 @@ function isNodeDos() {
 }
 
 /**
- * Hold this node back from new placements. Idempotent.
- * @param {string} reason Identifies the owner; logged and reported.
+ * Hold this node back from new placements. Idempotent per owner.
+ * @param {string} owner A PlacementHoldOwner value. An unknown one throws: it is
+ * a caller that was never given an identity, and accepting it would create an
+ * owner nothing can ever release.
+ * @param {string} reason Logged and reported.
  */
-function setPlacementHold(reason) {
-  if (placementHold === reason) return;
-  placementHold = reason;
-  log.info(`Placement hold set: ${reason}`);
+function setPlacementHold(owner, reason) {
+  if (!Object.values(PlacementHoldOwner).includes(owner)) {
+    throw new Error(`setPlacementHold: unknown owner ${owner}`);
+  }
+  if (placementHolds.get(owner) === reason) return;
+  placementHolds.set(owner, reason);
+  log.info(`Placement hold set by ${owner}: ${reason}`);
 }
 
 /**
- * Release the hold. The owner clears it when the condition that set it lifts.
+ * Release one owner's hold. Any other owner's hold stands, and the node stays
+ * held until every one of them has released - so a feature clearing its own
+ * condition can never speak for a condition it knows nothing about.
+ * @param {string} owner A PlacementHoldOwner value.
  */
-function clearPlacementHold() {
-  if (placementHold === null) return;
-  log.info(`Placement hold cleared (was: ${placementHold})`);
-  placementHold = null;
+function clearPlacementHold(owner) {
+  const reason = placementHolds.get(owner);
+  if (reason === undefined) return;
+  placementHolds.delete(owner);
+  log.info(`Placement hold cleared by ${owner} (was: ${reason})`);
 }
 
 /**
  * @returns {string|null} Why the node is held, or null when it is not.
  */
 function getPlacementHold() {
-  return placementHold;
+  if (!placementHolds.size) return null;
+  // Every reason, not an arbitrary one: the spawner logs this to say why the
+  // node is not installing, and naming one of two holds would send an operator
+  // to lift a condition that would not release the node.
+  return [...placementHolds.values()].join('; ');
 }
 
 /**
  * @returns {boolean} True when this node must not take on new apps.
  */
 function isPlacementHeld() {
-  return placementHold !== null;
+  return placementHolds.size > 0;
 }
 
 /**
@@ -2656,6 +2686,7 @@ module.exports = {
   setDosStateValue,
   getDosStateValue,
   isNodeDos,
+  PlacementHoldOwner,
   setPlacementHold,
   clearPlacementHold,
   getPlacementHold,

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -104,9 +104,12 @@ async function isInterfaceUp(interfaceName) {
 }
 
 /**
- * Gets the IP address assigned to a specific network interface.
+ * Gets the first routable IPv4 address assigned to a network interface. An
+ * interface can carry a private primary and a public secondary; stopping at
+ * the first non-internal address would answer for whichever the kernel lists
+ * first rather than for the interface.
  * @param {string} interfaceName - The name of the network interface
- * @returns {string|null} The IPv4 address or null if not found
+ * @returns {string|null} The routable IPv4 address or null if none is bound
  */
 function getInterfaceIp(interfaceName) {
   const interfaces = os.networkInterfaces();
@@ -114,7 +117,7 @@ function getInterfaceIp(interfaceName) {
   if (!iface) return null;
 
   for (const addr of iface) {
-    if (addr.family === 'IPv4' && !addr.internal) {
+    if (addr.family === 'IPv4' && !addr.internal && !serviceHelper.isNonRoutableAddress(addr.address)) {
       return addr.address;
     }
   }
@@ -181,7 +184,7 @@ async function hasPublicIpOnInterface() {
       const isUp = await isInterfaceUp(route.iface);
       if (isUp) {
         const ip = getInterfaceIp(route.iface);
-        if (ip && !serviceHelper.isNonRoutableAddress(ip)) {
+        if (ip) {
           log.info(`Public IP ${ip} found on default route interface ${route.iface}`);
           return true;
         }

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -126,7 +126,9 @@ function getInterfaceIp(interfaceName) {
  * This is a strong indicator of a static IP (data center/VPS/dedicated server).
  * Uses the Linux routing table to find the default route interface, then checks
  * if that interface has a public IP assigned.
- * @returns {Promise<boolean>} True if a public IP is configured on the default route interface
+ * @returns {Promise<boolean|null>} True if a public IP is configured on the
+ *   default route interface, false if none is, null if the routing table could
+ *   not be read - which is not the same answer as "there is none".
  */
 async function hasPublicIpOnInterface() {
   try {
@@ -188,8 +190,13 @@ async function hasPublicIpOnInterface() {
 
     return false;
   } catch (error) {
+    // Null, not false. "There is no public address on any interface" is a fact
+    // about the node; "I could not read the routing table" is a fact about this
+    // process, and answering the second with the first asserts NAT on a node
+    // that may well hold a public address. The one caller that decides anything
+    // on this treats null as unknown.
     log.error(`Failed to check network interfaces via routing table: ${error.message}`);
-    return false;
+    return null;
   }
 }
 

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -861,6 +861,7 @@ function getDosMessage() {
  */
 function setStickyDosMessage(message) {
   stickyDosMessage = message;
+  publishEffectiveDosState();
 }
 
 /**
@@ -877,6 +878,30 @@ function getStickyDosMessage() {
 function clearStickyDosMessage() {
   stickyDosMessage = null;
   stickyDosState = 0;
+  publishEffectiveDosState();
+}
+
+/**
+ * Publish the DOS state a reader would actually see.
+ *
+ * isNodeDos() answers on `stickyDosMessage ? stickyDosState : dosState`, so the
+ * effective value moves when EITHER half of the sticky pair moves, and neither
+ * setter emitted anything. A consumer therefore had to poll /flux/info, and a
+ * poll cannot order a DOS against anything else: the installed-apps record
+ * outlives the removal it follows by ~20s, so two polls of two sources disagree
+ * about what happened first. On one event stream the ids settle it.
+ *
+ * Inert in production - fluxEventBus.publish returns immediately unless
+ * config.testEventStream is set, which it is only under the harness. This is
+ * not the 21-site refactor noted below getDosStateValue; that one is about the
+ * product's own scattered dosState mutations.
+ */
+function publishEffectiveDosState() {
+  const effectiveDosState = stickyDosMessage ? stickyDosState : dosState;
+  fluxEventBus.publish('dos:changed', {
+    dosState: effectiveDosState,
+    dosMessage: stickyDosMessage || dosMessage,
+  });
 }
 
 /**
@@ -885,6 +910,7 @@ function clearStickyDosMessage() {
  */
 function setStickyDosStateValue(value) {
   stickyDosState = value;
+  publishEffectiveDosState();
 }
 
 /**

--- a/ZelBack/src/services/fluxService.js
+++ b/ZelBack/src/services/fluxService.js
@@ -1388,6 +1388,20 @@ async function getFluxInfo(req, res) {
     }
     info.flux.ip = ipRes.data;
     info.flux.staticIp = geolocationService.isStaticIP();
+    // How far this node is through being staged out of service, or null. Read
+    // beside `dos` below, which reports the last stage: the three read together
+    // as HOLD, then EVACUATE, then EVACUATE with a DOS.
+    //
+    // Reported at all because the first stage is otherwise invisible. A held
+    // node stops taking new apps and looks in every other way like one that has
+    // simply not been given work - and that stage is the whole settling window,
+    // the only part of this where an operator can still put the node right and
+    // lose nothing.
+    //
+    // Lazily required: this service is loaded by half the tree and the enforcer
+    // reaches back into fluxNetworkHelper, which reaches here.
+    // eslint-disable-next-line global-require
+    info.flux.dosStaging = require('./residentialNodeDosService').getDosStaging();
     info.flux.upnp = upnpService.isUPNP();
     info.flux.maxNumberOfIpChanges = fluxNetworkHelper.getMaxNumberOfIpChanges();
     const zelidRes = await getFluxZelID();

--- a/ZelBack/src/services/geolocationService.js
+++ b/ZelBack/src/services/geolocationService.js
@@ -304,28 +304,103 @@ async function setNodeGeolocation() {
       ipFirstSeenAt = now;
       log.info(`IP changed from ${previousIp} to ${currentIp}. Static IP observation restarts.`);
     } else if (!ipFirstSeenAt) {
-      // An address just met has been held for no time at all. It becomes STATIC
-      // by being held, never by assumption.
-      ipFirstSeenAt = now;
-      log.info(`First observation of ${currentIp}. Static IP unknown until it has been held for ${staticIpStabilityDays} days.`);
+      // Seeded from the last change on record rather than from now: an address
+      // held since a change 400 days ago has been held for 400 days, and that
+      // record is persisted and restored. Without this, an in-place upgrade
+      // introducing ipFirstSeenAt restarts the window on a node that has held
+      // its address for years.
+      ipFirstSeenAt = lastIpChangeDate ?? now;
+      log.info(`First observation of ${currentIp} by this build`
+        + `${lastIpChangeDate ? `, held since the change recorded ${new Date(lastIpChangeDate).toISOString()}` : ', with no change ever recorded'}.`);
     }
 
     const hasPublicIp = await fluxNetworkHelper.hasPublicIpOnInterface();
     const heldForMs = now - ipFirstSeenAt;
     const heldDays = heldForMs / (24 * 60 * 60 * 1000);
 
-    if (!hasPublicIp) {
-      // The public address is not on any local interface, so the node is behind
-      // NAT. Nothing about the operator changes that.
-      staticIpState = STATIC_IP_STATE.DYNAMIC;
+    // THE WHOLE DECISION, in one table. Read down the first two columns; the
+    // third is consulted only where the first two cannot settle it.
+    //
+    //   public IP on   this node has     published     verdict
+    //   the interface  SEEN it change    table says
+    //   -------------  ---------------   -----------   -------------------
+    //   yes            no                (not asked)   STATIC
+    //   yes            yes, >10d ago     (not asked)   STATIC
+    //   yes            yes, <10d ago     hosting       STATIC
+    //   yes            yes, <10d ago     anything else UNKNOWN
+    //   no  (NAT)      -                 hosting       STATIC
+    //   no  (NAT)      -                 anything else DYNAMIC
+    //   unreadable     -                 hosting       STATIC
+    //   unreadable     -                 anything else UNKNOWN
+    //
+    // Only STATIC satisfies an app's `staticip` requirement; UNKNOWN and
+    // DYNAMIC both fail it, and are kept apart so a node that could not answer
+    // does not read as one that answered "behind NAT".
+    //
+    // Row 1 is the common case and the one that matters most: a node has SEEN
+    // no change because it started watching after the fact, which every node
+    // does exactly once. That is not evidence the address moves. Measured on
+    // the fleet an address changes on 0.29% of node-days, so treating
+    // not-yet-watched as suspect is wrong about ~97% of nodes for the ten days
+    // it lasts - and it lands on all of them together, because they upgrade
+    // together. An observed change is what withdraws the trust; rows 2-4 are
+    // the address earning it back.
+    //
+    // Where the local test cannot answer, the published table can. A 1:1-NAT
+    // cloud instance holds a genuinely static address that never appears on any
+    // local interface - every AWS, Azure, GCP and Oracle box fails the test
+    // above - and a range the table calls hosting is that case.
+    //
+    // This is the job the deleted staticIpOrgs list was doing, done on evidence
+    // that has been measured. That list was nine hoster names matched against
+    // the block REGISTRANT, which disagrees with the operator on 67% of fleet
+    // hosts, backed by an ip-api `static` field that is literally
+    // `proxy || hosting`.
+    //
+    // Measured against the two signals over the whole fleet - 5,661 node slots
+    // on 2,349 machines - the table treats 268 more slots as static than the
+    // list did, on 153 machines it never named (83 of them one operator), and
+    // withdraws it from 49 slots on 11 machines. Seven of those eleven are
+    // consumer ISPs the list was wrong about - Verizon, Comcast, Free SAS,
+    // Bouygues - flagged `proxy`, which is a VPN artefact and not an address
+    // that stays put. The remaining four are genuine hosting the table has not
+    // classified yet, and data/orgclass-overrides.json in
+    // fluxos-network-policy is where that is corrected.
+    const publishedHosting = (await publishedClassification(currentIp)).classification
+      === networkClassifier.CLASSIFICATION.DATACENTER;
+
+    if (hasPublicIp === null) {
+      // The routing table could not be read. Not evidence of anything about the
+      // address, and in particular not evidence of NAT.
+      staticIpState = publishedHosting ? STATIC_IP_STATE.STATIC : STATIC_IP_STATE.UNKNOWN;
+    } else if (!hasPublicIp) {
+      // Behind NAT as far as this node can see.
+      staticIpState = publishedHosting ? STATIC_IP_STATE.STATIC : STATIC_IP_STATE.DYNAMIC;
+    } else if (!lastIpChangeDate) {
+      // A public address on the interface, and this node has never seen it
+      // change. Absence of an observed change is not evidence that the address
+      // moves - it is this node having started watching after the fact, which
+      // every node does exactly once. Measured on the fleet, an address changes
+      // on 0.29% of node-days, so treating "not yet watched" as suspect is
+      // wrong about roughly 97% of nodes for the whole ten days it lasts, and
+      // it lands on all of them at once because they upgrade together.
+      //
+      // Trusted until it is seen to move, and one observed change is what
+      // withdraws it - the branch below then makes the address earn it back.
+      staticIpState = STATIC_IP_STATE.STATIC;
     } else if (heldForMs >= stabilityThreshold) {
       staticIpState = STATIC_IP_STATE.STATIC;
+    } else if (publishedHosting) {
+      // It has moved recently, but it is in a hosting range: an address that
+      // moves within a data centre is still handed back as a fixed one.
+      staticIpState = STATIC_IP_STATE.STATIC;
     } else {
-      // Public IP on the interface, but not yet held long enough to know.
+      // It has demonstrably moved and has not been held long enough since.
       staticIpState = STATIC_IP_STATE.UNKNOWN;
     }
     staticIp = staticIpState === STATIC_IP_STATE.STATIC;
-    log.info(`Static IP: ${staticIpState} (public IP on interface: ${hasPublicIp}, address held ${heldDays.toFixed(1)} of ${staticIpStabilityDays} days)`);
+    log.info(`Static IP: ${staticIpState} (public IP on interface: ${hasPublicIp}, address held ${heldDays.toFixed(1)} of ${staticIpStabilityDays} days`
+      + `, published hosting range: ${publishedHosting})`);
 
     // Whether the address is held (above) and what network it sits on (here) are
     // separate questions, answered from separate evidence.

--- a/ZelBack/src/services/geolocationService.js
+++ b/ZelBack/src/services/geolocationService.js
@@ -234,6 +234,16 @@ async function setNodeGeolocation() {
 
     const localIp = extractIp(localSocketAddr);
 
+    // Restore what this node already observed before deciding anything from it.
+    // serviceManager calls this function directly at boot, with nothing having
+    // read the collection, so every module variable below starts null: the
+    // address the node held reads as "no previous address", a change across the
+    // restart is therefore invisible, and the write at the end of this pass
+    // persists lastIpChangeDate: null over a record that may go back years.
+    // getNodeGeolocation returns immediately once storedGeolocation is set, so
+    // this costs one read on the first pass and nothing after it.
+    await getNodeGeolocation();
+
     // Store previous IP to detect changes
     const previousIp = storedGeolocation ? storedGeolocation.ip : null;
 

--- a/ZelBack/src/services/geolocationService.js
+++ b/ZelBack/src/services/geolocationService.js
@@ -360,12 +360,18 @@ async function setNodeGeolocation() {
       evidenceFor: Object.freeze([...classified.evidenceFor]),
       evidenceAgainst: Object.freeze([...classified.evidenceAgainst]),
       ptr: ptr || null,
+      // Whether this pass had the signals that can contradict a residential
+      // reading. False on the stats.runonflux.io fallback, which carries none
+      // of them - and an empty evidenceAgainst from that path is nobody having
+      // looked, not nothing having been found.
+      contradictionSignalsGathered: classified.contradictionSignalsGathered,
       gatheredAt: now,
     });
     dataCenter = classified.classification === networkClassifier.CLASSIFICATION.DATACENTER;
     log.info(`Network evidence for ${currentIp}: the node's own reading is ${classified.classification}`
       + ` (for: ${classified.evidenceFor.join(', ') || 'none'};`
-      + ` against: ${classified.evidenceAgainst.join(', ') || 'none'})`);
+      + ` against: ${classified.evidenceAgainst.join(', ') || 'none'}`
+      + `${classified.contradictionSignalsGathered ? '' : '; hosting/proxy/operator signals were NOT gathered'})`);
 
     // Store geolocation to database for persistence across restarts
     await storeGeolocationToDb(storedGeolocation, staticIp, dataCenter, lastIpChangeDate, {
@@ -469,26 +475,51 @@ function isDataCenter() {
 async function getNetworkClassification() {
   if (!networkEvidence) return null;
 
+  // Nothing usable was gathered about what kind of network this is, so this
+  // node has no verdict - not even the table's. The veto below is the only
+  // thing that can decline a published RESIDENTIAL, and it fires on local
+  // evidence AGAINST; on a pass that never obtained any, it cannot fire, so a
+  // published verdict would go unchallenged precisely where challenging it
+  // matters. Returning null leaves the node unclassified, which enforces
+  // nothing and re-derives on the next pass that reaches ip-api.
+  if (!networkEvidence.contradictionSignalsGathered) return null;
+
   const published = await publishedClassification(networkEvidence.ip);
   if (!published.consulted) return null;
 
+  // THE TABLE DECIDES, OR NOBODY DOES. Where it carries no verdict this returns
+  // null and the node is simply not classified, which enforces nothing.
+  //
+  // It used to fall back to the node's own reading. That rule is the published
+  // rule with its strongest signal removed - six thousand nodes cannot each
+  // query the RIRs, so registration data belongs in the table - and its error
+  // rate has never been measured: 0.13% is reverse DNS alone and 0.00% is the
+  // combined rule WITH registration, and neither is what a node runs. It decided
+  // for the ~8% of hosts whose organisation carries no published verdict, on the
+  // one path that deletes customer data.
+  //
+  // Tuning belongs in fluxos-network-policy, where a verdict is evidence-backed,
+  // auditable by anyone, correctable by hand through
+  // data/orgclass-overrides.json, and fixable without a FluxOS release.
+  if (!published.classification) return null;
+
   // The table decides, but a node that can see hosting evidence about its OWN
-  // address exempts itself. An organisation is published on a strong majority
-  // of its hosts rather than on all of them, so a minority of its addresses may
-  // be the other kind - and this is how one of them declines a verdict meant
-  // for its neighbours. The veto only ever removes a node from enforcement;
-  // local evidence can never impose one the table did not give.
+  // address exempts itself. An organisation is decided by 80% of its hosts
+  // agreeing, so a minority tail of the other kind is guaranteed by
+  // construction - and this is how one of them declines a verdict meant for its
+  // neighbours, until someone adjudicates the range. The veto only ever removes
+  // a node from enforcement; local evidence can never impose one the table did
+  // not give.
   const vetoed = published.classification === networkClassifier.CLASSIFICATION.RESIDENTIAL
     && networkEvidence.evidenceAgainst.length > 0;
 
   return Object.freeze({
     classification: vetoed
       ? networkClassifier.CLASSIFICATION.CONFLICTED
-      : (published.classification ?? networkEvidence.classification),
+      : published.classification,
     // Which authority decided, so a verdict can be traced to the table that
-    // carried it, to the node that worked it out, or to the node declining one.
-    // eslint-disable-next-line no-nested-ternary
-    source: vetoed ? 'node-veto' : (published.classification ? 'published-table' : 'node'),
+    // carried it or to the node declining one.
+    source: vetoed ? 'node-veto' : 'published-table',
     evidenceFor: networkEvidence.evidenceFor,
     evidenceAgainst: networkEvidence.evidenceAgainst,
     ptr: networkEvidence.ptr,

--- a/ZelBack/src/services/geolocationService.js
+++ b/ZelBack/src/services/geolocationService.js
@@ -218,17 +218,65 @@ async function benchLinkSpeeds() {
   }
 }
 
+// How long until the next pass, by outcome.
+const AWAITING_IP_RETRY_MS = 10 * 1000;
+const REFRESH_INTERVAL_MS = 3 * 24 * 60 * 60 * 1000;
+const FAILURE_RETRY_MS = 5 * 60 * 1000;
+
+// THE LOOP IS A SINGLETON, because it has two callers and it reschedules itself.
+// serviceManager starts it at boot and fluxNetworkHelper restarts it on EVERY IP
+// change, and each pass used to arm a bare setTimeout whose handle nobody kept.
+// So a second caller did not resume the loop, it forked another one, and no
+// chain could ever be stopped: a node that changed IP three times ran four
+// independent loops for the life of the process, each hitting the geolocation
+// API and writing the same record, and on a node that never detected its IP each
+// one logged an error every ten seconds. Only restarting FluxOS ended any of it.
+//
+// One handle, cancelled before it is re-armed, is what makes a second caller
+// resume the loop instead of adding one.
+let scheduledRun = null;
+// The pass currently executing, and whether a caller arrived while it ran. That
+// is the normal case rather than the exotic one - an IP change lands while the
+// previous pass is still awaiting the geolocation API - and letting the two
+// interleave would settle lastIpChangeDate on whichever finished last rather
+// than on the order the addresses actually changed. The late caller is not
+// dropped; it runs once the pass in flight is done.
+let runInFlight = null;
+let rerunRequested = false;
+
 /**
- * Method responsable for setting node geolocation information
+ * Arms the next pass, cancelling any pass already pending. Every exit from
+ * runGeolocationPass goes through here, so there is at most one at any moment.
+ * @param {number} delayMs
  */
-async function setNodeGeolocation() {
+function scheduleNext(delayMs) {
+  if (scheduledRun) clearTimeout(scheduledRun);
+  scheduledRun = setTimeout(() => {
+    scheduledRun = null;
+    setNodeGeolocation();
+  }, delayMs);
+}
+
+/**
+ * Ends the geolocation loop. Exported because a timer nobody can stop is a leak
+ * wherever it runs - a node that wants to shut down cleanly, and a test that
+ * would otherwise leave a three-day timer armed for the rest of the run.
+ */
+function stopNodeGeolocation() {
+  if (scheduledRun) clearTimeout(scheduledRun);
+  scheduledRun = null;
+  rerunRequested = false;
+}
+
+/**
+ * One pass: read the address, classify it, persist it, and arm the next.
+ */
+async function runGeolocationPass() {
   try {
     const localSocketAddr = await fluxNetworkHelper.getLocalSocketAddress();
     if (!localSocketAddr) {
       log.error('Flux IP not detected. Flux geolocation service is awaiting');
-      setTimeout(() => {
-        setNodeGeolocation();
-      }, 10 * 1000);
+      scheduleNext(AWAITING_IP_RETRY_MS);
       return;
     }
 
@@ -472,16 +520,35 @@ async function setNodeGeolocation() {
       networkEvidence,
     });
     execution += 1;
-    setTimeout(() => { // executes again in 3 days
-      setNodeGeolocation();
-    }, 3 * 24 * 60 * 60 * 1000);
+    scheduleNext(REFRESH_INTERVAL_MS);
   } catch (error) {
     log.error(`Failed to get Geolocation with ${error}`);
     log.error(error);
-    setTimeout(() => {
-      setNodeGeolocation();
-    }, 5 * 60 * 1000);
+    scheduleNext(FAILURE_RETRY_MS);
   }
+}
+
+/**
+ * Method responsable for setting node geolocation information. Safe to call from
+ * anywhere, any number of times: it resumes the one loop rather than starting
+ * another, and never runs two passes at once.
+ */
+async function setNodeGeolocation() {
+  if (runInFlight) {
+    rerunRequested = true;
+    return runInFlight;
+  }
+  runInFlight = runGeolocationPass();
+  try {
+    await runInFlight;
+  } finally {
+    runInFlight = null;
+  }
+  if (rerunRequested) {
+    rerunRequested = false;
+    return setNodeGeolocation();
+  }
+  return undefined;
 }
 
 /**
@@ -646,6 +713,7 @@ async function hasPublicIp() {
 
 module.exports = {
   setNodeGeolocation,
+  stopNodeGeolocation,
   getNodeGeolocation,
   isStaticIP,
   getStaticIpState,

--- a/ZelBack/src/services/geolocationService.js
+++ b/ZelBack/src/services/geolocationService.js
@@ -503,7 +503,14 @@ async function getNodeGeolocation() {
       ipFirstSeenAt,
       networkEvidence,
     } = dbData);
-    staticIpState = dbData.staticIpState ?? STATIC_IP_STATE.UNKNOWN;
+    // A record from before the state machine carries only the boolean, and the
+    // state must agree with it: a node that restores as not-static fails
+    // checkAppStaticIpRequirements in the redeploy paths, which remove the app
+    // when it throws. STATIC here is a carried prior the first refresh pass
+    // replaces; a stored false restores as UNKNOWN because an old record
+    // cannot tell dynamic from never-checked.
+    staticIpState = dbData.staticIpState
+      ?? (staticIp ? STATIC_IP_STATE.STATIC : STATIC_IP_STATE.UNKNOWN);
     log.info('Geolocation restored from database');
   }
   return storedGeolocation;

--- a/ZelBack/src/services/geolocationService.js
+++ b/ZelBack/src/services/geolocationService.js
@@ -292,8 +292,10 @@ async function setNodeGeolocation() {
     }
     log.info(`Geolocation of ${localIp} is ${JSON.stringify(storedGeolocation)}`);
 
-    // Static IP is observed, never inferred from the operator: the address must
-    // be bound to a local interface and have been held for the stability window.
+    // Static IP is observed, never inferred from the operator. A public address
+    // is trusted until this node WATCHES it move; the stability window is how
+    // one that moved earns the trust back, not a probation every node serves
+    // once. The whole rule is the table below.
     const currentIp = storedGeolocation.ip;
     const ipChanged = previousIp && previousIp !== currentIp;
     const now = Date.now();

--- a/ZelBack/src/services/geolocationService.js
+++ b/ZelBack/src/services/geolocationService.js
@@ -1,9 +1,11 @@
 const config = require('config');
+const dns = require('node:dns').promises;
 const log = require('../lib/log');
 const fluxNetworkHelper = require('./fluxNetworkHelper');
 const { extractIp } = require('./utils/socketAddressUtils');
 const serviceHelper = require('./serviceHelper');
 const dbHelper = require('./dbHelper');
+const networkClassifier = require('./utils/networkClassifier');
 
 const { geolocation: geolocationCollection } = config.database.local.collections;
 
@@ -13,7 +15,25 @@ let staticIp = false;
 let dataCenter = false;
 let lastIpChangeDate = null;
 let execution = 1;
-const staticIpOrgs = ['hetzner', 'ovh', 'netcup', 'hostnodes', 'contabo', 'hostslim', 'zayo', 'cogent', 'lumen'];
+// Null means no verdict has been reached yet, which readers must distinguish
+// from a verdict of UNKNOWN: "not computed" against "computed, and the evidence
+// does not decide".
+let networkClassification = null;
+
+/**
+ * Whether this address stays put. Three-state, because "we have not observed it
+ * long enough" is a different answer from "it moves", and only one of them
+ * should keep a node away from apps that need a stable address.
+ */
+const STATIC_IP_STATE = Object.freeze({
+  STATIC: 'STATIC',
+  DYNAMIC: 'DYNAMIC',
+  UNKNOWN: 'UNKNOWN',
+});
+let staticIpState = STATIC_IP_STATE.UNKNOWN;
+// The stability window is measured from here, not from lastIpChangeDate, which
+// stays null until a change is actually seen.
+let ipFirstSeenAt = null;
 const staticIpStabilityDays = 10;
 
 /**
@@ -23,7 +43,7 @@ const staticIpStabilityDays = 10;
  * @param {boolean} isDataCenter - Whether the node is in a data center
  * @param {number|null} ipChangeDate - Timestamp of when the IP last changed
  */
-async function storeGeolocationToDb(geolocation, isStaticIp, isDataCenter, ipChangeDate) {
+async function storeGeolocationToDb(geolocation, isStaticIp, isDataCenter, ipChangeDate, observations = {}) {
   try {
     const dbClient = dbHelper.databaseConnection();
     if (!dbClient) {
@@ -38,6 +58,11 @@ async function storeGeolocationToDb(geolocation, isStaticIp, isDataCenter, ipCha
         staticIp: isStaticIp,
         dataCenter: isDataCenter,
         lastIpChangeDate: ipChangeDate,
+        // The window is an observation, so it outlives the process: a restart
+        // that reset it would hold every node at UNKNOWN for another ten days.
+        ipFirstSeenAt: observations.ipFirstSeenAt ?? null,
+        staticIpState: observations.staticIpState ?? null,
+        networkClassification: observations.networkClassification ?? null,
         updatedAt: Date.now(),
       },
     };
@@ -68,12 +93,102 @@ async function getGeolocationFromDb() {
         staticIp: result.staticIp || false,
         dataCenter: result.dataCenter || false,
         lastIpChangeDate: result.lastIpChangeDate || null,
+        ipFirstSeenAt: result.ipFirstSeenAt || null,
+        // `?? null`: a document written before these fields existed carries no
+        // observation, and saying so lets the next pass start the window.
+        staticIpState: result.staticIpState ?? null,
+        networkClassification: result.networkClassification ?? null,
       };
     }
-    return { geolocation: null, staticIp: false, dataCenter: false, lastIpChangeDate: null };
+    return {
+      geolocation: null,
+      staticIp: false,
+      dataCenter: false,
+      lastIpChangeDate: null,
+      ipFirstSeenAt: null,
+      staticIpState: null,
+      networkClassification: null,
+    };
   } catch (error) {
     log.error(`Failed to retrieve geolocation from database: ${error.message}`);
-    return { geolocation: null, staticIp: false, dataCenter: false, lastIpChangeDate: null };
+    return {
+      geolocation: null,
+      staticIp: false,
+      dataCenter: false,
+      lastIpChangeDate: null,
+      ipFirstSeenAt: null,
+      staticIpState: null,
+      networkClassification: null,
+    };
+  }
+}
+
+/**
+ * Reverse DNS for this node's own address - the strongest signal about the
+ * network that does not come from a vendor.
+ * @param {string} ip The node's public address.
+ * @returns {Promise<string|null>} The first PTR name, or null when there is none.
+ */
+async function resolvePtr(ip) {
+  try {
+    const names = await dns.reverse(ip);
+    return (names && names.length) ? names[0] : null;
+  } catch (error) {
+    // No PTR is ordinary - roughly a quarter of fleet hosts have none. It costs
+    // one signal, and the classifier decides on what remains.
+    return null;
+  }
+}
+
+/**
+ * The published verdict for an address, from the location table.
+ *
+ * This is the authority. The table is built in the policy repo from evidence a
+ * node cannot gather for itself - chiefly the registries' own record of what a
+ * block was assigned for, which six thousand nodes cannot each go and fetch -
+ * and it is reviewed there with its reasons rather than derived here.
+ * @param {string} ip The node's public address.
+ * @returns {Promise<string|null>} The verdict, or null when the table has none
+ *   for this address: no table yet, no covering row, or an organisation the
+ *   policy repo deliberately left unclassified.
+ */
+async function publishedClassification(ip) {
+  try {
+    // Lazily required, like the benchmark service below: the location store
+    // pulls in the database layer, and geolocation is read on paths that must
+    // not depend on it being up.
+    // eslint-disable-next-line global-require
+    const ipLocationStore = require('./appPlacement/ipLocationStore');
+    const hit = await ipLocationStore.lookup(ip);
+    return hit?.networkClass ?? null;
+  } catch (error) {
+    // The table being unreadable is not evidence about the address.
+    log.info(`Location table could not answer for ${ip}: ${error.message}`);
+    return null;
+  }
+}
+
+/**
+ * Bench upload/download, for the link-asymmetry signal. Required lazily to keep
+ * geolocation off the benchmark service's load path.
+ * @returns {Promise<{uploadSpeed: number, downloadSpeed: number}>} Zeroes when
+ * bench cannot be read, which the classifier reads as no signal rather than as a
+ * symmetric link.
+ */
+async function benchLinkSpeeds() {
+  try {
+    // eslint-disable-next-line global-require
+    const benchmarkService = require('./benchmarkService');
+    const response = await benchmarkService.getBenchmarks();
+    if (!response || response.status !== 'success' || !response.data) {
+      return { uploadSpeed: 0, downloadSpeed: 0 };
+    }
+    return {
+      uploadSpeed: response.data.upload_speed || 0,
+      downloadSpeed: response.data.download_speed || 0,
+    };
+  } catch (error) {
+    return { uploadSpeed: 0, downloadSpeed: 0 };
   }
 }
 
@@ -100,7 +215,11 @@ async function setNodeGeolocation() {
       log.info(`Checking geolocation of ${localIp}`);
       storedIp = localSocketAddr;
       // consider another service failover or stats db
-      const ipApiUrl = `${config.geolocation.ipApiBaseUrl}/json/${localIp}?fields=status,continent,continentCode,country,countryCode,region,regionName,lat,lon,query,org,isp,proxy,hosting`;
+      // `as` names the operator's own autonomous system, which does not vary
+      // with who registered a /29: across the fleet 227 ASNs separate hosting
+      // from access networks with only 8 carrying both, against 87 distinct
+      // `org` strings for the 329 nodes this decides about.
+      const ipApiUrl = `${config.geolocation.ipApiBaseUrl}/json/${localIp}?fields=status,continent,continentCode,country,countryCode,region,regionName,lat,lon,query,org,isp,as,proxy,hosting,mobile`;
       const ipRes = await serviceHelper.axiosGet(ipApiUrl);
       if (ipRes.data.status === 'success' && ipRes.data.query !== '') {
         storedGeolocation = {
@@ -114,6 +233,11 @@ async function setNodeGeolocation() {
           lat: ipRes.data.lat,
           lon: ipRes.data.lon,
           org: ipRes.data.org || ipRes.data.isp,
+          isp: ipRes.data.isp,
+          asn: ipRes.data.as,
+          mobile: ipRes.data.mobile,
+          proxy: ipRes.data.proxy,
+          hosting: ipRes.data.hosting,
           static: ipRes.data.proxy || ipRes.data.hosting,
           dataCenter: ipRes.data.hosting,
         };
@@ -142,88 +266,105 @@ async function setNodeGeolocation() {
     }
     log.info(`Geolocation of ${localIp} is ${JSON.stringify(storedGeolocation)}`);
 
-    // Check if IP has changed
+    // Static IP is observed, never inferred from the operator: the address must
+    // be bound to a local interface and have been held for the stability window.
     const currentIp = storedGeolocation.ip;
     const ipChanged = previousIp && previousIp !== currentIp;
+    const now = Date.now();
+    const stabilityThreshold = staticIpStabilityDays * 24 * 60 * 60 * 1000;
 
     if (ipChanged) {
-      // IP changed - set static to false and record the change date
-      staticIp = false;
-      lastIpChangeDate = Date.now();
-      log.info(`IP changed from ${previousIp} to ${currentIp}. Setting staticIp to false.`);
-    } else {
-      // IP has not changed - check static IP conditions
-      const hasPublicIp = await fluxNetworkHelper.hasPublicIpOnInterface();
-      const now = Date.now();
-      const stabilityThreshold = staticIpStabilityDays * 24 * 60 * 60 * 1000;
-
-      // If lastIpChangeDate is null (never recorded), consider IP as stable for more than 10 days
-      const effectiveLastIpChangeDate = lastIpChangeDate || (now - stabilityThreshold - 1);
-      const daysSinceChange = (now - effectiveLastIpChangeDate) / (24 * 60 * 60 * 1000);
-
-      // Determine static IP status based on multiple signals
-      if (hasPublicIp) {
-        // Has public IP on interface - strong indicator of static IP
-        if (now - effectiveLastIpChangeDate >= stabilityThreshold) {
-          // IP stable for 10+ days with public IP on interface - definitely static
-          staticIp = true;
-          if (lastIpChangeDate) {
-            log.info(`Node has public IP on interface and IP stable for ${daysSinceChange.toFixed(1)} days. Setting staticIp to true.`);
-          } else {
-            log.info('Node has public IP on interface and no IP change recorded. Assuming stable IP. Setting staticIp to true.');
-          }
-        } else {
-          // Has public IP but hasn't been stable long enough yet
-          // Check other signals (API and org-based)
-          staticIp = false;
-          if (storedGeolocation.static) {
-            staticIp = true;
-          } else if (storedGeolocation.org) {
-            for (let i = 0; i < staticIpOrgs.length; i += 1) {
-              const org = staticIpOrgs[i];
-              if (storedGeolocation.org.toLowerCase().includes(org)) {
-                staticIp = true;
-                break;
-              }
-            }
-          }
-          log.info(`Node has public IP on interface, IP stable for ${daysSinceChange.toFixed(1)} days (need ${staticIpStabilityDays}). staticIp=${staticIp}`);
-        }
-      } else {
-        // No public IP on interface - use API and org-based detection only
-        staticIp = false;
-        if (storedGeolocation.static) {
-          staticIp = true;
-        } else if (storedGeolocation.org) {
-          for (let i = 0; i < staticIpOrgs.length; i += 1) {
-            const org = staticIpOrgs[i];
-            if (storedGeolocation.org.toLowerCase().includes(org)) {
-              staticIp = true;
-              break;
-            }
-          }
-        }
-      }
+      lastIpChangeDate = now;
+      ipFirstSeenAt = now;
+      log.info(`IP changed from ${previousIp} to ${currentIp}. Static IP observation restarts.`);
+    } else if (!ipFirstSeenAt) {
+      // An address just met has been held for no time at all. It becomes STATIC
+      // by being held, never by assumption.
+      ipFirstSeenAt = now;
+      log.info(`First observation of ${currentIp}. Static IP unknown until it has been held for ${staticIpStabilityDays} days.`);
     }
 
-    // Data center detection (unchanged logic)
-    if (storedGeolocation.dataCenter) {
-      dataCenter = true;
+    const hasPublicIp = await fluxNetworkHelper.hasPublicIpOnInterface();
+    const heldForMs = now - ipFirstSeenAt;
+    const heldDays = heldForMs / (24 * 60 * 60 * 1000);
+
+    if (!hasPublicIp) {
+      // The public address is not on any local interface, so the node is behind
+      // NAT. Nothing about the operator changes that.
+      staticIpState = STATIC_IP_STATE.DYNAMIC;
+    } else if (heldForMs >= stabilityThreshold) {
+      staticIpState = STATIC_IP_STATE.STATIC;
     } else {
-      dataCenter = false;
-      if (storedGeolocation.org) {
-        for (let i = 0; i < staticIpOrgs.length; i += 1) {
-          const org = staticIpOrgs[i];
-          if (storedGeolocation.org.toLowerCase().includes(org)) {
-            dataCenter = true;
-            break;
-          }
-        }
-      }
+      // Public IP on the interface, but not yet held long enough to know.
+      staticIpState = STATIC_IP_STATE.UNKNOWN;
     }
+    staticIp = staticIpState === STATIC_IP_STATE.STATIC;
+    log.info(`Static IP: ${staticIpState} (public IP on interface: ${hasPublicIp}, address held ${heldDays.toFixed(1)} of ${staticIpStabilityDays} days)`);
+
+    // Whether the address is held (above) and what network it sits on (here) are
+    // separate questions, answered from separate evidence.
+    //
+    // The published table decides where it can. Where it cannot - a range no
+    // baseline covers, or an operator the policy repo left unclassified - the
+    // node falls back to what it can observe about itself. The fallback is not a
+    // weaker standard, only a narrower one: it still needs positive evidence
+    // with nothing contradicting it, so an address the table declined to call
+    // because its operator is mixed is one this will decline too.
+    const [published, ptr, linkSpeeds] = await Promise.all([
+      publishedClassification(currentIp),
+      resolvePtr(currentIp),
+      benchLinkSpeeds(),
+    ]);
+    const classified = networkClassifier.classifyNetwork({
+      ptr,
+      hosting: storedGeolocation.hosting,
+      proxy: storedGeolocation.proxy,
+      mobile: storedGeolocation.mobile,
+      isp: storedGeolocation.isp,
+      asn: storedGeolocation.asn,
+      uploadSpeed: linkSpeeds.uploadSpeed,
+      downloadSpeed: linkSpeeds.downloadSpeed,
+    });
+
+    // The table decides, but a node that can see hosting evidence about its OWN
+    // address exempts itself. An organisation is published on a strong majority
+    // of its hosts rather than on all of them, so a minority of its addresses
+    // may be the other kind - and this is how one of them declines a verdict
+    // meant for its neighbours. The veto only ever removes a node from
+    // enforcement; local evidence can never impose one the table did not give.
+    const vetoed = published === networkClassifier.CLASSIFICATION.RESIDENTIAL
+      && classified.evidenceAgainst.length > 0;
+    if (vetoed) {
+      log.info(`Published verdict RESIDENTIAL declined for this address: ${classified.evidenceAgainst.join(', ')}`);
+    }
+
+    // One whole object, assigned once every input has settled: a reader must
+    // never see a verdict computed from a half-finished pass.
+    networkClassification = Object.freeze({
+      classification: vetoed
+        ? networkClassifier.CLASSIFICATION.CONFLICTED
+        : (published ?? classified.classification),
+      // Which authority decided, so a verdict can be traced to the table that
+      // carried it, to the node that worked it out, or to the node declining one.
+      // eslint-disable-next-line no-nested-ternary
+      source: vetoed ? 'node-veto' : (published ? 'published-table' : 'node'),
+      evidenceFor: Object.freeze([...classified.evidenceFor]),
+      evidenceAgainst: Object.freeze([...classified.evidenceAgainst]),
+      ptr: ptr || null,
+      determinedAt: now,
+    });
+    dataCenter = classified.classification === networkClassifier.CLASSIFICATION.DATACENTER;
+    log.info(`Network classification: ${networkClassification.classification}`
+      + ` via ${networkClassification.source}`
+      + ` (node evidence for: ${classified.evidenceFor.join(', ') || 'none'};`
+      + ` against: ${classified.evidenceAgainst.join(', ') || 'none'})`);
 
     // Store geolocation to database for persistence across restarts
-    await storeGeolocationToDb(storedGeolocation, staticIp, dataCenter, lastIpChangeDate);
+    await storeGeolocationToDb(storedGeolocation, staticIp, dataCenter, lastIpChangeDate, {
+      ipFirstSeenAt,
+      staticIpState,
+      networkClassification,
+    });
     execution += 1;
     setTimeout(() => { // executes again in 3 days
       setNodeGeolocation();
@@ -249,25 +390,61 @@ async function getNodeGeolocation() {
   // Try to get from database if not in memory
   const dbData = await getGeolocationFromDb();
   if (dbData.geolocation) {
-    storedGeolocation = dbData.geolocation;
-    ({ staticIp, dataCenter, lastIpChangeDate } = dbData);
+    ({
+      geolocation: storedGeolocation,
+      staticIp,
+      dataCenter,
+      lastIpChangeDate,
+      ipFirstSeenAt,
+      networkClassification,
+    } = dbData);
+    staticIpState = dbData.staticIpState ?? STATIC_IP_STATE.UNKNOWN;
     log.info('Geolocation restored from database');
   }
   return storedGeolocation;
 }
 
 /**
- * Method responsible for returning if node ip is static based on IP org.
+ * Whether this node's address is known to stay put. True only when the address
+ * is bound to a local interface and has been held for the stability window; an
+ * address not yet observed that long is not static, so apps that require one are
+ * never placed on evidence the node does not have.
+ * @returns {boolean}
  */
 function isStaticIP() {
   return staticIp;
 }
 
 /**
- * Method responsible for returning if node is in a data center based on IP org.
+ * The three-state form of isStaticIP, for callers that need to tell "we have not
+ * watched it long enough" apart from "it moves".
+ * @returns {('STATIC'|'DYNAMIC'|'UNKNOWN')}
+ */
+function getStaticIpState() {
+  return staticIpState;
+}
+
+/**
+ * Whether this node sits in a data centre. True only on a positive verdict from
+ * networkClassifier - CONFLICTED and UNKNOWN are both false, because neither is
+ * evidence of a data centre.
+ * @returns {boolean}
  */
 function isDataCenter() {
   return dataCenter;
+}
+
+/**
+ * The node's access-network verdict and the evidence behind it.
+ * @returns {{classification: string, source: string, evidenceFor: string[],
+ *   evidenceAgainst: string[], ptr: string|null, determinedAt: number}|null} Null
+ *   when no verdict has been reached, which is not the same as a verdict of
+ *   UNKNOWN. `source` names the authority: 'published-table', 'node' when the
+ *   table had nothing for this address, or 'node-veto' when the node declined a
+ *   published RESIDENTIAL on evidence about its own address.
+ */
+function getNetworkClassification() {
+  return networkClassification;
 }
 
 /**
@@ -290,7 +467,10 @@ module.exports = {
   setNodeGeolocation,
   getNodeGeolocation,
   isStaticIP,
+  getStaticIpState,
   isDataCenter,
+  getNetworkClassification,
   getLastIpChangeDate,
   hasPublicIp,
+  STATIC_IP_STATE,
 };

--- a/ZelBack/src/services/geolocationService.js
+++ b/ZelBack/src/services/geolocationService.js
@@ -557,11 +557,12 @@ function isDataCenter() {
  * enforces on null.
  * @returns {Promise<{classification: string, source: string,
  *   evidenceFor: string[], evidenceAgainst: string[], ptr: string|null,
- *   gatheredAt: number}|null>} Null when nothing has been gathered yet, or when
- *   no location table has been consulted. `source` names the authority:
- *   'published-table', 'node' where the table holds no verdict for this
- *   address, or 'node-veto' where the node declined a published RESIDENTIAL on
- *   evidence about its own address.
+ *   gatheredAt: number}|null>} Null when nothing has been gathered yet, when no
+ *   location table has been consulted, or when the table holds no verdict for
+ *   this address. `source` names the authority: 'published-table', or
+ *   'node-veto' where the node declined a published RESIDENTIAL on evidence
+ *   about its own address. There is no 'node' source - a table carrying no
+ *   verdict yields null, it does not hand the decision back to the node.
  */
 async function getNetworkClassification() {
   if (!networkEvidence) return null;
@@ -586,8 +587,9 @@ async function getNetworkClassification() {
   // query the RIRs, so registration data belongs in the table - and its error
   // rate has never been measured: 0.13% is reverse DNS alone and 0.00% is the
   // combined rule WITH registration, and neither is what a node runs. It decided
-  // for the ~8% of hosts whose organisation carries no published verdict, on the
-  // one path that deletes customer data.
+  // for the 13% of the enforceable population - 70 of the 541 slots whose bench
+  // confirms they are not ArcaneOS - whose organisation carries no published
+  // verdict, on the one path that deletes customer data.
   //
   // Tuning belongs in fluxos-network-policy, where a verdict is evidence-backed,
   // auditable by anyone, correctable by hand through

--- a/ZelBack/src/services/geolocationService.js
+++ b/ZelBack/src/services/geolocationService.js
@@ -318,33 +318,39 @@ async function setNodeGeolocation() {
     const heldForMs = now - ipFirstSeenAt;
     const heldDays = heldForMs / (24 * 60 * 60 * 1000);
 
-    // THE WHOLE DECISION, in one table. Read down the first two columns; the
-    // third is consulted only where the first two cannot settle it.
+    // THE WHOLE DECISION, in one table, in the order it is asked.
     //
-    //   public IP on   this node has     published     verdict
-    //   the interface  SEEN it change    table says
-    //   -------------  ---------------   -----------   -------------------
-    //   yes            no                (not asked)   STATIC
-    //   yes            yes, >10d ago     (not asked)   STATIC
-    //   yes            yes, <10d ago     hosting       STATIC
-    //   yes            yes, <10d ago     anything else UNKNOWN
-    //   no  (NAT)      -                 hosting       STATIC
-    //   no  (NAT)      -                 anything else DYNAMIC
-    //   unreadable     -                 hosting       STATIC
-    //   unreadable     -                 anything else UNKNOWN
+    //   this node WATCHED    public IP on    published      verdict
+    //   it change <10d ago   the interface   table says
+    //   ------------------   -------------   ------------   -------
+    //   yes                  -               -              UNKNOWN
+    //   no                   yes             (not asked)    STATIC
+    //   no                   no  (NAT)       hosting        STATIC
+    //   no                   no  (NAT)       anything else  DYNAMIC
+    //   no                   unreadable      hosting        STATIC
+    //   no                   unreadable      anything else  UNKNOWN
     //
     // Only STATIC satisfies an app's `staticip` requirement; UNKNOWN and
     // DYNAMIC both fail it, and are kept apart so a node that could not answer
     // does not read as one that answered "behind NAT".
     //
-    // Row 1 is the common case and the one that matters most: a node has SEEN
-    // no change because it started watching after the fact, which every node
-    // does exactly once. That is not evidence the address moves. Measured on
-    // the fleet an address changes on 0.29% of node-days, so treating
-    // not-yet-watched as suspect is wrong about ~97% of nodes for the ten days
-    // it lasts - and it lands on all of them together, because they upgrade
-    // together. An observed change is what withdraws the trust; rows 2-4 are
-    // the address earning it back.
+    // A watched change is asked FIRST and nothing overrides it. It is the only
+    // evidence here that is about this exact address rather than about the
+    // range it sits in, and it is a record of the address actually moving. A
+    // hosting range whose addresses do move is still a node whose address
+    // moved, which is the whole of what an app requiring a fixed address cares
+    // about. lastIpChangeDate comes from the geolocation fetch, so it is
+    // available whether or not the node can see the address on an interface -
+    // deciding rows 3 to 6 without consulting it threw away the best evidence
+    // held, in exactly the cases where the rest of it is weakest.
+    //
+    // Row 2 is the common case: a node has WATCHED no change because it started
+    // watching after the fact, which every node does exactly once. That is not
+    // evidence the address moves. Measured on the fleet an address changes on
+    // 0.29% of node-days, so treating not-yet-watched as suspect is wrong about
+    // ~97% of nodes for the whole ten days it lasts - and it lands on all of
+    // them together, because they upgrade together. An observed change is what
+    // withdraws the trust, and the window is how the address earns it back.
     //
     // Where the local test cannot answer, the published table can. A 1:1-NAT
     // cloud instance holds a genuinely static address that never appears on any
@@ -369,33 +375,25 @@ async function setNodeGeolocation() {
     const publishedHosting = (await publishedClassification(currentIp)).classification
       === networkClassifier.CLASSIFICATION.DATACENTER;
 
-    if (hasPublicIp === null) {
-      // The routing table could not be read. Not evidence of anything about the
-      // address, and in particular not evidence of NAT.
-      staticIpState = publishedHosting ? STATIC_IP_STATE.STATIC : STATIC_IP_STATE.UNKNOWN;
-    } else if (!hasPublicIp) {
-      // Behind NAT as far as this node can see.
-      staticIpState = publishedHosting ? STATIC_IP_STATE.STATIC : STATIC_IP_STATE.DYNAMIC;
-    } else if (!lastIpChangeDate) {
-      // A public address on the interface, and this node has never seen it
-      // change. Absence of an observed change is not evidence that the address
-      // moves - it is this node having started watching after the fact, which
-      // every node does exactly once. Measured on the fleet, an address changes
-      // on 0.29% of node-days, so treating "not yet watched" as suspect is
-      // wrong about roughly 97% of nodes for the whole ten days it lasts, and
-      // it lands on all of them at once because they upgrade together.
-      //
-      // Trusted until it is seen to move, and one observed change is what
-      // withdraws it - the branch below then makes the address earn it back.
-      staticIpState = STATIC_IP_STATE.STATIC;
-    } else if (heldForMs >= stabilityThreshold) {
+    const watchedItChange = Boolean(lastIpChangeDate) && heldForMs < stabilityThreshold;
+
+    if (watchedItChange) {
+      // Asked first, and nothing overrides it: this node saw this address move,
+      // and it has not been held long enough since to say it has settled.
+      staticIpState = STATIC_IP_STATE.UNKNOWN;
+    } else if (hasPublicIp === true) {
       staticIpState = STATIC_IP_STATE.STATIC;
     } else if (publishedHosting) {
-      // It has moved recently, but it is in a hosting range: an address that
-      // moves within a data centre is still handed back as a fixed one.
+      // The node cannot see the address on an interface, but the table places
+      // it in a hosting range - the 1:1-NAT case, where the address is fixed
+      // and simply never appears locally.
       staticIpState = STATIC_IP_STATE.STATIC;
+    } else if (hasPublicIp === false) {
+      // Behind NAT as far as this node can see, and nothing says otherwise.
+      staticIpState = STATIC_IP_STATE.DYNAMIC;
     } else {
-      // It has demonstrably moved and has not been held long enough since.
+      // The routing table could not be read. Not evidence of anything about the
+      // address, and in particular not evidence of NAT.
       staticIpState = STATIC_IP_STATE.UNKNOWN;
     }
     staticIp = staticIpState === STATIC_IP_STATE.STATIC;

--- a/ZelBack/src/services/geolocationService.js
+++ b/ZelBack/src/services/geolocationService.js
@@ -332,29 +332,36 @@ async function setNodeGeolocation() {
 
     // THE WHOLE DECISION, in one table, in the order it is asked.
     //
-    //   this node WATCHED    public IP on    published      verdict
-    //   it change <10d ago   the interface   table says
-    //   ------------------   -------------   ------------   -------
-    //   yes                  -               -              UNKNOWN
-    //   no                   yes             (not asked)    STATIC
-    //   no                   no  (NAT)       hosting        STATIC
-    //   no                   no  (NAT)       anything else  DYNAMIC
-    //   no                   unreadable      hosting        STATIC
-    //   no                   unreadable      anything else  UNKNOWN
+    //   this node WATCHED    public IP on    verdict
+    //   it change <10d ago   the interface
+    //   ------------------   -------------   -------
+    //   yes                  -               UNKNOWN
+    //   no                   yes             STATIC
+    //   no                   no  (NAT)       DYNAMIC
+    //   no                   unreadable      UNKNOWN
+    //
+    // A NODE IS STATIC ONLY IF IT HOLDS A PUBLIC ADDRESS ON AN INTERFACE.
+    // Nothing else confers it - not the published table, not an ip-api flag,
+    // not the operator's name. Every input here is something this node observed
+    // about itself.
     //
     // Only STATIC satisfies an app's `staticip` requirement; UNKNOWN and
     // DYNAMIC both fail it, and are kept apart so a node that could not answer
     // does not read as one that answered "behind NAT".
     //
-    // A watched change is asked FIRST and nothing overrides it. It is the only
-    // evidence here that is about this exact address rather than about the
-    // range it sits in, and it is a record of the address actually moving. A
-    // hosting range whose addresses do move is still a node whose address
-    // moved, which is the whole of what an app requiring a fixed address cares
-    // about. lastIpChangeDate comes from the geolocation fetch, so it is
-    // available whether or not the node can see the address on an interface -
-    // deciding rows 3 to 6 without consulting it threw away the best evidence
-    // held, in exactly the cases where the rest of it is weakest.
+    // `staticip` IS TWO PROMISES, AND BOTH ARE ANSWERED ABOVE. The apps that
+    // ask for it - VPN endpoints, chain nodes, bootstrap peers - need an
+    // endpoint that stays reachable at a fixed ip:port, because clients and
+    // peers hold that pair written down. So the node must be DIRECTLY CONNECTED
+    // (hasPublicIpOnInterface) and its address must not have been seen to MOVE
+    // (the watched-change window). A node reaching the world through a NAT port
+    // mapping keeps neither promise on its own account: 76% of fleet slots sit
+    // behind a UPnP router, and a mapping lapses on a router reboot, a lease
+    // expiry, or a firmware quirk while the address itself never moves - the
+    // fleet UPnP survey found 135 router models and defects in several.
+    //
+    // A watched change is asked FIRST and nothing overrides it: this node saw
+    // this address move, and that outranks seeing it on an interface now.
     //
     // Row 2 is the common case: a node has WATCHED no change because it started
     // watching after the fact, which every node does exactly once. That is not
@@ -364,29 +371,31 @@ async function setNodeGeolocation() {
     // them together, because they upgrade together. An observed change is what
     // withdraws the trust, and the window is how the address earns it back.
     //
-    // Where the local test cannot answer, the published table can. A 1:1-NAT
-    // cloud instance holds a genuinely static address that never appears on any
-    // local interface - every AWS, Azure, GCP and Oracle box fails the test
-    // above - and a range the table calls hosting is that case.
+    // A RANGE-LEVEL VERDICT CANNOT ANSWER EITHER PROMISE, which is why the
+    // published table is not consulted here even though it is loaded and
+    // authoritative elsewhere in this file.
+    //   - It cannot see whether this host is directly connected. Across a
+    //     random sample of 442 live slots, 126 of the 228 holding a static
+    //     address by range verdict - 55% - are UPnP nodes on RFC1918
+    //     addresses. 112 qualify on ip-api `hosting`, 12 on `proxy`, which is
+    //     a VPN artefact rather than an address that stays put.
+    //   - It does not imply a fixed address either. "This block is assigned to
+    //     a hosting company" states what the block is FOR. An operator
+    //     reassigns on rebuild, migration, or a released elastic address, and
+    //     the node returns on a different one - same hosting range, same
+    //     DATACENTER verdict, different address.
+    // Both promises are properties of this host, so only this host can attest
+    // to them. The table stays authoritative for the residential verdict, which
+    // IS a question about the range.
     //
-    // This is the job the deleted staticIpOrgs list was doing, done on evidence
-    // that has been measured. That list was nine hoster names matched against
-    // the block REGISTRANT, which disagrees with the operator on 67% of fleet
-    // hosts, backed by an ip-api `static` field that is literally
-    // `proxy || hosting`.
+    // THE CASE THIS RULE KNOWINGLY REFUSES: genuine 1:1 NAT, where a fixed
+    // address is mapped to a host that never sees it locally. The same sample
+    // holds 4 such nodes (~49 slots fleet-wide) and NONE claims a static
+    // address; the fleet's entire hyperscaler population is one Oracle slot.
+    // Real, and priced at nil.
     //
-    // Measured against the two signals over the whole fleet - 5,661 node slots
-    // on 2,349 machines - the table treats 268 more slots as static than the
-    // list did, on 153 machines it never named (83 of them one operator), and
-    // withdraws it from 49 slots on 11 machines. Seven of those eleven are
-    // consumer ISPs the list was wrong about - Verizon, Comcast, Free SAS,
-    // Bouygues - flagged `proxy`, which is a VPN artefact and not an address
-    // that stays put. The remaining four are genuine hosting the table has not
-    // classified yet, and data/orgclass-overrides.json in
-    // fluxos-network-policy is where that is corrected.
-    const publishedHosting = (await publishedClassification(currentIp)).classification
-      === networkClassifier.CLASSIFICATION.DATACENTER;
-
+    // Census and method: fluxModels
+    // investigations/PR1784_STATIC_IP_IS_A_RANGE_FLAG_NOT_AN_OBSERVATION.md
     const watchedItChange = Boolean(lastIpChangeDate) && heldForMs < stabilityThreshold;
 
     if (watchedItChange) {
@@ -395,13 +404,10 @@ async function setNodeGeolocation() {
       staticIpState = STATIC_IP_STATE.UNKNOWN;
     } else if (hasPublicIp === true) {
       staticIpState = STATIC_IP_STATE.STATIC;
-    } else if (publishedHosting) {
-      // The node cannot see the address on an interface, but the table places
-      // it in a hosting range - the 1:1-NAT case, where the address is fixed
-      // and simply never appears locally.
-      staticIpState = STATIC_IP_STATE.STATIC;
     } else if (hasPublicIp === false) {
-      // Behind NAT as far as this node can see, and nothing says otherwise.
+      // Behind NAT. The address may well be fixed upstream, but this node
+      // cannot see it, cannot attest to it, and reaches the world through a
+      // port mapping it does not control.
       staticIpState = STATIC_IP_STATE.DYNAMIC;
     } else {
       // The routing table could not be read. Not evidence of anything about the
@@ -409,8 +415,8 @@ async function setNodeGeolocation() {
       staticIpState = STATIC_IP_STATE.UNKNOWN;
     }
     staticIp = staticIpState === STATIC_IP_STATE.STATIC;
-    log.info(`Static IP: ${staticIpState} (public IP on interface: ${hasPublicIp}, address held ${heldDays.toFixed(1)} of ${staticIpStabilityDays} days`
-      + `, published hosting range: ${publishedHosting})`);
+    log.info(`Static IP: ${staticIpState} (public IP on interface: ${hasPublicIp}`
+      + `, address held ${heldDays.toFixed(1)} of ${staticIpStabilityDays} days)`);
 
     // Whether the address is held (above) and what network it sits on (here) are
     // separate questions, answered from separate evidence.

--- a/ZelBack/src/services/geolocationService.js
+++ b/ZelBack/src/services/geolocationService.js
@@ -394,8 +394,9 @@ async function setNodeGeolocation() {
     // address; the fleet's entire hyperscaler population is one Oracle slot.
     // Real, and priced at nil.
     //
-    // Census and method: fluxModels
-    // investigations/PR1784_STATIC_IP_IS_A_RANGE_FLAG_NOT_AN_OBSERVATION.md
+    // Every figure above was measured on the live fleet by reproducing
+    // hasPublicIpOnInterface() across a random sample of slots; the census and
+    // its bounds are recorded with the change that introduced this rule.
     const watchedItChange = Boolean(lastIpChangeDate) && heldForMs < stabilityThreshold;
 
     if (watchedItChange) {

--- a/ZelBack/src/services/geolocationService.js
+++ b/ZelBack/src/services/geolocationService.js
@@ -15,10 +15,15 @@ let staticIp = false;
 let dataCenter = false;
 let lastIpChangeDate = null;
 let execution = 1;
-// Null means no verdict has been reached yet, which readers must distinguish
-// from a verdict of UNKNOWN: "not computed" against "computed, and the evidence
-// does not decide".
-let networkClassification = null;
+// What this node observed about its own address - never the verdict drawn from
+// it. Gathering costs an ip-api call and a PTR lookup, so it happens on the slow
+// pass; the verdict also needs the published table, which is cheap to consult
+// and arrives later, so it is reached on demand.
+//
+// Null means nothing has been gathered yet, which readers must distinguish from
+// a verdict of UNKNOWN: "not observed" against "observed, and the evidence does
+// not decide".
+let networkEvidence = null;
 
 /**
  * Whether this address stays put. Three-state, because "we have not observed it
@@ -62,7 +67,7 @@ async function storeGeolocationToDb(geolocation, isStaticIp, isDataCenter, ipCha
         // that reset it would hold every node at UNKNOWN for another ten days.
         ipFirstSeenAt: observations.ipFirstSeenAt ?? null,
         staticIpState: observations.staticIpState ?? null,
-        networkClassification: observations.networkClassification ?? null,
+        networkEvidence: observations.networkEvidence ?? null,
         updatedAt: Date.now(),
       },
     };
@@ -97,7 +102,7 @@ async function getGeolocationFromDb() {
         // `?? null`: a document written before these fields existed carries no
         // observation, and saying so lets the next pass start the window.
         staticIpState: result.staticIpState ?? null,
-        networkClassification: result.networkClassification ?? null,
+        networkEvidence: result.networkEvidence ?? null,
       };
     }
     return {
@@ -107,7 +112,7 @@ async function getGeolocationFromDb() {
       lastIpChangeDate: null,
       ipFirstSeenAt: null,
       staticIpState: null,
-      networkClassification: null,
+      networkEvidence: null,
     };
   } catch (error) {
     log.error(`Failed to retrieve geolocation from database: ${error.message}`);
@@ -118,7 +123,7 @@ async function getGeolocationFromDb() {
       lastIpChangeDate: null,
       ipFirstSeenAt: null,
       staticIpState: null,
-      networkClassification: null,
+      networkEvidence: null,
     };
   }
 }
@@ -141,30 +146,51 @@ async function resolvePtr(ip) {
 }
 
 /**
- * The published verdict for an address, from the location table.
+ * What the published location table says about an address.
  *
- * This is the authority. The table is built in the policy repo from evidence a
+ * The table is the authority. It is built in the policy repo from evidence a
  * node cannot gather for itself - chiefly the registries' own record of what a
  * block was assigned for, which six thousand nodes cannot each go and fetch -
  * and it is reviewed there with its reasons rather than derived here.
+ *
+ * TWO OUTCOMES, AND THEY MUST NOT BE CONFUSED:
+ *
+ *   consulted: false  the table could not be asked - none has been ingested
+ *                     yet, or the store could not be read. Nothing is known,
+ *                     and a node must reach no verdict at all.
+ *   consulted: true   the table answered. `classification` is its verdict, or
+ *                     null where it holds none for this address: no covering
+ *                     row, or an organisation the policy repo deliberately
+ *                     left unclassified. THAT null is an answer, and it is what
+ *                     hands the decision to the node's own evidence.
+ *
+ * Collapsing the two is the very mistake this whole classifier exists to
+ * avoid, one level up: "I have not asked" is not "there is no verdict". A node
+ * boots, fetches a 4.6 MB artifact, and ingests two million rows, while a
+ * single ip-api call answers in milliseconds - so the table is reliably absent
+ * at the moment a booting node would otherwise decide, and treating that as an
+ * abstention lets the node act on its own guess against a verdict the table
+ * was about to give it.
  * @param {string} ip The node's public address.
- * @returns {Promise<string|null>} The verdict, or null when the table has none
- *   for this address: no table yet, no covering row, or an organisation the
- *   policy repo deliberately left unclassified.
+ * @returns {Promise<{consulted: boolean, classification: string|null}>}
  */
 async function publishedClassification(ip) {
+  // Lazily required, like the benchmark service below: the location store
+  // pulls in the database layer, and geolocation is read on paths that must
+  // not depend on it being up.
+  // eslint-disable-next-line global-require
+  const ipLocationStore = require('./appPlacement/ipLocationStore');
+  if (!ipLocationStore.status().ready) {
+    return { consulted: false, classification: null };
+  }
   try {
-    // Lazily required, like the benchmark service below: the location store
-    // pulls in the database layer, and geolocation is read on paths that must
-    // not depend on it being up.
-    // eslint-disable-next-line global-require
-    const ipLocationStore = require('./appPlacement/ipLocationStore');
     const hit = await ipLocationStore.lookup(ip);
-    return hit?.networkClass ?? null;
+    return { consulted: true, classification: hit?.networkClass ?? null };
   } catch (error) {
-    // The table being unreadable is not evidence about the address.
+    // A table that cannot be read is a table that was not asked. Same as above:
+    // not evidence about the address, and not an abstention either.
     log.info(`Location table could not answer for ${ip}: ${error.message}`);
-    return null;
+    return { consulted: false, classification: null };
   }
 }
 
@@ -304,14 +330,14 @@ async function setNodeGeolocation() {
     // Whether the address is held (above) and what network it sits on (here) are
     // separate questions, answered from separate evidence.
     //
-    // The published table decides where it can. Where it cannot - a range no
-    // baseline covers, or an operator the policy repo left unclassified - the
-    // node falls back to what it can observe about itself. The fallback is not a
-    // weaker standard, only a narrower one: it still needs positive evidence
-    // with nothing contradicting it, so an address the table declined to call
-    // because its operator is mixed is one this will decline too.
-    const [published, ptr, linkSpeeds] = await Promise.all([
-      publishedClassification(currentIp),
+    // This pass gathers the EVIDENCE and stops there. Reaching a verdict also
+    // needs the published table, and the table is not this pass's to wait for:
+    // it arrives in a 4.6 MB artifact the node is still ingesting while this
+    // runs, and a pass that recorded its own conclusion here would be recording
+    // "the table said nothing" and standing by it until the next pass, three
+    // days later. getNetworkClassification() reaches the verdict when asked,
+    // which is what every other consumer of that table already does.
+    const [ptr, linkSpeeds] = await Promise.all([
       resolvePtr(currentIp),
       benchLinkSpeeds(),
     ]);
@@ -326,44 +352,26 @@ async function setNodeGeolocation() {
       downloadSpeed: linkSpeeds.downloadSpeed,
     });
 
-    // The table decides, but a node that can see hosting evidence about its OWN
-    // address exempts itself. An organisation is published on a strong majority
-    // of its hosts rather than on all of them, so a minority of its addresses
-    // may be the other kind - and this is how one of them declines a verdict
-    // meant for its neighbours. The veto only ever removes a node from
-    // enforcement; local evidence can never impose one the table did not give.
-    const vetoed = published === networkClassifier.CLASSIFICATION.RESIDENTIAL
-      && classified.evidenceAgainst.length > 0;
-    if (vetoed) {
-      log.info(`Published verdict RESIDENTIAL declined for this address: ${classified.evidenceAgainst.join(', ')}`);
-    }
-
     // One whole object, assigned once every input has settled: a reader must
-    // never see a verdict computed from a half-finished pass.
-    networkClassification = Object.freeze({
-      classification: vetoed
-        ? networkClassifier.CLASSIFICATION.CONFLICTED
-        : (published ?? classified.classification),
-      // Which authority decided, so a verdict can be traced to the table that
-      // carried it, to the node that worked it out, or to the node declining one.
-      // eslint-disable-next-line no-nested-ternary
-      source: vetoed ? 'node-veto' : (published ? 'published-table' : 'node'),
+    // never combine evidence from a half-finished pass.
+    networkEvidence = Object.freeze({
+      ip: currentIp,
+      classification: classified.classification,
       evidenceFor: Object.freeze([...classified.evidenceFor]),
       evidenceAgainst: Object.freeze([...classified.evidenceAgainst]),
       ptr: ptr || null,
-      determinedAt: now,
+      gatheredAt: now,
     });
     dataCenter = classified.classification === networkClassifier.CLASSIFICATION.DATACENTER;
-    log.info(`Network classification: ${networkClassification.classification}`
-      + ` via ${networkClassification.source}`
-      + ` (node evidence for: ${classified.evidenceFor.join(', ') || 'none'};`
+    log.info(`Network evidence for ${currentIp}: the node's own reading is ${classified.classification}`
+      + ` (for: ${classified.evidenceFor.join(', ') || 'none'};`
       + ` against: ${classified.evidenceAgainst.join(', ') || 'none'})`);
 
     // Store geolocation to database for persistence across restarts
     await storeGeolocationToDb(storedGeolocation, staticIp, dataCenter, lastIpChangeDate, {
       ipFirstSeenAt,
       staticIpState,
-      networkClassification,
+      networkEvidence,
     });
     execution += 1;
     setTimeout(() => { // executes again in 3 days
@@ -396,7 +404,7 @@ async function getNodeGeolocation() {
       dataCenter,
       lastIpChangeDate,
       ipFirstSeenAt,
-      networkClassification,
+      networkEvidence,
     } = dbData);
     staticIpState = dbData.staticIpState ?? STATIC_IP_STATE.UNKNOWN;
     log.info('Geolocation restored from database');
@@ -435,16 +443,57 @@ function isDataCenter() {
 }
 
 /**
- * The node's access-network verdict and the evidence behind it.
- * @returns {{classification: string, source: string, evidenceFor: string[],
- *   evidenceAgainst: string[], ptr: string|null, determinedAt: number}|null} Null
- *   when no verdict has been reached, which is not the same as a verdict of
- *   UNKNOWN. `source` names the authority: 'published-table', 'node' when the
- *   table had nothing for this address, or 'node-veto' when the node declined a
- *   published RESIDENTIAL on evidence about its own address.
+ * The node's access-network verdict, reached now from the evidence it gathered
+ * and the table it currently holds.
+ *
+ * Reached here rather than stored because its two halves arrive at different
+ * times and on different clocks. The evidence is expensive and refreshed every
+ * three days; the published table is a local read that a booting node does not
+ * have yet and will have shortly. Deciding once, at the moment only one half
+ * exists, is how a node ends up acting for three days on a verdict the table
+ * would have overruled.
+ *
+ * NO TABLE MEANS NO VERDICT. Not a fallback to the node's own reading - the
+ * fallback belongs to a table that WAS consulted and holds nothing for this
+ * address. Until one has been ingested, this node knows nothing about which
+ * kind of network it is on, and null is the only honest answer. Nothing
+ * enforces on null.
+ * @returns {Promise<{classification: string, source: string,
+ *   evidenceFor: string[], evidenceAgainst: string[], ptr: string|null,
+ *   gatheredAt: number}|null>} Null when nothing has been gathered yet, or when
+ *   no location table has been consulted. `source` names the authority:
+ *   'published-table', 'node' where the table holds no verdict for this
+ *   address, or 'node-veto' where the node declined a published RESIDENTIAL on
+ *   evidence about its own address.
  */
-function getNetworkClassification() {
-  return networkClassification;
+async function getNetworkClassification() {
+  if (!networkEvidence) return null;
+
+  const published = await publishedClassification(networkEvidence.ip);
+  if (!published.consulted) return null;
+
+  // The table decides, but a node that can see hosting evidence about its OWN
+  // address exempts itself. An organisation is published on a strong majority
+  // of its hosts rather than on all of them, so a minority of its addresses may
+  // be the other kind - and this is how one of them declines a verdict meant
+  // for its neighbours. The veto only ever removes a node from enforcement;
+  // local evidence can never impose one the table did not give.
+  const vetoed = published.classification === networkClassifier.CLASSIFICATION.RESIDENTIAL
+    && networkEvidence.evidenceAgainst.length > 0;
+
+  return Object.freeze({
+    classification: vetoed
+      ? networkClassifier.CLASSIFICATION.CONFLICTED
+      : (published.classification ?? networkEvidence.classification),
+    // Which authority decided, so a verdict can be traced to the table that
+    // carried it, to the node that worked it out, or to the node declining one.
+    // eslint-disable-next-line no-nested-ternary
+    source: vetoed ? 'node-veto' : (published.classification ? 'published-table' : 'node'),
+    evidenceFor: networkEvidence.evidenceFor,
+    evidenceAgainst: networkEvidence.evidenceAgainst,
+    ptr: networkEvidence.ptr,
+    gatheredAt: networkEvidence.gatheredAt,
+  });
 }
 
 /**

--- a/ZelBack/src/services/idService.js
+++ b/ZelBack/src/services/idService.js
@@ -873,7 +873,19 @@ async function checkLoggedUser(req, res) {
       res.json(message);
     } catch (error) {
       log.error(error);
-      const errMessage = messageHelper.createErrorMessage(error.message, error.name, error.code);
+      // `message` stays inside the PRIVILEGE_RESPONSE contract even here, because
+      // the frontend reads it AS the privilege whether the status says success or
+      // error, and logs the user out on exactly 'none' (fluxos-frontend
+      // guards.js). A thrown error's text landing in that field set the privilege
+      // to something like 'No user Flux ID specificed' - not 'none' - so the stale
+      // zelidauth stayed in localStorage instead of being cleared, and every later
+      // navigation repeated the same failure. Access still failed closed, since no
+      // route's privilege list contains an error string, but the session never
+      // ended.
+      //
+      // The error is not lost. It is logged above, and `name`/`code` still
+      // separate a failure from a plain refusal, which carries neither.
+      const errMessage = messageHelper.createErrorMessage(PRIVILEGE_RESPONSE.NONE, error.name, error.code);
       res.json(errMessage);
     }
   });

--- a/ZelBack/src/services/residentialNodeDosService.js
+++ b/ZelBack/src/services/residentialNodeDosService.js
@@ -686,7 +686,7 @@ async function enforceResidentialPolicy(deps) {
   publishDecision({ residential, arcaneOs: arcane, enforce: shouldEnforce, undecidedBecause: null });
 
   if (!shouldEnforce) {
-    fluxNetworkHelper.clearPlacementHold();
+    fluxNetworkHelper.clearPlacementHold(fluxNetworkHelper.PlacementHoldOwner.RESIDENTIAL_DOS);
     releaseOurDos(`residential=${residential}, arcaneOs=${arcane}`);
     await clearSettleMarker();
     evacuating = false;
@@ -697,7 +697,7 @@ async function enforceResidentialPolicy(deps) {
   }
 
   // Costs the node nothing it already holds, so it needs no settling period.
-  fluxNetworkHelper.setPlacementHold(HOLD_REASON);
+  fluxNetworkHelper.setPlacementHold(fluxNetworkHelper.PlacementHoldOwner.RESIDENTIAL_DOS, HOLD_REASON);
   // Set with the hold and cleared with it: the two are the same fact, and the
   // hold is the first thing that happens to an enforced node.
   enforcing = true;

--- a/ZelBack/src/services/residentialNodeDosService.js
+++ b/ZelBack/src/services/residentialNodeDosService.js
@@ -61,6 +61,29 @@ const MAX_CONFIRMATION_GAP_MS = CHECK_INTERVAL_MS * 2;
 // the replacement is itself the most junior and does not want to leave.
 const QUEUE_BASE_MS = config.fluxapps.residentialQueueBaseMs;
 const QUEUE_STEP_MS = config.fluxapps.residentialQueueStepMs;
+// The ticket is served against an UNINTERRUPTED observation - the wait means
+// nothing if it can be accumulated across periods this node was not watching -
+// and this is what counts as the interruption. A gap longer than one queue step
+// means at least one whole give-up pass went by without this node evaluating
+// the app, so the observation starts again rather than carrying over.
+//
+// It is what stops the departure interval leaking into the queue. A node inside
+// its interval returns ABOVE the accounting below, so it records nothing for
+// the whole block; the first pass after the block clears sees one six-hour gap
+// and every ticket starts again. Without that, position separates the FIRST
+// departure and nothing after it: every ticket matures untouched during the
+// block, and the node is instantly ready for all of them the moment it clears.
+// Two nodes whose blocks expire in the same pass then hand back the same app
+// together, which is the defect the step was widened to 40 minutes to close -
+// reached by the other door.
+//
+// Derived from the step rather than written as its own number, because the step
+// is ALREADY required to outlast the pass: that inequality is asserted against
+// production's config in the unit tests and re-derived per fleet by
+// test-infra's coupled knobs. A literal here would be a third place that has to
+// be kept in step with the block time, and the last hand-written number in this
+// neighbourhood inverted the property it was meant to enforce.
+const MAX_TICKET_GAP_MS = QUEUE_STEP_MS;
 // Minimum gap between this node's departures. The give-up-an-app pass runs every
 // 11 blocks (~22 min), which unpaced would empty the busiest node in the fleet in
 // about four hours; there is no deadline here and slower is strictly safer.
@@ -74,23 +97,35 @@ let started = false;
 let stopping = false;
 let ourDosActive = false;
 let inconclusiveStreak = 0;
-// appName -> epoch ms at which we first saw the app at full strength. Process
-// lifetime only: losing it costs a queue wait, never a premature removal.
-const wholeSince = new Map();
+// appName -> { since, lastSeenAt } on the MONOTONIC clock, for an app this node
+// has seen at full strength on every pass since `since`. Process lifetime only:
+// losing it costs a queue wait, never a premature removal.
+//
+// Two fields rather than one, because the ticket is an uninterrupted observation
+// and not an elapsed time. `since` is what the wait is measured from;
+// `lastSeenAt` is the only way an interruption can be detected at all - without
+// it a node that stopped looking, or one that was not allowed to act, goes on
+// accruing credit for time it never spent watching.
+const wholeObservation = new Map();
 // Whether the settling window has elapsed and departures may begin.
 let evacuating = false;
 // The network verdict behind the most recent isResidential(), carried into the
 // decision event so a consumer can tell the three nulls apart.
 let lastVerdict = { classification: null, source: null };
-// Paces departures, and PERSISTED in the settle marker rather than held for the
-// process lifetime. At 0 the gate below reads `now - 0`, about 1.7e12 ms, so it
-// is open on the first call after every process start: a node restarting on a
-// cron, crash-looping, or taking the ~4h auto-update shed an app every queue
-// wait instead of every departure interval, and the busiest node in the fleet
-// finished in hours rather than the three days the cadence is set for. Same
-// reasoning as the settling clock - a counter a restart resets makes restarting
-// the way to go faster.
-let lastEvacuationAt = 0;
+// Paces departures, on the MONOTONIC clock, and PERSISTED in the settle marker
+// rather than held for the process lifetime. Same reasoning as the settling
+// clock - a counter a restart resets makes restarting the way to go faster: a
+// node restarting on a cron, crash-looping, or taking the ~4h auto-update shed
+// an app every queue wait instead of every departure interval, and the busiest
+// node in the fleet finished in hours rather than the three days the cadence is
+// set for.
+//
+// `null`, not 0, for "no departure recorded". The gate used to read `now - 0`
+// and get about 1.7e12 ms, which is open by arithmetic - but 0 on the monotonic
+// clock is the start of THIS process, so the same expression would hold the
+// gate SHUT on a freshly booted node for the first six hours. The state is
+// named rather than encoded in a magic origin.
+let lastEvacuationAt = null;
 
 // Whether this node yet knows what it is running. Starts false and is only
 // raised by the orchestrator's own signal - the same one appSpawner waits on.
@@ -100,6 +135,22 @@ let lastEvacuationAt = 0;
 let nodeReady = false;
 appSyncEvents.on(SYNC_EVENTS.SPAWNER_READY, () => { nodeReady = true; });
 appSyncEvents.on(SYNC_EVENTS.READINESS_LOST, () => { nodeReady = false; });
+
+/**
+ * Milliseconds on the monotonic clock. Every elapsed-time decision the queue
+ * ticket makes reads this rather than the wall clock, so an NTP step cannot
+ * mature a ticket against time this node never spent watching. The backward
+ * step matters too, and more here than in most places: this runs on a box its
+ * own operator administers, and the operator has an incentive to stall the
+ * drain.
+ *
+ * Only values that must survive a restart stay on the wall clock, because a
+ * monotonic reading means nothing to the next process.
+ * @returns {number} Milliseconds since an arbitrary fixed origin.
+ */
+function monotonicMs() {
+  return Number(process.hrtime.bigint() / 1000000n);
+}
 
 /**
  * True when the current sticky DOS message was set by this service.
@@ -246,9 +297,19 @@ async function noteVerdictConfirmed(now) {
   const observedMs = numberOrNull(marker && marker.observedMs) ?? 0;
   // Restored here rather than at boot: this is the pass that reads the marker,
   // and it runs before any departure can be considered.
+  //
+  // CONVERTED, not read. The marker holds wall-clock ms and the gate runs on the
+  // monotonic clock, so what survives a restart is how long AGO the last
+  // departure was, not the instant it happened. A marker stamped in the future -
+  // the clock moved back between processes - would otherwise restore an origin
+  // ahead of now and hold the gate shut; it is floored at no elapsed time
+  // instead, which is the same answer as a departure that just happened.
   const persistedEvacuation = numberOrNull(marker && marker.lastEvacuationAt);
-  if (persistedEvacuation && persistedEvacuation > lastEvacuationAt) {
-    lastEvacuationAt = persistedEvacuation;
+  if (persistedEvacuation) {
+    const restored = monotonicMs() - Math.max(0, now - persistedEvacuation);
+    if (lastEvacuationAt === null || restored > lastEvacuationAt) {
+      lastEvacuationAt = restored;
+    }
   }
   const credited = previousConfirmedAt ? creditForGap(now - previousConfirmedAt) : 0;
   const totalObservedMs = observedMs + credited;
@@ -361,18 +422,42 @@ function isEvacuating() {
  * @param {string} appName Global app name.
  * @param {object[]} locations Instance locations for the app.
  * @param {string} localSocketAddr This node's socket address.
- * @param {number} [now] Epoch ms, injectable for tests.
+ * @param {number} minInstances How many instances this app is meant to have.
+ *   Passed in rather than derived here, so the pacing half of the decision and
+ *   the SURPLUS half are ranked by one number instead of two. It is the LOCAL
+ *   record's count; appEvacuationSafety re-derives from the global spec, which
+ *   is the authority at the moment of removal. They can differ while an owner's
+ *   instance-count change propagates, and either way round is safe: too low
+ *   here lets a ticket run that the safety gate then refuses as short, which
+ *   restarts the observation, and too high only makes the turn wait longer.
+ * @param {number} [now] Monotonic ms, injectable for tests.
  * @returns {{ok: boolean, reason: string}}
  */
-function mayEvacuateApp(appName, locations, localSocketAddr, now = Date.now()) {
+function mayEvacuateApp(appName, locations, localSocketAddr, minInstances, now = monotonicMs()) {
   if (!evacuating) return { ok: false, reason: 'node is not evacuating' };
-  if (now - lastEvacuationAt < EVACUATION_INTERVAL_MS) {
+  if (lastEvacuationAt !== null && now - lastEvacuationAt < EVACUATION_INTERVAL_MS) {
     const wait = Math.round((EVACUATION_INTERVAL_MS - (now - lastEvacuationAt)) / 60000);
     return { ok: false, reason: `next departure in ${wait}m` };
   }
-  if (!wholeSince.has(appName)) wholeSince.set(appName, now);
+
+  // Everything below is the ticket, and it sits BELOW the interval gate on
+  // purpose: a blocked node records nothing, so its own block reads as one long
+  // gap and the ticket starts again. See MAX_TICKET_GAP_MS.
+  const previous = wholeObservation.get(appName);
+  const gap = previous ? now - previous.lastSeenAt : Infinity;
+  // Strength is tested HERE, where the clock is stamped, rather than left to
+  // the safety gate. The wait is "seen at full strength for base + position x
+  // step"; a clock that starts on the first ASK measures something else, and an
+  // app short of its count is one the spawner is part way through replacing.
+  // Time spent watching that is not time spent watching it whole.
+  const whole = locations.length >= minInstances;
+  const since = (!whole || gap > MAX_TICKET_GAP_MS) ? now : previous.since;
+  wholeObservation.set(appName, { since, lastSeenAt: now });
+  if (!whole) {
+    return { ok: false, reason: `app is short (${locations.length}/${minInstances}); its turn starts again` };
+  }
   const wait = queueDelayMs(locations, localSocketAddr);
-  const observed = now - wholeSince.get(appName);
+  const observed = now - since;
   if (observed < wait) {
     return { ok: false, reason: `its turn is in ${Math.round((wait - observed) / 60000)}m` };
   }
@@ -384,13 +469,17 @@ function mayEvacuateApp(appName, locations, localSocketAddr, now = Date.now()) {
  * @param {string} appName Global app name.
  * @param {number} [now] Epoch ms, injectable for tests.
  */
-function noteEvacuated(appName, now = Date.now()) {
+function noteEvacuated(appName, now = monotonicMs()) {
   lastEvacuationAt = now;
-  wholeSince.delete(appName);
+  wholeObservation.delete(appName);
   // Written through to the marker, so a restart does not re-open the gate. Best
   // effort: the in-memory value already paces this process, and the persisted
   // one only has to survive into the next.
-  persistLastEvacuationAt(now).catch(() => {});
+  //
+  // The WALL clock is what gets written. The next process cannot read this
+  // one's monotonic origin, so the only thing worth recording is an instant it
+  // can convert back into "how long ago".
+  persistLastEvacuationAt(Date.now()).catch(() => {});
   log.info(`residentialNodeDos - ${appName} handed back; next departure no sooner than ${EVACUATION_INTERVAL_MS / 3600000}h`);
 }
 
@@ -423,7 +512,7 @@ async function persistLastEvacuationAt(now) {
  * @param {string} appName Global app name.
  */
 function forgetAppObservation(appName) {
-  wholeSince.delete(appName);
+  wholeObservation.delete(appName);
 }
 
 /**
@@ -538,7 +627,7 @@ async function enforceResidentialPolicy(deps) {
     releaseOurDos(`residential=${residential}, arcaneOs=${arcane}`);
     await clearSettleMarker();
     evacuating = false;
-    wholeSince.clear();
+    wholeObservation.clear();
     return true;
   }
 
@@ -666,7 +755,7 @@ function stop() {
   // previous run and skip the read-back that decides whether the slot is ours.
   ourDosActive = false;
   evacuating = false;
-  wholeSince.clear();
+  wholeObservation.clear();
   if (timerHandle) {
     clearTimeout(timerHandle);
     timerHandle = null;
@@ -699,5 +788,6 @@ module.exports = {
   SETTLE_MS,
   QUEUE_BASE_MS,
   QUEUE_STEP_MS,
+  MAX_TICKET_GAP_MS,
   EVACUATION_INTERVAL_MS,
 };

--- a/ZelBack/src/services/residentialNodeDosService.js
+++ b/ZelBack/src/services/residentialNodeDosService.js
@@ -39,6 +39,20 @@ const RETRY_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 // The placement hold deletes nothing and needs no window; this paces only the
 // part that moves customer data, so a momentary misread can correct itself.
 const SETTLE_MS = config.fluxapps.residentialSettleMs;
+// The window counts time this node OBSERVED the verdict, not time that passed.
+// A tick that cannot decide - an unreadable bench, a table that will not load -
+// returns without touching state, so measuring from the first verdict alone let
+// two evaluations 24h apart satisfy a window meant to prove the verdict held
+// throughout. Silence is not agreement, and the node that cannot read its own
+// hardware is the one to be most careful with.
+//
+// Each confirming tick credits the time since the last one, capped at a single
+// check interval so a long-ish gap cannot buy more than a tick's worth, and
+// credited as nothing at all once the gap is long enough that this node
+// plainly stopped watching. Derived from the check cadence rather than written
+// as its own number, so it holds the same proportion at any scale the harness
+// compresses that cadence to.
+const MAX_CONFIRMATION_GAP_MS = CHECK_INTERVAL_MS * 2;
 // A node may act on an app only once it has seen that app at full strength for
 // base + position * step. Position in the shared instance order is a DELAY,
 // never a veto: a rule of "only the most junior may leave" deadlocks, because
@@ -139,20 +153,20 @@ async function isResidential() {
 }
 
 /**
- * When this node first held the residential-and-not-ArcaneOS verdict.
+ * The settling marker as stored, or null when it cannot be read.
  *
- * Persisted, and measured in wall-clock: a counter of consecutive evaluations
- * held in memory is reset by restarting FluxOS, which would make restarting on a
- * timer a way to postpone the drain indefinitely.
- * @returns {Promise<number|null>} Epoch ms, or null when never recorded.
+ * Persisted rather than held in memory: a counter of consecutive evaluations in
+ * memory is reset by restarting FluxOS, which would make restarting on a timer a
+ * way to postpone the drain indefinitely.
+ * @returns {Promise<object|null>} The marker document, or null.
  */
-async function getSettleStartedAt() {
+async function getSettleMarker() {
   try {
     const db = dbHelper.databaseConnection();
     if (!db) return null;
     const database = db.db(config.database.local.database);
     const marker = await dbHelper.findOneInDatabase(database, startupCollection, { _id: SETTLE_MARKER_KEY });
-    return marker && marker.residentialSince ? marker.residentialSince : null;
+    return marker || null;
   } catch (error) {
     log.warn(`residentialNodeDos - could not read settle marker: ${error.message}`);
     return null;
@@ -160,16 +174,42 @@ async function getSettleStartedAt() {
 }
 
 /**
- * Record the start of the settling window, if it is not already running. Keyed
- * on the VERDICT, not on the address: residential lines get dynamic addresses,
- * so restarting the clock on an IP change would make power-cycling the router
- * the way to postpone enforcement.
- * @param {number} now Epoch ms.
- * @returns {Promise<number|null>} The settle start in force after this call.
+ * How much of the gap since the last confirmation counts towards the window.
+ *
+ * Nothing once the gap is long enough that this node plainly stopped watching -
+ * that is the whole point, and it is what stops a day of silence reading as a
+ * day of agreement. Otherwise the gap itself, capped at one check interval so a
+ * long-ish gap cannot buy more than a tick's worth of credit.
+ * @param {number} gapMs Time since the last confirmation.
+ * @returns {number} Milliseconds to credit.
  */
-async function markSettleStarted(now) {
-  const existing = await getSettleStartedAt();
-  if (existing) return existing;
+function creditForGap(gapMs) {
+  if (gapMs > MAX_CONFIRMATION_GAP_MS) return 0;
+  return Math.min(gapMs, CHECK_INTERVAL_MS);
+}
+
+/**
+ * Record that this tick confirmed the verdict, and return the observed time the
+ * verdict has now held for.
+ *
+ * Keyed on the VERDICT, not on the address: residential lines get dynamic
+ * addresses, so restarting the clock on an IP change would make power-cycling
+ * the router the way to postpone enforcement.
+ * @param {number} now Epoch ms.
+ * @returns {Promise<number|null>} Observed milliseconds, or null when the marker
+ *   cannot be written.
+ */
+async function noteVerdictConfirmed(now) {
+  const marker = await getSettleMarker();
+  // A marker written before this node kept an observed total has no record of
+  // what was watched, only of when the clock started - and that is exactly the
+  // measure being replaced. It starts accumulating from here rather than being
+  // credited for time nobody can vouch for.
+  const previousConfirmedAt = marker && marker.lastConfirmedAt;
+  const observedMs = (marker && marker.observedMs) || 0;
+  const credited = previousConfirmedAt ? creditForGap(now - previousConfirmedAt) : 0;
+  const totalObservedMs = observedMs + credited;
+
   try {
     const db = dbHelper.databaseConnection();
     if (!db) return null;
@@ -178,11 +218,20 @@ async function markSettleStarted(now) {
       database,
       startupCollection,
       { _id: SETTLE_MARKER_KEY },
-      { $set: { residentialSince: now, lastVerdict: CLASSIFICATION.RESIDENTIAL } },
+      {
+        $set: {
+          // Kept for the operator reading the record, not for the gate: it is
+          // when the verdict was FIRST seen, which is not what the window
+          // measures.
+          residentialSince: (marker && marker.residentialSince) || now,
+          lastConfirmedAt: now,
+          observedMs: totalObservedMs,
+        },
+      },
       { upsert: true },
     );
-    log.info('residentialNodeDos - settling window started');
-    return now;
+    if (!marker) log.info('residentialNodeDos - settling window started');
+    return totalObservedMs;
   } catch (error) {
     log.warn(`residentialNodeDos - could not write settle marker: ${error.message}`);
     return null;
@@ -389,16 +438,19 @@ async function enforceResidentialPolicy(deps) {
   }
 
   const now = Date.now();
-  const settleStartedAt = await markSettleStarted(now);
-  if (!settleStartedAt) {
+  const observedMs = await noteVerdictConfirmed(now);
+  if (observedMs === null) {
     evacuating = false;
     log.info('residentialNodeDos - settle marker unavailable, evacuation stays off');
     return false;
   }
-  if (now - settleStartedAt < SETTLE_MS) {
+  if (observedMs < SETTLE_MS) {
     evacuating = false;
-    const remaining = Math.round((SETTLE_MS - (now - settleStartedAt)) / (60 * 60 * 1000));
-    log.info(`residentialNodeDos - held, evacuation begins in about ${remaining}h (${installed.length} app(s) installed)`);
+    // Hours of the verdict actually WATCHED, so a node whose checks keep coming
+    // back inconclusive sees this figure stall rather than count down - which
+    // is the difference the window is there to make.
+    const remaining = Math.round((SETTLE_MS - observedMs) / (60 * 60 * 1000));
+    log.info(`residentialNodeDos - held, evacuation begins after about ${remaining}h more of confirmed verdict (${installed.length} app(s) installed)`);
     return true;
   }
 

--- a/ZelBack/src/services/residentialNodeDosService.js
+++ b/ZelBack/src/services/residentialNodeDosService.js
@@ -324,10 +324,18 @@ async function listInstalledApps(installedAppsFn) {
  * @returns {number} Milliseconds.
  */
 function queueDelayMs(locations, localSocketAddr) {
-  const ordered = [...locations].sort(compareInstanceSeniority);
+  // Junior end first - the same order reasonToGiveUpApp ranks SURPLUS by, and
+  // for the same reason: the newest copy stands aside and the senior one goes
+  // on holding the data. Ranking the senior end first also put the ONE case
+  // that cannot simply leave at the front of the queue, because the elected
+  // primary is the senior instance: the node needing a stand-down was asked to
+  // go before any of the nodes that could just go, and every node behind it
+  // waited out its step while it negotiated. Senior last is both orders
+  // agreeing and the cheap departures happening first.
+  const ordered = [...locations].sort((a, b) => compareInstanceSeniority(b, a));
   const index = ordered.findIndex((entry) => socketAddressesMatch(entry.ip, localSocketAddr));
   // An instance this node cannot find in the list waits longest. For an EMPTY
-  // list `ordered.length` is 0, which is the most senior slot - the shortest
+  // list `ordered.length` is 0, which is the front of the queue - the shortest
   // wait of all, inverting the rule. An empty list is the ordinary result of
   // expired location records, so it is not an exotic input.
   const position = index < 0 ? Math.max(ordered.length, 1) : index;

--- a/ZelBack/src/services/residentialNodeDosService.js
+++ b/ZelBack/src/services/residentialNodeDosService.js
@@ -1,23 +1,79 @@
+// A node on a residential connection is only fit to serve the network when it
+// runs ArcaneOS. This service moves such a node off the network in three stages:
+//
+//   HOLD   it stops accepting NEW apps. Immediate, and it deletes nothing.
+//   EVACUATE  it gives up one app at a time, and only ones another host
+//          demonstrably holds. Each departure leaves the app one short, the
+//          spawner replaces it on a node that is not held, and that is what
+//          releases the next holder. The removing is done by the single
+//          give-up-an-app pass in advancedWorkflows; this service owns only the
+//          policy and the pacing.
+//   DOS    once the node runs nothing, the sticky DOS goes on. By then
+//          removeAllAppsLocally has nothing to find.
+//
+// DOS >= 100 is not a mark: it makes nodeStatusMonitor and appStartupManager
+// `rm -rf` every app directory and volume on the box. Reaching that state only
+// on an empty node is the whole point of the staging.
+//
+// Nothing here enforces against a node that is not PROVABLY residential.
+// geolocationService's classification is four-state and only RESIDENTIAL acts:
+// CONFLICTED and UNKNOWN are left alone, as is a node whose bench cannot be read.
+
 const config = require('config');
 const log = require('../lib/log');
+const dbHelper = require('./dbHelper');
 const fluxNetworkHelper = require('./fluxNetworkHelper');
 const geolocationService = require('./geolocationService');
 const benchmarkService = require('./benchmarkService');
+const { CLASSIFICATION } = require('./utils/networkClassifier');
+const { appSyncEvents, EVENTS: SYNC_EVENTS } = require('./utils/appSyncEvents');
+const { compareInstanceSeniority } = require('./utils/instanceOrdering');
+const { socketAddressesMatch } = require('./utils/socketAddressUtils');
 
 const DOS_MESSAGE_PREFIX = 'Residential node not running ArcaneOS';
+const HOLD_REASON = 'residential node not running ArcaneOS';
 
-// A tick that could not read both inputs decides nothing, so it is retried on a
-// short delay instead of waiting out the full interval - geolocation is only
-// available once fluxbench has resolved this node's IP, which can be minutes
-// after boot.
-const CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
+const CHECK_INTERVAL_MS = config.fluxapps.residentialCheckIntervalMs;
 const RETRY_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+// Before the first app is given up, the verdict must have held this long.
+// The placement hold deletes nothing and needs no window; this paces only the
+// part that moves customer data, so a momentary misread can correct itself.
+const SETTLE_MS = config.fluxapps.residentialSettleMs;
+// A node may act on an app only once it has seen that app at full strength for
+// base + position * step. Position in the shared instance order is a DELAY,
+// never a veto: a rule of "only the most junior may leave" deadlocks, because
+// the replacement is itself the most junior and does not want to leave.
+const QUEUE_BASE_MS = config.fluxapps.residentialQueueBaseMs;
+const QUEUE_STEP_MS = config.fluxapps.residentialQueueStepMs;
+// Minimum gap between this node's departures. The give-up-an-app pass runs every
+// 11 blocks (~22 min), which unpaced would empty the busiest node in the fleet in
+// about four hours; there is no deadline here and slower is strictly safer.
+const EVACUATION_INTERVAL_MS = config.fluxapps.residentialEvacuationIntervalMs;
+
+const startupCollection = config.database.local.collections.nodeStartupTracker;
+const SETTLE_MARKER_KEY = 'residentialDos';
 
 let timerHandle = null;
 let started = false;
 let stopping = false;
 let ourDosActive = false;
 let inconclusiveStreak = 0;
+// appName -> epoch ms at which we first saw the app at full strength. Process
+// lifetime only: losing it costs a queue wait, never a premature removal.
+const wholeSince = new Map();
+// Whether the settling window has elapsed and departures may begin.
+let evacuating = false;
+// Paces departures. Process lifetime: a restart costs at most one extra wait.
+let lastEvacuationAt = 0;
+
+// Whether this node yet knows what it is running. Starts false and is only
+// raised by the orchestrator's own signal - the same one appSpawner waits on.
+// globalState.spawnerPaused is NOT this signal: it initialises to false, so
+// reading it would report a freshly booted node as ready, and an app list read
+// then is not evidence of an empty node.
+let nodeReady = false;
+appSyncEvents.on(SYNC_EVENTS.SPAWNER_READY, () => { nodeReady = true; });
+appSyncEvents.on(SYNC_EVENTS.READINESS_LOST, () => { nodeReady = false; });
 
 /**
  * True when the current sticky DOS message was set by this service.
@@ -30,14 +86,14 @@ function isOurStickyDos() {
 
 /**
  * Three-state ArcaneOS check via fluxbenchd.
- *   true  — confirmed ArcaneOS, nothing to enforce
- *   false — confirmed NOT ArcaneOS
- *   null  — fluxbenchd unreachable or response malformed, decide nothing
+ *   true  - confirmed ArcaneOS, nothing to enforce
+ *   false - confirmed NOT ArcaneOS
+ *   null  - fluxbenchd unreachable or malformed, decide nothing
  *
  * Read from bench rather than `process.env.FLUXOS_PATH` because the env var is
  * set by whoever launches FluxOS, and this check is exactly what a residential
- * operator has an incentive to fake. The null case is deliberate: a momentarily
- * unreachable bench must never DOS a real ArcaneOS node.
+ * operator has an incentive to fake.
+ * @returns {Promise<boolean|null>}
  */
 async function isArcaneOs() {
   try {
@@ -55,22 +111,24 @@ async function isArcaneOs() {
 }
 
 /**
- * Three-state residential check.
- *   true  — geolocation resolved and says this IP is not a data center
- *   false — geolocation resolved and says this IP is a data center
- *   null  — no geolocation yet (in memory or in db), decide nothing
+ * Three-state residential check, read as one settled verdict.
+ *   true  - RESIDENTIAL: positive evidence with no contradiction
+ *   false - DATACENTER
+ *   null  - no verdict yet, or CONFLICTED/UNKNOWN: decide nothing
  *
- * isDataCenter() alone cannot answer this: it defaults to false before the
- * first successful lookup, so a node whose geolocation never resolved would
- * read as residential. The geolocation object is what says the lookup actually
- * happened, and getNodeGeolocation() is also what restores the flag from the db
- * after a restart - so it has to be awaited before the flag is read.
+ * Awaiting getNodeGeolocation() first is what restores a verdict from the db
+ * after a restart. The verdict and its evidence are published together, so this
+ * can never read a classification computed from a half-finished pass.
+ * @returns {Promise<boolean|null>}
  */
 async function isResidential() {
   try {
-    const geolocation = await geolocationService.getNodeGeolocation();
-    if (!geolocation) return null;
-    return geolocationService.isDataCenter() !== true;
+    await geolocationService.getNodeGeolocation();
+    const verdict = geolocationService.getNetworkClassification();
+    if (!verdict) return null;
+    if (verdict.classification === CLASSIFICATION.RESIDENTIAL) return true;
+    if (verdict.classification === CLASSIFICATION.DATACENTER) return false;
+    return null;
   } catch (error) {
     log.warn(`residentialNodeDos - geolocation check failed: ${error.message}`);
     return null;
@@ -78,10 +136,167 @@ async function isResidential() {
 }
 
 /**
+ * When this node first held the residential-and-not-ArcaneOS verdict.
+ *
+ * Persisted, and measured in wall-clock: a counter of consecutive evaluations
+ * held in memory is reset by restarting FluxOS, which would make restarting on a
+ * timer a way to postpone the drain indefinitely.
+ * @returns {Promise<number|null>} Epoch ms, or null when never recorded.
+ */
+async function getSettleStartedAt() {
+  try {
+    const db = dbHelper.databaseConnection();
+    if (!db) return null;
+    const database = db.db(config.database.local.database);
+    const marker = await dbHelper.findOneInDatabase(database, startupCollection, { _id: SETTLE_MARKER_KEY });
+    return marker && marker.residentialSince ? marker.residentialSince : null;
+  } catch (error) {
+    log.warn(`residentialNodeDos - could not read settle marker: ${error.message}`);
+    return null;
+  }
+}
+
+/**
+ * Record the start of the settling window, if it is not already running. Keyed
+ * on the VERDICT, not on the address: residential lines get dynamic addresses,
+ * so restarting the clock on an IP change would make power-cycling the router
+ * the way to postpone enforcement.
+ * @param {number} now Epoch ms.
+ * @returns {Promise<number|null>} The settle start in force after this call.
+ */
+async function markSettleStarted(now) {
+  const existing = await getSettleStartedAt();
+  if (existing) return existing;
+  try {
+    const db = dbHelper.databaseConnection();
+    if (!db) return null;
+    const database = db.db(config.database.local.database);
+    await dbHelper.findOneAndUpdateInDatabase(
+      database,
+      startupCollection,
+      { _id: SETTLE_MARKER_KEY },
+      { $set: { residentialSince: now, lastVerdict: CLASSIFICATION.RESIDENTIAL } },
+      { upsert: true },
+    );
+    log.info('residentialNodeDos - settling window started');
+    return now;
+  } catch (error) {
+    log.warn(`residentialNodeDos - could not write settle marker: ${error.message}`);
+    return null;
+  }
+}
+
+/**
+ * Clear the settling window. Only a verdict flip does this - the node is no
+ * longer residential, or is now ArcaneOS.
+ */
+async function clearSettleMarker() {
+  try {
+    const db = dbHelper.databaseConnection();
+    if (!db) return;
+    const database = db.db(config.database.local.database);
+    await dbHelper.findOneAndDeleteInDatabase(database, startupCollection, { _id: SETTLE_MARKER_KEY }, {});
+  } catch (error) {
+    log.warn(`residentialNodeDos - could not clear settle marker: ${error.message}`);
+  }
+}
+
+/**
+ * The apps installed on this node, or null when that cannot be established.
+ *
+ * The null is load-bearing. Setting the DOS on a node believed empty that is not
+ * makes nodeStatusMonitor delete every app it holds - the exact outcome this
+ * service exists to avoid - so "could not read" must never arrive here as an
+ * empty list.
+ * @param {Function} installedAppsFn Injected app lister.
+ * @returns {Promise<string[]|null>}
+ */
+async function listInstalledApps(installedAppsFn) {
+  try {
+    const response = await installedAppsFn();
+    if (!response || response.status !== 'success' || !Array.isArray(response.data)) return null;
+    return response.data.map((app) => app.name);
+  } catch (error) {
+    log.warn(`residentialNodeDos - could not list installed apps: ${error.message}`);
+    return null;
+  }
+}
+
+/**
+ * How long this node must have seen an app whole before it may act on it.
+ * @param {object[]} locations Instance locations, any order.
+ * @param {string} localSocketAddr This node's socket address.
+ * @returns {number} Milliseconds.
+ */
+function queueDelayMs(locations, localSocketAddr) {
+  const ordered = [...locations].sort(compareInstanceSeniority);
+  const index = ordered.findIndex((entry) => socketAddressesMatch(entry.ip, localSocketAddr));
+  const position = index < 0 ? ordered.length : index;
+  return QUEUE_BASE_MS + (position * QUEUE_STEP_MS);
+}
+
+/**
+ * Whether this node is currently shedding the apps it holds.
+ *
+ * True only once the verdict has held for the settling window - the placement
+ * hold starts immediately, but nothing that moves customer data does.
+ * @returns {boolean}
+ */
+function isEvacuating() {
+  return evacuating;
+}
+
+/**
+ * May this node give up this particular app right now?
+ *
+ * This is the pacing half of the decision and says nothing about safety; the
+ * give-up-an-app pass asks appEvacuationSafety separately, and both must agree.
+ * @param {string} appName Global app name.
+ * @param {object[]} locations Instance locations for the app.
+ * @param {string} localSocketAddr This node's socket address.
+ * @param {number} [now] Epoch ms, injectable for tests.
+ * @returns {{ok: boolean, reason: string}}
+ */
+function mayEvacuateApp(appName, locations, localSocketAddr, now = Date.now()) {
+  if (!evacuating) return { ok: false, reason: 'node is not evacuating' };
+  if (now - lastEvacuationAt < EVACUATION_INTERVAL_MS) {
+    const wait = Math.round((EVACUATION_INTERVAL_MS - (now - lastEvacuationAt)) / 60000);
+    return { ok: false, reason: `next departure in ${wait}m` };
+  }
+  if (!wholeSince.has(appName)) wholeSince.set(appName, now);
+  const wait = queueDelayMs(locations, localSocketAddr);
+  const observed = now - wholeSince.get(appName);
+  if (observed < wait) {
+    return { ok: false, reason: `its turn is in ${Math.round((wait - observed) / 60000)}m` };
+  }
+  return { ok: true, reason: 'ready' };
+}
+
+/**
+ * Record that this app has gone, so the interval before the next one starts.
+ * @param {string} appName Global app name.
+ * @param {number} [now] Epoch ms, injectable for tests.
+ */
+function noteEvacuated(appName, now = Date.now()) {
+  lastEvacuationAt = now;
+  wholeSince.delete(appName);
+  log.info(`residentialNodeDos - ${appName} handed back; next departure no sooner than ${EVACUATION_INTERVAL_MS / 3600000}h`);
+}
+
+/**
+ * Forget an app's queue observation. Called when it stops being safe to give up,
+ * so the wait is served against an uninterrupted observation rather than
+ * accumulated across a gap.
+ * @param {string} appName Global app name.
+ */
+function forgetAppObservation(appName) {
+  wholeSince.delete(appName);
+}
+
+/**
  * Give up the DOS this service is holding. The slot is only cleared when the
  * message in it is still ours: another owner may have taken it since we wrote,
- * and clearing that would drop their DOS on the floor. Dropping our own claim
- * is all we are entitled to do in that case.
+ * and clearing that would drop their DOS on the floor.
  * @param {string} reason Logged context for the release.
  */
 function releaseOurDos(reason) {
@@ -98,19 +313,35 @@ function releaseOurDos(reason) {
 }
 
 /**
- * Core check: a node on a residential connection that is not running ArcaneOS
- * is DOSed. Otherwise, if we previously DOSed it, the DOS is cleared. This
- * service owns the DOS message it sets and only clears its own.
- *
- * @returns {Promise<boolean>} True when the tick reached a decision, false when
- * an input was unavailable and the tick decided nothing (caller retries sooner).
+ * Put the node fully out of service. Only ever reached once it holds no apps.
  */
-async function enforceResidentialPolicy() {
-  if (config.residentialDos && config.residentialDos.enabled === false) {
-    log.info('residentialNodeDos - enforcement disabled by config');
-    releaseOurDos('disabled by config');
-    return true;
+function applyDos() {
+  const sticky = fluxNetworkHelper.getStickyDosMessage();
+  if (sticky && !isOurStickyDos()) {
+    // Another owner's DOS already has this node out of service for its own
+    // reason, and taking the single slot would leave it unable to recognise or
+    // release its own state.
+    log.info('residentialNodeDos - another sticky DOS is active, not overwriting it');
+    return;
   }
+  if (isOurStickyDos()) return;
+  const message = `${DOS_MESSAGE_PREFIX}. Migrate this node to ArcaneOS or move it to a data center connection.`;
+  fluxNetworkHelper.setStickyDosMessage(message);
+  fluxNetworkHelper.setStickyDosStateValue(100);
+  ourDosActive = true;
+  log.error(message);
+}
+
+/**
+ * One evaluation of the policy.
+ *
+ * @param {object} deps Injected collaborators.
+ * @param {Function} deps.installedAppsFn Lists apps installed on this node.
+ * @returns {Promise<boolean>} True when the tick reached a decision, false when
+ *   an input was unavailable and the caller should retry sooner.
+ */
+async function enforceResidentialPolicy(deps) {
+  const { installedAppsFn } = deps;
 
   const [arcane, residential] = await Promise.all([isArcaneOs(), isResidential()]);
 
@@ -119,41 +350,66 @@ async function enforceResidentialPolicy() {
     return false;
   }
   if (residential === null) {
-    log.info('residentialNodeDos - geolocation not available yet, skipping this tick');
+    log.info('residentialNodeDos - no settled network classification yet, skipping this tick');
     return false;
   }
 
-  const shouldDos = residential && !arcane;
+  const shouldEnforce = residential && !arcane;
+  log.info(`residentialNodeDos - residential=${residential} arcaneOs=${arcane} enforce=${shouldEnforce}`);
 
-  log.info(`residentialNodeDos - residential=${residential} arcaneOs=${arcane} shouldDos=${shouldDos}`);
-
-  if (shouldDos) {
-    // The sticky slot holds one message. Another owner's DOS already has this
-    // node out of service for its own reason, and overwriting it would take
-    // that owner's state away from it - so leave it and re-check next tick.
-    const sticky = fluxNetworkHelper.getStickyDosMessage();
-    if (sticky && !isOurStickyDos()) {
-      log.info('residentialNodeDos - another sticky DOS is active, not overwriting it');
-      return true;
-    }
-    const message = `${DOS_MESSAGE_PREFIX}. Migrate this node to ArcaneOS or move it to a data center connection.`;
-    fluxNetworkHelper.setStickyDosMessage(message);
-    fluxNetworkHelper.setStickyDosStateValue(100);
-    ourDosActive = true;
-    log.error(message);
+  if (!shouldEnforce) {
+    fluxNetworkHelper.clearPlacementHold();
+    releaseOurDos(`residential=${residential}, arcaneOs=${arcane}`);
+    await clearSettleMarker();
+    evacuating = false;
+    wholeSince.clear();
     return true;
   }
 
-  releaseOurDos(`residential=${residential}, arcaneOs=${arcane}`);
+  // Costs the node nothing it already holds, so it needs no settling period.
+  fluxNetworkHelper.setPlacementHold(HOLD_REASON);
+
+  if (!nodeReady) {
+    log.info('residentialNodeDos - node not ready yet, holding placement only this tick');
+    return false;
+  }
+
+  const installed = await listInstalledApps(installedAppsFn);
+  if (installed === null) {
+    log.info('residentialNodeDos - installed app list unavailable, holding placement only this tick');
+    return false;
+  }
+
+  if (!installed.length) {
+    applyDos();
+    return true;
+  }
+
+  const now = Date.now();
+  const settleStartedAt = await markSettleStarted(now);
+  if (!settleStartedAt) {
+    evacuating = false;
+    log.info('residentialNodeDos - settle marker unavailable, evacuation stays off');
+    return false;
+  }
+  if (now - settleStartedAt < SETTLE_MS) {
+    evacuating = false;
+    const remaining = Math.round((SETTLE_MS - (now - settleStartedAt)) / (60 * 60 * 1000));
+    log.info(`residentialNodeDos - held, evacuation begins in about ${remaining}h (${installed.length} app(s) installed)`);
+    return true;
+  }
+
+  // The give-up-an-app pass reads this and does the removing; it asks
+  // mayEvacuateApp for the pacing and appEvacuationSafety for the safety.
+  if (!evacuating) log.warn(`residentialNodeDos - evacuation begins, ${installed.length} app(s) to hand back`);
+  evacuating = true;
   return true;
 }
 
 /**
  * Delay before the next tick. A decided tick waits out the full interval; an
  * inconclusive one comes back on the short retry, doubling each time it stays
- * inconclusive. The doubling matters for the node whose geolocation never
- * resolves at all: a flat 5-minute retry would have it deciding nothing and
- * logging that it decided nothing 288 times a day, forever.
+ * inconclusive, so a node that can never decide stops saying so 288 times a day.
  * @param {boolean} decided Whether the tick reached a decision.
  * @param {number} streak Consecutive inconclusive ticks, this one included.
  * @returns {number} Milliseconds until the next tick.
@@ -165,24 +421,26 @@ function nextDelay(decided, streak) {
 
 /**
  * Run one tick and schedule the next one.
+ * @param {object} deps Injected collaborators, as enforceResidentialPolicy.
  */
-async function tick() {
+async function tick(deps) {
   let decided = false;
   try {
-    decided = await enforceResidentialPolicy();
+    decided = await enforceResidentialPolicy(deps);
   } catch (error) {
     log.error(`residentialNodeDos - tick error: ${error.message}`);
   }
   inconclusiveStreak = decided ? 0 : inconclusiveStreak + 1;
   if (stopping) return;
-  timerHandle = setTimeout(tick, nextDelay(decided, inconclusiveStreak));
+  timerHandle = setTimeout(() => tick(deps), nextDelay(decided, inconclusiveStreak));
 }
 
 /**
  * Start the enforcer. Performs the first check immediately, then reschedules
- * itself. Safe to call multiple times (no-ops if already started).
+ * itself. Safe to call multiple times.
+ * @param {object} deps Injected collaborators, as enforceResidentialPolicy.
  */
-async function start() {
+async function start(deps) {
   // The guard is `started`, not `timerHandle`: the first tick is awaited before
   // any timer exists, so a second start() landing inside it would run a second
   // self-rescheduling chain.
@@ -191,12 +449,17 @@ async function start() {
   stopping = false;
   inconclusiveStreak = 0;
   log.info('residentialNodeDos - enforcer starting');
-  await tick();
+  await tick(deps);
 }
 
 function stop() {
   stopping = true;
   started = false;
+  // Cleared with the timer: a later start() must not inherit a claim from the
+  // previous run and skip the read-back that decides whether the slot is ours.
+  ourDosActive = false;
+  evacuating = false;
+  wholeSince.clear();
   if (timerHandle) {
     clearTimeout(timerHandle);
     timerHandle = null;
@@ -214,7 +477,20 @@ module.exports = {
   isArcaneOs,
   isResidential,
   isDosActive,
+  queueDelayMs,
+  listInstalledApps,
+  isEvacuating,
+  mayEvacuateApp,
+  noteEvacuated,
+  forgetAppObservation,
+  // Test seam for the readiness gate, which is otherwise only moved by events.
+  setNodeReadyForTests: (value) => { nodeReady = value; },
   DOS_MESSAGE_PREFIX,
+  HOLD_REASON,
   CHECK_INTERVAL_MS,
   RETRY_INTERVAL_MS,
+  SETTLE_MS,
+  QUEUE_BASE_MS,
+  QUEUE_STEP_MS,
+  EVACUATION_INTERVAL_MS,
 };

--- a/ZelBack/src/services/residentialNodeDosService.js
+++ b/ZelBack/src/services/residentialNodeDosService.js
@@ -109,6 +109,20 @@ let inconclusiveStreak = 0;
 const wholeObservation = new Map();
 // Whether the settling window has elapsed and departures may begin.
 let evacuating = false;
+// What /flux/info reports, and DELIBERATELY not derived from `evacuating`.
+//
+// `evacuating` is a per-tick permission for the give-up pass: any tick that
+// cannot read something turns it off, correctly, because a node that cannot
+// establish its own state must not hand an app back. It is not a description of
+// how far through the staging the node is, and reporting it as one would show
+// the node moving BACKWARDS through a staging it never moved backwards through.
+//
+// The window is what actually progresses. `observedWindowMs` only ever grows
+// while the verdict holds - a tick that cannot decide leaves it alone rather
+// than resetting it - and both are cleared together the moment the node stops
+// being enforced, which is the one transition that really is a reversal.
+let enforcing = false;
+let observedWindowMs = 0;
 // The network verdict behind the most recent isResidential(), carried into the
 // decision event so a consumer can tell the three nulls apart.
 let lastVerdict = { classification: null, source: null };
@@ -404,6 +418,29 @@ function queueDelayMs(locations, localSocketAddr) {
 }
 
 /**
+ * How far this node is through being staged out of service, for /flux/info.
+ *
+ *   null       nothing is being enforced against this node
+ *   HOLD       enforced: it takes no NEW apps, and nothing has been deleted
+ *   EVACUATE   the settling window is served and it is handing apps back
+ *
+ * HOLD is the state worth reporting. It is the longest one - a full settling
+ * window - it is the only one where the operator can still fix the node and
+ * lose nothing, and without it a held node is indistinguishable from an
+ * ordinary one that happens not to have been given work.
+ *
+ * The DOS itself is already reported beside this as `dos`, so the three stages
+ * read together: HOLD with no DOS, EVACUATE with no DOS, then EVACUATE with
+ * one. An EMPTY node reports HOLD with a DOS, having skipped the window it had
+ * no data to need.
+ * @returns {('HOLD'|'EVACUATE'|null)}
+ */
+function getDosStaging() {
+  if (!enforcing) return null;
+  return observedWindowMs >= SETTLE_MS ? 'EVACUATE' : 'HOLD';
+}
+
+/**
  * Whether this node is currently shedding the apps it holds.
  *
  * True only once the verdict has held for the settling window - the placement
@@ -627,12 +664,17 @@ async function enforceResidentialPolicy(deps) {
     releaseOurDos(`residential=${residential}, arcaneOs=${arcane}`);
     await clearSettleMarker();
     evacuating = false;
+    enforcing = false;
+    observedWindowMs = 0;
     wholeObservation.clear();
     return true;
   }
 
   // Costs the node nothing it already holds, so it needs no settling period.
   fluxNetworkHelper.setPlacementHold(HOLD_REASON);
+  // Set with the hold and cleared with it: the two are the same fact, and the
+  // hold is the first thing that happens to an enforced node.
+  enforcing = true;
 
   if (!nodeReady) {
     evacuating = false;
@@ -670,6 +712,7 @@ async function enforceResidentialPolicy(deps) {
 
   const now = Date.now();
   const observedMs = await noteVerdictConfirmed(now);
+  if (observedMs !== null) observedWindowMs = observedMs;
   if (observedMs === null) {
     evacuating = false;
     log.info('residentialNodeDos - settle marker unavailable, evacuation stays off');
@@ -755,6 +798,8 @@ function stop() {
   // previous run and skip the read-back that decides whether the slot is ours.
   ourDosActive = false;
   evacuating = false;
+  enforcing = false;
+  observedWindowMs = 0;
   wholeObservation.clear();
   if (timerHandle) {
     clearTimeout(timerHandle);
@@ -776,6 +821,7 @@ module.exports = {
   queueDelayMs,
   listInstalledApps,
   isEvacuating,
+  getDosStaging,
   mayEvacuateApp,
   noteEvacuated,
   forgetAppObservation,

--- a/ZelBack/src/services/residentialNodeDosService.js
+++ b/ZelBack/src/services/residentialNodeDosService.js
@@ -111,20 +111,23 @@ async function isArcaneOs() {
 }
 
 /**
- * Three-state residential check, read as one settled verdict.
+ * Three-state residential check.
  *   true  - RESIDENTIAL: positive evidence with no contradiction
  *   false - DATACENTER
- *   null  - no verdict yet, or CONFLICTED/UNKNOWN: decide nothing
+ *   null  - decide nothing. Either CONFLICTED/UNKNOWN, or there is no verdict
+ *           to be had: nothing observed yet, or no published location table has
+ *           been consulted. A node that has not read the table does not know
+ *           what kind of network it is on, and enforcing on its own reading
+ *           alone is what this whole staging exists to avoid.
  *
- * Awaiting getNodeGeolocation() first is what restores a verdict from the db
- * after a restart. The verdict and its evidence are published together, so this
- * can never read a classification computed from a half-finished pass.
+ * Awaiting getNodeGeolocation() first is what restores the observations from the
+ * db after a restart.
  * @returns {Promise<boolean|null>}
  */
 async function isResidential() {
   try {
     await geolocationService.getNodeGeolocation();
-    const verdict = geolocationService.getNetworkClassification();
+    const verdict = await geolocationService.getNetworkClassification();
     if (!verdict) return null;
     if (verdict.classification === CLASSIFICATION.RESIDENTIAL) return true;
     if (verdict.classification === CLASSIFICATION.DATACENTER) return false;
@@ -350,7 +353,7 @@ async function enforceResidentialPolicy(deps) {
     return false;
   }
   if (residential === null) {
-    log.info('residentialNodeDos - no settled network classification yet, skipping this tick');
+    log.info('residentialNodeDos - no network verdict to act on yet, skipping this tick');
     return false;
   }
 

--- a/ZelBack/src/services/residentialNodeDosService.js
+++ b/ZelBack/src/services/residentialNodeDosService.js
@@ -30,6 +30,7 @@ const { appSyncEvents, EVENTS: SYNC_EVENTS } = require('./utils/appSyncEvents');
 const globalState = require('./utils/globalState');
 const { compareInstanceSeniority } = require('./utils/instanceOrdering');
 const { socketAddressesMatch } = require('./utils/socketAddressUtils');
+const fluxEventBus = require('./utils/fluxEventBus');
 
 const DOS_MESSAGE_PREFIX = 'Residential node not running ArcaneOS';
 const HOLD_REASON = 'residential node not running ArcaneOS';
@@ -445,6 +446,29 @@ function applyDos() {
 }
 
 /**
+ * What this tick concluded, whichever way it went.
+ *
+ * Deciding NOT to enforce leaves no trace: no placement hold, no settle marker,
+ * no DOS - the outcome IS the absence of all three. So a caller with no event
+ * here can only wait out a duration and infer from nothing having happened,
+ * which is indistinguishable from the tick never having run. That is what the
+ * harness was doing, at thirty seconds a test.
+ *
+ * `enforce: null` is a tick that could not decide, with `undecidedBecause`
+ * naming the input that was missing. Kept apart from `false` because they are
+ * opposite states: one says this node is fit to serve, the other says nobody
+ * knows yet.
+ *
+ * fluxEventBus is inert on a real node - config.testEventStream is false - so
+ * this exists for the harness and costs production nothing.
+ * @param {{residential: boolean|null, arcaneOs: boolean|null,
+ *   enforce: boolean|null, undecidedBecause: string|null}} verdict
+ */
+function publishDecision(verdict) {
+  fluxEventBus.publish('residential:decided', verdict);
+}
+
+/**
  * One evaluation of the policy.
  *
  * @param {object} deps Injected collaborators.
@@ -467,16 +491,19 @@ async function enforceResidentialPolicy(deps) {
   if (arcane === null) {
     evacuating = false;
     log.info('residentialNodeDos - benchmark unreachable, skipping this tick');
+    publishDecision({ residential, arcaneOs: arcane, enforce: null, undecidedBecause: 'benchmark' });
     return false;
   }
   if (residential === null) {
     evacuating = false;
     log.info('residentialNodeDos - no network verdict to act on yet, skipping this tick');
+    publishDecision({ residential, arcaneOs: arcane, enforce: null, undecidedBecause: 'classification' });
     return false;
   }
 
   const shouldEnforce = residential && !arcane;
   log.info(`residentialNodeDos - residential=${residential} arcaneOs=${arcane} enforce=${shouldEnforce}`);
+  publishDecision({ residential, arcaneOs: arcane, enforce: shouldEnforce, undecidedBecause: null });
 
   if (!shouldEnforce) {
     fluxNetworkHelper.clearPlacementHold();

--- a/ZelBack/src/services/residentialNodeDosService.js
+++ b/ZelBack/src/services/residentialNodeDosService.js
@@ -446,8 +446,9 @@ function queueDelayMs(locations, localSocketAddr) {
  *
  * The DOS itself is already reported beside this as `dos`, so the three stages
  * read together: HOLD with no DOS, EVACUATE with no DOS, then EVACUATE with
- * one. An EMPTY node reports HOLD with a DOS, having skipped the window it had
- * no data to need.
+ * one. A node EMPTY FROM THE START reports HOLD with a DOS, having skipped the
+ * window it had no data to need; one that DRAINED to empty has served the whole
+ * window by the time it gets there, so it reports EVACUATE with a DOS.
  * @returns {('HOLD'|'EVACUATE'|null)}
  */
 function getDosStaging() {

--- a/ZelBack/src/services/residentialNodeDosService.js
+++ b/ZelBack/src/services/residentialNodeDosService.js
@@ -79,6 +79,9 @@ let inconclusiveStreak = 0;
 const wholeSince = new Map();
 // Whether the settling window has elapsed and departures may begin.
 let evacuating = false;
+// The network verdict behind the most recent isResidential(), carried into the
+// decision event so a consumer can tell the three nulls apart.
+let lastVerdict = { classification: null, source: null };
 // Paces departures, and PERSISTED in the settle marker rather than held for the
 // process lifetime. At 0 the gate below reads `now - 0`, about 1.7e12 ms, so it
 // is open on the first call after every process start: a node restarting on a
@@ -151,11 +154,20 @@ async function isResidential() {
   try {
     await geolocationService.getNodeGeolocation();
     const verdict = await geolocationService.getNetworkClassification();
+    // Kept for the decision event. The boolean below collapses CONFLICTED,
+    // UNKNOWN and no-table-consulted into one null, which is right for the
+    // enforcement decision and useless to anything trying to understand it - a
+    // node declining a published verdict about its own address and a node that
+    // has not read the table yet are the same answer here and nothing alike.
+    lastVerdict = verdict
+      ? { classification: verdict.classification, source: verdict.source }
+      : { classification: null, source: null };
     if (!verdict) return null;
     if (verdict.classification === CLASSIFICATION.RESIDENTIAL) return true;
     if (verdict.classification === CLASSIFICATION.DATACENTER) return false;
     return null;
   } catch (error) {
+    lastVerdict = { classification: null, source: null };
     log.warn(`residentialNodeDos - geolocation check failed: ${error.message}`);
     return null;
   }
@@ -465,7 +477,15 @@ function applyDos() {
  *   enforce: boolean|null, undecidedBecause: string|null}} verdict
  */
 function publishDecision(verdict) {
-  fluxEventBus.publish('residential:decided', verdict);
+  fluxEventBus.publish('residential:decided', {
+    ...verdict,
+    // Which network verdict produced this, and which authority reached it -
+    // 'published-table' or 'node-veto'. Without these, enforce: null covers
+    // CONFLICTED, UNKNOWN and "no table consulted" alike, and a suite waiting
+    // on a veto cannot tell it from a node that has read nothing.
+    classification: lastVerdict.classification,
+    source: lastVerdict.source,
+  });
 }
 
 /**

--- a/ZelBack/src/services/residentialNodeDosService.js
+++ b/ZelBack/src/services/residentialNodeDosService.js
@@ -27,6 +27,7 @@ const geolocationService = require('./geolocationService');
 const benchmarkService = require('./benchmarkService');
 const { CLASSIFICATION } = require('./utils/networkClassifier');
 const { appSyncEvents, EVENTS: SYNC_EVENTS } = require('./utils/appSyncEvents');
+const globalState = require('./utils/globalState');
 const { compareInstanceSeniority } = require('./utils/instanceOrdering');
 const { socketAddressesMatch } = require('./utils/socketAddressUtils');
 
@@ -77,7 +78,14 @@ let inconclusiveStreak = 0;
 const wholeSince = new Map();
 // Whether the settling window has elapsed and departures may begin.
 let evacuating = false;
-// Paces departures. Process lifetime: a restart costs at most one extra wait.
+// Paces departures, and PERSISTED in the settle marker rather than held for the
+// process lifetime. At 0 the gate below reads `now - 0`, about 1.7e12 ms, so it
+// is open on the first call after every process start: a node restarting on a
+// cron, crash-looping, or taking the ~4h auto-update shed an app every queue
+// wait instead of every departure interval, and the busiest node in the fleet
+// finished in hours rather than the three days the cadence is set for. Same
+// reasoning as the settling clock - a counter a restart resets makes restarting
+// the way to go faster.
 let lastEvacuationAt = 0;
 
 // Whether this node yet knows what it is running. Starts false and is only
@@ -174,6 +182,22 @@ async function getSettleMarker() {
 }
 
 /**
+ * A finite number, or null.
+ *
+ * Everything the window is computed from comes off a stored document, and a
+ * value that is not a finite number poisons every comparison downstream: NaN is
+ * neither `< SETTLE_MS` nor `>= SETTLE_MS`, so a gate written the obvious way
+ * around falls through to draining on it. Rejected at the read instead, where
+ * the alternative is "we have no record", which starts the window rather than
+ * ending it.
+ * @param {*} value The stored value.
+ * @returns {number|null} The number, or null.
+ */
+function numberOrNull(value) {
+  return Number.isFinite(value) ? value : null;
+}
+
+/**
  * How much of the gap since the last confirmation counts towards the window.
  *
  * Nothing once the gap is long enough that this node plainly stopped watching -
@@ -205,8 +229,14 @@ async function noteVerdictConfirmed(now) {
   // what was watched, only of when the clock started - and that is exactly the
   // measure being replaced. It starts accumulating from here rather than being
   // credited for time nobody can vouch for.
-  const previousConfirmedAt = marker && marker.lastConfirmedAt;
-  const observedMs = (marker && marker.observedMs) || 0;
+  const previousConfirmedAt = numberOrNull(marker && marker.lastConfirmedAt);
+  const observedMs = numberOrNull(marker && marker.observedMs) ?? 0;
+  // Restored here rather than at boot: this is the pass that reads the marker,
+  // and it runs before any departure can be considered.
+  const persistedEvacuation = numberOrNull(marker && marker.lastEvacuationAt);
+  if (persistedEvacuation && persistedEvacuation > lastEvacuationAt) {
+    lastEvacuationAt = persistedEvacuation;
+  }
   const credited = previousConfirmedAt ? creditForGap(now - previousConfirmedAt) : 0;
   const totalObservedMs = observedMs + credited;
 
@@ -283,7 +313,11 @@ async function listInstalledApps(installedAppsFn) {
 function queueDelayMs(locations, localSocketAddr) {
   const ordered = [...locations].sort(compareInstanceSeniority);
   const index = ordered.findIndex((entry) => socketAddressesMatch(entry.ip, localSocketAddr));
-  const position = index < 0 ? ordered.length : index;
+  // An instance this node cannot find in the list waits longest. For an EMPTY
+  // list `ordered.length` is 0, which is the most senior slot - the shortest
+  // wait of all, inverting the rule. An empty list is the ordinary result of
+  // expired location records, so it is not an exotic input.
+  const position = index < 0 ? Math.max(ordered.length, 1) : index;
   return QUEUE_BASE_MS + (position * QUEUE_STEP_MS);
 }
 
@@ -332,7 +366,33 @@ function mayEvacuateApp(appName, locations, localSocketAddr, now = Date.now()) {
 function noteEvacuated(appName, now = Date.now()) {
   lastEvacuationAt = now;
   wholeSince.delete(appName);
+  // Written through to the marker, so a restart does not re-open the gate. Best
+  // effort: the in-memory value already paces this process, and the persisted
+  // one only has to survive into the next.
+  persistLastEvacuationAt(now).catch(() => {});
   log.info(`residentialNodeDos - ${appName} handed back; next departure no sooner than ${EVACUATION_INTERVAL_MS / 3600000}h`);
+}
+
+/**
+ * Record when this node last handed an app back.
+ * @param {number} now Epoch ms.
+ * @returns {Promise<void>}
+ */
+async function persistLastEvacuationAt(now) {
+  try {
+    const db = dbHelper.databaseConnection();
+    if (!db) return;
+    const database = db.db(config.database.local.database);
+    await dbHelper.findOneAndUpdateInDatabase(
+      database,
+      startupCollection,
+      { _id: SETTLE_MARKER_KEY },
+      { $set: { lastEvacuationAt: now } },
+      { upsert: true },
+    );
+  } catch (error) {
+    log.warn(`residentialNodeDos - could not record the departure time: ${error.message}`);
+  }
 }
 
 /**
@@ -397,11 +457,20 @@ async function enforceResidentialPolicy(deps) {
 
   const [arcane, residential] = await Promise.all([isArcaneOs(), isResidential()]);
 
+  // A tick that cannot decide stops the DRAIN but leaves the placement hold.
+  // The two fail in opposite directions on purpose: holding placement costs the
+  // node nothing it already has, so leaving it on through an unreadable tick is
+  // safe, while continuing to hand back an app every departure interval with no
+  // current verdict is not. `evacuating` was latched, so a node already draining
+  // whose bench or classification became unreadable kept going for as long as
+  // the input stayed unavailable.
   if (arcane === null) {
+    evacuating = false;
     log.info('residentialNodeDos - benchmark unreachable, skipping this tick');
     return false;
   }
   if (residential === null) {
+    evacuating = false;
     log.info('residentialNodeDos - no network verdict to act on yet, skipping this tick');
     return false;
   }
@@ -422,17 +491,35 @@ async function enforceResidentialPolicy(deps) {
   fluxNetworkHelper.setPlacementHold(HOLD_REASON);
 
   if (!nodeReady) {
+    evacuating = false;
     log.info('residentialNodeDos - node not ready yet, holding placement only this tick');
     return false;
   }
 
   const installed = await listInstalledApps(installedAppsFn);
   if (installed === null) {
+    evacuating = false;
     log.info('residentialNodeDos - installed app list unavailable, holding placement only this tick');
     return false;
   }
 
   if (!installed.length) {
+    // The placement hold above stops the spawner taking anything NEW, but an
+    // install already running is not stopped by it - and an install is real
+    // from appInstaller's installationInProgress flag, some way before its
+    // database record exists for listInstalledApps to see. A tick landing in
+    // that gap reads an empty node, DOSes it, and nodeStatusMonitor tears the
+    // arriving app down on its next loop.
+    //
+    // Undecided rather than "not empty": the retry backoff re-asks in minutes
+    // instead of deferring the DOS for a full check interval, and an install
+    // resolves on that timescale. Bounded today by appInstaller writing its
+    // database entry before creating the container, so no volume exists in the
+    // window - nothing here referenced that ordering, and nothing tested it.
+    if (globalState.installationInProgress) {
+      log.info('residentialNodeDos - an install is in flight, not treating this node as empty yet');
+      return false;
+    }
     applyDos();
     return true;
   }
@@ -444,7 +531,17 @@ async function enforceResidentialPolicy(deps) {
     log.info('residentialNodeDos - settle marker unavailable, evacuation stays off');
     return false;
   }
-  if (observedMs < SETTLE_MS) {
+  // Negated rather than written as `<`, so a value that is not a number refuses
+  // rather than reading as elapsed. numberOrNull above is the guard that
+  // actually stands between a stored value and this comparison; this form is
+  // the backstop for a path that ever reaches it another way, and the two are
+  // only distinguishable on an input like Infinity, which numberOrNull rejects
+  // and `>=` would accept. It is reachable without malformed data: the
+  // clock is Date.now(), and a node whose clock is behind when the marker is
+  // written - no RTC, a VM restored from snapshot, timesyncd not yet stepped -
+  // and is then corrected FORWARD reads the whole window as served. A backwards
+  // step fails safe; a forward step failed toward moving customer data.
+  if (!(observedMs >= SETTLE_MS)) {
     evacuating = false;
     // Hours of the verdict actually WATCHED, so a node whose checks keep coming
     // back inconclusive sees this figure stall rather than count down - which

--- a/ZelBack/src/services/residentialNodeDosService.js
+++ b/ZelBack/src/services/residentialNodeDosService.js
@@ -83,7 +83,22 @@ const QUEUE_STEP_MS = config.fluxapps.residentialQueueStepMs;
 // test-infra's coupled knobs. A literal here would be a third place that has to
 // be kept in step with the block time, and the last hand-written number in this
 // neighbourhood inverted the property it was meant to enforce.
-const MAX_TICKET_GAP_MS = QUEUE_STEP_MS;
+//
+// TWICE the step, not once. A gap has to mean "a pass did not happen", and one
+// step is 1.82 passes - so a single pass running late trips it. Production
+// hardly notices that (40 minutes of lateness on a 22-minute pass is an
+// incident in itself), but the harness compresses the same ratio to about 30
+// seconds, where six fleets booting at once make a late pass ordinary. The
+// ticket then restarts every few passes and never matures at all: on chud it
+// counted 2m, 1m, 0m, and jumped back to 2m, three times over, and the suite
+// waiting on it timed out.
+//
+// The ABSOLUTE jitter does not compress with the clocks, which is why a ratio
+// that is comfortable at production scale is not comfortable at harness scale.
+// Two steps is ~3.6 passes: a pass has to be missed outright, not merely be
+// slow. The departure interval is what must still exceed it - see the coupled
+// knob that enforces exactly that.
+const MAX_TICKET_GAP_MS = QUEUE_STEP_MS * 2;
 // Minimum gap between this node's departures. The give-up-an-app pass runs every
 // 11 blocks (~22 min), which unpaced would empty the busiest node in the fleet in
 // about four hours; there is no deadline here and slower is strictly safer.
@@ -468,13 +483,19 @@ function isEvacuating() {
  *   here lets a ticket run that the safety gate then refuses as short, which
  *   restarts the observation, and too high only makes the turn wait longer.
  * @param {number} [now] Monotonic ms, injectable for tests.
- * @returns {{ok: boolean, reason: string}}
+ * @returns {{ok: boolean, code: string, reason: string}} `code` is the
+ *   machine-readable half. A caller that has to tell "waiting its turn" from
+ *   "the app is short" cannot do it by matching prose, and the difference
+ *   matters: the first is this working, the second is a node that wants to
+ *   leave and cannot, which is the thing worth escalating. BELOW_INSTANCE_COUNT
+ *   is deliberately the name appEvacuationSafety already uses for the same
+ *   fact, because it IS the same fact asked one layer earlier.
  */
 function mayEvacuateApp(appName, locations, localSocketAddr, minInstances, now = monotonicMs()) {
-  if (!evacuating) return { ok: false, reason: 'node is not evacuating' };
+  if (!evacuating) return { ok: false, code: 'NOT_EVACUATING', reason: 'node is not evacuating' };
   if (lastEvacuationAt !== null && now - lastEvacuationAt < EVACUATION_INTERVAL_MS) {
     const wait = Math.round((EVACUATION_INTERVAL_MS - (now - lastEvacuationAt)) / 60000);
-    return { ok: false, reason: `next departure in ${wait}m` };
+    return { ok: false, code: 'DEPARTURE_INTERVAL', reason: `next departure in ${wait}m` };
   }
 
   // Everything below is the ticket, and it sits BELOW the interval gate on
@@ -491,14 +512,18 @@ function mayEvacuateApp(appName, locations, localSocketAddr, minInstances, now =
   const since = (!whole || gap > MAX_TICKET_GAP_MS) ? now : previous.since;
   wholeObservation.set(appName, { since, lastSeenAt: now });
   if (!whole) {
-    return { ok: false, reason: `app is short (${locations.length}/${minInstances}); its turn starts again` };
+    return {
+      ok: false,
+      code: 'BELOW_INSTANCE_COUNT',
+      reason: `app is below its instance count (${locations.length}/${minInstances}); its turn starts again`,
+    };
   }
   const wait = queueDelayMs(locations, localSocketAddr);
   const observed = now - since;
   if (observed < wait) {
-    return { ok: false, reason: `its turn is in ${Math.round((wait - observed) / 60000)}m` };
+    return { ok: false, code: 'AWAITING_TURN', reason: `its turn is in ${Math.round((wait - observed) / 60000)}m` };
   }
-  return { ok: true, reason: 'ready' };
+  return { ok: true, code: 'READY', reason: 'ready' };
 }
 
 /**

--- a/ZelBack/src/services/residentialNodeDosService.js
+++ b/ZelBack/src/services/residentialNodeDosService.js
@@ -141,6 +141,10 @@ let observedWindowMs = 0;
 // The network verdict behind the most recent isResidential(), carried into the
 // decision event so a consumer can tell the three nulls apart.
 let lastVerdict = { classification: null, source: null };
+// What the last evaluation concluded, in full. The tick answers with it, so a
+// caller that needs to know WHICH decision was reached does not have to read
+// the harness event stream to find out.
+let lastDecision = null;
 // Paces departures, on the MONOTONIC clock, and PERSISTED in the settle marker
 // rather than held for the process lifetime. Same reasoning as the settling
 // clock - a counter a restart resets makes restarting the way to go faster: a
@@ -637,7 +641,7 @@ function applyDos() {
  *   enforce: boolean|null, undecidedBecause: string|null}} verdict
  */
 function publishDecision(verdict) {
-  fluxEventBus.publish('residential:decided', {
+  lastDecision = {
     ...verdict,
     // Which network verdict produced this, and which authority reached it -
     // 'published-table' or 'node-veto'. Without these, enforce: null covers
@@ -645,7 +649,10 @@ function publishDecision(verdict) {
     // on a veto cannot tell it from a node that has read nothing.
     classification: lastVerdict.classification,
     source: lastVerdict.source,
-  });
+  };
+  // One object, answered to the caller and published to the harness. Two copies
+  // of a decision are two things that can disagree.
+  fluxEventBus.publish('residential:decided', lastDecision);
 }
 
 /**
@@ -656,7 +663,7 @@ function publishDecision(verdict) {
  * @returns {Promise<boolean>} True when the tick reached a decision, false when
  *   an input was unavailable and the caller should retry sooner.
  */
-async function enforceResidentialPolicy(deps) {
+async function runResidentialPolicy(deps) {
   const { installedAppsFn } = deps;
 
   const [arcane, residential] = await Promise.all([isArcaneOs(), isResidential()]);
@@ -785,13 +792,31 @@ function nextDelay(decided, streak) {
 }
 
 /**
+ * One evaluation of the policy, answered as what it concluded.
+ *
+ * `decided` is the caller's question - was every input available, or should the
+ * next tick come sooner. `decision` is what was actually concluded, and it is
+ * the same object published to the harness: enforce false and enforce null are
+ * opposite claims, and nothing outside this module could previously tell them
+ * apart without reading the event stream.
+ *
+ * @param {object} deps Injected collaborators.
+ * @returns {Promise<{decided: boolean, decision: object|null}>}
+ */
+async function enforceResidentialPolicy(deps) {
+  lastDecision = null;
+  const decided = await runResidentialPolicy(deps);
+  return { decided, decision: lastDecision };
+}
+
+/**
  * Run one tick and schedule the next one.
  * @param {object} deps Injected collaborators, as enforceResidentialPolicy.
  */
 async function tick(deps) {
   let decided = false;
   try {
-    decided = await enforceResidentialPolicy(deps);
+    ({ decided } = await enforceResidentialPolicy(deps));
   } catch (error) {
     log.error(`residentialNodeDos - tick error: ${error.message}`);
   }

--- a/ZelBack/src/services/residentialNodeDosService.js
+++ b/ZelBack/src/services/residentialNodeDosService.js
@@ -1,0 +1,220 @@
+const config = require('config');
+const log = require('../lib/log');
+const fluxNetworkHelper = require('./fluxNetworkHelper');
+const geolocationService = require('./geolocationService');
+const benchmarkService = require('./benchmarkService');
+
+const DOS_MESSAGE_PREFIX = 'Residential node not running ArcaneOS';
+
+// A tick that could not read both inputs decides nothing, so it is retried on a
+// short delay instead of waiting out the full interval - geolocation is only
+// available once fluxbench has resolved this node's IP, which can be minutes
+// after boot.
+const CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
+const RETRY_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
+let timerHandle = null;
+let started = false;
+let stopping = false;
+let ourDosActive = false;
+let inconclusiveStreak = 0;
+
+/**
+ * True when the current sticky DOS message was set by this service.
+ * Identified by the DOS_MESSAGE_PREFIX we always prepend when we set it.
+ */
+function isOurStickyDos() {
+  const msg = fluxNetworkHelper.getStickyDosMessage();
+  return typeof msg === 'string' && msg.startsWith(DOS_MESSAGE_PREFIX);
+}
+
+/**
+ * Three-state ArcaneOS check via fluxbenchd.
+ *   true  — confirmed ArcaneOS, nothing to enforce
+ *   false — confirmed NOT ArcaneOS
+ *   null  — fluxbenchd unreachable or response malformed, decide nothing
+ *
+ * Read from bench rather than `process.env.FLUXOS_PATH` because the env var is
+ * set by whoever launches FluxOS, and this check is exactly what a residential
+ * operator has an incentive to fake. The null case is deliberate: a momentarily
+ * unreachable bench must never DOS a real ArcaneOS node.
+ */
+async function isArcaneOs() {
+  try {
+    const benchmarkResponse = await benchmarkService.getBenchmarks();
+    if (!benchmarkResponse || benchmarkResponse.status !== 'success' || !benchmarkResponse.data) {
+      return null;
+    }
+    const { systemsecure } = benchmarkResponse.data;
+    if (typeof systemsecure !== 'boolean') return null;
+    return systemsecure;
+  } catch (error) {
+    log.warn(`residentialNodeDos - benchmark check failed: ${error.message}`);
+    return null;
+  }
+}
+
+/**
+ * Three-state residential check.
+ *   true  — geolocation resolved and says this IP is not a data center
+ *   false — geolocation resolved and says this IP is a data center
+ *   null  — no geolocation yet (in memory or in db), decide nothing
+ *
+ * isDataCenter() alone cannot answer this: it defaults to false before the
+ * first successful lookup, so a node whose geolocation never resolved would
+ * read as residential. The geolocation object is what says the lookup actually
+ * happened, and getNodeGeolocation() is also what restores the flag from the db
+ * after a restart - so it has to be awaited before the flag is read.
+ */
+async function isResidential() {
+  try {
+    const geolocation = await geolocationService.getNodeGeolocation();
+    if (!geolocation) return null;
+    return geolocationService.isDataCenter() !== true;
+  } catch (error) {
+    log.warn(`residentialNodeDos - geolocation check failed: ${error.message}`);
+    return null;
+  }
+}
+
+/**
+ * Give up the DOS this service is holding. The slot is only cleared when the
+ * message in it is still ours: another owner may have taken it since we wrote,
+ * and clearing that would drop their DOS on the floor. Dropping our own claim
+ * is all we are entitled to do in that case.
+ * @param {string} reason Logged context for the release.
+ */
+function releaseOurDos(reason) {
+  if (isOurStickyDos()) {
+    log.info(`residentialNodeDos - clearing sticky DOS (${reason})`);
+    fluxNetworkHelper.clearStickyDosMessage();
+    ourDosActive = false;
+    return;
+  }
+  if (ourDosActive) {
+    log.info(`residentialNodeDos - our DOS was replaced by another owner, releasing our claim only (${reason})`);
+    ourDosActive = false;
+  }
+}
+
+/**
+ * Core check: a node on a residential connection that is not running ArcaneOS
+ * is DOSed. Otherwise, if we previously DOSed it, the DOS is cleared. This
+ * service owns the DOS message it sets and only clears its own.
+ *
+ * @returns {Promise<boolean>} True when the tick reached a decision, false when
+ * an input was unavailable and the tick decided nothing (caller retries sooner).
+ */
+async function enforceResidentialPolicy() {
+  if (config.residentialDos && config.residentialDos.enabled === false) {
+    log.info('residentialNodeDos - enforcement disabled by config');
+    releaseOurDos('disabled by config');
+    return true;
+  }
+
+  const [arcane, residential] = await Promise.all([isArcaneOs(), isResidential()]);
+
+  if (arcane === null) {
+    log.info('residentialNodeDos - benchmark unreachable, skipping this tick');
+    return false;
+  }
+  if (residential === null) {
+    log.info('residentialNodeDos - geolocation not available yet, skipping this tick');
+    return false;
+  }
+
+  const shouldDos = residential && !arcane;
+
+  log.info(`residentialNodeDos - residential=${residential} arcaneOs=${arcane} shouldDos=${shouldDos}`);
+
+  if (shouldDos) {
+    // The sticky slot holds one message. Another owner's DOS already has this
+    // node out of service for its own reason, and overwriting it would take
+    // that owner's state away from it - so leave it and re-check next tick.
+    const sticky = fluxNetworkHelper.getStickyDosMessage();
+    if (sticky && !isOurStickyDos()) {
+      log.info('residentialNodeDos - another sticky DOS is active, not overwriting it');
+      return true;
+    }
+    const message = `${DOS_MESSAGE_PREFIX}. Migrate this node to ArcaneOS or move it to a data center connection.`;
+    fluxNetworkHelper.setStickyDosMessage(message);
+    fluxNetworkHelper.setStickyDosStateValue(100);
+    ourDosActive = true;
+    log.error(message);
+    return true;
+  }
+
+  releaseOurDos(`residential=${residential}, arcaneOs=${arcane}`);
+  return true;
+}
+
+/**
+ * Delay before the next tick. A decided tick waits out the full interval; an
+ * inconclusive one comes back on the short retry, doubling each time it stays
+ * inconclusive. The doubling matters for the node whose geolocation never
+ * resolves at all: a flat 5-minute retry would have it deciding nothing and
+ * logging that it decided nothing 288 times a day, forever.
+ * @param {boolean} decided Whether the tick reached a decision.
+ * @param {number} streak Consecutive inconclusive ticks, this one included.
+ * @returns {number} Milliseconds until the next tick.
+ */
+function nextDelay(decided, streak) {
+  if (decided) return CHECK_INTERVAL_MS;
+  return Math.min(RETRY_INTERVAL_MS * 2 ** (streak - 1), CHECK_INTERVAL_MS);
+}
+
+/**
+ * Run one tick and schedule the next one.
+ */
+async function tick() {
+  let decided = false;
+  try {
+    decided = await enforceResidentialPolicy();
+  } catch (error) {
+    log.error(`residentialNodeDos - tick error: ${error.message}`);
+  }
+  inconclusiveStreak = decided ? 0 : inconclusiveStreak + 1;
+  if (stopping) return;
+  timerHandle = setTimeout(tick, nextDelay(decided, inconclusiveStreak));
+}
+
+/**
+ * Start the enforcer. Performs the first check immediately, then reschedules
+ * itself. Safe to call multiple times (no-ops if already started).
+ */
+async function start() {
+  // The guard is `started`, not `timerHandle`: the first tick is awaited before
+  // any timer exists, so a second start() landing inside it would run a second
+  // self-rescheduling chain.
+  if (started) return;
+  started = true;
+  stopping = false;
+  inconclusiveStreak = 0;
+  log.info('residentialNodeDos - enforcer starting');
+  await tick();
+}
+
+function stop() {
+  stopping = true;
+  started = false;
+  if (timerHandle) {
+    clearTimeout(timerHandle);
+    timerHandle = null;
+  }
+}
+
+function isDosActive() {
+  return ourDosActive;
+}
+
+module.exports = {
+  start,
+  stop,
+  enforceResidentialPolicy,
+  isArcaneOs,
+  isResidential,
+  isDosActive,
+  DOS_MESSAGE_PREFIX,
+  CHECK_INTERVAL_MS,
+  RETRY_INTERVAL_MS,
+};

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -56,6 +56,7 @@ const volumeValidationService = require('./volumeValidationService');
 const watchdogService = require('./watchdogService');
 const cloudUIUpdateService = require('./cloudUIUpdateService');
 const appTamperingBlocklistService = require('./appTamperingBlocklistService');
+const residentialNodeDosService = require('./residentialNodeDosService');
 const nodeConfirmationService = require('./nodeConfirmationService');
 const appTamperingDetectionService = require('./appTamperingDetectionService');
 const appsRuntimeState = require('./appManagement/appsRuntimeState');
@@ -518,6 +519,12 @@ async function startFluxFunctions() {
     fluxNetworkHelper.checkDeterministicNodesCollisions();
     appTamperingBlocklistService.start().catch((err) => {
       log.error(`appTamperingBlocklist start error: ${err.message}`);
+    });
+    // Not awaited, and started ahead of setNodeGeolocation below on purpose: the
+    // first tick reads geolocation from the db when there is one, and otherwise
+    // decides nothing and retries until the lookup this boot has landed.
+    residentialNodeDosService.start().catch((err) => {
+      log.error(`residentialNodeDos start error: ${err.message}`);
     });
     log.info('Flux checks operational');
     fluxCommunication.initializeDiscovery();

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -523,7 +523,15 @@ async function startFluxFunctions() {
     // Not awaited, and started ahead of setNodeGeolocation below on purpose: the
     // first tick reads geolocation from the db when there is one, and otherwise
     // decides nothing and retries until the lookup this boot has landed.
-    residentialNodeDosService.start().catch((err) => {
+    //
+    // Injected the same way nodeStatusMonitor is, and for the same reason: the
+    // app list is read from a query service deep enough in the lifecycle graph
+    // that requiring it here would put geolocation and the network helper on
+    // that load path. Removing the app is not this service's job - the single
+    // give-up-an-app pass in advancedWorkflows does that.
+    residentialNodeDosService.start({
+      installedAppsFn: appQueryService.installedApps,
+    }).catch((err) => {
       log.error(`residentialNodeDos start error: ${err.message}`);
     });
     log.info('Flux checks operational');

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -422,6 +422,16 @@ async function startFluxFunctions() {
     // we can remove this.
     await dbHelper.repairNanInAppsMessagesDb();
 
+    // The location table this node already holds, brought back as soon as the
+    // database is up. Detached and best-effort - every consumer degrades safely
+    // without it. On a node that has run before this is a single marker read
+    // against rows already in mongo, so the residential verdict and placement's
+    // fault domains hold their table within milliseconds of boot rather than
+    // behind the app-database rebuild, which neither depends on. Fetching a NEW
+    // baseline is the expensive half and stays in startDbDependentServices,
+    // where its two-million-row ingest cannot land on top of that rebuild.
+    ipLocationSync.restoreCachedTable().catch((err) => log.error(`ipLocationSync restore error: ${err.message}`));
+
     // Check for apps with incorrect volume mounts (containing /flux/ path)
     log.info('Checking for apps with incorrect volume mounts...');
     setTimeout(() => {
@@ -645,8 +655,11 @@ async function startFluxFunctions() {
       await globalState.waitForDbReady();
       log.info('DB ready - starting db-dependent services');
       // Interim until policyStore supersedes it at the userconfig rebase (see the
-      // module header): restore the iplocation table from its GridFS cache and keep
-      // it fresh. Detached - placement degrades to /16 arithmetic without a table.
+      // module header): keep the iplocation table fresh. The cached copy is
+      // already back - restoreCachedTable ran with the schema prep above - so
+      // what starts here is the fetch loop, whose ingest is the half worth
+      // keeping clear of the rebuild that just finished. Detached; placement
+      // degrades to /16 arithmetic without a table.
       ipLocationSync.startSync().catch((err) => log.error(`ipLocationSync start error: ${err.message}`));
       advancedWorkflows.checkAndRemoveEnterpriseAppsOnNonArcane();
       await identityReady;

--- a/ZelBack/src/services/utils/appConstants.js
+++ b/ZelBack/src/services/utils/appConstants.js
@@ -76,11 +76,23 @@ const defaultNodeSpecs = {
   ssdStorage: 0,
 };
 
-// Expiry / TTL constants (milliseconds)
+// Expiry / TTL constants (milliseconds).
+//
+// The three stamped onto records live in config as seconds, so the harness can
+// compress them the way it compresses every other cadence; the literal after
+// `??` is the production default and is what a node runs when the key is absent.
+// They lived here as bare literals from the day expiry moved per-document: the
+// config keys were wired to the collection-level TTL indexes that scheme
+// replaced, so when those indexes were dropped the keys were left reading
+// nothing, and a later unused-variable sweep removed the last binding to them.
+// Reading config here cannot reintroduce the cycle those literals were moved to
+// break - that was messageVerifier -> registryManager -> messageStore ->
+// messageVerifier, entirely between services, and `config` is a leaf this file
+// already requires for the collection names above.
 const GOSSIP_VALIDITY_MS = 5 * 60 * 1000;
-const RUNNING_EXPIRY_MS = 125 * 60 * 1000;
-const INSTALLING_EXPIRY_MS = 15 * 60 * 1000;
-const INSTALLING_ERRORS_EXPIRY_MS = 24 * 60 * 60 * 1000;
+const RUNNING_EXPIRY_MS = (config.fluxapps.locationTtlS ?? 7500) * 1000;
+const INSTALLING_EXPIRY_MS = (config.fluxapps.installingTtlS ?? 900) * 1000;
+const INSTALLING_ERRORS_EXPIRY_MS = (config.fluxapps.installErrorTtlS ?? 86400) * 1000;
 const SIGTERM_EXPIRY_MS = 420 * 1000;
 const EVICTED_EXPIRY_MS = RUNNING_EXPIRY_MS;
 

--- a/ZelBack/src/services/utils/appConstants.js
+++ b/ZelBack/src/services/utils/appConstants.js
@@ -93,7 +93,20 @@ const GOSSIP_VALIDITY_MS = 5 * 60 * 1000;
 const RUNNING_EXPIRY_MS = (config.fluxapps.locationTtlS ?? 7500) * 1000;
 const INSTALLING_EXPIRY_MS = (config.fluxapps.installingTtlS ?? 900) * 1000;
 const INSTALLING_ERRORS_EXPIRY_MS = (config.fluxapps.installErrorTtlS ?? 86400) * 1000;
-const SIGTERM_EXPIRY_MS = 420 * 1000;
+// The grace a node gets after announcing its own shutdown, before peers treat
+// its locations as gone. Config-driven like the three above, and for the same
+// reason they are: a harness that compresses RUNNING_EXPIRY_MS and cannot
+// compress this one inverts the pair. The `||` in appStartupManager's
+// locationsExpired then fires on the running expiry first and this window
+// becomes unreachable - a clean shutdown gets no grace at all, which is the
+// opposite of what it is for.
+//
+// NOT compressible by the same ratio as RUNNING_EXPIRY_MS, though. What that
+// one is coupled to is the announce interval, which is a compressed clock; what
+// THIS one is measured across is a node boot, and a boot is real work the
+// harness does not compress - see installingTtlS above for the same argument.
+// Bound it by what it must outlive, not by a factor.
+const SIGTERM_EXPIRY_MS = (config.fluxapps.sigtermExpiryS ?? 420) * 1000;
 const EVICTED_EXPIRY_MS = RUNNING_EXPIRY_MS;
 
 // Hash sync constants (blocks, at 30s per block)

--- a/ZelBack/src/services/utils/networkClassifier.js
+++ b/ZelBack/src/services/utils/networkClassifier.js
@@ -158,17 +158,41 @@ function classifyNetwork(facts = {}) {
   const contradictionSignalsGathered = hosting !== undefined || proxy !== undefined
     || mobile !== undefined || isp !== undefined || asn !== undefined;
 
+  // Evidence that this IS hosting - a narrower claim than "not a home line".
+  // Everything in evidenceAgainst contradicts a residential reading; only these
+  // say anything positive about a data centre, and DATACENTER is reached from
+  // this list rather than from the absence of residential evidence.
+  //
+  // `proxy` is the signal that belongs in one and not the other. It is a VPN
+  // artefact - this branch argues exactly that where static IP is concerned,
+  // and deleted a rule that granted static on it - so an address behind a VPN
+  // exit says nothing about the machine. Granting DATACENTER on it would be the
+  // same category error one function away, and it points the wrong way: an
+  // owner paying for `datacenter: true` is buying "not someone's house", and a
+  // home machine on a VPN carries this signature and nothing else. Measured on
+  // the fleet of 2026-08-18: 8 of 2,432 hosts reached DATACENTER on proxy alone.
+  const hostingEvidence = [];
+
   const ptrClass = classifyPtr(ptr);
   if (ptrClass === 'residential') evidenceFor.push(`ptr access-network: ${ptr}`);
   // 'both' is a contradiction on its own: a name carrying hosting vocabulary is
   // not cleared by also carrying access vocabulary.
-  if (ptrClass === 'datacenter' || ptrClass === 'both') evidenceAgainst.push(`ptr hosting: ${ptr}`);
+  if (ptrClass === 'datacenter' || ptrClass === 'both') {
+    evidenceAgainst.push(`ptr hosting: ${ptr}`);
+    hostingEvidence.push('ptr');
+  }
 
   if (mobile === true) evidenceFor.push('ip-api mobile');
-  if (hosting === true) evidenceAgainst.push('ip-api hosting');
+  if (hosting === true) {
+    evidenceAgainst.push('ip-api hosting');
+    hostingEvidence.push('ip-api hosting');
+  }
   if (proxy === true) evidenceAgainst.push('ip-api proxy');
 
-  if (isHostingOperator(isp, asn)) evidenceAgainst.push(`operator sells hosting: ${isp || asn}`);
+  if (isHostingOperator(isp, asn)) {
+    evidenceAgainst.push(`operator sells hosting: ${isp || asn}`);
+    hostingEvidence.push('operator');
+  }
 
   // Corroboration only, and deliberately not counted as evidence. A bench figure
   // is a speed test's result, not a property of the link: on its own it would
@@ -190,9 +214,14 @@ function classifyNetwork(facts = {}) {
       : CLASSIFICATION.UNKNOWN;
     if (contradictionSignalsGathered) evidenceFor.push(...corroborating);
   } else if (evidenceAgainst.length && !evidenceFor.length) {
-    // DATACENTER stands either way: it rests on something found, not on
-    // something absent, and it enforces nothing.
-    classification = CLASSIFICATION.DATACENTER;
+    // DATACENTER stands either way where it stands at all: it rests on
+    // something found, not on something absent, and it enforces nothing. But it
+    // rests on POSITIVE hosting evidence specifically - a contradiction that
+    // only rules out a home line leaves this UNKNOWN, which confers nothing and
+    // enforces nothing, rather than promoting "not residential" to "hosting".
+    classification = hostingEvidence.length
+      ? CLASSIFICATION.DATACENTER
+      : CLASSIFICATION.UNKNOWN;
   } else if (evidenceFor.length && evidenceAgainst.length) {
     classification = CLASSIFICATION.CONFLICTED;
   }

--- a/ZelBack/src/services/utils/networkClassifier.js
+++ b/ZelBack/src/services/utils/networkClassifier.js
@@ -1,0 +1,172 @@
+// Is this node's address on an access (consumer) network, or in a data centre?
+//
+// The question `isDataCenter()` answers today is "did anything tell me this was
+// hosting", so its false branch means "nothing told me", and absence of evidence
+// reads as residential. Enforcing against that is what this module exists to
+// avoid: here a node is RESIDENTIAL only when something positively says so and
+// nothing contradicts it, and every other outcome is a state enforcement must
+// leave alone.
+//
+// The four outcomes:
+//   RESIDENTIAL  at least one positive signal, no contradiction
+//   DATACENTER   at least one contradiction, no positive signal
+//   CONFLICTED   both - the signals disagree, so we do not know
+//   UNKNOWN      neither - nothing to go on
+//
+// CONFLICTED is not a rounding error on the way to a binary. Measured against
+// every host in the fleet that ip-api positively asserts is hosting (1,569 hosts
+// across all 29 hosting ASNs the fleet uses), this rule calls 0 of them
+// residential - and 39 of them land in CONFLICTED. Those 39 trip a residential
+// signal AND a contradiction; collapsing that bucket either way is precisely how
+// the accuracy would be lost. See
+// fluxModels/investigations/PR1784_RESIDENTIAL_DOS_BLAST_RADIUS.md §4.
+//
+// Signals are limited to what a node can determine about itself: the PTR record
+// for its own address, the ip-api response geolocationService already fetches,
+// and bench figures it already holds. Registration (RDAP) data separates these
+// populations better still, but six thousand nodes cannot each query the RIRs -
+// that signal belongs in the published location artifact, read as a table.
+
+// Access-network vocabulary. Generic across ISPs worldwide, which is the
+// property that makes it worth more than a list of provider names: it fires on
+// Optus, Charter, Vodafone and Slovak Telekom without any of them being listed.
+const PTR_RESIDENTIAL = [
+  'dsl', 'ppp', 'dial', 'dyn', 'pool', 'dhcp', 'cpe', 'cust', 'client',
+  'subscriber', 'subs.', 'user', 'home', 'broadband', 'bband', 'cable',
+  'docsis', 'hsd', 'fios', 'lightspeed', 'bras', 'gpon', 'ftth', 'fibre',
+  'abo.', 'wanadoo', 'hispeed', 'optusnet', 'res.', 'resnet', 'retail',
+  'access', 'mobile', 'lte', 'wireless', 'wifi', 'ipoe', 'rev.', 'fixed.',
+];
+
+// Hosting vocabulary. Only ever read as a contradiction, never as evidence of
+// anything by itself.
+const PTR_DATACENTER = [
+  'vps', 'vmi', 'srv', 'server', 'dedi', 'cloud', 'hosted', 'hosting',
+  'colo', 'datacenter', 'datacentre', 'instance', 'compute', 'baremetal',
+  'your-server', 'contabo', 'ovh', 'hetzner', 'linode', 'vultr',
+  'digitalocean', 'amazonaws', 'azure', 'leaseweb', 'infomaniak', 'static.tds',
+];
+
+// Operators known to sell hosting. Matched against ip-api's `isp` and `as` -
+// the network operator - and deliberately NOT against `org`, which is the block
+// registrant and is frequently a reseller or downstream customer. The two
+// disagree on 67% of fleet hosts: 46.250.240.89 carries isp "Contabo Asia
+// Private Limited" and org "Yorkshire Tech Limited", and reading org is why
+// Contabo appears on this list today and is still classified residential.
+const HOSTING_OPERATORS = [
+  'hetzner', 'ovh', 'netcup', 'hostnodes', 'contabo', 'hostslim', 'zayo',
+  'cogent', 'lumen', 'digitalocean', 'linode', 'vultr', 'leaseweb', 'scaleway',
+  'infomaniak', 'oracle', 'amazon', 'google', 'microsoft', 'azure', 'alibaba',
+  'ionos', 'aruba', 'hostinger', 'namecheap', 'godaddy', 'upcloud',
+];
+
+const CLASSIFICATION = Object.freeze({
+  RESIDENTIAL: 'RESIDENTIAL',
+  DATACENTER: 'DATACENTER',
+  CONFLICTED: 'CONFLICTED',
+  UNKNOWN: 'UNKNOWN',
+});
+
+// An access link is typically far faster down than up. A symmetric link proves
+// nothing either way - FTTH in France and Sweden is ordinary consumer service -
+// so this is only ever corroboration, never the sole reason for a verdict.
+const ASYMMETRY_RATIO = 0.5;
+
+/**
+ * Which vocabularies a PTR record carries.
+ * @param {string} hostname Reverse DNS name, or empty when there is none.
+ * @returns {('residential'|'datacenter'|'both'|'neither'|'none')}
+ */
+function classifyPtr(hostname) {
+  if (!hostname || typeof hostname !== 'string') return 'none';
+  const lower = hostname.toLowerCase();
+  const residential = PTR_RESIDENTIAL.some((token) => lower.includes(token));
+  const datacenter = PTR_DATACENTER.some((token) => lower.includes(token));
+  if (residential && datacenter) return 'both';
+  if (residential) return 'residential';
+  if (datacenter) return 'datacenter';
+  return 'neither';
+}
+
+/**
+ * True when the operator string names a company that sells hosting.
+ * @param {string} isp ip-api `isp`.
+ * @param {string} asn ip-api `as`, e.g. "AS24940 Hetzner Online GmbH".
+ * @returns {boolean}
+ */
+function isHostingOperator(isp, asn) {
+  const haystack = `${isp || ''} ${asn || ''}`.toLowerCase();
+  return HOSTING_OPERATORS.some((operator) => haystack.includes(operator));
+}
+
+/**
+ * Classify a node's own network from the facts it holds about itself.
+ *
+ * Every input is optional: a node that could not resolve its PTR, or whose
+ * bench figures are missing, still gets an answer from whatever remains - it
+ * just gets a less decided one. Passing nothing yields UNKNOWN, which is the
+ * correct answer to "I know nothing about this address".
+ *
+ * @param {object} facts
+ * @param {string} [facts.ptr] Reverse DNS for the node's own address.
+ * @param {boolean} [facts.hosting] ip-api `hosting`.
+ * @param {boolean} [facts.proxy] ip-api `proxy`.
+ * @param {boolean} [facts.mobile] ip-api `mobile`.
+ * @param {string} [facts.isp] ip-api `isp` - the operator.
+ * @param {string} [facts.asn] ip-api `as` - the operator's AS.
+ * @param {number} [facts.uploadSpeed] Bench upload, Mbps.
+ * @param {number} [facts.downloadSpeed] Bench download, Mbps.
+ * @returns {{classification: string, evidenceFor: string[], evidenceAgainst: string[]}}
+ */
+function classifyNetwork(facts = {}) {
+  const {
+    ptr, hosting, proxy, mobile, isp, asn, uploadSpeed, downloadSpeed,
+  } = facts;
+
+  const evidenceFor = [];
+  const evidenceAgainst = [];
+
+  const ptrClass = classifyPtr(ptr);
+  if (ptrClass === 'residential') evidenceFor.push(`ptr access-network: ${ptr}`);
+  // 'both' is a contradiction on its own: a name carrying hosting vocabulary is
+  // not cleared by also carrying access vocabulary.
+  if (ptrClass === 'datacenter' || ptrClass === 'both') evidenceAgainst.push(`ptr hosting: ${ptr}`);
+
+  if (mobile === true) evidenceFor.push('ip-api mobile');
+  if (hosting === true) evidenceAgainst.push('ip-api hosting');
+  if (proxy === true) evidenceAgainst.push('ip-api proxy');
+
+  if (isHostingOperator(isp, asn)) evidenceAgainst.push(`operator sells hosting: ${isp || asn}`);
+
+  // Corroboration only, and deliberately not counted as evidence. A bench figure
+  // is a speed test's result, not a property of the link: on its own it would
+  // call any node with a lopsided measurement residential, and enforcement would
+  // act on an instrument reading. It can support a verdict the real signals
+  // already reached; it can never reach one.
+  const corroborating = [];
+  if (uploadSpeed > 0 && downloadSpeed > 0 && uploadSpeed / downloadSpeed < ASYMMETRY_RATIO) {
+    corroborating.push(`asymmetric link ${Math.round(uploadSpeed)}/${Math.round(downloadSpeed)}`);
+  }
+
+  let classification = CLASSIFICATION.UNKNOWN;
+  if (evidenceFor.length && !evidenceAgainst.length) {
+    classification = CLASSIFICATION.RESIDENTIAL;
+    evidenceFor.push(...corroborating);
+  } else if (evidenceAgainst.length && !evidenceFor.length) {
+    classification = CLASSIFICATION.DATACENTER;
+  } else if (evidenceFor.length && evidenceAgainst.length) {
+    classification = CLASSIFICATION.CONFLICTED;
+  }
+
+  return { classification, evidenceFor, evidenceAgainst };
+}
+
+module.exports = {
+  CLASSIFICATION,
+  classifyNetwork,
+  classifyPtr,
+  isHostingOperator,
+  PTR_RESIDENTIAL,
+  PTR_DATACENTER,
+  HOSTING_OPERATORS,
+};

--- a/ZelBack/src/services/utils/networkClassifier.js
+++ b/ZelBack/src/services/utils/networkClassifier.js
@@ -32,8 +32,9 @@
 // and uses evidenceAgainst only to DECLINE a published RESIDENTIAL. Of those
 // same 1,569, exactly one carries a published residential verdict -
 // 213.44.137.57 - and the veto covers it, so none is enforced against. One
-// ledger-level error in 1,569, zero enforced. See
-// fluxModels/investigations/PR1784_RESIDENTIAL_DOS_BLAST_RADIUS.md §4 and §9.
+// ledger-level error in 1,569, zero enforced. Measured against the published
+// artifact read through this branch's own ipLocationStore, over every fleet host
+// carrying an ip-api record.
 //
 // Signals are limited to what a node can determine about itself: the PTR record
 // for its own address, the ip-api response geolocationService already fetches,

--- a/ZelBack/src/services/utils/networkClassifier.js
+++ b/ZelBack/src/services/utils/networkClassifier.js
@@ -126,6 +126,24 @@ function classifyNetwork(facts = {}) {
   const evidenceFor = [];
   const evidenceAgainst = [];
 
+  // Whether the signals that can CONTRADICT a residential reading were gathered
+  // at all. RESIDENTIAL means "something says residential and nothing says
+  // otherwise", and the second half is only worth anything if the question was
+  // asked. It is not always asked: when ip-api answers 200 with an unusable
+  // body, geolocationService falls back to stats.runonflux.io, which carries
+  // none of these - it never requests hosting, proxy, mobile or `as` from
+  // ip-api in the first place, and its /fluxlocation endpoint projects away
+  // everything but location and `org`. On that path all five arrive undefined,
+  // an empty evidenceAgainst means nobody looked rather than nothing was found,
+  // and a datacentre host reads as enforceably RESIDENTIAL.
+  //
+  // Inferred from the inputs rather than passed as a flag: a flag can be
+  // forgotten by a new caller and would default to whichever answer is
+  // convenient, and this survives a geolocation restored from the database,
+  // which persists these fields.
+  const contradictionSignalsGathered = hosting !== undefined || proxy !== undefined
+    || mobile !== undefined || isp !== undefined || asn !== undefined;
+
   const ptrClass = classifyPtr(ptr);
   if (ptrClass === 'residential') evidenceFor.push(`ptr access-network: ${ptr}`);
   // 'both' is a contradiction on its own: a name carrying hosting vocabulary is
@@ -150,15 +168,24 @@ function classifyNetwork(facts = {}) {
 
   let classification = CLASSIFICATION.UNKNOWN;
   if (evidenceFor.length && !evidenceAgainst.length) {
-    classification = CLASSIFICATION.RESIDENTIAL;
-    evidenceFor.push(...corroborating);
+    // Only reachable when the contradicting signals were actually consulted.
+    // Without them this is UNKNOWN, which never enforces - the same answer the
+    // module already gives to every other question it cannot settle.
+    classification = contradictionSignalsGathered
+      ? CLASSIFICATION.RESIDENTIAL
+      : CLASSIFICATION.UNKNOWN;
+    if (contradictionSignalsGathered) evidenceFor.push(...corroborating);
   } else if (evidenceAgainst.length && !evidenceFor.length) {
+    // DATACENTER stands either way: it rests on something found, not on
+    // something absent, and it enforces nothing.
     classification = CLASSIFICATION.DATACENTER;
   } else if (evidenceFor.length && evidenceAgainst.length) {
     classification = CLASSIFICATION.CONFLICTED;
   }
 
-  return { classification, evidenceFor, evidenceAgainst };
+  return {
+    classification, evidenceFor, evidenceAgainst, contradictionSignalsGathered,
+  };
 }
 
 module.exports = {

--- a/ZelBack/src/services/utils/networkClassifier.js
+++ b/ZelBack/src/services/utils/networkClassifier.js
@@ -13,13 +13,27 @@
 //   CONFLICTED   both - the signals disagree, so we do not know
 //   UNKNOWN      neither - nothing to go on
 //
-// CONFLICTED is not a rounding error on the way to a binary. Measured against
-// every host in the fleet that ip-api positively asserts is hosting (1,569 hosts
-// across all 29 hosting ASNs the fleet uses), this rule calls 0 of them
-// residential - and 39 of them land in CONFLICTED. Those 39 trip a residential
-// signal AND a contradiction; collapsing that bucket either way is precisely how
-// the accuracy would be lost. See
-// fluxModels/investigations/PR1784_RESIDENTIAL_DOS_BLAST_RADIUS.md §4.
+// CONFLICTED is not a rounding error on the way to a binary. Run over the 1,569
+// fleet hosts ip-api positively asserts are hosting, across all 29 hosting ASNs
+// the fleet uses, this rule puts 1,567 in DATACENTER and 2 in CONFLICTED -
+// 213.44.137.57 in Bouygues' consumer space and 212.83.170.245 on Online/
+// Scaleway, each carrying an access-network PTR over a hosting flag. Collapsing
+// that bucket either way is what would lose them.
+//
+// It calls none of those 1,569 residential, and that is NOT a measured accuracy:
+// `hosting` is itself a contradiction, so on this population RESIDENTIAL is
+// unreachable by construction, whatever the other signals say. Quoting it as a
+// false-positive rate - as this header did - measures the arithmetic rather than
+// the rule.
+//
+// The rate that means anything is the one at the point of enforcement, and this
+// module is not the authority there. It supplies evidence;
+// geolocationService.getNetworkClassification lets the published table decide
+// and uses evidenceAgainst only to DECLINE a published RESIDENTIAL. Of those
+// same 1,569, exactly one carries a published residential verdict -
+// 213.44.137.57 - and the veto covers it, so none is enforced against. One
+// ledger-level error in 1,569, zero enforced. See
+// fluxModels/investigations/PR1784_RESIDENTIAL_DOS_BLAST_RADIUS.md §4 and §9.
 //
 // Signals are limited to what a node can determine about itself: the PTR record
 // for its own address, the ip-api response geolocationService already fetches,

--- a/test-infra/Dockerfile.fluxos
+++ b/test-infra/Dockerfile.fluxos
@@ -117,6 +117,30 @@ COPY test-infra/fixtures/userconfig-template.js /flux/config/userconfig.js
 RUN touch /flux/debug.log /flux/error.log /flux/info.log /flux/warn.log \
     && ln -s /flux /root/zelflux
 
+# Preseed CloudUI so no node fetches it at boot.
+#
+# cloudUIUpdateService treats FLUXOS_PATH being set as "this is ArcaneOS, the
+# watchdog handles CloudUI" and skips entirely - and test-env sets FLUXOS_PATH on
+# every NON-legacy node. So the install path is reached only by legacy fleets,
+# which is why this went unnoticed: CloudUI/ is gitignored and nothing in this
+# file fetched it, so every legacy node found the folder empty and ran
+# `npm run update:cloudui` at boot. That script hardcodes api.github.com and
+# curls a release tarball - it does not read config.github.apiBaseUrl - so a
+# harness fleet was reaching the real internet, and taking 60s over it. Suite 21
+# waits 90s for daemon:polled and seven of ten nodes had not finished.
+#
+# Two files, because cloudUIExists() wants one that is not `version`, and
+# getLocalVersionHash() must return something or the script runs anyway. With
+# both present the service asks the STUBBED github for a newer release, gets a
+# 404, logs "Could not fetch remote version info, skipping update check" and
+# returns. No network, no boot cost.
+#
+# Deliberately not the real frontend: no suite serves or asserts on it, and
+# fetching it here would put a live GitHub dependency into every image build.
+RUN mkdir -p /flux/CloudUI \
+    && echo "0000000000000000000000000000000000000000" > /flux/CloudUI/version \
+    && printf '<!doctype html><title>CloudUI harness placeholder</title>' > /flux/CloudUI/index.html
+
 ENV NODE_CONFIG_DIR=/flux/ZelBack/config
 
 COPY test-infra/entrypoint.sh /entrypoint.sh

--- a/test-infra/Dockerfile.fluxos
+++ b/test-infra/Dockerfile.fluxos
@@ -117,30 +117,6 @@ COPY test-infra/fixtures/userconfig-template.js /flux/config/userconfig.js
 RUN touch /flux/debug.log /flux/error.log /flux/info.log /flux/warn.log \
     && ln -s /flux /root/zelflux
 
-# Preseed CloudUI so no node fetches it at boot.
-#
-# cloudUIUpdateService treats FLUXOS_PATH being set as "this is ArcaneOS, the
-# watchdog handles CloudUI" and skips entirely - and test-env sets FLUXOS_PATH on
-# every NON-legacy node. So the install path is reached only by legacy fleets,
-# which is why this went unnoticed: CloudUI/ is gitignored and nothing in this
-# file fetched it, so every legacy node found the folder empty and ran
-# `npm run update:cloudui` at boot. That script hardcodes api.github.com and
-# curls a release tarball - it does not read config.github.apiBaseUrl - so a
-# harness fleet was reaching the real internet, and taking 60s over it. Suite 21
-# waits 90s for daemon:polled and seven of ten nodes had not finished.
-#
-# Two files, because cloudUIExists() wants one that is not `version`, and
-# getLocalVersionHash() must return something or the script runs anyway. With
-# both present the service asks the STUBBED github for a newer release, gets a
-# 404, logs "Could not fetch remote version info, skipping update check" and
-# returns. No network, no boot cost.
-#
-# Deliberately not the real frontend: no suite serves or asserts on it, and
-# fetching it here would put a live GitHub dependency into every image build.
-RUN mkdir -p /flux/CloudUI \
-    && echo "0000000000000000000000000000000000000000" > /flux/CloudUI/version \
-    && printf '<!doctype html><title>CloudUI harness placeholder</title>' > /flux/CloudUI/index.html
-
 ENV NODE_CONFIG_DIR=/flux/ZelBack/config
 
 COPY test-infra/entrypoint.sh /entrypoint.sh

--- a/test-infra/config/HARNESS_TUNABLES.md
+++ b/test-infra/config/HARNESS_TUNABLES.md
@@ -6,8 +6,7 @@ checker verifies them.
 
 A **factor** is production divided by harness: 10x means the harness reaches the
 same behaviour ten times sooner. Two knobs the code relates by an inequality must
-carry the SAME factor, or the property between them is deleted or inverted - see
-`fluxModels/workstreams/test-harness/HARNESS_CONFIG_COMPRESSION.md`.
+carry the SAME factor, or the property between them is deleted or inverted.
 
 ## Pairs checked at fleet boot
 

--- a/test-infra/config/HARNESS_TUNABLES.md
+++ b/test-infra/config/HARNESS_TUNABLES.md
@@ -26,6 +26,19 @@ wrong. Under throws.
 | property | harness pair | production ratio | how the harness gets it |
 |---|---|---:|---|
 | two holders of one app cannot mature on the same give-up pass | `residentialQueueStepMs` : `removeFluxAppsPeriod` x 4 x `explorerPollIntervalMs` | 1.82 | `derivedQueueStepMs(fluxapps)` - never a literal |
+| a departure restarts the other holders' queue tickets | `residentialEvacuationIntervalMs` : `residentialQueueStepMs` | 9.0 | `derivedEvacuationIntervalMs(fluxapps)` - never a literal |
+
+The second pair is bounded by what it must OUTLIVE rather than by production's
+ratio, the same way the sigterm window is bounded by a node boot. A node inside
+its departure interval records nothing against its queue tickets, so the block is
+what restarts them - and it only reads as a restart if it is longer than the gap
+a ticket tolerates, which IS the step. Production holds 6h against 40min and
+clears it by 9x; the harness needs only step + one pass, and the rule demands
+that rather than the ratio nobody reasoned about. Below it, tickets carry
+straight across the block, every app is instantly ready the moment the interval
+clears, and the suite goes green on a queue that stopped separating anything
+after the first departure - the same defect a too-short step causes, through the
+other door.
 
 A block costs more than its poll; `BLOCK_COST_OVERHEAD` carries the difference
 and is calibrated against a measurement, not chosen (model 15994ms against 15900ms

--- a/test-infra/config/HARNESS_TUNABLES.md
+++ b/test-infra/config/HARNESS_TUNABLES.md
@@ -25,19 +25,35 @@ wrong. Under throws.
 | property | harness pair | production ratio | how the harness gets it |
 |---|---|---:|---|
 | two holders of one app cannot mature on the same give-up pass | `residentialQueueStepMs` : `removeFluxAppsPeriod` x 4 x `explorerPollIntervalMs` | 1.82 | `derivedQueueStepMs(fluxapps)` - never a literal |
-| a departure restarts the other holders' queue tickets | `residentialEvacuationIntervalMs` : `residentialQueueStepMs` | 9.0 | `derivedEvacuationIntervalMs(fluxapps)` - never a literal |
+| a departure restarts the other holders' queue tickets | `residentialEvacuationIntervalMs` : `residentialQueueStepMs` x `TICKET_GAP_STEPS` | 4.5 | `derivedEvacuationIntervalMs(fluxapps)` - never a literal |
+| a suite's wait covers a whole departure | `driveUntil` timeout : interval + base + position x step | - | `departureCycleMs(fluxapps, instances)` - never a literal |
 
 The second pair is bounded by what it must OUTLIVE rather than by production's
 ratio, the same way the sigterm window is bounded by a node boot. A node inside
 its departure interval records nothing against its queue tickets, so the block is
 what restarts them - and it only reads as a restart if it is longer than the gap
-a ticket tolerates, which IS the step. Production holds 6h against 40min and
-clears it by 9x; the harness needs only step + one pass, and the rule demands
-that rather than the ratio nobody reasoned about. Below it, tickets carry
-straight across the block, every app is instantly ready the moment the interval
-clears, and the suite goes green on a queue that stopped separating anything
-after the first departure - the same defect a too-short step causes, through the
-other door.
+a ticket tolerates. Production holds 6h against an 80min tolerance; the harness
+needs only that tolerance plus one pass. Below it, tickets carry straight across
+the block, every app is instantly ready the moment the interval clears, and the
+suite goes green on a queue that stopped separating anything after the first
+departure - the same defect a too-short step causes, through the other door.
+
+**The tolerance is TWO steps, and that factor is the whole lesson.** One step is
+1.82 passes, so at one step a single LATE pass restarts a ticket. Production
+hardly notices - 40 minutes of lateness on a 22-minute pass is an incident in its
+own right - but the harness compresses the same ratio to about 30 seconds, where
+six fleets booting at once make a late pass ordinary. On chud the countdown ran
+2m, 1m, 0m and jumped back to 2m, three times over, never matured, and two suites
+timed out on nodes that were behaving correctly. **Absolute jitter does not
+compress with the clocks**, so a ratio that is comfortable at production scale is
+not automatically comfortable here. `TICKET_GAP_STEPS` carries the factor, and a
+unit test pins it to the product constant it models.
+
+The third pair is the same mistake one layer out. Suite 55's waits were four
+minutes, written when the interval was four seconds; a departure is now an
+interval PLUS a full ticket served again from scratch, and the typed number
+quietly stopped covering one. A wait is as coupled to the pacing as the step is
+to the pass.
 
 A block costs more than its poll; `BLOCK_COST_OVERHEAD` carries the difference
 and is calibrated against a measurement, not chosen (model 15994ms against 15900ms

--- a/test-infra/config/HARNESS_TUNABLES.md
+++ b/test-infra/config/HARNESS_TUNABLES.md
@@ -1,0 +1,119 @@
+# Harness config tunables, as ratios of production
+
+Generated from `ZelBack/config/default.js` and `test-infra/config/shared.js`.
+Regenerate rather than hand-edit; every suite header quotes these numbers and a
+checker verifies them.
+
+A **factor** is production divided by harness: 10x means the harness reaches the
+same behaviour ten times sooner. Two knobs the code relates by an inequality must
+carry the SAME factor, or the property between them is deleted or inverted - see
+`fluxModels/workstreams/test-harness/HARNESS_CONFIG_COMPRESSION.md`.
+
+## Layer 2 - `shared.js`, applied to every suite
+
+| key | production | harness | factor |
+|---|---:|---:|---:|
+| `confirmation.daemonExpiredMs` | 19200000 | 600000 | 32.0x |
+| `confirmation.daemonStaleMs` | 7500000 | 300000 | 25.0x |
+| `confirmation.pollIntervalMs` | 30000 | 5000 | 6.0x |
+| `fluxapps.appSyncDegradedThreshold` | 4 | 1 | 4.0x |
+| `fluxapps.appSyncMinCompletions` | 3 | 1 | 3.0x |
+| `fluxapps.appSyncMinPeerUptime` | 7500 | 0 | n/a |
+| `fluxapps.appSyncPeerThreshold` | 12 | 2 | 6.0x |
+| `fluxapps.bootDelayMultiplier` | 1 | 0.01 | 100.0x |
+| `fluxapps.cpuCheckIntervalMs` | 900000 | 30000 | 30.0x |
+| `fluxapps.daemonInfoIntervalMs` | 30000 | 5000 | 6.0x |
+| `fluxapps.defaultSwap` | 2 | 0 | n/a |
+| `fluxapps.discoveryConnectionDelayMs` | 500 | 100 | 5.0x |
+| `fluxapps.discoveryFailRetryMs` | 120000 | 5000 | 24.0x |
+| `fluxapps.discoveryRetryMs` | 60000 | 5000 | 12.0x |
+| `fluxapps.explorerDeepRestoreBlocks` | 100 | 0 | n/a |
+| `fluxapps.explorerPollIntervalMs` | 5000 | 250 | 20.0x |
+| `fluxapps.explorerSyncRetryMs` | 120000 | 5000 | 24.0x |
+| `fluxapps.forceRemovalIntervalMs` | 7200000 | 120000 | 60.0x |
+| `fluxapps.globalCmdDelayMs` | 500 | 100 | 5.0x |
+| `fluxapps.hashSyncEphemeralPeers` | 5 | 3 | 1.7x |
+| `fluxapps.hashSyncFallbackRecheckBlocks` | 100 | 10 | 10.0x |
+| `fluxapps.hashSyncMaxRetries` | 3 | 2 | 1.5x |
+| `fluxapps.hashSyncRetryMs` | 300000 | 10000 | 30.0x |
+| `fluxapps.hashSyncSettleMs` | 4000 | 2000 | 2.0x |
+| `fluxapps.hddFileSystemMinimum` | 10 | 2 | 5.0x |
+| `fluxapps.imageComplianceIntervalMs` | 3600000 | 60000 | 60.0x |
+| `fluxapps.imageUpdateCheckIntervalMs` | 21600000 | 5000 | 4320.0x |
+| `fluxapps.imageUpdateDelayAfterRedeployMs` | 120000 | 1000 | 120.0x |
+| `fluxapps.imageUpdateDelayBetweenAppsMs` | 5000 | 100 | 50.0x |
+| `fluxapps.imageUpdateDelayBetweenComponentsMs` | 1000 | 100 | 10.0x |
+| `fluxapps.imageUpdateInitialDelayMaxMs` | 1800000 | 2000 | 900.0x |
+| `fluxapps.imageUpdateInitialDelayMinMs` | 600000 | 1000 | 600.0x |
+| `fluxapps.installation.delay` | 120 | 5 | 24.0x |
+| `fluxapps.installCollisionWaitMs` | 90000 | 5000 | 18.0x |
+| `fluxapps.locationTtlS` | 7500 | 63 | 119.0x |
+| `fluxapps.masterSlaveIntervalMs` | 30000 | 3000 | 10.0x |
+| `fluxapps.minHashSyncPeers` | 12 | 1 | 12.0x |
+| `fluxapps.minIncoming` | 4 | 2 | 2.0x |
+| `fluxapps.minOutgoing` | 8 | 4 | 2.0x |
+| `fluxapps.minUniqueIpsIncoming` | 3 | 2 | 1.5x |
+| `fluxapps.minUniqueIpsOutgoing` | 7 | 3 | 2.3x |
+| `fluxapps.minUpTime` | 1800 | 10 | 180.0x |
+| `fluxapps.nodeMonitorCheckTimeoutMs` | 10000 | 5000 | 2.0x |
+| `fluxapps.nodeMonitorConfirmationLossDelayMs` | 1200000 | 10000 | 120.0x |
+| `fluxapps.nodeMonitorDosRecoveryDelayMs` | 600000 | 10000 | 60.0x |
+| `fluxapps.nodeMonitorErrorRecoveryDelayMs` | 120000 | 5000 | 24.0x |
+| `fluxapps.nodeMonitorIntervalMs` | 1200000 | 10000 | 120.0x |
+| `fluxapps.nodeMonitorRemovalDelayMs` | 60000 | 1000 | 60.0x |
+| `fluxapps.nonEnterpriseSpawnDelayMs` | 120000 | 500 | 240.0x |
+| `fluxapps.peerNotifyIntervalMs` | 3600000 | 30000 | 120.0x |
+| `fluxapps.portRestoreIntervalMs` | 600000 | 30000 | 20.0x |
+| `fluxapps.portTestBindDelayMs` | 5000 | 100 | 50.0x |
+| `fluxapps.portTestMaxAttempts` | 5 | 2 | 2.5x |
+| `fluxapps.portTestPeerTimeoutMs` | 30000 | 3000 | 10.0x |
+| `fluxapps.portTestPropagationDelayMs` | 10000 | 100 | 100.0x |
+| `fluxapps.redeploy.composedDelay` | 5 | 1 | 5.0x |
+| `fluxapps.redeploy.delay` | 30 | 1 | 30.0x |
+| `fluxapps.removal.delay` | 300 | 5 | 60.0x |
+| `fluxapps.spawnDeferrals.capacityGap.largeMs.enterprise` | 1800000 | 350 | 5142.9x |
+| `fluxapps.spawnDeferrals.capacityGap.largeMs.standard` | 7020000 | 700 | 10028.6x |
+| `fluxapps.spawnDeferrals.capacityGap.mediumMs.enterprise` | 1260000 | 400 | 3150.0x |
+| `fluxapps.spawnDeferrals.capacityGap.mediumMs.standard` | 5220000 | 800 | 6525.0x |
+| `fluxapps.spawnDeferrals.capacityGap.smallMs.enterprise` | 720000 | 450 | 1600.0x |
+| `fluxapps.spawnDeferrals.capacityGap.smallMs.standard` | 3420000 | 900 | 3800.0x |
+| `fluxapps.spawnDeferrals.datacenterMs.enterprise` | 1620000 | 250 | 6480.0x |
+| `fluxapps.spawnDeferrals.datacenterMs.standard` | 3420000 | 500 | 6840.0x |
+| `fluxapps.spawnDeferrals.staticIpMs.enterprise` | 1620000 | 200 | 8100.0x |
+| `fluxapps.spawnDeferrals.staticIpMs.standard` | 3420000 | 400 | 8550.0x |
+| `fluxapps.spawnDeferrals.targetedNodesMs.enterprise` | 1800000 | 150 | 12000.0x |
+| `fluxapps.spawnDeferrals.targetedNodesMs.standard` | 3420000 | 300 | 11400.0x |
+| `fluxapps.spawnDelayMultiplier` | 1 | 0.002 | 500.0x |
+| `fluxapps.spawnReconfirmDelayMs` | 7500000 | 30000 | 250.0x |
+| `fluxapps.syncResponseThrottleMs` | 300000 | 10000 | 30.0x |
+| `fluxapps.syncTimeoutMs` | 120000 | 30000 | 4.0x |
+| `fluxapps.tempMsgTtlS` | 3600 | 300 | 12.0x |
+| `fluxapps.wsHandshakeTimeoutMs` | 10000 | 5000 | 2.0x |
+| `peers.wsMaxMissedPongs` | 3 | 2 | 1.5x |
+| `peers.wsPingIntervalMs` | 15000 | 2000 | 7.5x |
+| `syncthing.monitorIntervalMs` | 30000 | 3000 | 10.0x |
+| `syncthing.stallNudgeAfterMs` | 180000 | 6000 | 30.0x |
+| `syncthing.stallNudgeMaxIntervalMs` | 900000 | 12000 | 75.0x |
+| `syncthing.stallRemoveMinNudges` | 3 | 2 | 1.5x |
+| `syncthing.stallRemoveMinWindowMs` | 1200000 | 30000 | 40.0x |
+| `system.bootDaemonTimeoutMs` | 300000 | 30000 | 10.0x |
+| `system.bootSyncTimeoutMs` | 300000 | 30000 | 10.0x |
+| `system.heartbeatIntervalMs` | 30000 | 10000 | 3.0x |
+
+## Knobs with no reader - the harness value changes nothing
+
+These are set in `shared.js` and look like compression. The code never reads them;
+it uses a hardcoded constant instead, at the production value, in every suite.
+
+| key | production | harness | apparent factor | what the code actually uses |
+|---|---:|---:|---:|---|
+| `fluxapps.hashSyncIntervalMs` | 1800000 | 30000 | 60.0x | literal `30 * 60 * 1000` (serviceManager.js:679) |
+| `fluxapps.removalSpacingMs` | 60000 | 1000 | 60.0x | nothing - no equivalent |
+| `fluxapps.spawnDelayMs` | 0 | 10000 | n/a | nothing - no equivalent |
+
+## Values production and the harness share
+
+Deliberately uncompressed - a suite depending on one of these is depending on the
+production number.
+
+`syncthing.port` = 8384 · `fluxapps.maxAppsPerNode` = 200 · `fluxapps.blocksLasting` = 22000 · `fluxapps.newMinBlocksAllowance` = 100 · `fluxapps.daemonPONFork` = 2020000 · `fluxapps.hashSyncResponseTimePerHashMs` = 150 · `fluxapps.hashSyncBufferMs` = 5000 · `fluxapps.hashSyncMaxRounds` = 4 · `fluxapps.hashSyncPeersPerRound` = 3 · `fluxapps.installingTtlS` = 900 · `fluxapps.installErrorTtlS` = 86400 · `fluxapps.installation.probability` = 100 · `fluxapps.removal.probability` = 25 · `fluxapps.redeploy.probability` = 2

--- a/test-infra/config/HARNESS_TUNABLES.md
+++ b/test-infra/config/HARNESS_TUNABLES.md
@@ -9,6 +9,30 @@ same behaviour ten times sooner. Two knobs the code relates by an inequality mus
 carry the SAME factor, or the property between them is deleted or inverted - see
 `fluxModels/workstreams/test-harness/HARNESS_CONFIG_COMPRESSION.md`.
 
+## Pairs checked at fleet boot
+
+The rule above was written here and broken anyway, because the two halves of a
+pair need not live in the same layer: `explorerPollIntervalMs` is in `shared.js`
+and `residentialQueueStepMs` was a literal in one suite's overrides. Nothing
+related them, so moving the poll 250ms -> 833ms moved the pass 4s -> 16s and
+left the step at 15s - below the pass, where the property inverts. Two holders
+of one app matured on the same pass and both handed it back.
+
+`test-infra/runner/framework/coupled-knobs.js` now derives these and
+`test-env.js` asserts them on the EFFECTIVE config of every node of every fleet
+before boot. Over production's ratio passes - an uncompressed knob is slow, not
+wrong. Under throws.
+
+| property | harness pair | production ratio | how the harness gets it |
+|---|---|---:|---|
+| two holders of one app cannot mature on the same give-up pass | `residentialQueueStepMs` : `removeFluxAppsPeriod` x 4 x `explorerPollIntervalMs` | 1.82 | `derivedQueueStepMs(fluxapps)` - never a literal |
+
+A block costs more than its poll; `BLOCK_COST_OVERHEAD` carries the difference
+and is calibrated against a measurement, not chosen (model 15994ms against 15900ms
+observed over nine consecutive passes on cindy, 2026-08-20). Modelling a block as
+exactly one poll derives a step that is too SHORT, which is the direction that
+loses the property, so the factor is pinned by a unit test.
+
 ## Layer 2 - `shared.js`, applied to every suite
 
 | key | production | harness | factor |

--- a/test-infra/config/HARNESS_TUNABLES.md
+++ b/test-infra/config/HARNESS_TUNABLES.md
@@ -28,7 +28,7 @@ carry the SAME factor, or the property between them is deleted or inverted - see
 | `fluxapps.discoveryFailRetryMs` | 120000 | 5000 | 24.0x |
 | `fluxapps.discoveryRetryMs` | 60000 | 5000 | 12.0x |
 | `fluxapps.explorerDeepRestoreBlocks` | 100 | 0 | n/a |
-| `fluxapps.explorerPollIntervalMs` | 5000 | 250 | 20.0x |
+| `fluxapps.explorerPollIntervalMs` | 5000 | 833 | 6.0x |
 | `fluxapps.explorerSyncRetryMs` | 120000 | 5000 | 24.0x |
 | `fluxapps.forceRemovalIntervalMs` | 7200000 | 120000 | 60.0x |
 | `fluxapps.globalCmdDelayMs` | 500 | 100 | 5.0x |

--- a/test-infra/config/shared.js
+++ b/test-infra/config/shared.js
@@ -149,6 +149,12 @@ module.exports = {
     },
     spawnDelayMultiplier: 0.002,
     daemonInfoIntervalMs: 5000,
+    // The floor on how fast a driven chain can be processed: a block is not
+    // looked at until the next poll, so at production's 5000 a suite driving its
+    // own blocks still waits five seconds for each one, and everything hung off
+    // block processing - the give-up pass among them - inherits that. Measured
+    // at 4.8s a block before this was tunable.
+    explorerPollIntervalMs: 250,
     explorerSyncRetryMs: 5000,
     explorerDeepRestoreBlocks: 0,
     imageUpdateCheckIntervalMs: 5000,

--- a/test-infra/config/shared.js
+++ b/test-infra/config/shared.js
@@ -131,6 +131,18 @@ module.exports = {
     // announcements a node may miss before its apps look gone. Production is
     // 7500s/3600s = 2.08, so this tracks the announce interval's 120x.
     locationTtlS: 63, // 2.10 announces, against production's 2.08
+    // NOT the announce ratio, deliberately. What locationTtlS is coupled to is
+    // a compressed clock; what this is measured across is a NODE BOOT, and the
+    // harness does not compress boots. Measured on cindy under a MAXN=6 gate: a
+    // fixture pinning 300s of downtime was read by the node as 316s, so a boot
+    // costs 16s of drift. At production's 120x this key would be 3.5s - smaller
+    // than the drift - and the within-the-window test could never pass.
+    //
+    // So it is bounded by what it must outlive, like installingTtlS below:
+    // comfortably above the 16s drift, comfortably below locationTtlS's 63s so
+    // the ordering holds and a clean shutdown still gets a grace the running
+    // expiry does not pre-empt. coupled-knobs.js asserts both ends.
+    sigtermExpiryS: 30,
     // NOT compressed, and not compressible by a ratio. What this must outlive is
     // an install, and the harness does not compress installs - they are real
     // image pulls and real container starts. The suites' own budgets say so:

--- a/test-infra/config/shared.js
+++ b/test-infra/config/shared.js
@@ -175,12 +175,29 @@ module.exports = {
     },
     spawnDelayMultiplier: 0.002,
     daemonInfoIntervalMs: 5000,
-    // The floor on how fast a driven chain can be processed: a block is not
-    // looked at until the next poll, so at production's 5000 a suite driving its
-    // own blocks still waits five seconds for each one, and everything hung off
-    // block processing - the give-up pass among them - inherits that. Measured
-    // at 4.8s a block before this was tunable.
-    explorerPollIntervalMs: 250,
+    // The poll is NOT how often the chain is asked - pollForNewBlocks reads a
+    // height cached by daemonServiceMiscRpcs and refreshed on its own
+    // daemonInfoIntervalMs timer. It is the rate at which the node works
+    // through blocks once it knows it is behind, and its share of the
+    // tip-refresh window is what decides whether a block is still the tip when
+    // it is processed - which is what gates every maintenance pass hung off
+    // block processing.
+    //
+    // Both clocks are already 1:1 with block time at either scale - 30s/30s in
+    // production, 5s/5s here - so one block arrives per window either way. What
+    // has to hold is the poll's share of that window:
+    //
+    //   production   5000 / 30000  =  16.7%
+    //   here          833 /  5000  =  16.7%
+    //
+    // 250ms was three times MORE forgiving than production, which is the wrong
+    // direction: a node too slow to clear a window's block, so blocks bunch and
+    // maintenance is skipped, is a production failure the harness would never
+    // show. Suite 55 hit that failure twice and it was read as a harness
+    // artefact; making the harness faster until it stops happening is the same
+    // move one layer down. Measured at 4.8s a block at the old hardcoded 5000,
+    // which was poll-dominated - a block sat unnoticed for a whole window.
+    explorerPollIntervalMs: 833,
     explorerSyncRetryMs: 5000,
     explorerDeepRestoreBlocks: 0,
     imageUpdateCheckIntervalMs: 5000,

--- a/test-infra/config/shared.js
+++ b/test-infra/config/shared.js
@@ -113,9 +113,35 @@ module.exports = {
     bootDelayMultiplier: 0.01,
     spawnDelayMs: 10000,
     removalSpacingMs: 1000,
-    locationTtlS: 300,
-    installingTtlS: 60,
-    installErrorTtlS: 300,
+    // Per-document expiry for the ephemeral app collections, in seconds. These
+    // three also serve as GOSSIP ACCEPTANCE WINDOWS - messageStore drops an
+    // incoming broadcast whose broadcastedAt is older than the window - so a
+    // value below what the fleet takes to produce and deliver a message does
+    // not make a suite faster, it makes peers refuse each other.
+    //
+    // They read as 300/60/300 from the day the harness was first stood up until
+    // 2026-08-20 and none of them ever took effect: the config keys were wired
+    // to collection-level TTL indexes that were dropped when expiry moved
+    // per-document, so every suite ran on the production durations while this
+    // file claimed otherwise. The numbers below are derived; the old ones were
+    // round guesses that nothing could contradict.
+    //
+    // A running-app location record is refreshed by the peerNotifyIntervalMs
+    // re-announce, so the ratio between them IS the property: how many
+    // announcements a node may miss before its apps look gone. Production is
+    // 7500s/3600s = 2.08, so this tracks the announce interval's 120x.
+    locationTtlS: 63, // 2.10 announces, against production's 2.08
+    // NOT compressed, and not compressible by a ratio. What this must outlive is
+    // an install, and the harness does not compress installs - they are real
+    // image pulls and real container starts. The suites' own budgets say so:
+    // waitForAppInstalled is given 120s routinely and 300s at the top end. At
+    // the old 60s the marker expired mid-install and peers rejected any
+    // installing claim older than a minute; suite 78 reads exactly that claim.
+    installingTtlS: 900,
+    // NOT compressed, for the same reason: the errors it accumulates come from
+    // real failed installs, and suite 27 waits for five of them to reach the
+    // network-wide threshold. No knob paces that, so there is no ratio to hold.
+    installErrorTtlS: 86400,
     tempMsgTtlS: 300,
     hashSyncIntervalMs: 30000,
     peerNotifyIntervalMs: 30000,

--- a/test-infra/daemon-stub/index.js
+++ b/test-infra/daemon-stub/index.js
@@ -40,6 +40,10 @@ let pendingBlocks = [];
 
 const nodeStatusOverrides = new Map();
 const rpcFailures = new Map();
+// ip -> false. Absent means ArcaneOS, which is what 85% of the real fleet runs
+// and what every suite that does not care about this should see: a node reading
+// systemsecure=true is never a residential-DOS target.
+const nonArcaneNodes = new Map();
 const requestJournal = [];
 const MAX_JOURNAL_SIZE = 10000;
 
@@ -400,6 +404,9 @@ const benchHandlers = {
       bench_version: BENCH_VERSION,
       flux_version: FLUX_VERSION,
       architecture: 'amd64',
+      // The ArcaneOS attestation residentialNodeDosService reads. A node absent
+      // from the override map is attested.
+      systemsecure: !nonArcaneNodes.has(node ? node.ip.split(':')[0] : ''),
       thunder: false,
       real_cores: s.cores,
       speed: 3000,
@@ -547,6 +554,7 @@ control.get('/state', (req, res) => {
     tickerRunning: tickerHandle !== null,
     statusOverrides: nodeStatusOverrides.size,
     rpcFailures: rpcFailures.size,
+    nonArcaneNodes: [...nonArcaneNodes.keys()],
   });
 });
 
@@ -768,6 +776,23 @@ control.post('/node-tier/:ip', (req, res) => {
   node.tier = tier;
   const amounts = { CUMULUS: 1000, NIMBUS: 12500, STRATUS: 40000 };
   return res.json({ ip, tier, collateral: amounts[tier] });
+});
+
+// -- ArcaneOS attestation control --
+
+control.post('/system-secure/:ip', (req, res) => {
+  const { secure } = req.body;
+  if (typeof secure !== 'boolean') {
+    return res.status(400).json({ error: 'secure must be a boolean' });
+  }
+  if (secure) nonArcaneNodes.delete(req.params.ip);
+  else nonArcaneNodes.set(req.params.ip, false);
+  return res.json({ ip: req.params.ip, systemsecure: secure });
+});
+
+control.delete('/system-secure', (req, res) => {
+  nonArcaneNodes.clear();
+  res.json({ cleared: true });
 });
 
 // -- RPC failure simulation --

--- a/test-infra/daemon-stub/index.js
+++ b/test-infra/daemon-stub/index.js
@@ -606,7 +606,12 @@ control.post('/advance-block', (req, res) => {
   if (block) {
     block.height = block.height || currentHeight;
     block.hash = block.hash || `000000000000stub${currentHeight}`;
-    block.confirmations = 1;
+    // Computed live, the way a synthesized block computes it at the top of this
+    // file. Stamping 1 at push time made a block carrying transactions read as
+    // the chain tip no matter how far behind the node was, while an empty block
+    // did not - so the one class of block whose isSynced skip matters most, an
+    // app registration, was the one class the stub had made unskippable.
+    block.confirmations = currentHeight - block.height + 1;
     block.tx = [...(block.tx || []), ...txs];
     pendingBlocks.push(block);
   } else if (txs.length > 0) {

--- a/test-infra/entrypoint.sh
+++ b/test-infra/entrypoint.sh
@@ -3,6 +3,32 @@ set -e
 
 ip addr add 169.254.43.43/32 dev lo 2>/dev/null || true
 
+# A default route, or deliberately none - declared by the suite, never inherited
+# from the topology.
+#
+# The harness network is created Internal, so docker gives the container no
+# default route at all. FluxOS decides whether this node holds a fixed public
+# address by looking for one (fluxNetworkHelper.hasPublicIpOnInterface reads
+# /proc/net/route), so left to the wiring EVERY node reads DYNAMIC - which is how
+# suite 21's static_ip deferrals silently stopped firing.
+#
+# This restores the FACT, not connectivity: an internal network's gateway
+# forwards nothing outward, so the fleet stays exactly as isolated as Internal
+# makes it. Installed here because a node reads its address once during boot -
+# anything applied after the fleet is up is never seen.
+#
+# NOT swallowed. A `|| true` here would make the one failure that matters -
+# the route not being installable - look exactly like a node that was never
+# asked for one, and the suite would then fail somewhere far away on a
+# classification it could not explain.
+if [ -n "$FLUX_E2E_DEFAULT_ROUTE" ]; then
+  if ! ip route replace default via "$FLUX_E2E_DEFAULT_ROUTE"; then
+    echo "ERROR: could not install default route via $FLUX_E2E_DEFAULT_ROUTE;" \
+         "this node would read DYNAMIC and any static-IP assertion would fail" >&2
+    exit 1
+  fi
+fi
+
 # App installs mount each app's FLUXFSVOL via `mount -o loop`. Loop devices are a
 # shared host-kernel resource (not namespaced); the kernel default pool (max_loop,
 # typically 8) is small and on-demand creation races under concurrent installs, so a

--- a/test-infra/external-http-stub/index.js
+++ b/test-infra/external-http-stub/index.js
@@ -142,8 +142,8 @@ function regionAssignment(domains, withRegions) {
  * `networkClasses` says which of the organisations run access networks and
  * which sell hosting - `{ 0: 'residential', 1: 'hosting' }` keyed by
  * organisation INDEX, since that is what a caller controls. Omitted, the
- * artifact carries no orgClasses section at all, which is what a real build
- * carrying no verdicts publishes and what every suite that does not care about
+ * artifact carries an EMPTY orgClasses section - which is what a real build
+ * carrying no verdicts publishes, and what every suite that does not care about
  * classification should see: an organisation with no verdict is one nothing
  * enforces against.
  * @param {number} domains How many organisations to split across
@@ -262,8 +262,12 @@ function encodeGeoTable(artifact, { pad = true } = {}) {
     // omitted when nothing is classified, for the same reason: a build carrying
     // no verdicts is a state the reader already handles, and it must stay
     // distinguishable from one that carries them
-    ...(artifact.orgClasses && Object.keys(artifact.orgClasses).length
-      ? { orgClasses: artifact.orgClasses } : {}),
+    // ALWAYS emitted, including as {}, because that is what the real builder
+    // does. Omitting it when empty meant the stub covered a shape production
+    // never produces, and did not cover the one production produces when the
+    // ledger classifies nothing - the shape every node saw the day the section
+    // shipped.
+    orgClasses: artifact.orgClasses ?? {},
   }), 'utf8');
   const preamble = Buffer.alloc(GEO_MAGIC.length + 1 + 4);
   preamble.write(GEO_MAGIC, 0, 'ascii');
@@ -715,7 +719,7 @@ control.post('/iplocation', (req, res) => {
     const domains = req.body.domains ?? 1;
     const withRegions = req.body.regions === true;
     // { classes: { 0: 'residential' } } publishes a verdict for organisation 0.
-    // Absent, the artifact carries no orgClasses section, so every node falls
+    // Absent, the artifact carries an empty orgClasses section, so every node falls
     // back to deciding its own address - which is what the reader does with a
     // build that classified nothing.
     serveIpLocation(

--- a/test-infra/external-http-stub/index.js
+++ b/test-infra/external-http-stub/index.js
@@ -411,8 +411,10 @@ function defaultGeoResponse(ip) {
     query: ip,
     org: 'Hetzner Online GmbH',
     isp: 'Hetzner Online GmbH',
+    as: 'AS24940 Hetzner Online GmbH',
     proxy: false,
     hosting: true,
+    mobile: false,
   };
 }
 

--- a/test-infra/external-http-stub/index.js
+++ b/test-infra/external-http-stub/index.js
@@ -24,6 +24,10 @@ const GEO_FILLER_ROWS = 1500000;
 const GEO_FILLER_START = 16 * 2 ** 24;
 const GEO_FILLER_END = GEO_FILLER_START + GEO_FILLER_ROWS - 1;
 const GEO_FILLER_ORGS = ['harness:filler-0', 'harness:filler-1'];
+// The class codes the artifact carries, and the only two a reader knows. Named
+// here so a suite says 'residential' and the wire value stays the publisher's
+// business - fluxos-network-policy's scripts/orgclasses.js is the definition.
+const NETWORK_CLASS_CODES = { residential: 1, hosting: 2 };
 
 // The artifact's country and region vocabularies, index-aligned: regions[k] is
 // a region OF countries[k]. The split gives organisation k country k, so the
@@ -134,12 +138,21 @@ function regionAssignment(domains, withRegions) {
  * it the rows stay four elements long and no row claims a region, so both
  * representations are byte-identical to what a caller that never asks for
  * regions has always been served.
+ *
+ * `networkClasses` says which of the organisations run access networks and
+ * which sell hosting - `{ 0: 'residential', 1: 'hosting' }` keyed by
+ * organisation INDEX, since that is what a caller controls. Omitted, the
+ * artifact carries no orgClasses section at all, which is what a real build
+ * carrying no verdicts publishes and what every suite that does not care about
+ * classification should see: an organisation with no verdict is one nothing
+ * enforces against.
  * @param {number} domains How many organisations to split across
  * @param {string} [subnet] Dotted /24 prefix to split, e.g. '198.18.5'
  * @param {boolean} [withRegions] Whether rows carry a region
+ * @param {object} [networkClasses] Organisation index -> 'residential'|'hosting'
  * @returns {object} artifact in format 1
  */
-function buildIpLocationArtifact(domains, subnet, withRegions = false) {
+function buildIpLocationArtifact(domains, subnet, withRegions = false, networkClasses = null) {
   const orgs = Array.from({ length: Math.max(domains, 1) }, (unused, i) => `harness:org-${i}`);
   const countries = GEO_COUNTRIES;
   const { assigned } = regionAssignment(domains, withRegions);
@@ -176,6 +189,16 @@ function buildIpLocationArtifact(domains, subnet, withRegions = false) {
     regionNames: Object.fromEntries(
       GEO_REGIONS.map((code, k) => [`${GEO_COUNTRIES[k]}|${GEO_REGION_NAMES[k]}`, code]),
     ),
+    // Keyed by organisation TOKEN, which is what the header carries and what a
+    // reader looks up - the caller names an index because that is what it
+    // controls, and the two are joined here rather than in the suite.
+    ...(networkClasses ? {
+      orgClasses: Object.fromEntries(
+        Object.entries(networkClasses)
+          .filter(([index]) => orgs[Number(index)])
+          .map(([index, klass]) => [orgs[Number(index)], NETWORK_CLASS_CODES[klass]]),
+      ),
+    } : {}),
     v4,
     v6: [],
   };
@@ -236,6 +259,11 @@ function encodeGeoTable(artifact, { pad = true } = {}) {
     // omitted when the artifact carries no regions, so a suite can publish the
     // pre-vocabulary artifact a node held before the section existed
     ...(regions.length ? { regionNames: artifact.regionNames ?? {} } : {}),
+    // omitted when nothing is classified, for the same reason: a build carrying
+    // no verdicts is a state the reader already handles, and it must stay
+    // distinguishable from one that carries them
+    ...(artifact.orgClasses && Object.keys(artifact.orgClasses).length
+      ? { orgClasses: artifact.orgClasses } : {}),
   }), 'utf8');
   const preamble = Buffer.alloc(GEO_MAGIC.length + 1 + 4);
   preamble.write(GEO_MAGIC, 0, 'ascii');
@@ -678,7 +706,14 @@ control.post('/iplocation', (req, res) => {
   } else {
     const domains = req.body.domains ?? 1;
     const withRegions = req.body.regions === true;
-    serveIpLocation(buildIpLocationArtifact(domains, req.body.subnet, withRegions), { pad });
+    // { classes: { 0: 'residential' } } publishes a verdict for organisation 0.
+    // Absent, the artifact carries no orgClasses section, so every node falls
+    // back to deciding its own address - which is what the reader does with a
+    // build that classified nothing.
+    serveIpLocation(
+      buildIpLocationArtifact(domains, req.body.subnet, withRegions, req.body.classes ?? null),
+      { pad },
+    );
     regions = regionAssignment(domains, withRegions);
   }
   res.json({
@@ -690,6 +725,7 @@ control.post('/iplocation', (req, res) => {
     padded: pad,
     bytes: state.ipLocationBinary?.length ?? 0,
     regions,
+    orgClasses: state.ipLocation?.orgClasses ?? null,
   });
 });
 

--- a/test-infra/external-http-stub/index.js
+++ b/test-infra/external-http-stub/index.js
@@ -583,6 +583,16 @@ app.get('/json/:ip', (req, res) => {
 });
 
 // Geolocation: stats.runonflux.io format (fallback)
+//
+// LOCATION ONLY, and deliberately so. The real service builds this collection
+// by batch-querying ip-api itself for every IP on the deterministic node list,
+// asking for `status,continent,continentCode,country,countryCode,region,
+// regionName,lat,lon,query,org,isp` - no hosting, no proxy, no mobile, no `as`
+// - and its /fluxlocation/:ip handler then projects to exactly the ten fields
+// below. It has never carried `static` or `dataCenter`; this stub used to
+// synthesise both from the ip-api fixture, which made the fallback look richer
+// here than it is on a real node and put the one path where the classifier
+// loses its contradiction signals beyond anything a suite could observe.
 app.get('/fluxlocation/:ip', (req, res) => {
   const { ip } = req.params;
   const custom = state.geolocation[ip];
@@ -600,8 +610,6 @@ app.get('/fluxlocation/:ip', (req, res) => {
       lat: geo.lat,
       lon: geo.lon,
       org: geo.org,
-      static: !geo.proxy && geo.hosting,
-      dataCenter: geo.hosting,
     },
   });
 });

--- a/test-infra/peer-stub/index.js
+++ b/test-infra/peer-stub/index.js
@@ -402,6 +402,13 @@ const controlServer = http.createServer(async (req, res) => {
         ready: wanted.ready !== false,
         folders: Array.isArray(wanted.folders) ? wanted.folders : [],
       };
+      // Reset the arrival log HERE, in the same request that states the claim,
+      // because /clear does both and a caller that wants a fresh log without
+      // dropping the claim has to make two calls. Between them this peer claims
+      // to hold nothing, and a node polling in that gap sees the folder free,
+      // promotes, and stops asking - which is the measurement suite 79 exists
+      // to take, ruined by the act of starting it.
+      if (wanted.resetRequests) promotedFolderRequests.length = 0;
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ status: 'ok', promotedFolders }));
       return;

--- a/test-infra/runner/framework/control-fetch.js
+++ b/test-infra/runner/framework/control-fetch.js
@@ -1,4 +1,4 @@
-// Talking to a stub's control API, with the failure legible.
+// Talking to a stub's control API or a node's own API, with the failure legible.
 //
 // `fetch` reports every transport failure as the same three words - "TypeError:
 // fetch failed" - and puts the part that identifies it (ECONNREFUSED, socket
@@ -9,6 +9,11 @@
 //
 // That cost this suite three ten-minute runs. So every control call goes through
 // here, and a failure names the method, the URL and the cause.
+//
+// The node clients go through it too. They were left on bare `fetch` when this
+// was written, and a gate found the gap the same way: a suite that passes twice
+// on an idle box loses a wait to one unattributable `fetch failed` under load,
+// and the report names neither which node nor why.
 
 /**
  * fetch, with the failure identifying itself.

--- a/test-infra/runner/framework/control-fetch.js
+++ b/test-infra/runner/framework/control-fetch.js
@@ -1,0 +1,53 @@
+// Talking to a stub's control API, with the failure legible.
+//
+// `fetch` reports every transport failure as the same three words - "TypeError:
+// fetch failed" - and puts the part that identifies it (ECONNREFUSED, socket
+// hang up, EAI_AGAIN) in `cause`, which nothing prints. A suite that loses a
+// control call therefore fails with no endpoint, no errno and no stack into the
+// harness, and the only way to find out which of a dozen control APIs went
+// quiet is to run it again with a guess bolted on.
+//
+// That cost this suite three ten-minute runs. So every control call goes through
+// here, and a failure names the method, the URL and the cause.
+
+/**
+ * fetch, with the failure identifying itself.
+ * @param {string} url Absolute control-API URL.
+ * @param {object} [init] fetch init.
+ * @returns {Promise<Response>}
+ */
+export async function controlFetch(url, init) {
+  try {
+    return await fetch(url, init);
+  } catch (error) {
+    const method = init?.method ?? 'GET';
+    const cause = error?.cause;
+    const detail = cause
+      ? `${cause.code ?? cause.name ?? 'unknown'}${cause.message ? `: ${cause.message}` : ''}`
+      : 'no cause reported';
+    const wrapped = new Error(`${method} ${url} failed - ${detail}`);
+    wrapped.cause = error;
+    throw wrapped;
+  }
+}
+
+/**
+ * The same, parsed as JSON. A control API that answers with a body the caller
+ * cannot read is its own failure, and it reads identically to a transport one
+ * unless it says so.
+ * @param {string} url Absolute control-API URL.
+ * @param {object} [init] fetch init.
+ * @returns {Promise<any>}
+ */
+export async function controlJson(url, init) {
+  const res = await controlFetch(url, init);
+  const text = await res.text();
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error(
+      `${init?.method ?? 'GET'} ${url} answered ${res.status} with a body that is not JSON: `
+      + `${text.slice(0, 200)}`,
+    );
+  }
+}

--- a/test-infra/runner/framework/coupled-knobs.js
+++ b/test-infra/runner/framework/coupled-knobs.js
@@ -1,0 +1,141 @@
+// Harness knobs that only mean anything RELATIVE to another knob.
+//
+// A compressed harness is a set of ratios, not a set of numbers. Compress two
+// coupled knobs by different factors and the property between them does not get
+// faster - it inverts, and the suite that was written to prove it goes green
+// while proving the opposite.
+//
+// That is not hypothetical here. residentialQueueStepMs was set to 15s against
+// a pass the comment beside it called "about 4s", giving an apparent 3.75x
+// margin. The pass is a function of explorerPollIntervalMs - a block costs one
+// poll - and when that moved 250ms -> 833ms the pass moved with it to ~16s.
+// Nothing re-derived the step, so the harness ended up at 0.94x, BELOW one,
+// while production sits at 1.8x. Two nodes then matured on the same pass and
+// both handed the same app back - the exact defect production's own 15-minute
+// step had, which was a merge blocker on this branch.
+//
+// So the numbers below are derived from production's ratios and checked at
+// fleet boot, for every suite, against whatever that suite overrode.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const SHARED_PATH = path.join(HERE, '../../config/shared.js');
+
+/**
+ * config/shared.js is CJS text inside a package declaring "type": "module", so
+ * it can be neither imported nor required - it is evaluated.
+ * @returns {object} The shared harness config.
+ */
+export function loadSharedConfig() {
+  const sandbox = { module: { exports: {} }, exports: null };
+  sandbox.exports = sandbox.module.exports;
+  vm.runInNewContext(fs.readFileSync(SHARED_PATH, 'utf8'), sandbox);
+  return sandbox.module.exports;
+}
+
+// Production's side of every ratio here. Held as constants rather than read
+// from ZelBack/config/default.js because that file requires the gitignored
+// config/userconfig.js; tests/unit/coupledKnobs.test.js asserts they still
+// match the fleet's, so drift fails a test rather than silently weakening the
+// check.
+export const PRODUCTION = Object.freeze({
+  blockMs: 30000, // post-PON; stated in-repo at fluxService.js:1774
+  removeFluxAppsPeriod: 11,
+  residentialQueueBaseMs: 30 * 60 * 1000,
+  residentialQueueStepMs: 40 * 60 * 1000,
+});
+
+// explorerService.js:610. Applies to both sides, so it cancels out of the
+// ratio - named anyway, because the pass interval is not readable without it.
+export const PON_SPEED_MULTIPLIER = 4;
+
+// A block costs at least one poll, and in practice more: processing, the
+// database write and the maintenance hung off it all land between polls.
+// Measured on cindy 2026-08-20 at explorerPollIntervalMs 833 - modelled pass
+// 13.3s, observed 15.9s over nine consecutive give-up passes. Applied so the
+// model is not optimistic, because optimism here derives a step that is too
+// SHORT, which is the direction that loses the property.
+export const BLOCK_COST_OVERHEAD = 1.2;
+
+/**
+ * How long between two runs of the give-up pass.
+ *
+ * The pass runs every removeFluxAppsPeriod * PON_SPEED_MULTIPLIER blocks. What a
+ * block COSTS is the only part that differs between production and the harness:
+ * production waits out a real 30s block, the harness drives its own and pays one
+ * explorer poll for each.
+ * @param {{removeFluxAppsPeriod: number}} fluxapps Effective app config.
+ * @param {number} blockCostMs What one block costs to reach and process.
+ * @returns {number} Milliseconds between passes.
+ */
+export function giveUpPassMs(fluxapps, blockCostMs) {
+  return fluxapps.removeFluxAppsPeriod * PON_SPEED_MULTIPLIER * blockCostMs;
+}
+
+/** What one block costs the harness: a poll, plus what processing adds. */
+export function harnessBlockCostMs(fluxapps) {
+  return fluxapps.explorerPollIntervalMs * BLOCK_COST_OVERHEAD;
+}
+
+/**
+ * The ratio the queue step has to hold against the pass, taken from production.
+ *
+ * Above 1 is the property; production's specific margin is what the fleet has
+ * been reasoned about, so the harness matches it rather than merely clearing 1.
+ * @returns {number}
+ */
+export function productionQueueRatio() {
+  const pass = giveUpPassMs(PRODUCTION, PRODUCTION.blockMs);
+  return PRODUCTION.residentialQueueStepMs / pass;
+}
+
+/**
+ * The queue step a suite should use, derived rather than chosen.
+ *
+ * Call this instead of writing a number: it moves when explorerPollIntervalMs
+ * or removeFluxAppsPeriod moves, which is the whole failure this file exists
+ * for.
+ * @param {{removeFluxAppsPeriod: number, explorerPollIntervalMs: number}} fluxapps
+ * @returns {number} residentialQueueStepMs, in milliseconds.
+ */
+export function derivedQueueStepMs(fluxapps) {
+  const pass = giveUpPassMs(fluxapps, harnessBlockCostMs(fluxapps));
+  return Math.ceil((pass * productionQueueRatio()) / 1000) * 1000;
+}
+
+/**
+ * Refuse to boot a fleet whose coupled knobs do not hold production's ratios.
+ *
+ * Runs on the EFFECTIVE config - shared.js plus whatever the suite overrode -
+ * because the override is where this went wrong, not the shared file. Throws
+ * rather than warning: a fleet configured this way produces a green suite that
+ * has stopped testing its property, which is worse than no run.
+ *
+ * Over production's ratio is fine and is not flagged. A suite may deliberately
+ * leave a knob uncompressed, and a step longer than it needs only costs time.
+ * UNDER is the failure, because that is where the property inverts.
+ * @param {object} fluxapps Effective fluxapps config for the fleet.
+ * @throws {Error} When a ratio is below production's.
+ */
+export function assertCoupledRatios(fluxapps) {
+  if (!fluxapps || !fluxapps.residentialQueueStepMs) return;
+  const blockCost = harnessBlockCostMs(fluxapps);
+  const pass = giveUpPassMs(fluxapps, blockCost);
+  const ratio = fluxapps.residentialQueueStepMs / pass;
+  const required = productionQueueRatio();
+  if (ratio >= required) return;
+  throw new Error(
+    'coupled-knobs: residentialQueueStepMs is too short for this fleet\'s give-up pass.\n'
+    + `  pass    ${Math.round(pass)}ms  (removeFluxAppsPeriod ${fluxapps.removeFluxAppsPeriod}`
+    + ` x ${PON_SPEED_MULTIPLIER} blocks, each costing ${Math.round(blockCost)}ms`
+    + ` at explorerPollIntervalMs ${fluxapps.explorerPollIntervalMs})\n`
+    + `  step    ${fluxapps.residentialQueueStepMs}ms  -> ratio ${ratio.toFixed(2)}\n`
+    + `  needed  ${Math.round(pass * required)}ms  -> production's ratio ${required.toFixed(2)}\n`
+    + '  Two holders of one app mature on the same pass at this ratio and both hand it\n'
+    + '  back. Use derivedQueueStepMs(fluxapps) rather than a literal.',
+  );
+}

--- a/test-infra/runner/framework/coupled-knobs.js
+++ b/test-infra/runner/framework/coupled-knobs.js
@@ -117,6 +117,26 @@ export function derivedQueueStepMs(fluxapps) {
 }
 
 /**
+ * The departure interval a suite should use, derived rather than chosen.
+ *
+ * A node inside its departure interval records nothing against its queue
+ * tickets, so the block has to read afterwards as a gap the ticket will not
+ * carry across - otherwise a departure stops restarting the queue and position
+ * separates the first departure and nothing after it. Bounded by what it must
+ * OUTLIVE rather than by production's ratio, the same way the boot-drift rule
+ * below is: the ticket's tolerance is MAX_TICKET_GAP_MS, which IS the queue
+ * step. One extra pass on top, so the restart cannot land ambiguously on the
+ * pass grid.
+ * @param {{removeFluxAppsPeriod: number, explorerPollIntervalMs: number, residentialQueueStepMs: number}} fluxapps
+ * @returns {number} residentialEvacuationIntervalMs, in milliseconds.
+ */
+export function derivedEvacuationIntervalMs(fluxapps) {
+  const pass = giveUpPassMs(fluxapps, harnessBlockCostMs(fluxapps));
+  const step = fluxapps.residentialQueueStepMs ?? derivedQueueStepMs(fluxapps);
+  return Math.ceil((step + pass) / 1000) * 1000;
+}
+
+/**
  * Refuse to boot a fleet whose coupled knobs do not hold production's ratios.
  *
  * Runs on the EFFECTIVE config - shared.js plus whatever the suite overrode -
@@ -163,6 +183,41 @@ export function assertSigtermOrdering(fluxapps) {
 }
 
 /**
+ * Refuse to boot a fleet whose departure interval is shorter than the gap its
+ * queue tickets tolerate.
+ *
+ * mayEvacuateApp records nothing while the interval gate is refusing, so the
+ * block is meant to read afterwards as one long gap and restart every ticket.
+ * That is what keeps position binding on the SECOND departure and every one
+ * after it. Compress the interval below the step and the block stops looking
+ * like a gap: tickets carry straight across it, every app is instantly ready
+ * the moment the block clears, and two holders whose blocks expire in the same
+ * pass hand back the same app together - the same defect a too-short step
+ * causes, through the other door, and just as invisible to a green suite.
+ *
+ * Production holds 6h against a 40min step, ~9x. The bound here is 1x plus a
+ * pass, because this pair is fixed by what it must outlive rather than by a
+ * ratio anyone reasoned about.
+ * @param {object} fluxapps Effective fluxapps config for the fleet.
+ * @throws {Error} When the interval does not outlive the ticket gap.
+ */
+export function assertDepartureOutlivesTicket(fluxapps) {
+  const interval = fluxapps.residentialEvacuationIntervalMs;
+  if (!interval) return;
+  const required = derivedEvacuationIntervalMs(fluxapps);
+  if (interval >= required) return;
+  throw new Error(
+    'coupled-knobs: residentialEvacuationIntervalMs does not outlive the queue ticket.\n'
+    + `  interval ${interval}ms\n`
+    + `  step     ${fluxapps.residentialQueueStepMs}ms  (this IS the ticket's gap tolerance)\n`
+    + `  needed   ${required}ms  -> step + one give-up pass\n`
+    + '  Below this a departure no longer restarts the other holders\' tickets, so position\n'
+    + '  separates the first departure and nothing after it. Use\n'
+    + '  derivedEvacuationIntervalMs(fluxapps) rather than a literal.',
+  );
+}
+
+/**
  * Every coupled-knob rule this harness enforces, in one call.
  * @param {object} fluxapps Effective fluxapps config for the fleet.
  * @throws {Error} When any relationship does not hold.
@@ -171,6 +226,7 @@ export function assertCoupledRatios(fluxapps) {
   if (!fluxapps) return;
   assertSigtermOrdering(fluxapps);
   if (!fluxapps.residentialQueueStepMs) return;
+  assertDepartureOutlivesTicket(fluxapps);
   const blockCost = harnessBlockCostMs(fluxapps);
   const pass = giveUpPassMs(fluxapps, blockCost);
   const ratio = fluxapps.residentialQueueStepMs / pass;

--- a/test-infra/runner/framework/coupled-knobs.js
+++ b/test-infra/runner/framework/coupled-knobs.js
@@ -47,7 +47,16 @@ export const PRODUCTION = Object.freeze({
   removeFluxAppsPeriod: 11,
   residentialQueueBaseMs: 30 * 60 * 1000,
   residentialQueueStepMs: 40 * 60 * 1000,
+  locationTtlS: 7500,
+  sigtermExpiryS: 420,
 });
+
+// What one node boot costs, measured: a suite-19 fixture pinning 300s of
+// downtime was read by the node as 316s, on cindy under a MAXN=6 gate - so this
+// is a loaded figure, not an idle-box one. Any window a fixture has to be
+// measured INSIDE must clear it with room, because the boot lands in the middle
+// of the measurement and no ratio shrinks it.
+export const BOOT_DRIFT_MS = 16000;
 
 // explorerService.js:610. Applies to both sides, so it cancels out of the
 // ratio - named anyway, because the pass interval is not readable without it.
@@ -121,8 +130,47 @@ export function derivedQueueStepMs(fluxapps) {
  * @param {object} fluxapps Effective fluxapps config for the fleet.
  * @throws {Error} When a ratio is below production's.
  */
+export function assertSigtermOrdering(fluxapps) {
+  const sigtermMs = (fluxapps.sigtermExpiryS ?? PRODUCTION.sigtermExpiryS) * 1000;
+  const runningMs = (fluxapps.locationTtlS ?? PRODUCTION.locationTtlS) * 1000;
+
+  // appStartupManager: (cleanShutdown && downtime > sigterm) || downtime >
+  // running. Above the running expiry this window is unreachable and a clean
+  // shutdown gets no grace, which is the opposite of what it is for. Production
+  // holds 420s under 7500s.
+  if (sigtermMs >= runningMs) {
+    throw new Error(
+      'coupled-knobs: sigtermExpiryS is not below locationTtlS.\n'
+      + `  sigterm ${sigtermMs}ms, running ${runningMs}ms\n`
+      + '  appStartupManager expires on (cleanShutdown && downtime > sigterm) || downtime >\n'
+      + '  running, so at this ordering the running expiry fires first and the clean-shutdown\n'
+      + '  grace can never be reached.',
+    );
+  }
+
+  // A fixture asserting "within the window" is measured across a node boot, and
+  // the boot lands inside the measurement. A window at or under the drift can
+  // never be tested from the inside, whatever the fixture pins.
+  if (sigtermMs <= BOOT_DRIFT_MS) {
+    throw new Error(
+      'coupled-knobs: sigtermExpiryS is at or below one node boot.\n'
+      + `  sigterm ${sigtermMs}ms, measured boot drift ${BOOT_DRIFT_MS}ms\n`
+      + '  A fixture pinning any downtime is read by the node as that downtime PLUS a boot,\n'
+      + '  so nothing can land inside this window. It is bounded by what it must outlive,\n'
+      + '  not by production\'s ratio - a boot is not a compressed clock.',
+    );
+  }
+}
+
+/**
+ * Every coupled-knob rule this harness enforces, in one call.
+ * @param {object} fluxapps Effective fluxapps config for the fleet.
+ * @throws {Error} When any relationship does not hold.
+ */
 export function assertCoupledRatios(fluxapps) {
-  if (!fluxapps || !fluxapps.residentialQueueStepMs) return;
+  if (!fluxapps) return;
+  assertSigtermOrdering(fluxapps);
+  if (!fluxapps.residentialQueueStepMs) return;
   const blockCost = harnessBlockCostMs(fluxapps);
   const pass = giveUpPassMs(fluxapps, blockCost);
   const ratio = fluxapps.residentialQueueStepMs / pass;

--- a/test-infra/runner/framework/coupled-knobs.js
+++ b/test-infra/runner/framework/coupled-knobs.js
@@ -111,6 +111,15 @@ export function productionQueueRatio() {
  * @param {{removeFluxAppsPeriod: number, explorerPollIntervalMs: number}} fluxapps
  * @returns {number} residentialQueueStepMs, in milliseconds.
  */
+// How many queue steps a ticket tolerates going unobserved before it starts
+// again. Mirrors MAX_TICKET_GAP_MS in residentialNodeDosService: a gap has to
+// mean a pass was MISSED, and one step is only 1.82 passes - so at one step a
+// single late pass restarts the ticket. Production hardly notices; the harness
+// compresses the same ratio to about 30 seconds, where six fleets booting at
+// once make a late pass ordinary, and the ticket then never matures at all.
+// Absolute jitter does not compress with the clocks.
+export const TICKET_GAP_STEPS = 2;
+
 export function derivedQueueStepMs(fluxapps) {
   const pass = giveUpPassMs(fluxapps, harnessBlockCostMs(fluxapps));
   return Math.ceil((pass * productionQueueRatio()) / 1000) * 1000;
@@ -133,7 +142,31 @@ export function derivedQueueStepMs(fluxapps) {
 export function derivedEvacuationIntervalMs(fluxapps) {
   const pass = giveUpPassMs(fluxapps, harnessBlockCostMs(fluxapps));
   const step = fluxapps.residentialQueueStepMs ?? derivedQueueStepMs(fluxapps);
-  return Math.ceil((step + pass) / 1000) * 1000;
+  return Math.ceil(((step * TICKET_GAP_STEPS) + pass) / 1000) * 1000;
+}
+
+/**
+ * How long ONE departure takes end to end, for a suite that has to wait for it.
+ *
+ * A departure is not just the removal. The node serves its departure interval,
+ * and then serves its queue ticket AGAIN from scratch - the interval reads as a
+ * gap and restarts it, which is the point of the interval - and the ticket is
+ * base plus position times step, the worst position being one short of the
+ * instance count.
+ *
+ * Derived because it MOVED. Suite 55's waits were four minutes against a
+ * four-second interval; the interval is now tens of seconds, and a hand-typed
+ * four minutes quietly stopped covering a single departure. A wait is as coupled
+ * to the pacing as the step is to the pass, and belongs here for the same reason.
+ * @param {object} fluxapps Effective fluxapps config for the fleet.
+ * @param {number} instances How many instances the app under test carries.
+ * @returns {number} Milliseconds one departure can take, at the worst position.
+ */
+export function departureCycleMs(fluxapps, instances) {
+  const step = fluxapps.residentialQueueStepMs ?? derivedQueueStepMs(fluxapps);
+  const base = fluxapps.residentialQueueBaseMs ?? PRODUCTION.residentialQueueBaseMs;
+  const interval = fluxapps.residentialEvacuationIntervalMs ?? derivedEvacuationIntervalMs(fluxapps);
+  return interval + base + (Math.max(instances - 1, 0) * step);
 }
 
 /**
@@ -209,8 +242,8 @@ export function assertDepartureOutlivesTicket(fluxapps) {
   throw new Error(
     'coupled-knobs: residentialEvacuationIntervalMs does not outlive the queue ticket.\n'
     + `  interval ${interval}ms\n`
-    + `  step     ${fluxapps.residentialQueueStepMs}ms  (this IS the ticket's gap tolerance)\n`
-    + `  needed   ${required}ms  -> step + one give-up pass\n`
+    + `  step     ${fluxapps.residentialQueueStepMs}ms  x ${TICKET_GAP_STEPS} = the ticket's gap tolerance\n`
+    + `  needed   ${required}ms  -> that tolerance plus one give-up pass\n`
     + '  Below this a departure no longer restarts the other holders\' tickets, so position\n'
     + '  separates the first departure and nothing after it. Use\n'
     + '  derivedEvacuationIntervalMs(fluxapps) rather than a literal.',

--- a/test-infra/runner/framework/daemon-control.js
+++ b/test-infra/runner/framework/daemon-control.js
@@ -1,4 +1,5 @@
 import { getSubnetConfig } from './subnet-config.js';
+import { loadSharedConfig } from './coupled-knobs.js';
 
 const CONTROL = process.env.DAEMON_CONTROL || `http://${getSubnetConfig().daemon}:18232`;
 
@@ -46,6 +47,78 @@ export async function advanceBlocks(count) {
     // eslint-disable-next-line no-await-in-loop
     await advanceBlock();
   }
+}
+
+/**
+ * Drive the chain until a condition holds, at a stated RATE, up to a stated
+ * deadline.
+ *
+ * Two reasons to drive rather than let the ticker free-run:
+ *
+ * The ticker produces blocks on the same period the explorer polls on, so the
+ * node learns about them in bursts and processes a burst back to back - and only
+ * the last block of a burst is still the chain tip. FluxOS runs its app
+ * maintenance, the give-up pass included, only for a block that was the tip and
+ * only on every Nth block, so whether the pass runs at all comes down to which
+ * parity the race settles on. Suite 96 asserted that nothing had happened after
+ * a 24-block burst and was right for the wrong reason: the pass had run once
+ * across five nodes, so there was nothing for the assertion to have caught.
+ *
+ * And these waits are WALL-CLOCK. A node's queue ticket is real time, so a
+ * budget counted in blocks means nothing: the deadline is therefore in
+ * milliseconds. The chain's actual rate is not this function's to set - a block
+ * is not processed until the node's next explorer poll, so
+ * `explorerPollIntervalMs` is the floor, and that floor is what fixes how long a
+ * give-up pass takes in wall-clock, which is what the queue step has to outlast.
+ * Changing one without the other is what quietly deletes the ordering those
+ * tests exist to check.
+ *
+ * THE RATE IS THE NODE'S POLL, not something faster. Driving four blocks per
+ * poll produces four times the work for the same pass cadence: a height only
+ * counts when it lands as the tip, tips arrive one per poll, and the pass comes
+ * every `removeFluxAppsPeriod x N` polls whatever rate this drives at. The extra
+ * blocks are pure load. At 200ms one suite drove about a thousand blocks per
+ * wait, held a runner slot for the full 1800s wall clock and starved the box:
+ * two unrelated suites ran 3-4x slower in the same gate and hit that wall
+ * themselves.
+ *
+ * @param {object} node The node client to pace against - the one whose
+ *   `block:processed` decides when the next block may be sent. A CLIENT, not an
+ *   index: the two suites that grew this independently disagreed about whether
+ *   the index was 0- or 1-based, which is not a mistake worth leaving available.
+ * @param {Function} condition Async predicate; driving stops when it holds.
+ * @param {object} opts
+ * @param {number} opts.timeoutMs How long to keep driving before giving up.
+ * @param {number} [opts.blockIntervalMs] Minimum wall-clock between blocks.
+ * @param {string} [opts.label] What the caller was waiting for, for the error.
+ * @returns {Promise<number>} Blocks driven.
+ */
+export async function driveUntil(node, condition, { timeoutMs, blockIntervalMs, label } = {}) {
+  if (!Number.isFinite(timeoutMs)) {
+    // No default. The deadline is wall-clock and every caller's is derived from
+    // something different - a departure cycle, an election cycle - so a shared
+    // default would be one suite's number silently applied to another's wait.
+    throw new Error('driveUntil: timeoutMs is required');
+  }
+  const interval = blockIntervalMs ?? loadSharedConfig().fluxapps.explorerPollIntervalMs;
+  const deadline = Date.now() + timeoutMs;
+  let blocks = 0;
+  while (Date.now() < deadline) {
+    // eslint-disable-next-line no-await-in-loop
+    if (await condition()) return blocks;
+    const startedAt = Date.now();
+    const afterId = node.getLastEventId();
+    // eslint-disable-next-line no-await-in-loop
+    await advanceBlock();
+    // eslint-disable-next-line no-await-in-loop
+    await node.waitForEvent('block:processed', () => true, 60000, { afterId });
+    blocks += 1;
+    const spent = Date.now() - startedAt;
+    // eslint-disable-next-line no-await-in-loop
+    if (spent < interval) await new Promise((resolve) => { setTimeout(resolve, interval - spent); });
+  }
+  if (await condition()) return blocks;
+  throw new Error(`${label ? `${label}: ` : ''}condition not reached in ${timeoutMs}ms (${blocks} blocks driven)`);
 }
 
 export async function setHeight(height) {

--- a/test-infra/runner/framework/daemon-control.js
+++ b/test-infra/runner/framework/daemon-control.js
@@ -157,6 +157,20 @@ export async function setNodeTier(ip, tier) {
   return post(`/node-tier/${ip}`, { tier });
 }
 
+// -- ArcaneOS attestation --
+
+/**
+ * Set whether a node's benchmark reports it as attested (ArcaneOS). Nodes are
+ * attested by default, so only a suite that cares has to say anything.
+ */
+export async function setSystemSecure(ip, secure) {
+  return post(`/system-secure/${ip}`, { secure });
+}
+
+export async function clearSystemSecure() {
+  return del('/system-secure');
+}
+
 // -- RPC failure --
 
 export async function enableRpcFailure(ip) {

--- a/test-infra/runner/framework/db-client.js
+++ b/test-infra/runner/framework/db-client.js
@@ -195,36 +195,6 @@ export function dbClient(nodeNum) {
       );
     },
 
-    async seedGeolocation(ip) {
-      const localDb = await db('local');
-      await localDb.collection('geolocation').updateOne(
-        { _id: 'nodeGeolocation' },
-        {
-          $set: {
-            geolocation: {
-              ip,
-              continent: 'Europe',
-              continentCode: 'EU',
-              country: 'Germany',
-              countryCode: 'DE',
-              region: 'HE',
-              regionName: 'Hesse',
-              lat: 50.1109,
-              lon: 8.6821,
-              org: 'Test Network',
-              static: true,
-              dataCenter: true,
-            },
-            staticIp: true,
-            dataCenter: true,
-            lastIpChangeDate: null,
-            updatedAt: Date.now(),
-          },
-        },
-        { upsert: true },
-      );
-    },
-
     async seedAppHash(hash, height, resolved = false) {
       const explorerDb = await db('explorer');
       await explorerDb.collection('zelappshashes').insertOne({
@@ -346,15 +316,6 @@ export function dbClient(nodeNum) {
         broadcastedAt: new Date(ts),
         expireAt: new Date(ts + 24 * 60 * 60 * 1000),
       });
-    },
-
-    async dropAndReseed(ip, height) {
-      const client = await getClient();
-      for (const name of Object.values(dbNames)) {
-        await client.db(name).dropDatabase();
-      }
-      await this.seedScannedHeight(height);
-      await this.seedGeolocation(ip);
     },
 
     async failpointFind(collection, { times = 1, errorCode = 50 } = {}) {

--- a/test-infra/runner/framework/db-client.js
+++ b/test-infra/runner/framework/db-client.js
@@ -136,11 +136,19 @@ export function dbClient(nodeNum) {
       return localDb.collection('nodestartuptracker').findOne({ _id: 'residentialDos' });
     },
 
-    async setResidentialSince(since) {
+    // Serve the settling window without waiting it out.
+    //
+    // The gate counts time the node OBSERVED the verdict, not time that passed,
+    // so backdating residentialSince alone no longer serves it - that field is
+    // kept for the operator reading the record. observedMs is what the node
+    // compares against residentialSettleMs, and lastConfirmedAt is set to now so
+    // the node's next tick credits nothing on top and the total stays put.
+    async serveSettleWindow(observedMs = 48 * 60 * 60 * 1000) {
       const localDb = await db('local');
+      const now = Date.now();
       await localDb.collection('nodestartuptracker').updateOne(
         { _id: 'residentialDos' },
-        { $set: { residentialSince: since } },
+        { $set: { residentialSince: now - observedMs, lastConfirmedAt: now, observedMs } },
         { upsert: true },
       );
     },

--- a/test-infra/runner/framework/db-client.js
+++ b/test-infra/runner/framework/db-client.js
@@ -301,6 +301,23 @@ export function dbClient(nodeNum) {
       await globalDb.collection('appstateevents').insertOne(event);
     },
 
+    /**
+     * The same, for a whole set, in ONE round trip.
+     *
+     * These events carry `broadcastedAt`, and the window that accepts them is
+     * real - messageStore refuses a broadcast older than locationTtlS, which the
+     * harness compresses to 63s. Seeding a few hundred of them an insertOne at a
+     * time costs more wall-clock than the window itself, so the events expire
+     * during their own seeding and the suite reads an empty location list rather
+     * than a rejected message. Ordered, because a suite that seeds two broadcasts
+     * from one node is usually proving which of them wins.
+     */
+    async seedAppStateEvents(events) {
+      if (!events.length) return;
+      const globalDb = await db('appsGlobal');
+      await globalDb.collection('appstateevents').insertMany(events, { ordered: true });
+    },
+
     async seedLocalApp(spec) {
       const localDb = await db('appsLocal');
       await localDb.collection('zelappsinformation').insertOne(spec);

--- a/test-infra/runner/framework/db-client.js
+++ b/test-infra/runner/framework/db-client.js
@@ -128,6 +128,23 @@ export function dbClient(nodeNum) {
       return cpDb.collection('chainmessages').find({}).toArray();
     },
 
+    // residentialNodeDosService's settling window. Persisted so that restarting
+    // FluxOS cannot restart the clock; a suite reads it to tell "held" from
+    // "evacuating", and writes it to put the window in the past.
+    async residentialMarker() {
+      const localDb = await db('local');
+      return localDb.collection('nodestartuptracker').findOne({ _id: 'residentialDos' });
+    },
+
+    async setResidentialSince(since) {
+      const localDb = await db('local');
+      await localDb.collection('nodestartuptracker').updateOne(
+        { _id: 'residentialDos' },
+        { $set: { residentialSince: since } },
+        { upsert: true },
+      );
+    },
+
     async geolocation() {
       const localDb = await db('local');
       return localDb.collection('geolocation').findOne({ _id: 'nodeGeolocation' });

--- a/test-infra/runner/framework/fdm-control.js
+++ b/test-infra/runner/framework/fdm-control.js
@@ -1,11 +1,12 @@
 // Drives the FDM stub (test-infra/fdm-stub) that masterSlaveApps polls for the
 // elected g: primary. Default host matches test-env's FDM_IP/control port.
 import { getSubnetConfig } from './subnet-config.js';
+import { controlFetch } from './control-fetch.js';
 
 const CONTROL = process.env.FDM_CONTROL || `http://${getSubnetConfig().fdm}:16131`;
 
 async function post(path, body) {
-  const res = await fetch(`${CONTROL}${path}`, {
+  const res = await controlFetch(`${CONTROL}${path}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: body != null ? JSON.stringify(body) : undefined,
@@ -14,7 +15,7 @@ async function post(path, body) {
 }
 
 async function get(path) {
-  const res = await fetch(`${CONTROL}${path}`);
+  const res = await controlFetch(`${CONTROL}${path}`);
   return res.json();
 }
 

--- a/test-infra/runner/framework/g-app-placement.js
+++ b/test-infra/runner/framework/g-app-placement.js
@@ -1,0 +1,89 @@
+// Where a `g:` app's writer ends up, and how a suite arranges for it to end up
+// somewhere in particular.
+//
+// TWO ORDERINGS decide what a g: app looks like on a fleet, and different things
+// set them:
+//
+//   the WRITER   the holder that gets the writable folder at a cold start and
+//                runs the component. It is the LOWEST IP among the holders - the
+//                syncthing state machine's designated leader - and the election
+//                does not choose it.
+//   the ORDER    runningSince ascending, which records the order the holders
+//                were PLACED. masterSlaveApps ranks its senior end; the surplus
+//                rule and the evacuation queue rank its junior end.
+//
+// ELECTING A MASTER DOES NOT MOVE THE WRITER. FDM reports which node is primary;
+// it does not start containers, and the election refuses to start a second
+// writer while a peer is running one - the split-brain guard. A suite that wants
+// the writer in a particular position must PLACE the holders so it lands there,
+// and suite 96 spent three minutes of its first run waiting on a container that
+// was never going to start because it tried to elect one instead.
+//
+// Owned here because three suites depend on this and each used to restate it in
+// its own words, hand-deriving a placement order from it. A fact written down in
+// three places is a fact that drifts in two of them.
+//
+// Pure, and deliberately dependent on nothing but the subnet layout, so the
+// orders it produces are unit-testable without a fleet.
+
+import { getSubnetConfig } from './subnet-config.js';
+
+const defaultIpOf = (index) => getSubnetConfig().nodeIp(index + 1);
+
+/**
+ * Numeric IP ordering. A lexical compare puts `.10` before `.9`, which is the
+ * kind of thing that is right for every fixture anyone happens to write and
+ * wrong for the first one that spans the boundary.
+ * @param {string} a Dotted-quad address.
+ * @param {string} b Dotted-quad address.
+ * @returns {number} Comparator result.
+ */
+function compareIps(a, b) {
+  const left = a.split('.').map(Number);
+  const right = b.split('.').map(Number);
+  for (let i = 0; i < Math.max(left.length, right.length); i += 1) {
+    const diff = (left[i] ?? 0) - (right[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+/**
+ * Which holder will seed the folder, and therefore run the g: component.
+ * @param {number[]} holders Node indices holding the app.
+ * @param {Function} [ipOf] Index to address, injectable for tests.
+ * @returns {number} The seeding holder's node index.
+ */
+export function syncthingSeedIndex(holders, ipOf = defaultIpOf) {
+  if (!Array.isArray(holders) || !holders.length) {
+    throw new Error('syncthingSeedIndex: holders must be a non-empty array of node indices');
+  }
+  return [...holders].sort((a, b) => compareIps(ipOf(a), ipOf(b)))[0];
+}
+
+/**
+ * A placement order that lands the seed at a chosen position in the instance
+ * order - which is the same thing as its election index, because both are
+ * runningSince ascending and placement is what sets runningSince.
+ *
+ * Position 0 is the SENIOR end (first placed, lowest election index); the last
+ * position is the newest copy, which is the one the surplus rule and the
+ * evacuation queue pick first.
+ * @param {number[]} holders Node indices holding the app.
+ * @param {number} seedPosition Where the seed should land, 0-based.
+ * @param {Function} [ipOf] Index to address, injectable for tests.
+ * @returns {number[]} Placement order for placeGAppInOrder.
+ */
+export function placementOrderWithSeedAt(holders, seedPosition, ipOf = defaultIpOf) {
+  const seed = syncthingSeedIndex(holders, ipOf);
+  if (!Number.isInteger(seedPosition) || seedPosition < 0 || seedPosition >= holders.length) {
+    // Thrown rather than clamped: a position off the end means the caller has a
+    // different fleet in mind than the one it is describing, and clamping would
+    // hand it a plausible order for the wrong shape.
+    throw new Error(
+      `placementOrderWithSeedAt: seedPosition ${seedPosition} is outside 0..${holders.length - 1}`,
+    );
+  }
+  const others = holders.filter((index) => index !== seed);
+  return [...others.slice(0, seedPosition), seed, ...others.slice(seedPosition)];
+}

--- a/test-infra/runner/framework/node-client.js
+++ b/test-infra/runner/framework/node-client.js
@@ -249,6 +249,8 @@ export function nodeClient(nodeNum) {
         'reconciler:desiredChanged',
         'app:operatorIntent',
         'reconciler:swept',
+        'giveUp:considered',
+        'giveUp:safety',
       ]) {
         eventSource.addEventListener(name, (e) => {
           const entry = {

--- a/test-infra/runner/framework/node-client.js
+++ b/test-infra/runner/framework/node-client.js
@@ -251,6 +251,7 @@ export function nodeClient(nodeNum) {
         'reconciler:swept',
         'giveUp:considered',
         'giveUp:safety',
+        'spawner:noCandidates',
       ]) {
         eventSource.addEventListener(name, (e) => {
           const entry = {

--- a/test-infra/runner/framework/node-client.js
+++ b/test-infra/runner/framework/node-client.js
@@ -254,15 +254,15 @@ export function nodeClient(nodeNum) {
         'giveUp:safety',
         'giveUp:standDown',
         'residential:decided',
-        // NOT subscribed: 'spawner:noCandidates'. Zero candidates is the steady
-        // state of any fleet whose apps are all at their instance count, and at
-        // spawnDelayMultiplier 0.002 it fires roughly every 240ms per node. The
-        // eventBuffer below is an unbounded array that waitForEvent
-        // linear-scans on every call, and FluxOS's replay ring is 1024 entries,
-        // so subscribing shrank the Last-Event-ID window a reconnect can replay
-        // from most of a suite to about four minutes - and no suite waits on it.
-        // waitForNoCandidates in wait.js stays, so re-adding the name here is
-        // all a suite that wants it has to do.
+        // spawner:noCandidates USED to be published here and was not subscribed:
+        // it fires on every pass of a fleet whose apps are all at their instance
+        // count, roughly every 240ms per node, and subscribing shrank the
+        // Last-Event-ID replay window from most of a suite to about four minutes.
+        // An event nothing could afford to receive is not a telemetry surface, so
+        // it is a counter now, and this is the fact it was standing in for: the
+        // pass over an app CHANGING - excluded becoming a candidate, or the
+        // reverse. That happens rarely, which is what makes it an event.
+        'spawner:candidacy',
       ]) {
         eventSource.addEventListener(name, (e) => {
           const entry = {

--- a/test-infra/runner/framework/node-client.js
+++ b/test-infra/runner/framework/node-client.js
@@ -251,6 +251,7 @@ export function nodeClient(nodeNum) {
         'reconciler:swept',
         'giveUp:considered',
         'giveUp:safety',
+        'residential:decided',
         // NOT subscribed: 'spawner:noCandidates'. Zero candidates is the steady
         // state of any fleet whose apps are all at their instance count, and at
         // spawnDelayMultiplier 0.002 it fires roughly every 240ms per node. The

--- a/test-infra/runner/framework/node-client.js
+++ b/test-infra/runner/framework/node-client.js
@@ -251,7 +251,15 @@ export function nodeClient(nodeNum) {
         'reconciler:swept',
         'giveUp:considered',
         'giveUp:safety',
-        'spawner:noCandidates',
+        // NOT subscribed: 'spawner:noCandidates'. Zero candidates is the steady
+        // state of any fleet whose apps are all at their instance count, and at
+        // spawnDelayMultiplier 0.002 it fires roughly every 240ms per node. The
+        // eventBuffer below is an unbounded array that waitForEvent
+        // linear-scans on every call, and FluxOS's replay ring is 1024 entries,
+        // so subscribing shrank the Last-Event-ID window a reconnect can replay
+        // from most of a suite to about four minutes - and no suite waits on it.
+        // waitForNoCandidates in wait.js stays, so re-adding the name here is
+        // all a suite that wants it has to do.
       ]) {
         eventSource.addEventListener(name, (e) => {
           const entry = {

--- a/test-infra/runner/framework/node-client.js
+++ b/test-infra/runner/framework/node-client.js
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'node:events';
+import { controlFetch } from './control-fetch.js';
 import { EventSource } from 'eventsource';
 import { getSubnetConfig } from './subnet-config.js';
 import { infraDeathError, offInfraDeath, onInfraDeath } from './infra-death.js';
@@ -11,18 +12,18 @@ export function nodeClient(nodeNum) {
   let url = `http://${ip}:16127`;
 
   async function get(path) {
-    const res = await fetch(`${url}${path}`);
+    const res = await controlFetch(`${url}${path}`);
     return res.json();
   }
 
   async function getAuthed(path, zelidauth) {
-    const res = await fetch(`${url}${path}`, { headers: { zelidauth } });
+    const res = await controlFetch(`${url}${path}`, { headers: { zelidauth } });
     return res.json();
   }
 
   async function post(path, body, headers = {}) {
     const contentType = headers['Content-Type'] ?? 'application/json';
-    const res = await fetch(`${url}${path}`, {
+    const res = await controlFetch(`${url}${path}`, {
       method: 'POST',
       headers: { 'Content-Type': contentType, ...headers },
       body: JSON.stringify(body),
@@ -44,7 +45,7 @@ export function nodeClient(nodeNum) {
       init.headers['Content-Type'] = headers['Content-Type'] ?? 'application/json';
       init.body = JSON.stringify(body);
     }
-    const res = await fetch(`${url}${path}`, init);
+    const res = await controlFetch(`${url}${path}`, init);
     const text = await res.text();
     let data = text;
     try {
@@ -56,7 +57,7 @@ export function nodeClient(nodeNum) {
   }
 
   async function del(path, zelidauth) {
-    const res = await fetch(`${url}${path}`, {
+    const res = await controlFetch(`${url}${path}`, {
       method: 'DELETE',
       headers: zelidauth ? { zelidauth } : {},
     });
@@ -91,7 +92,7 @@ export function nodeClient(nodeNum) {
     // Content-Type is deliberately not set: fetch fills it in with the
     // multipart boundary it generated, and overriding it produces a body no
     // parser can read.
-    const res = await fetch(`${url}${path}`, { method: 'POST', headers, body: form });
+    const res = await controlFetch(`${url}${path}`, { method: 'POST', headers, body: form });
     return { status: res.status, body: await res.text() };
   }
 
@@ -136,7 +137,7 @@ export function nodeClient(nodeNum) {
       },
     });
 
-    const res = await fetch(`${url}${path}`, {
+    const res = await controlFetch(`${url}${path}`, {
       method: 'POST',
       headers: { ...headers, 'Content-Type': `multipart/form-data; boundary=${boundary}` },
       body,
@@ -420,7 +421,7 @@ export function nodeClient(nodeNum) {
     // body as text; resolves when the install stream ends. Confirm completion via
     // the app:installed event (waitForAppInstalled).
     installAppLocally: async (appname, zelidauth) => {
-      const res = await fetch(`${url}/apps/installapplocally/${appname}`, { headers: { zelidauth } });
+      const res = await controlFetch(`${url}/apps/installapplocally/${appname}`, { headers: { zelidauth } });
       return res.text();
     },
     // Backup/restore drive the whole-app lease (B1). The endpoints stream chunked
@@ -431,7 +432,7 @@ export function nodeClient(nodeNum) {
     appendBackupTask: async (appname, components, zelidauth, { force = false } = {}) => {
       const body = { appname, backup: components.map((component) => ({ component, backup: true })) };
       if (force) body.force = true;
-      const res = await fetch(`${url}/apps/appendbackuptask`, {
+      const res = await controlFetch(`${url}/apps/appendbackuptask`, {
         method: 'POST',
         headers: { zelidauth, 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
@@ -439,7 +440,7 @@ export function nodeClient(nodeNum) {
       return res.text();
     },
     appendRestoreTask: async (appname, restore, type, zelidauth, { force = false } = {}) => {
-      const res = await fetch(`${url}/apps/appendrestoretask`, {
+      const res = await controlFetch(`${url}/apps/appendrestoretask`, {
         method: 'POST',
         headers: { zelidauth, 'Content-Type': 'application/json' },
         // force is API-only by design - the UI cannot send it - so a suite is the

--- a/test-infra/runner/framework/node-client.js
+++ b/test-infra/runner/framework/node-client.js
@@ -251,6 +251,7 @@ export function nodeClient(nodeNum) {
         'reconciler:swept',
         'giveUp:considered',
         'giveUp:safety',
+        'giveUp:standDown',
         'residential:decided',
         // NOT subscribed: 'spawner:noCandidates'. Zero candidates is the steady
         // state of any fleet whose apps are all at their instance count, and at

--- a/test-infra/runner/framework/reconciler-suite.js
+++ b/test-infra/runner/framework/reconciler-suite.js
@@ -150,6 +150,30 @@ export async function placeGAppInOrder(env, app, {
     await waitForReconcileActuated(env.clients[i], identifier, 'dataCleared', 60000, { afterId: installAfter });
     // eslint-disable-next-line no-await-in-loop
     await seedSyncScopedData(env, app.spec.name, i);
+
+    // WAITED FOR, not slept past. The ordering these placements exist to create
+    // is the runningSince stamps, and a fixed gap produces it only while every
+    // install finishes inside the gap. Under a parallel gate they do not: suite
+    // 96 lost a run to a holder that registered after the next one had already
+    // been placed, so "the newest copy" named a different node than the fixture
+    // had arranged and the suite refused on its own precondition.
+    //
+    // Registration is the fact the order is ranked on, so waiting for it makes
+    // the order what the caller asked for at any speed. The gap below stays: it
+    // separates two stamps that would otherwise land in the same millisecond and
+    // fall through to the ip tiebreak.
+    // eslint-disable-next-line no-await-in-loop
+    await waitFor(async () => {
+      const res = await env.clients[i].getAppLocations(app.spec.name);
+      if (res?.status !== 'success' || !Array.isArray(res.data)) return false;
+      const mine = getSubnetConfig().nodeIp(i + 1);
+      return res.data.some((location) => location.ip.split(':')[0] === mine);
+    }, {
+      timeout: 120000,
+      interval: 1000,
+      label: `holder ${i} registered before the next is placed`,
+    });
+
     // eslint-disable-next-line no-await-in-loop
     await sleepUnlessInfraDead(gapMs);
   }

--- a/test-infra/runner/framework/reconciler-suite.js
+++ b/test-infra/runner/framework/reconciler-suite.js
@@ -424,6 +424,15 @@ export async function waitForInstanceCount(env, appName, target, {
 // holds the data its index claims (see seedSyncScopedData). Whether/when to pin the
 // SUBJECT synced stays the caller's choice.
 /**
+ * DELETE THIS when flux#1784's allocateAppPort() lands in seed-helper.js.
+ *
+ * That is the same mechanism one layer down, where the builders live, and it is
+ * the one to keep: it covers every builder rather than this one caller. It does
+ * not exist on this branch yet - buildSeedableSyncthingApp still defaults to a
+ * hardcoded 31111 here - so removing this before that merges reopens the fault.
+ * On the merged tree, drop nextSeededPort and portForSeededApp and pass ports
+ * only when the caller named one; the builder's own default then allocates.
+ *
  * A port of this app's own, handed out in order.
  *
  * Counted rather than derived from the name: a hash would collide once in a

--- a/test-infra/runner/framework/reconciler-suite.js
+++ b/test-infra/runner/framework/reconciler-suite.js
@@ -423,44 +423,11 @@ export async function waitForInstanceCount(env, appName, target, {
 // then writes sync-scoped disk data, so a folder any test later pins synced already
 // holds the data its index claims (see seedSyncScopedData). Whether/when to pin the
 // SUBJECT synced stays the caller's choice.
-/**
- * DELETE THIS when flux#1784's allocateAppPort() lands in seed-helper.js.
- *
- * That is the same mechanism one layer down, where the builders live, and it is
- * the one to keep: it covers every builder rather than this one caller. It does
- * not exist on this branch yet - buildSeedableSyncthingApp still defaults to a
- * hardcoded 31111 here - so removing this before that merges reopens the fault.
- * On the merged tree, drop nextSeededPort and portForSeededApp and pass ports
- * only when the caller named one; the builder's own default then allocates.
- *
- * A port of this app's own, handed out in order.
- *
- * Counted rather than derived from the name: a hash would collide once in a
- * while and put two apps back on one port, which is the fault this exists to
- * remove - and a fault that appears occasionally is worse than one that appears
- * always. Each suite is its own process, so the count is per suite. Starts
- * clear of 31111, which suites building their own specs still use.
- */
-let nextSeededPort = 31200;
-function portForSeededApp() {
-  nextSeededPort += 1;
-  return nextSeededPort;
-}
-
 export async function seedSyncthingApp(env, {
-  name, mode = 'r', forceNonLeader = false, index = 0, port = null,
+  name, mode = 'r', forceNonLeader = false, index = 0,
 }) {
   await pushImage(name, 'v1');
-  // A port of this app's own, unless the caller names one.
-  //
-  // Every seeded syncthing app took the same default port, and forceNonLeader
-  // puts one app on a node as its subject and the next one on that same node as
-  // its peer - so two of them met on one node holding one port, and the install
-  // was refused with "already used with different application". It only showed
-  // when the first install finished registering before the second started, so
-  // the suite passed or failed on the gap between them.
-  const ports = [port ?? portForSeededApp()];
-  const app = await buildSeedableSyncthingApp({ name, mode, ports });
+  const app = await buildSeedableSyncthingApp({ name, mode });
   const folder = `flux${name}_${name}`;
   const identifier = `${name}_${name}`;
 

--- a/test-infra/runner/framework/reconciler-suite.js
+++ b/test-infra/runner/framework/reconciler-suite.js
@@ -423,11 +423,35 @@ export async function waitForInstanceCount(env, appName, target, {
 // then writes sync-scoped disk data, so a folder any test later pins synced already
 // holds the data its index claims (see seedSyncScopedData). Whether/when to pin the
 // SUBJECT synced stays the caller's choice.
+/**
+ * A port of this app's own, handed out in order.
+ *
+ * Counted rather than derived from the name: a hash would collide once in a
+ * while and put two apps back on one port, which is the fault this exists to
+ * remove - and a fault that appears occasionally is worse than one that appears
+ * always. Each suite is its own process, so the count is per suite. Starts
+ * clear of 31111, which suites building their own specs still use.
+ */
+let nextSeededPort = 31200;
+function portForSeededApp() {
+  nextSeededPort += 1;
+  return nextSeededPort;
+}
+
 export async function seedSyncthingApp(env, {
-  name, mode = 'r', forceNonLeader = false, index = 0,
+  name, mode = 'r', forceNonLeader = false, index = 0, port = null,
 }) {
   await pushImage(name, 'v1');
-  const app = await buildSeedableSyncthingApp({ name, mode });
+  // A port of this app's own, unless the caller names one.
+  //
+  // Every seeded syncthing app took the same default port, and forceNonLeader
+  // puts one app on a node as its subject and the next one on that same node as
+  // its peer - so two of them met on one node holding one port, and the install
+  // was refused with "already used with different application". It only showed
+  // when the first install finished registering before the second started, so
+  // the suite passed or failed on the gap between them.
+  const ports = [port ?? portForSeededApp()];
+  const app = await buildSeedableSyncthingApp({ name, mode, ports });
   const folder = `flux${name}_${name}`;
   const identifier = `${name}_${name}`;
 

--- a/test-infra/runner/framework/seed-helper.js
+++ b/test-infra/runner/framework/seed-helper.js
@@ -149,6 +149,7 @@ export async function buildSeedableLegacyApp({
   name,
   version = 3,
   containerData = '/appdata',
+  port = allocateAppPort(),
   // Chain-relative, same as buildSeedableApp above and for the same reason its
   // comment gives: a literal height seeds an app already expired on any suite
   // whose chain starts later, and assertAliveOnThisChain refuses it.
@@ -236,8 +237,11 @@ export async function buildSeedableLegacyApp({
 // as a log line on the nodes that refused it. Suite 68 hit this and hand-picked
 // 31111..31115 to escape it; suite 55 hit it again and lost a run to it.
 //
-// Every builder below defaults to a fresh allocation, so a suite has to go out
-// of its way to collide rather than having to remember not to.
+// Every builder in this file defaults to a fresh allocation, so a suite has to
+// go out of its way to collide rather than having to remember not to. That
+// includes every COMPONENT of a multi-component builder: buildSeedableIndexRefApp
+// pinned its second component to a literal, so suite 43 - which builds two of
+// them - gave both apps the same port and could never have placed both.
 const FIRST_APP_PORT = 31111;
 let nextAppPort = FIRST_APP_PORT;
 
@@ -451,7 +455,7 @@ export async function buildSeedableIndexRefApp({
         ...base,
         name: `${name}c1`,
         description: 'component referencing component 0 volume (index 1 -> 0)',
-        ports: [],
+        ports: [allocateAppPort()],
         containerData: '/own|0:/shared',
       },
     ];
@@ -539,7 +543,7 @@ export async function buildSeedableEnterpriseApp({
     name,
     description: 'seeded enterprise component',
     repotag: `${REGISTRY_REPO_HOST}/e2e-pause:v1`,
-    ports: [],
+    ports: [allocateAppPort()],
     domains: [''],
     environmentParameters: [],
     commands: [],

--- a/test-infra/runner/framework/seed-helper.js
+++ b/test-infra/runner/framework/seed-helper.js
@@ -57,7 +57,7 @@ export async function buildSeedableApp({
       // pull over live internet (rate-limit flakes); the env registry is
       // seeded with this image at bootstrap (test-env.js)
       repotag: `${REGISTRY_REPO_HOST}/e2e-pause:v1`,
-      ports: [],
+      ports: [allocateAppPort()],
       domains: [''],
       environmentParameters: [],
       commands: [],
@@ -227,10 +227,36 @@ export async function buildSeedableLegacyApp({
  * Pass `sibling: true` to add a plain (non-synced) component so a test can prove
  * the decider only acts on the g:/r: component and leaves siblings running.
  */
+// App ports are ALLOCATED, never chosen.
+//
+// A node refuses to install a second app on a port it already serves - "port
+// already used with different application" - so two apps sharing a number can
+// never both be placed on one fleet. The second silently stalls at one instance
+// while the suite waits for it to spread, and the install failure surfaces only
+// as a log line on the nodes that refused it. Suite 68 hit this and hand-picked
+// 31111..31115 to escape it; suite 55 hit it again and lost a run to it.
+//
+// Every builder below defaults to a fresh allocation, so a suite has to go out
+// of its way to collide rather than having to remember not to.
+const FIRST_APP_PORT = 31111;
+let nextAppPort = FIRST_APP_PORT;
+
+/**
+ * The next unused app port for this runner process.
+ * @param {number} count How many CONSECUTIVE ports to reserve.
+ * @returns {number} The first port of the reserved block.
+ */
+export function allocateAppPort(count = 1) {
+  const first = nextAppPort;
+  nextAppPort += count;
+  return first;
+}
+
 export async function buildSeedableSyncthingApp({
   name,
   mode = 'g',
   repotag = `${REGISTRY_REPO_HOST}/${name}:v1`,
+  ports = [allocateAppPort()],
   containerPorts = [80],
   sibling = false,
   ...rest
@@ -280,7 +306,7 @@ export async function buildSeedableSyncthingApp({
  * registry-helper.pushTestApp(name).
  */
 export async function buildSeedableTestApp({
-  name, exitCode = 0, exitAfterS = null, ...rest
+  name, exitCode = 0, exitAfterS = null, port = allocateAppPort(), ...rest
 }) {
   const environmentParameters = [`EXIT_CODE=${exitCode}`];
   if (exitAfterS != null) environmentParameters.push(`EXIT_AFTER_S=${exitAfterS}`);
@@ -317,6 +343,7 @@ export async function buildSeedableMixedMountApp({
   plainPath = '/data',
   syncPath = '/db',
   repotag = `${REGISTRY_REPO_HOST}/${name}:v1`,
+  ports = [allocateAppPort()],
   containerPorts = [80],
   ...rest
 }) {
@@ -350,6 +377,7 @@ export async function buildSeedableMultiSyncthingApp({
   mode = 'g',
   components = 2,
   repotag = `${REGISTRY_REPO_HOST}/${name}:v1`,
+  basePort = allocateAppPort(components),
   containerPorts = [80],
   ...rest
 }) {
@@ -408,7 +436,7 @@ export async function buildSeedableIndexRefApp({
       ...base,
       name,
       description: 'invalid self-referencing component (index 0 -> 0)',
-      ports: [],
+      ports: [allocateAppPort()],
       containerData: `${mode}:/appdata|0:/selfref`,
     }]
     : [
@@ -416,7 +444,7 @@ export async function buildSeedableIndexRefApp({
         ...base,
         name: `${name}c0`,
         description: `${mode}: base component (index 0)`,
-        ports: [],
+        ports: [allocateAppPort()],
         containerData: `${mode}:/appdata`,
       },
       {

--- a/test-infra/runner/framework/seed-helper.js
+++ b/test-infra/runner/framework/seed-helper.js
@@ -57,7 +57,7 @@ export async function buildSeedableApp({
       // pull over live internet (rate-limit flakes); the env registry is
       // seeded with this image at bootstrap (test-env.js)
       repotag: `${REGISTRY_REPO_HOST}/e2e-pause:v1`,
-      ports: [allocateAppPort()],
+      ports: [],
       domains: [''],
       environmentParameters: [],
       commands: [],
@@ -149,7 +149,6 @@ export async function buildSeedableLegacyApp({
   name,
   version = 3,
   containerData = '/appdata',
-  port = allocateAppPort(),
   // Chain-relative, same as buildSeedableApp above and for the same reason its
   // comment gives: a literal height seeds an app already expired on any suite
   // whose chain starts later, and assertAliveOnThisChain refuses it.
@@ -228,12 +227,10 @@ export async function buildSeedableLegacyApp({
  * Pass `sibling: true` to add a plain (non-synced) component so a test can prove
  * the decider only acts on the g:/r: component and leaves siblings running.
  */
-
 export async function buildSeedableSyncthingApp({
   name,
   mode = 'g',
   repotag = `${REGISTRY_REPO_HOST}/${name}:v1`,
-  ports = [allocateAppPort()],
   containerPorts = [80],
   sibling = false,
   ...rest
@@ -283,7 +280,7 @@ export async function buildSeedableSyncthingApp({
  * registry-helper.pushTestApp(name).
  */
 export async function buildSeedableTestApp({
-  name, exitCode = 0, exitAfterS = null, port = allocateAppPort(), ...rest
+  name, exitCode = 0, exitAfterS = null, ...rest
 }) {
   const environmentParameters = [`EXIT_CODE=${exitCode}`];
   if (exitAfterS != null) environmentParameters.push(`EXIT_AFTER_S=${exitAfterS}`);
@@ -320,7 +317,6 @@ export async function buildSeedableMixedMountApp({
   plainPath = '/data',
   syncPath = '/db',
   repotag = `${REGISTRY_REPO_HOST}/${name}:v1`,
-  ports = [allocateAppPort()],
   containerPorts = [80],
   ...rest
 }) {
@@ -354,7 +350,6 @@ export async function buildSeedableMultiSyncthingApp({
   mode = 'g',
   components = 2,
   repotag = `${REGISTRY_REPO_HOST}/${name}:v1`,
-  basePort = allocateAppPort(components),
   containerPorts = [80],
   ...rest
 }) {
@@ -413,7 +408,7 @@ export async function buildSeedableIndexRefApp({
       ...base,
       name,
       description: 'invalid self-referencing component (index 0 -> 0)',
-      ports: [allocateAppPort()],
+      ports: [],
       containerData: `${mode}:/appdata|0:/selfref`,
     }]
     : [
@@ -421,14 +416,14 @@ export async function buildSeedableIndexRefApp({
         ...base,
         name: `${name}c0`,
         description: `${mode}: base component (index 0)`,
-        ports: [allocateAppPort()],
+        ports: [],
         containerData: `${mode}:/appdata`,
       },
       {
         ...base,
         name: `${name}c1`,
         description: 'component referencing component 0 volume (index 1 -> 0)',
-        ports: [allocateAppPort()],
+        ports: [],
         containerData: '/own|0:/shared',
       },
     ];
@@ -516,7 +511,7 @@ export async function buildSeedableEnterpriseApp({
     name,
     description: 'seeded enterprise component',
     repotag: `${REGISTRY_REPO_HOST}/e2e-pause:v1`,
-    ports: [allocateAppPort()],
+    ports: [],
     domains: [''],
     environmentParameters: [],
     commands: [],

--- a/test-infra/runner/framework/seed-helper.js
+++ b/test-infra/runner/framework/seed-helper.js
@@ -228,33 +228,6 @@ export async function buildSeedableLegacyApp({
  * Pass `sibling: true` to add a plain (non-synced) component so a test can prove
  * the decider only acts on the g:/r: component and leaves siblings running.
  */
-// App ports are ALLOCATED, never chosen.
-//
-// A node refuses to install a second app on a port it already serves - "port
-// already used with different application" - so two apps sharing a number can
-// never both be placed on one fleet. The second silently stalls at one instance
-// while the suite waits for it to spread, and the install failure surfaces only
-// as a log line on the nodes that refused it. Suite 68 hit this and hand-picked
-// 31111..31115 to escape it; suite 55 hit it again and lost a run to it.
-//
-// Every builder in this file defaults to a fresh allocation, so a suite has to
-// go out of its way to collide rather than having to remember not to. That
-// includes every COMPONENT of a multi-component builder: buildSeedableIndexRefApp
-// pinned its second component to a literal, so suite 43 - which builds two of
-// them - gave both apps the same port and could never have placed both.
-const FIRST_APP_PORT = 31111;
-let nextAppPort = FIRST_APP_PORT;
-
-/**
- * The next unused app port for this runner process.
- * @param {number} count How many CONSECUTIVE ports to reserve.
- * @returns {number} The first port of the reserved block.
- */
-export function allocateAppPort(count = 1) {
-  const first = nextAppPort;
-  nextAppPort += count;
-  return first;
-}
 
 export async function buildSeedableSyncthingApp({
   name,

--- a/test-infra/runner/framework/stub-peer-helper.js
+++ b/test-infra/runner/framework/stub-peer-helper.js
@@ -25,11 +25,15 @@ export function stubPeerClient(ip) {
     // What this peer claims to be holding. A folder named here blocks the asking
     // node's promotion, so it keeps asking every pass instead of promoting once
     // and falling silent.
-    async setPromotedFolders({ ready = true, folders = [] } = {}) {
+    // `resetRequests` clears the arrival log in the SAME request, for a caller
+    // that wants a fresh measurement without ever claiming to hold nothing.
+    // clear() drops the claim too, so clear-then-restate leaves a window in
+    // which a polling node sees the folder free and promotes.
+    async setPromotedFolders({ ready = true, folders = [], resetRequests = false } = {}) {
       const res = await controlFetch(`${controlUrl}/promoted-folders`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ready, folders }),
+        body: JSON.stringify({ ready, folders, resetRequests }),
       });
       return res.json();
     },

--- a/test-infra/runner/framework/stub-peer-helper.js
+++ b/test-infra/runner/framework/stub-peer-helper.js
@@ -121,6 +121,17 @@ export function stubPeerClient(ip) {
       });
     },
 
+    // How many fleet nodes hold an open connection to this peer RIGHT NOW.
+    //
+    // Everything this stub says is said over those sockets, so this is the
+    // precondition for any of it mattering. A suite that broadcasts before the
+    // fleet has dialled in is talking to an empty set, and the failure surfaces
+    // minutes later as whatever it was waiting for never happening.
+    async connectedNodes() {
+      const stats = await this.getStats();
+      return stats.connectedNodes ?? 0;
+    },
+
     // Announce this peer is RUNNING an app, the way any holder announces it.
     //
     // The harness had no way to say this. A stub could claim an app it was about
@@ -159,14 +170,25 @@ export function stubPeerClient(ip) {
     // Returns a stop function. Call it in `after`, or the interval outlives the
     // fleet it was talking to.
     holdApp(name, { hash, runningSince = Date.now(), everyMs = 20000, ...rest } = {}) {
-      // The FIRST announcement is not swallowed. A caller awaits `started` and
-      // then waits for the fleet to count this peer as a holder; if that first
-      // send failed, the caller otherwise sits out its whole timeout watching
-      // for something that was never sent, and reports it as the fleet failing
-      // to notice rather than as this failing to speak. Later re-announcements
-      // are best-effort - by then the holder is established and a dropped
-      // keep-alive is recovered by the next one.
-      const announce = () => this.runApp(name, { hash, runningSince, ...rest });
+      // /broadcast reports how many nodes it actually reached, and a peer with
+      // no open sockets reaches NONE - it serialises, signs, sends to an empty
+      // set and answers 200. A caller that ignores that awaits an outcome the
+      // fleet was never told about, times out, and reports the fleet as having
+      // failed to notice something nobody said.
+      //
+      // So the first announcement is checked, not merely unswallowed. Later
+      // keep-alives stay best-effort: by then the holder is established, and a
+      // dropped one is recovered by the next.
+      const announce = async () => {
+        const result = await this.runApp(name, { hash, runningSince, ...rest });
+        if (!result || !result.sent) {
+          throw new Error(
+            `stub peer announced ${name} to nobody (sent=${result?.sent ?? 'unknown'}, `
+            + `connected=${result?.connected ?? 'unknown'}) - it has no open connections to broadcast over`,
+          );
+        }
+        return result;
+      };
       const timer = setInterval(() => { announce().catch(() => {}); }, everyMs);
       return { started: announce(), stop: () => clearInterval(timer) };
     },

--- a/test-infra/runner/framework/stub-peer-helper.js
+++ b/test-infra/runner/framework/stub-peer-helper.js
@@ -159,10 +159,16 @@ export function stubPeerClient(ip) {
     // Returns a stop function. Call it in `after`, or the interval outlives the
     // fleet it was talking to.
     holdApp(name, { hash, runningSince = Date.now(), everyMs = 20000, ...rest } = {}) {
-      const announce = () => this.runApp(name, { hash, runningSince, ...rest }).catch(() => {});
-      const timer = setInterval(announce, everyMs);
-      const first = announce();
-      return { started: first, stop: () => clearInterval(timer) };
+      // The FIRST announcement is not swallowed. A caller awaits `started` and
+      // then waits for the fleet to count this peer as a holder; if that first
+      // send failed, the caller otherwise sits out its whole timeout watching
+      // for something that was never sent, and reports it as the fleet failing
+      // to notice rather than as this failing to speak. Later re-announcements
+      // are best-effort - by then the holder is established and a dropped
+      // keep-alive is recovered by the next one.
+      const announce = () => this.runApp(name, { hash, runningSince, ...rest });
+      const timer = setInterval(() => { announce().catch(() => {}); }, everyMs);
+      return { started: announce(), stop: () => clearInterval(timer) };
     },
 
     // Give that claim up. Version 2 of the claim's own message, which is what a

--- a/test-infra/runner/framework/stub-peer-helper.js
+++ b/test-infra/runner/framework/stub-peer-helper.js
@@ -1,3 +1,4 @@
+import { controlFetch } from './control-fetch.js';
 const CONTROL_PORT = 16128;
 
 export function stubPeerClient(ip) {
@@ -8,7 +9,7 @@ export function stubPeerClient(ip) {
     controlUrl,
 
     async loadMessage(permanentMessage) {
-      const res = await fetch(`${controlUrl}/load-message`, {
+      const res = await controlFetch(`${controlUrl}/load-message`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(permanentMessage),
@@ -17,7 +18,7 @@ export function stubPeerClient(ip) {
     },
 
     async getStats() {
-      const res = await fetch(`${controlUrl}/stats`);
+      const res = await controlFetch(`${controlUrl}/stats`);
       return res.json();
     },
 
@@ -25,7 +26,7 @@ export function stubPeerClient(ip) {
     // node's promotion, so it keeps asking every pass instead of promoting once
     // and falling silent.
     async setPromotedFolders({ ready = true, folders = [] } = {}) {
-      const res = await fetch(`${controlUrl}/promoted-folders`, {
+      const res = await controlFetch(`${controlUrl}/promoted-folders`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ ready, folders }),
@@ -38,7 +39,7 @@ export function stubPeerClient(ip) {
     // endpoint. The fleet runs one image, so this is the only way a suite can
     // put a node in front of a peer it cannot ask.
     async answerPromotedFoldersWith(status) {
-      const res = await fetch(`${controlUrl}/promoted-folders-status`, {
+      const res = await controlFetch(`${controlUrl}/promoted-folders-status`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ status }),
@@ -51,7 +52,7 @@ export function stubPeerClient(ip) {
     // reads any answer as "alive"; refusal is the only way a suite can put a
     // holder in front of it that is running but unanswerable.
     async refusePromotedFolders(refuse = true) {
-      const res = await fetch(`${controlUrl}/promoted-folders-refuse`, {
+      const res = await controlFetch(`${controlUrl}/promoted-folders-refuse`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ refuse }),
@@ -100,7 +101,7 @@ export function stubPeerClient(ip) {
     // path, so this is a peer saying something, not a row written behind a
     // node's back.
     async broadcast(data) {
-      const res = await fetch(`${controlUrl}/broadcast`, {
+      const res = await controlFetch(`${controlUrl}/broadcast`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data),
@@ -208,7 +209,7 @@ export function stubPeerClient(ip) {
     },
 
     async clear() {
-      const res = await fetch(`${controlUrl}/clear`, { method: 'POST' });
+      const res = await controlFetch(`${controlUrl}/clear`, { method: 'POST' });
       return res.json();
     },
   };

--- a/test-infra/runner/framework/stub-peer-helper.js
+++ b/test-infra/runner/framework/stub-peer-helper.js
@@ -121,6 +121,50 @@ export function stubPeerClient(ip) {
       });
     },
 
+    // Announce this peer is RUNNING an app, the way any holder announces it.
+    //
+    // The harness had no way to say this. A stub could claim an app it was about
+    // to install and it could withdraw that claim, but it could not hold one -
+    // so no suite could build a fleet where an app runs on more nodes than it
+    // needs, which is the only state the surplus rule is ever asked about. The
+    // suites that test surplus reach it through contested CLAIMS instead, and
+    // that is a different moment in an app's life: no volume, no election, no
+    // writer.
+    //
+    // `runningSince` is what every node ranks holders by, so it is the argument
+    // that matters here. Backdate it and this peer is the senior holder, which
+    // is how a test puts the surplus on a REAL node instead of on the stub.
+    //
+    // Sent as a broadcast like everything else - the receiving node validates
+    // and stores it through its ordinary path, so this is a peer saying it holds
+    // something, not a row written behind a node's back.
+    async runApp(name, { hash, broadcastedAt = Date.now(), runningSince = broadcastedAt, osUptime = 86400 } = {}) {
+      return this.broadcast({
+        type: 'fluxapprunning',
+        version: 2,
+        apps: [{ name, hash, runningSince: new Date(runningSince).toISOString() }],
+        ip,
+        broadcastedAt,
+        osUptime,
+        staticIp: false,
+      });
+    },
+
+    // Hold an app the way a real holder does: announce it, and keep announcing
+    // it. A single runApp() is not a holder - the location it creates expires
+    // after locationTtlS (63s in this harness), so a suite that announces once
+    // and then does anything slow watches its own fixture disappear halfway
+    // through, and reads the result as the code under test doing something.
+    //
+    // Returns a stop function. Call it in `after`, or the interval outlives the
+    // fleet it was talking to.
+    holdApp(name, { hash, runningSince = Date.now(), everyMs = 20000, ...rest } = {}) {
+      const announce = () => this.runApp(name, { hash, runningSince, ...rest }).catch(() => {});
+      const timer = setInterval(announce, everyMs);
+      const first = announce();
+      return { started: first, stop: () => clearInterval(timer) };
+    },
+
     // Give that claim up. Version 2 of the claim's own message, which is what a
     // node standing aside sends - so the fleet sees this peer leave the same way
     // it sees any other leave, and the app is free again.

--- a/test-infra/runner/framework/syncthing-control.js
+++ b/test-infra/runner/framework/syncthing-control.js
@@ -4,13 +4,14 @@
 // syncthing folder id FluxOS assigns to the component (== the reconciler
 // identifier); read it from getSyncthingState() if unsure.
 import { getSubnetConfig } from './subnet-config.js';
+import { controlFetch } from './control-fetch.js';
 
 const CONTROL = process.env.SYNCTHING_CONTROL || `http://${getSubnetConfig().syncthing}:8385`;
 
 const GLOBAL_BYTES = 100000;
 
 async function post(path, body) {
-  const res = await fetch(`${CONTROL}${path}`, {
+  const res = await controlFetch(`${CONTROL}${path}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: body != null ? JSON.stringify(body) : undefined,
@@ -19,7 +20,7 @@ async function post(path, body) {
 }
 
 async function get(path) {
-  const res = await fetch(`${CONTROL}${path}`);
+  const res = await controlFetch(`${CONTROL}${path}`);
   return res.json();
 }
 

--- a/test-infra/runner/framework/test-env.js
+++ b/test-infra/runner/framework/test-env.js
@@ -1054,7 +1054,19 @@ async function _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, conf
       // peer-topology.js. A suite TESTING a threshold sets its own in
       // configOverrides, which merges over this and wins.
       fluxapps: {
-        ...derivePeerThresholds(nodes, stubPeers.length),
+        // Deferred nodes are subtracted alongside stubs, because the ring cannot
+        // tell them apart: both hold an index that nothing answers on. 9fcabdc02
+        // taught bootAndPeer exactly this and stopped one function short - until
+        // startNode creates it, a deferred node neither dials nor answers an
+        // addoutgoingpeer request, so deriving thresholds that count it asks the
+        // fleet for a door that cannot open.
+        //
+        // No suite moves today, which is why it went unnoticed: the arc is a step
+        // function and every current fleet with a deferred node sits away from a
+        // step. 10/1, 11/1 and 12/2 stay at 4, 6/1 stays at 2, 3/1 stays at 1.
+        // 6/2 or 7/1 is the first shape that changes, so this was a trap set for
+        // the next suite written rather than a fault in any existing one.
+        ...derivePeerThresholds(nodes, stubPeers.length + deferredNodes),
         // Travels as configuration, like every other override. It used to be an
         // env var the entrypoint sed into shared.js - but the merged config is
         // written by REQUIRING the per-node file, which spreads shared.js at

--- a/test-infra/runner/framework/test-env.js
+++ b/test-infra/runner/framework/test-env.js
@@ -1291,6 +1291,16 @@ async function _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, conf
       }));
     },
 
+    // Undo holdOutPendingNode. Per-rule best-effort, like healPartition: a rule
+    // already gone is not an error. The caller re-runs discovery, since the held
+    // node was refused for the whole time the others were dialling.
+    async releasePendingNode(pendingIndex, runningIndices) {
+      const pendingIp = fluxNodes[pendingIndex].ip;
+      await Promise.all(runningIndices.map((node) => fluxNodes[node].container.exec(
+        ['sh', '-c', `iptables -D INPUT -s ${pendingIp} -j DROP || true`],
+      )));
+    },
+
     async partitionGroups(groupA, groupB, { awaitSever = true, severTimeoutMs = 60000 } = {}) {
       const ops = [];
       for (const a of groupA) {

--- a/test-infra/runner/framework/test-env.js
+++ b/test-infra/runner/framework/test-env.js
@@ -27,6 +27,7 @@ import { MongoClient } from 'mongodb';
 import { authenticate } from '../auth.js';
 import { fluxTeamKey, nodeKey } from './keys.js';
 import chainStart from './chain-start.cjs';
+import { assertCoupledRatios, loadSharedConfig } from './coupled-knobs.js';
 
 function createLogCollector() {
   // Each entry is { t, line }: t is the capture wall-clock (ISO), line is the raw
@@ -66,6 +67,10 @@ function createLogCollector() {
 }
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// The baseline a suite's overrides merge onto - read once, so the ratio check
+// sees what the node will actually run rather than only what the suite set.
+const sharedFluxapps = loadSharedConfig().fluxapps ?? {};
 const fixturesDir = join(__dirname, '..', '..', 'fixtures');
 const manifest = JSON.parse(readFileSync(join(fixturesDir, 'node-manifest.json'), 'utf-8'));
 // Identity for the fake-blockchain node list (collateral/pubkey/tier). Base-independent;
@@ -985,6 +990,13 @@ async function _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, conf
       },
     };
     const nodeConfig = mergeConfigs(infraOverride, mergeConfigs(configOverrides, nodeConfigOverrides[i]));
+    // Checked on the EFFECTIVE config, per node, before anything boots. A
+    // compressed harness is a set of ratios and this is where a suite's
+    // override lands on top of them - which is exactly where the queue step
+    // stopped tracking the give-up pass. Throws rather than warns: a fleet
+    // whose ratio has inverted still runs and still goes green, having quietly
+    // stopped testing the thing the suite is named after.
+    assertCoupledRatios({ ...sharedFluxapps, ...(nodeConfig.fluxapps ?? {}) });
     // Handed over as a file rather than as NODE_CONFIG. The config package merges
     // that variable over every file, which is a redirect no hash can see, so the
     // entry points delete it - production has no environment path into config at

--- a/test-infra/runner/framework/test-env.js
+++ b/test-infra/runner/framework/test-env.js
@@ -1204,6 +1204,38 @@ async function _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, conf
     // compress that interval in its configOverrides the same way it compresses every
     // other cadence. Pass { awaitSever: false } for a caller that only wants packets
     // dropped and is not asserting message loss.
+    // Refuse a node that has NOT STARTED YET, from the side that already exists.
+    //
+    // partitionGroups needs both groups' containers, because it puts a rule inside each.
+    // A node that is about to be started has no container, so the earliest it can be cut
+    // off is just after start() returns - by which point it may already have peered, and
+    // a suite that needed it deaf has no way to know it was not.
+    //
+    // One direction is enough: a connection needs both. The pending node dials out and
+    // its packets are dropped before they are read; the running nodes dial in and the
+    // reply is dropped on the way back. Nothing is established either way.
+    //
+    // The address is known before the node exists - the subnet assigns it, nothing
+    // discovers it - so the refusal can be in place before it draws breath. Undo with
+    // healPartition, whose deletes are best-effort and so tolerate the side that was
+    // never given a rule.
+    //
+    // For a suite that seeds time-stamped fixtures and then boots something to read
+    // them: hold the reader out, boot it, seed once the boot is behind you, then heal.
+    // The acceptance window then spans a sync rather than a boot, and stops depending on
+    // how loaded the box was.
+    async holdOutPendingNode(pendingIndex, runningIndices) {
+      const pendingIp = fluxNodes[pendingIndex].ip;
+      await Promise.all(runningIndices.map(async (node) => {
+        const res = await fluxNodes[node].container.exec(
+          ['sh', '-c', `iptables -I INPUT -s ${pendingIp} -j DROP`],
+        );
+        if (res.exitCode !== 0) {
+          throw new Error(`holdOutPendingNode: drop on node ${node} for ${pendingIp} failed (exit ${res.exitCode}): ${res.output}`);
+        }
+      }));
+    },
+
     async partitionGroups(groupA, groupB, { awaitSever = true, severTimeoutMs = 60000 } = {}) {
       const ops = [];
       for (const a of groupA) {

--- a/test-infra/runner/framework/test-env.js
+++ b/test-infra/runner/framework/test-env.js
@@ -470,10 +470,30 @@ function makeEnvShell(networkName) {
         ).catch((e) => warn('immutable-flag sweep', e));
       }));
       step(`immutable-sweep(${clients.filter(Boolean).length} nodes)`);
-      for (const c of [...started].reverse()) {
-        await c.stop().catch((e) => warn('container stop', e));
-      }
-      step(`stops(${started.length} containers)`);
+      // STOPPED CONCURRENTLY, because this is the step the budget is spent on.
+      // The per-step timing above put 3.6-13.9s of a 3.8-14.4s teardown in here
+      // on a quiet box, with every other step in milliseconds: sixteen
+      // containers at ~200-870ms each, one after another. That is work that
+      // scales with the fleet under an `after` hook budget that is a flat 30s in
+      // 123 of 137 suites, which is how seven suites lost a gate to it with
+      // every one of their tests green. The serial loop bought no politeness
+      // either - the docker daemon serialises stops across every concurrent
+      // suite regardless - only latency.
+      //
+      // The one ordering that means anything is kept: every node goes down
+      // before any infra does, so a node is never left running against a
+      // stopped mongo, writing errors into the dump that read as product
+      // faults. Within each group nothing depends on order - they are all about
+      // to be deleted.
+      const infraIds = new Set(infraContainers.map(({ container }) => container.getId()));
+      const nodeStarted = started.filter((c) => !infraIds.has(c.getId()));
+      const infraStarted = started.filter((c) => infraIds.has(c.getId()));
+      const stopAll = (list) => Promise.all(
+        list.map((c) => c.stop().catch((e) => warn('container stop', e))),
+      );
+      await stopAll(nodeStarted);
+      await stopAll(infraStarted);
+      step(`stops(${nodeStarted.length} nodes, ${infraStarted.length} infra)`);
       await closeDb();
       step('db');
       const cleanupClient = await getContainerRuntimeClient();

--- a/test-infra/runner/framework/test-env.js
+++ b/test-infra/runner/framework/test-env.js
@@ -584,7 +584,7 @@ export async function createTestEnv({
   configOverrides = null, nodeConfigOverrides = {}, nodeTiers = null, dataCenter = true,
   tickerAutostart = false, discoveryAutostart = false, nodeStatusOverrides = {},
   rpcFailures = [], bootContext = 'running', initialHeight = DEFAULT_INITIAL_HEIGHT, syncthing = 'stub', aptSeeded = true, aptBadSource = false,
-  geolocation = {},
+  geolocation = {}, locationTable = null,
 } = {}) {
   if (syncthing !== 'stub' && syncthing !== 'binary') {
     throw new Error(`createTestEnv: syncthing must be 'stub' or 'binary', got '${syncthing}'`);
@@ -636,7 +636,7 @@ export async function createTestEnv({
     // mongo starts, i.e. inside the fleet boot, where the waits at risk are the
     // boot's own.
     await startInfraDeathWatch(env);
-    await _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, configOverrides, nodeConfigOverrides, nodeTiers, dataCenter, tickerAutostart, discoveryAutostart, nodeStatusOverrides, rpcFailures, bootContext, initialHeight, syncthing, aptSeeded, aptBadSource, geolocation);
+    await _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, configOverrides, nodeConfigOverrides, nodeTiers, dataCenter, tickerAutostart, discoveryAutostart, nodeStatusOverrides, rpcFailures, bootContext, initialHeight, syncthing, aptSeeded, aptBadSource, geolocation, locationTable);
     return env;
   } catch (err) {
     // Boot failed: the env owns everything started so far. The shared teardown
@@ -665,7 +665,7 @@ function mergeConfigs(base, override) {
   return result;
 }
 
-async function _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, configOverrides, nodeConfigOverrides, nodeTiers, dataCenter, tickerAutostart, discoveryAutostart, nodeStatusOverrides, rpcFailures, bootContext, initialHeight, syncthing = 'stub', aptSeeded = true, aptBadSource = false, geolocation) {
+async function _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, configOverrides, nodeConfigOverrides, nodeTiers, dataCenter, tickerAutostart, discoveryAutostart, nodeStatusOverrides, rpcFailures, bootContext, initialHeight, syncthing = 'stub', aptSeeded = true, aptBadSource = false, geolocation, locationTable) {
   // Everything built here registers onto the env shell as it comes up, so a
   // boot-phase throw leaves the partial state reachable (see makeEnvShell).
   const {
@@ -807,6 +807,19 @@ async function _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, conf
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(override),
+    });
+  }
+
+  // The location table, published before the fleet boots for the same reason the
+  // geolocation overrides are. A node fetches the artifact once at startup and
+  // then not again for a day, so a suite publishing one after createTestEnv
+  // returns is racing that fetch - and losing it leaves the fleet on the default
+  // table, which carries no organisation classes at all.
+  if (locationTable) {
+    await fetch(`http://${EXTERNAL_STUB_IP}:3001/iplocation`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(locationTable),
     });
   }
 

--- a/test-infra/runner/framework/test-env.js
+++ b/test-infra/runner/framework/test-env.js
@@ -492,10 +492,30 @@ function makeEnvShell(networkName) {
         list.map((c) => c.stop().catch((e) => warn('container stop', e))),
       );
       await stopAll(nodeStarted);
-      await stopAll(infraStarted);
-      step(`stops(${nodeStarted.length} nodes, ${infraStarted.length} infra)`);
+      step(`stops(${nodeStarted.length} nodes)`);
+      // The harness's own mongo client is closed while mongo is STILL UP, and the
+      // cost of getting this backwards is 30 seconds that nothing logs. mongodb
+      // 7.5.0's _close() ends its pooled sessions with `endSessions`, a w:0 write
+      // that needs a connection but never a reply, and it skips that call ONLY
+      // when server selection over its CACHED topology description comes back
+      // empty. Stop mongo first and that cache is a coin flip: usually the monitor
+      // has already marked the server Unknown and the call is skipped, but when it
+      // has not, close() commits to an operation whose server goes Unknown
+      // mid-flight, and waits out the full 30s serverSelectionTimeoutMS before
+      // squashError swallows the error. An `after all` budget that is a flat 30s
+      // cannot absorb that, so the suite fails with every one of its tests green -
+      // which is how suite 02 lost the f8fe3db1b gate: `db 32831ms`, against the
+      // other 145 teardowns in that same gate at 0-2ms.
+      //
+      // Measured on chud, six suite-02 runs at a time so the stops land together:
+      // closing after the stop was slow in 27 of 30 runs at ~33s, the in-flight
+      // snapshot showing Standalone on entry and Unknown two seconds later;
+      // closing before it, 0 of 30, slowest 3ms. The nodes are already down by
+      // here, so nothing is still writing.
       await closeDb();
       step('db');
+      await stopAll(infraStarted);
+      step(`stops(${infraStarted.length} infra)`);
       const cleanupClient = await getContainerRuntimeClient();
       // The EPERM fallback below boots a whole container per volume, so how many times
       // it fired is the difference between a two-second volume phase and a long one.

--- a/test-infra/runner/framework/test-env.js
+++ b/test-infra/runner/framework/test-env.js
@@ -584,6 +584,7 @@ export async function createTestEnv({
   configOverrides = null, nodeConfigOverrides = {}, nodeTiers = null, dataCenter = true,
   tickerAutostart = false, discoveryAutostart = false, nodeStatusOverrides = {},
   rpcFailures = [], bootContext = 'running', initialHeight = DEFAULT_INITIAL_HEIGHT, syncthing = 'stub', aptSeeded = true, aptBadSource = false,
+  geolocation = {},
 } = {}) {
   if (syncthing !== 'stub' && syncthing !== 'binary') {
     throw new Error(`createTestEnv: syncthing must be 'stub' or 'binary', got '${syncthing}'`);
@@ -635,7 +636,7 @@ export async function createTestEnv({
     // mongo starts, i.e. inside the fleet boot, where the waits at risk are the
     // boot's own.
     await startInfraDeathWatch(env);
-    await _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, configOverrides, nodeConfigOverrides, nodeTiers, dataCenter, tickerAutostart, discoveryAutostart, nodeStatusOverrides, rpcFailures, bootContext, initialHeight, syncthing, aptSeeded, aptBadSource);
+    await _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, configOverrides, nodeConfigOverrides, nodeTiers, dataCenter, tickerAutostart, discoveryAutostart, nodeStatusOverrides, rpcFailures, bootContext, initialHeight, syncthing, aptSeeded, aptBadSource, geolocation);
     return env;
   } catch (err) {
     // Boot failed: the env owns everything started so far. The shared teardown
@@ -664,7 +665,7 @@ function mergeConfigs(base, override) {
   return result;
 }
 
-async function _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, configOverrides, nodeConfigOverrides, nodeTiers, dataCenter, tickerAutostart, discoveryAutostart, nodeStatusOverrides, rpcFailures, bootContext, initialHeight, syncthing = 'stub', aptSeeded = true, aptBadSource = false) {
+async function _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, configOverrides, nodeConfigOverrides, nodeTiers, dataCenter, tickerAutostart, discoveryAutostart, nodeStatusOverrides, rpcFailures, bootContext, initialHeight, syncthing = 'stub', aptSeeded = true, aptBadSource = false, geolocation) {
   // Everything built here registers onto the env shell as it comes up, so a
   // boot-phase throw leaves the partial state reachable (see makeEnvShell).
   const {
@@ -794,6 +795,19 @@ async function _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, conf
         body: JSON.stringify({ hosting: false }),
       });
     }
+  }
+
+  // Per-node geolocation, seeded HERE because a node looks its address up once
+  // during boot and then not again for three days. A suite POSTing an override
+  // after createTestEnv returns is already too late, and the node reads the
+  // stub's default instead - which is a data centre, so the override silently
+  // does nothing.
+  for (const [index, override] of Object.entries(geolocation ?? {})) {
+    await fetch(`http://${EXTERNAL_STUB_IP}:3001/geolocation/${subnet.nodeIp(Number(index))}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(override),
+    });
   }
 
   const registryTlsDir = join(fixturesDir, 'registry-tls');

--- a/test-infra/runner/framework/test-env.js
+++ b/test-infra/runner/framework/test-env.js
@@ -750,8 +750,16 @@ async function _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, conf
   }
 
   if (nodeTiers) {
-    for (const [index, tier] of Object.entries(nodeTiers)) {
-      const ip = subnet.nodeIp(Number(index) + 1);
+    // Keyed by NODE NUMBER, 1-based: `{ 1: … }` is node 1, the same as the
+    // geolocation map below and the same as the named constants suites declare
+    // (`const TARGET = 1`). It was 0-based-plus-one while the geolocation map
+    // fifty lines down was not, so the two idioms sat side by side meaning
+    // different things by their key - and a suite copying the nearer one
+    // classifies the wrong node, which here is the input to a DOS decision.
+    // Converted rather than commented because nothing in the repository passes
+    // nodeTiers, so there was no caller to break.
+    for (const [nodeNumber, tier] of Object.entries(nodeTiers)) {
+      const ip = subnet.nodeIp(Number(nodeNumber));
       await fetch(`http://${DAEMON_IP}:18232/node-tier/${ip}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -802,8 +810,9 @@ async function _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, conf
   // after createTestEnv returns is already too late, and the node reads the
   // stub's default instead - which is a data centre, so the override silently
   // does nothing.
-  for (const [index, override] of Object.entries(geolocation ?? {})) {
-    await fetch(`http://${EXTERNAL_STUB_IP}:3001/geolocation/${subnet.nodeIp(Number(index))}`, {
+  // Keyed by NODE NUMBER, 1-based, as nodeTiers above now is.
+  for (const [nodeNumber, override] of Object.entries(geolocation ?? {})) {
+    await fetch(`http://${EXTERNAL_STUB_IP}:3001/geolocation/${subnet.nodeIp(Number(nodeNumber))}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(override),

--- a/test-infra/runner/framework/test-env.js
+++ b/test-infra/runner/framework/test-env.js
@@ -415,6 +415,20 @@ function makeEnvShell(networkName) {
       if (tornDown) return;
       tornDown = true;
       const warn = (label, err) => console.warn(`teardown [${networkName}] ${label}: ${err.message}`);
+      // Every step below is a docker round trip with no timeout of its own, and until
+      // now they printed only on THROW - and being slow is not throwing. The `after`
+      // hook that calls this fails the suite on its own budget: on the bc5d86154 gate
+      // seven suites (36, 45, 46, 47, 48, 51, 53) died on "after all hook: Timeout of
+      // 30000ms exceeded" with every one of their tests green, and nothing anywhere
+      // recorded which step had spent the 30 seconds. So each step reports as it
+      // COMPLETES: the step whose line is missing is the one that ran out of budget.
+      const tStart = Date.now();
+      let tPrev = tStart;
+      const step = (name) => {
+        const now = Date.now();
+        console.log(`# teardown [${networkName}] ${name} ${now - tPrev}ms`);
+        tPrev = now;
+      };
       // Everything stopped below exits on purpose. Silence the death watch BEFORE
       // the first stop so a deliberate exit can never be reported as INFRA-DEAD:
       // the flag covers events already queued on the stream, closing it covers
@@ -432,6 +446,7 @@ function makeEnvShell(networkName) {
       if (infraDeathError()) {
         infraLogSnapshot = await readInfraLogs(infraContainers).catch(() => null);
       }
+      step('infra-snapshot');
       // disconnectEventStream wipes the client's event buffer — snapshot first so
       // a failure dump running after teardown still has the events
       clients.forEach((client, i) => {
@@ -440,6 +455,7 @@ function makeEnvShell(networkName) {
       for (const client of clients) {
         if (client) client.disconnectEventStream();
       }
+      step('streams');
       // FluxOS sets app mountpoints immutable (chattr +i) so an unmounted app
       // dir rejects writes. The flag lives on the BARE dir under the loop mount
       // and survives into the node's named volume - Docker then cannot delete
@@ -453,11 +469,17 @@ function makeEnvShell(networkName) {
           'for d in /mnt/appdata/flux-apps/*/; do umount -l "$d" 2>/dev/null; done; chattr -R -i /mnt/appdata/flux-apps 2>/dev/null; true',
         ).catch((e) => warn('immutable-flag sweep', e));
       }));
+      step(`immutable-sweep(${clients.filter(Boolean).length} nodes)`);
       for (const c of [...started].reverse()) {
         await c.stop().catch((e) => warn('container stop', e));
       }
+      step(`stops(${started.length} containers)`);
       await closeDb();
+      step('db');
       const cleanupClient = await getContainerRuntimeClient();
+      // The EPERM fallback below boots a whole container per volume, so how many times
+      // it fired is the difference between a two-second volume phase and a long one.
+      let helperRuns = 0;
       for (const volName of volumeNames) {
         const volume = cleanupClient.container.dockerode.getVolume(volName);
         try {
@@ -468,6 +490,7 @@ function makeEnvShell(networkName) {
           // volume delete. Strip the flags from the volume side with a
           // throwaway container and retry, so even a wedged fleet cleans up.
           try {
+            helperRuns += 1;
             const helper = await cleanupClient.container.dockerode.createContainer({
               Image: image('flux-e2e-fluxos-01'),
               Entrypoint: ['bash', '-c', 'chattr -R -i /v/flux-apps 2>/dev/null; true'],
@@ -482,11 +505,14 @@ function makeEnvShell(networkName) {
           }
         }
       }
+      step(`volumes(${volumeNames.length}, ${helperRuns} needed the flag-strip helper)`);
       await removeNetwork(networkName);
+      step('network');
       for (const cfg of nodeConfigs) {
         if (cfg.bootIdDir) rmSync(cfg.bootIdDir, { recursive: true, force: true });
       }
       http.globalAgent.destroy();
+      console.log(`# teardown [${networkName}] complete ${Date.now() - tStart}ms`);
     },
   };
   return env;

--- a/test-infra/runner/framework/test-env.js
+++ b/test-infra/runner/framework/test-env.js
@@ -542,7 +542,7 @@ function getBootId(nodeNum) {
   return `test-boot-id-node-${String(nodeNum).padStart(2, '0')}`;
 }
 
-async function seedMongo(mongoIp, nodeCount, bootContext = 'running', { dataCenter = true, initialHeight = DEFAULT_INITIAL_HEIGHT } = {}) {
+async function seedMongo(mongoIp, nodeCount, bootContext = 'running', { dataCenter = true, staticIp = true, initialHeight = DEFAULT_INITIAL_HEIGHT } = {}) {
   const client = new MongoClient(`mongodb://${mongoIp}:27017`);
   try {
     await client.connect();
@@ -565,9 +565,15 @@ async function seedMongo(mongoIp, nodeCount, bootContext = 'running', { dataCent
               country: 'Germany', countryCode: 'DE',
               region: 'HE', regionName: 'Hesse',
               lat: 50.1109, lon: 8.6821,
-              org: 'Test Network', static: true, dataCenter,
+              org: 'Test Network', static: staticIp, dataCenter,
             },
-            staticIp: true, dataCenter,
+            // The value the node answers with during boot, before its first
+            // lookup completes and setNodeGeolocation recomputes both from the
+            // routing table and the classifier. Driven by the same declaration
+            // as the route below, so the seed and the recompute cannot disagree
+            // - which is the state that made this seed look like a control while
+            // being silently overwritten.
+            staticIp, dataCenter,
             lastIpChangeDate: null, updatedAt: Date.now(),
           },
         },
@@ -635,7 +641,7 @@ export async function createTestEnv({
   configOverrides = null, nodeConfigOverrides = {}, nodeTiers = null, dataCenter = true,
   tickerAutostart = false, discoveryAutostart = false, nodeStatusOverrides = {},
   rpcFailures = [], bootContext = 'running', initialHeight = DEFAULT_INITIAL_HEIGHT, syncthing = 'stub', aptSeeded = true, aptBadSource = false,
-  geolocation = {}, locationTable = null,
+  geolocation = {}, locationTable = null, staticIp = true,
 } = {}) {
   if (syncthing !== 'stub' && syncthing !== 'binary') {
     throw new Error(`createTestEnv: syncthing must be 'stub' or 'binary', got '${syncthing}'`);
@@ -687,7 +693,7 @@ export async function createTestEnv({
     // mongo starts, i.e. inside the fleet boot, where the waits at risk are the
     // boot's own.
     await startInfraDeathWatch(env);
-    await _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, configOverrides, nodeConfigOverrides, nodeTiers, dataCenter, tickerAutostart, discoveryAutostart, nodeStatusOverrides, rpcFailures, bootContext, initialHeight, syncthing, aptSeeded, aptBadSource, geolocation, locationTable);
+    await _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, configOverrides, nodeConfigOverrides, nodeTiers, dataCenter, tickerAutostart, discoveryAutostart, nodeStatusOverrides, rpcFailures, bootContext, initialHeight, syncthing, aptSeeded, aptBadSource, geolocation, locationTable, staticIp);
     return env;
   } catch (err) {
     // Boot failed: the env owns everything started so far. The shared teardown
@@ -716,7 +722,7 @@ function mergeConfigs(base, override) {
   return result;
 }
 
-async function _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, configOverrides, nodeConfigOverrides, nodeTiers, dataCenter, tickerAutostart, discoveryAutostart, nodeStatusOverrides, rpcFailures, bootContext, initialHeight, syncthing = 'stub', aptSeeded = true, aptBadSource = false, geolocation, locationTable) {
+async function _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, configOverrides, nodeConfigOverrides, nodeTiers, dataCenter, tickerAutostart, discoveryAutostart, nodeStatusOverrides, rpcFailures, bootContext, initialHeight, syncthing = 'stub', aptSeeded = true, aptBadSource = false, geolocation, locationTable, staticIp = true) {
   // Everything built here registers onto the env shell as it comes up, so a
   // boot-phase throw leaves the partial state reachable (see makeEnvShell).
   const {
@@ -753,7 +759,7 @@ async function _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, conf
   containers.mongo = mongo;
   watchInfra(env, 'mongo', mongo);
 
-  await seedMongo(MONGO_IP, nodes, bootContext, { dataCenter, initialHeight });
+  await seedMongo(MONGO_IP, nodes, bootContext, { dataCenter, staticIp, initialHeight });
 
   const daemonStub = await new StaticIpContainer(image('flux-e2e-daemon-stub'))
     .withStaticIp(networkName, DAEMON_IP)
@@ -958,6 +964,9 @@ async function _buildEnv(env, nodes, deferredNodes, legacyNodes, stubPeers, conf
       FLUX_SYNCTHING_HOST: SYNCTHING_IP,
       FLUX_SYNCTHING_PORT: '8384',
       NODE_EXTRA_CA_CERTS: '/usr/local/share/ca-certificates/test-registry.crt',
+      // Present for a node declared static, absent for one behind NAT. The
+      // entrypoint installs it before FluxOS starts; see the note there.
+      ...(staticIp ? { FLUX_E2E_DEFAULT_ROUTE: subnet.gateway } : {}),
     };
     if (syncthing === 'binary') {
       // the node runs its own daemon and binds apiport+2 itself, so there is

--- a/test-infra/runner/framework/wait.js
+++ b/test-infra/runner/framework/wait.js
@@ -202,6 +202,21 @@ export async function waitForImageUpdateRedeployComplete(node, appName, timeout 
   return node.waitForEvent('imageUpdate:redeployComplete', (d) => d.appName === appName, timeout);
 }
 
+/**
+ * The give-up pass reporting what it decided about one app. Emitted once per
+ * app per pass, whichever way the decision went, so a suite can tell "the pass
+ * declined" from "the pass never ran" - which the logs cannot, since a pass
+ * with nothing to give up says nothing at all.
+ */
+export async function waitForGiveUpConsidered(node, appName, predicate, timeout = 120000, opts) {
+  return node.waitForEvent('giveUp:considered', (d) => d.appName === appName && (!predicate || predicate(d)), timeout, opts);
+}
+
+/** The safety gate's verdict on an app the pass wanted to give up. */
+export async function waitForGiveUpSafety(node, appName, predicate, timeout = 120000, opts) {
+  return node.waitForEvent('giveUp:safety', (d) => d.appName === appName && (!predicate || predicate(d)), timeout, opts);
+}
+
 export async function waitForSpawnerDeferred(node, appName, reason, timeout = 60000) {
   const entry = await node.waitForEvent('spawner:deferred', (d) => d.appName === appName && (!reason || d.reason === reason), timeout);
   return entry.data;

--- a/test-infra/runner/framework/wait.js
+++ b/test-infra/runner/framework/wait.js
@@ -224,6 +224,21 @@ export async function waitForNoCandidates(node, predicate, timeout = 60000, opts
   return node.waitForEvent('spawner:noCandidates', (d) => (!predicate || predicate(d)), timeout, opts);
 }
 
+/**
+ * One residential tick's conclusion.
+ *
+ * The reason this event exists: deciding NOT to enforce produces no placement
+ * hold, no settle marker and no DOS, so its whole signature is the absence of
+ * three things. Without an event a suite can only sleep and infer from nothing
+ * having happened - which reads the same as the tick never running.
+ *
+ * `enforce` is three-state. false means this node is fit to serve; null means
+ * the tick could not decide, with `undecidedBecause` naming the missing input.
+ */
+export async function waitForResidentialDecision(node, predicate, timeout = 60000, opts) {
+  return node.waitForEvent('residential:decided', (d) => (!predicate || predicate(d)), timeout, opts);
+}
+
 /** The safety gate's verdict on an app the pass wanted to give up. */
 export async function waitForGiveUpSafety(node, appName, predicate, timeout = 120000, opts) {
   return node.waitForEvent('giveUp:safety', (d) => d.appName === appName && (!predicate || predicate(d)), timeout, opts);

--- a/test-infra/runner/framework/wait.js
+++ b/test-infra/runner/framework/wait.js
@@ -212,6 +212,16 @@ export async function waitForGiveUpConsidered(node, appName, predicate, timeout 
   return node.waitForEvent('giveUp:considered', (d) => d.appName === appName && (!predicate || predicate(d)), timeout, opts);
 }
 
+/**
+ * A spawner pass that found candidates and placed none, with the count
+ * surviving each filter. `found` is what was short on the network; the rest name
+ * where they went. A suite waiting for an app that never arrives reads this to
+ * see WHICH filter took it rather than guessing.
+ */
+export async function waitForNoCandidates(node, predicate, timeout = 60000, opts) {
+  return node.waitForEvent('spawner:noCandidates', (d) => (!predicate || predicate(d)), timeout, opts);
+}
+
 /** The safety gate's verdict on an app the pass wanted to give up. */
 export async function waitForGiveUpSafety(node, appName, predicate, timeout = 120000, opts) {
   return node.waitForEvent('giveUp:safety', (d) => d.appName === appName && (!predicate || predicate(d)), timeout, opts);

--- a/test-infra/runner/framework/wait.js
+++ b/test-infra/runner/framework/wait.js
@@ -235,15 +235,18 @@ export async function waitForGiveUpConsidered(node, appName, predicate, timeout 
 }
 
 /**
- * A spawner pass that found candidates and placed none, with the count
- * surviving each filter. `found` is what was short on the network; the rest name
- * where they went. A suite waiting for an app that never arrives reads this to
- * see WHICH filter took it rather than guessing.
+ * This node's verdict on ONE app changing: `{ name, stage, candidate }`, where
+ * stage is 'candidate' or the filter that removed it - afterAlreadyHeldOrTried,
+ * afterNodePin, afterGeolocation, afterOwnership, afterClaims.
+ *
+ * Published on CHANGE only, so it says what happened rather than what is still
+ * true. That is what makes eligibility assertable: a node that stood down and is
+ * later allowed to take the app again reports exactly one of these, whether or
+ * not it goes on to win the draw - which is a lottery among every eligible node
+ * and proves nothing about this one.
  */
-export async function waitForNoCandidates(node, predicate, timeout = 60000, opts) {
-  // The client does not subscribe to this event by default - see node-client.js
-  // for why. Add the name to its list before using this.
-  return node.waitForEvent('spawner:noCandidates', (d) => (!predicate || predicate(d)), timeout, opts);
+export async function waitForCandidacy(node, predicate, timeout = 60000, opts) {
+  return node.waitForEvent('spawner:candidacy', (d) => (!predicate || predicate(d)), timeout, opts);
 }
 
 /**

--- a/test-infra/runner/framework/wait.js
+++ b/test-infra/runner/framework/wait.js
@@ -219,6 +219,8 @@ export async function waitForGiveUpConsidered(node, appName, predicate, timeout 
  * see WHICH filter took it rather than guessing.
  */
 export async function waitForNoCandidates(node, predicate, timeout = 60000, opts) {
+  // The client does not subscribe to this event by default - see node-client.js
+  // for why. Add the name to its list before using this.
   return node.waitForEvent('spawner:noCandidates', (d) => (!predicate || predicate(d)), timeout, opts);
 }
 

--- a/test-infra/runner/framework/wait.js
+++ b/test-infra/runner/framework/wait.js
@@ -3,16 +3,38 @@ import { throwIfInfraDead, sleepUnlessInfraDead } from './infra-death.js';
 
 export async function waitFor(condition, { timeout = 60000, interval = 2000, label = '' } = {}) {
   const start = Date.now();
+  let lastError = null;
   while (Date.now() - start < timeout) {
     // An infra container died: the condition is unreachable, not merely unmet.
     throwIfInfraDead();
-    if (await condition()) return true;
+    try {
+      if (await condition()) return true;
+      lastError = null;
+    } catch (error) {
+      // A POLL THAT COULD NOT BE TAKEN IS NOT A POLL THAT CAME BACK FALSE, and
+      // it is not a reason to abandon the wait. Under gate load a node's API
+      // refuses one connection and answers on the next tick: suite 96 lost a
+      // two-minute wait to a single `fetch failed`, on a fleet that was healthy
+      // either side of it, having passed that same wait twice on an idle box.
+      //
+      // Four suites had already worked this around one predicate at a time with
+      // `.catch(() => null)`; every other wait in the harness was exposed to it.
+      //
+      // Kept rather than swallowed. A predicate that throws EVERY time still
+      // times out - this cannot turn a red into a green - and the timeout now
+      // reports what it was throwing, instead of saying only that a condition
+      // never held.
+      lastError = error;
+    }
     await sleepUnlessInfraDead(interval);
   }
   // ...including a death that landed during the last sleep, which would
   // otherwise be reported as this wait's own timeout.
   throwIfInfraDead();
-  throw new Error(`Timeout after ${timeout}ms waiting for: ${label || 'condition'}`);
+  throw new Error(
+    `Timeout after ${timeout}ms waiting for: ${label || 'condition'}`
+    + (lastError ? ` - the last attempt failed with: ${lastError.message}` : ''),
+  );
 }
 
 // Container-state wait helpers (docker-level, via the node's DinD)

--- a/test-infra/runner/run-parallel.sh
+++ b/test-infra/runner/run-parallel.sh
@@ -205,11 +205,42 @@ sweep_harness_leftovers(){
 sweep_harness_leftovers
 
 # ---- capture sidecars (best-effort; killed on exit) ----
-( sudo dmesg -wT 2>/dev/null | grep --line-buffered -iE 'oom|killed process' ) > "$LOGROOT/cap-dmesg.log" 2>&1 & CAP1=$!
+# CAP1 records the PID of its root half so the trap can signal it directly.
+# `kill $CAP1` reaches the subshell and nothing else: `sudo` and the `dmesg` it
+# execs are root-owned, so they survive an unprivileged kill of their parent,
+# reparent to init, and `grep` then blocks forever on a pipe nobody will close.
+# Three processes per gate, and because they stay in the ssh session's cgroup
+# the scope goes `abandoned` and logind never reaps the session - which is why
+# `uptime` reported 54 users on an idle chud with `who` reporting none. Leaking
+# since 2026-08-07 and hand-cleared at least three times without the cause being
+# fixed: 66 runs' worth on chud, 31 on cindy, the oldest there since boot.
+# Killing the root `dmesg` first is what makes the rest fall over - grep sees
+# EOF and exits, and the subshell goes with it.
+CAP_DMESG_PID="$LOGROOT/cap-dmesg.pid"
+( sudo sh -c 'echo $$ >"$1"; exec dmesg -wT' _ "$CAP_DMESG_PID" 2>/dev/null \
+    | grep --line-buffered -iE 'oom|killed process' ) > "$LOGROOT/cap-dmesg.log" 2>&1 & CAP1=$!
 ( while true; do echo "$(date -u +%H:%M:%S) avail=$(free_mb)MB load=$(cut -d' ' -f1 /proc/loadavg) containers=$(docker ps -q 2>/dev/null | wc -l)"; sleep 5; done ) > "$LOGROOT/cap-mem.log" 2>&1 & CAP2=$!
 ( docker events --filter event=die --filter event=kill --filter event=oom \
     --format '{{.Time}} {{.Action}} name={{.Actor.Attributes.name}} exitCode={{.Actor.Attributes.exitCode}}' ) > "$LOGROOT/cap-events.log" 2>&1 & CAP3=$!
-trap 'kill $CAP1 $CAP2 $CAP3 2>/dev/null' EXIT
+stop_captures(){
+  local root_dmesg pid kid
+  root_dmesg=$(cat "$CAP_DMESG_PID" 2>/dev/null)
+  # Root-owned, so it needs sudo, and it has to go first: once `dmesg` is gone
+  # `grep` sees EOF and the subshell follows it out.
+  [ -n "$root_dmesg" ] && sudo -n kill "$root_dmesg" 2>/dev/null
+  # Children BEFORE parents, and by explicit PID. `$CAPn` is the subshell, whose
+  # children outlive it and reparent to init - `docker events` was found orphaned
+  # on cindy beside the dmesg trio, ten hours after the gate that started it.
+  # Killing the parent first would lose the ppid link that finds them.
+  for pid in $CAP1 $CAP2 $CAP3; do
+    for kid in $(ps -eo pid,ppid --no-headers 2>/dev/null | awk -v p="$pid" '$2==p{print $1}'); do
+      kill "$kid" 2>/dev/null
+    done
+    kill "$pid" 2>/dev/null
+  done
+  rm -f "$CAP_DMESG_PID"
+}
+trap stop_captures EXIT
 
 declare -A PID2SUITE
 

--- a/test-infra/runner/tests/13-orchestrator-state-machine.js
+++ b/test-infra/runner/tests/13-orchestrator-state-machine.js
@@ -12,6 +12,57 @@ import {
   clearAllNodeStatus, setNodeStatus, disableAllRpcFailure,
 } from '../framework/daemon-control.js';
 import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
+import { loadSharedConfig } from '../framework/coupled-knobs.js';
+
+// How long a node takes to notice a peer that has been unplugged rather than
+// disconnected. Derived, because it is the thing every DEGRADED wait below is
+// really waiting for: a missed pong per interval, and a socket is declared dead
+// after `wsMaxMissedPongs` of them, plus up to one more interval of phase
+// because the timer is not aligned to the moment the peer vanished.
+const PEERS = loadSharedConfig().peers ?? {};
+const PEER_DEATH_MS = (PEERS.wsPingIntervalMs ?? 15000) * ((PEERS.wsMaxMissedPongs ?? 3) + 1);
+
+/**
+ * Take every peer away from node 0, WAIT FOR IT TO NOTICE, and only then ask
+ * what it did about it.
+ *
+ * `disconnectNode` removes the container from the docker network and returns as
+ * soon as dockerd has done so - which says nothing about when this node finds
+ * out. An unplugged container sends no close frame: node 0 discovers each peer
+ * through its own ping/pong liveness, one socket at a time, and the orchestrator
+ * has nothing to react to until the survivors fall below the threshold.
+ *
+ * SPLITTING THE TWO WAITS IS THE POINT. As one deadline they covered "liveness
+ * detection AND the reaction", and a gate run spent it all on the first: three
+ * of four peers had gone, node 0 still counted one against a threshold of one,
+ * so it was never below it and DEGRADED was correct not to fire. What the report
+ * said was "Timeout waiting for event: orchestrator:stateChanged" - which is
+ * also exactly what a genuinely broken orchestrator says. Apart, the two
+ * failures read differently, and only the second is a product bug.
+ *
+ * The four budgets this replaced were 30s, 10s, 30s and 30s for the same
+ * operation. None was derived from anything; the 10s was the one that failed.
+ * @param {object} env Test environment.
+ * @param {object} [opts]
+ * @param {number} [opts.detectMs] Budget for node 0 to observe the peers leave.
+ * @param {number} [opts.reactMs] Budget for the orchestrator to then act.
+ */
+async function dropEveryPeerAndAwaitDegraded(env, { detectMs, reactMs = 15000 } = {}) {
+  // Detection is concurrent across the sockets, so the bound is one peer death
+  // and not four; the multiplier is headroom for scheduling, not for a fourth
+  // serial timeout. Registered BEFORE the first disconnect, or the event can
+  // land while nothing is listening for it.
+  const observed = waitForPeersBelowThreshold(env.clients[0], detectMs ?? 3 * PEER_DEATH_MS);
+  for (let i = 1; i < env.clients.length; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    await env.disconnectNode(i);
+  }
+  await observed;
+  // Returned, not swallowed: a caller that cares WHICH state was left - suite 2
+  // asserts SYNCING so its block cannot quietly become a copy of the READY one -
+  // needs the transition itself.
+  return waitForOrchestratorState(env.clients[0], 'DEGRADED', reactMs);
+}
 
 async function bootNodes(env, { discover = false } = {}) {
   await Promise.all(env.clients.map((c) => waitForDaemonReady(c)));
@@ -170,11 +221,10 @@ describe('Orchestrator: READY to DEGRADED', function () {
   });
 
   it('should transition to DEGRADED when all peers disconnected', async function () {
-    this.timeout(60000);
-    for (let i = 1; i < env.clients.length; i++) {
-      await env.disconnectNode(i);
-    }
-    await waitForOrchestratorState(env.clients[0], 'DEGRADED', 30000);
+    // A ceiling, not a wait: the bounds that mean anything are derived inside
+    // dropEveryPeerAndAwaitDegraded and this only has to clear their sum.
+    this.timeout(120000);
+    await dropEveryPeerAndAwaitDegraded(env);
   });
 
   it('should emit READINESS_LOST (spawner paused)', async function () {
@@ -218,18 +268,8 @@ describe('Orchestrator: peer drop during SYNCING', function () {
   });
 
   it('should transition to DEGRADED when peers drop during SYNCING', async function () {
-    this.timeout(60000);
-    // waitForEvent answers from the buffer of every event since boot, so this anchor is
-    // what makes the wait below describe the transition this test causes.
-    const beforeDrop = env.clients[0].getLastEventId();
-
-    for (let i = 1; i < env.clients.length; i++) {
-      await env.disconnectNode(i);
-    }
-
-    const degraded = await env.clients[0].waitForEvent(
-      'orchestrator:stateChanged', (d) => d.to === 'DEGRADED', 30000, { afterId: beforeDrop },
-    );
+    this.timeout(120000);
+    const degraded = await dropEveryPeerAndAwaitDegraded(env);
     // Names the entry state, so this block cannot quietly become a second copy of the
     // READY one if the order these two facts arrive in ever changes.
     expect(degraded.data.from).to.equal('SYNCING');
@@ -250,10 +290,7 @@ describe('Orchestrator: DEGRADED recovery cycle', function () {
     await waitForOrchestratorState(env.clients[0], 'READY', 120000);
     await stopTicker();
     // Disconnect all peers to trigger DEGRADED
-    for (let i = 1; i < env.clients.length; i++) {
-      await env.disconnectNode(i);
-    }
-    await waitForOrchestratorState(env.clients[0], 'DEGRADED', 30000);
+    await dropEveryPeerAndAwaitDegraded(env);
   });
 
   after(async function () {
@@ -293,10 +330,7 @@ describe('Orchestrator: block timer during RESYNCING', function () {
     await waitForOrchestratorState(env.clients[0], 'READY', 120000);
     await stopTicker();
     // Enter DEGRADED
-    for (let i = 1; i < env.clients.length; i++) {
-      await env.disconnectNode(i);
-    }
-    await waitForOrchestratorState(env.clients[0], 'DEGRADED', 30000);
+    await dropEveryPeerAndAwaitDegraded(env);
     // Recover peers → RESYNCING
     for (let i = 1; i < env.clients.length; i++) {
       await env.reconnectNode(i);

--- a/test-infra/runner/tests/19-boundary-conditions.js
+++ b/test-infra/runner/tests/19-boundary-conditions.js
@@ -166,11 +166,19 @@ describe('Boundary: clean shutdown within SIGTERM_EXPIRY', function () {
 
   before(async function () {
     this.timeout(120000);
-    // 300s ago with sigterm — within 420s SIGTERM_EXPIRY_MS
+    // 1s pinned, which the node reads as ~17s - within the harness's 30s
+    // sigtermExpiryS.
+    //
+    // The pin is not what the node measures. lastAlive is seeded just before
+    // the container starts and the downtime is computed when the node reads it
+    // at boot, so ONE BOOT lands inside the measurement: a 300s pin was read as
+    // 316s on cindy under a full gate. That 16s is why this window cannot be
+    // compressed at production's ratio - 420s at 120x is 3.5s, smaller than the
+    // drift, and nothing could ever land inside it. See coupled-knobs.js.
     env = await createTestEnv({ hookCtx: this,
       nodes: 1,
       tickerAutostart: false,
-      bootContext: { lastAliveAgoMs: 300000, machineBootId: 'old-boot-id', shutdownReason: 'sigterm' },
+      bootContext: { lastAliveAgoMs: 1000, machineBootId: 'old-boot-id', shutdownReason: 'sigterm' },
     });
     await waitForDaemonReady(env.clients[0]);
   });
@@ -196,11 +204,19 @@ describe('Boundary: clean shutdown beyond SIGTERM_EXPIRY', function () {
 
   before(async function () {
     this.timeout(120000);
-    // 500s ago with sigterm — exceeds 420s SIGTERM_EXPIRY_MS
+    // 25s pinned, read as ~41s: past the 30s sigtermExpiryS, and deliberately
+    // still UNDER locationTtlS at 63s.
+    //
+    // That second bound is the one that matters. locationsExpired is
+    // `(cleanShutdown && downtime > sigterm) || downtime > running`, so a
+    // downtime past the running expiry expires on the second clause and this
+    // test passes without the sigterm window being involved at all. The old
+    // 500s pin did exactly that once locationTtlS became live - green, and
+    // proving nothing about the thing in its name.
     env = await createTestEnv({ hookCtx: this,
       nodes: 1,
       tickerAutostart: false,
-      bootContext: { lastAliveAgoMs: 500000, machineBootId: 'old-boot-id', shutdownReason: 'sigterm' },
+      bootContext: { lastAliveAgoMs: 25000, machineBootId: 'old-boot-id', shutdownReason: 'sigterm' },
     });
   });
 

--- a/test-infra/runner/tests/51-reconciler-syncthing-coldstart.js
+++ b/test-infra/runner/tests/51-reconciler-syncthing-coldstart.js
@@ -9,6 +9,7 @@ import { electMaster, resetFdm } from '../framework/fdm-control.js';
 import { getSubnetConfig } from '../framework/subnet-config.js';
 import { waitFor } from '../framework/wait.js';
 import { bootAndPeer, installOnNodes } from '../framework/reconciler-suite.js';
+import { syncthingSeedIndex } from '../framework/g-app-placement.js';
 import { buildSeedableSyncthingApp } from '../framework/seed-helper.js';
 import { pushImage } from '../framework/registry-helper.js';
 import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
@@ -59,7 +60,10 @@ describe('reconciler cold start - fresh multi-node placement, no seeded source',
   const rApp = `e2ecoldr${Date.now()}`;
   const gApp = `e2ecoldg${Date.now()}`;
   const holders = [0, 1, 2];
-  const seedIndex = holders[0]; // lowest IP among the holders = the deterministic seed
+  // Asked rather than assumed. `holders[0]` is the lowest address only while the
+  // list happens to be written in order, and it silently names the wrong node
+  // for the first fixture that is not.
+  const seedIndex = syncthingSeedIndex(holders);
 
   before(async function () {
     this.timeout(480000);

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -791,6 +791,40 @@ describe('Residential node evacuation', function () {
     // The restart cost it nothing it had already watched.
     expect(after.observedMs).to.be.at.least(before.observedMs);
   });
+});
+
+// A FLEET OF ITS OWN, for the same arithmetic as the describe below.
+//
+// Both of these need a departure to actually happen, and a node sheds ONE app per
+// departure interval while a node inside that interval accrues nothing towards
+// any other app's turn. Left on the shared fleet these sit behind everything the
+// thirteen tests above them left on node 1, and DEPARTURE_WAIT_MS is two cycles.
+//
+// On the 4fc95ac35 gate that was exactly enough to fail: node 1 held clockapp and
+// sharedapp, sharedapp drew eight AWAITING_TURN and node 3 four DEPARTURE_INTERVAL,
+// neither node ever departed, so the app never went short and the
+// BELOW_INSTANCE_COUNT refusal this test waits for on the OTHER node could not be
+// published. One departure interval plus one full ticket against a budget of two
+// cycles is no headroom at all, which is why it passed until something moved.
+//
+// Splitting rather than widening the budget, for the reason the describe below
+// was split: a budget sized for the queue leaves the queue there for whoever adds
+// the next test.
+describe('Residential node evacuation: one holder at a time', function () {
+  let env;
+  dumpLogsOnFailure(() => env);
+
+  before(async function () {
+    this.timeout(600000);
+    env = await bootResidentialFleet(this);
+  });
+
+  after(async function () {
+    this.timeout(120000);
+    await clearSystemSecure().catch(() => {});
+    await stopTicker().catch(() => {});
+    if (env) await env.teardown();
+  });
 
   it('only one residential node gives up an app at a time', async function () {
     this.timeout(900000);

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -35,9 +35,23 @@ const subnet = getSubnetConfig();
 // either as a literal is what broke this suite before. test-env asserts both
 // relationships on every node of every fleet before boot.
 const SHARED_POLL_MS = loadSharedConfig().fluxapps.explorerPollIntervalMs;
+// THE PASS PERIOD, and everything about this suite's cost hangs off it. The
+// give-up pass runs every `removeFluxAppsPeriod x 4` blocks, a block costs one
+// explorer poll, and the queue step, the ticket tolerance and the departure
+// interval are each derived from that pass in turn - so this number multiplies
+// through every departure the suite makes, about six of them.
+//
+// At 4 it put the pass at ~13s and a departure at ~197s, and the suite spent
+// twenty minutes on departures alone, blew the runner's 1800s wall clock, and
+// starved two unrelated suites off the same box. At 2 the pass is ~7s and a
+// departure ~99s. The lower bound is PROPAGATION, not comfort: the removal
+// broadcast has to reach the other holder before its next pass, and at a
+// 1-block pass (~1s) it measurably did not - the other node evaluated twice
+// more before network:appremoved arrived and both holders left.
+const PASS_PERIOD_BLOCKS = 2;
 const RESIDENTIAL_PACING = (() => {
   const fleet = {
-    removeFluxAppsPeriod: 4,
+    removeFluxAppsPeriod: PASS_PERIOD_BLOCKS,
     explorerPollIntervalMs: SHARED_POLL_MS,
   };
   const residentialQueueStepMs = derivedQueueStepMs(fleet);
@@ -52,7 +66,12 @@ const RESIDENTIAL_PACING = (() => {
 // four seconds. Two cycles' worth: several of these waits contain a departure
 // AND the pass on which another holder reacts to it.
 const DEPARTURE_WAIT_MS = 2 * departureCycleMs(
-  { ...RESIDENTIAL_PACING, removeFluxAppsPeriod: 4, explorerPollIntervalMs: SHARED_POLL_MS, residentialQueueBaseMs: 1000 },
+  {
+    ...RESIDENTIAL_PACING,
+    removeFluxAppsPeriod: PASS_PERIOD_BLOCKS,
+    explorerPollIntervalMs: SHARED_POLL_MS,
+    residentialQueueBaseMs: 1000,
+  },
   5,
 );
 
@@ -332,11 +351,10 @@ describe('Residential node evacuation', function () {
           // network:appremoved reached it - propagation lost the race, both
           // holders saw the app at full strength, and both left.
           //
-          // 4 here puts the pass at 16 blocks. What that costs in wall time is
-          // set by explorerPollIntervalMs, not by this number: at the harness's
-          // 833ms poll it is about 16s, measured at 15.9s over nine consecutive
-          // passes on cindy. Still far shorter than production's 44 blocks.
-          removeFluxAppsPeriod: 4,
+          // Set from PASS_PERIOD_BLOCKS at the top of this file, which explains
+          // what it costs and what bounds it from below. What it costs in wall
+          // time is set by explorerPollIntervalMs, not by this number.
+          removeFluxAppsPeriod: PASS_PERIOD_BLOCKS,
           // Left LONG on purpose, and opened by the test when it is ready. A
           // short window would let evacuation start while the hold is still
           // being asserted, and the ordering - hold first, deletes nothing, and

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -148,11 +148,22 @@ async function seedApp(env, appName, { instances = 3, containerData = '/tmp', po
  * Changing one without the other is what quietly deletes the ordering these
  * tests exist to check.
  *
+ * THE RATE IS THE NODE'S POLL, not something faster. A block is not processed
+ * until the next explorer poll, so driving four blocks per poll produces four
+ * times the work for the same pass cadence: a height only counts when it lands
+ * as the tip, tips arrive one per poll, and the give-up pass therefore comes
+ * every `removeFluxAppsPeriod x 4` polls whatever rate this drives at. The
+ * extra blocks are pure load - and this suite drives for the length of a
+ * departure, which is now minutes rather than seconds. At 200ms it drove about
+ * a thousand blocks per wait, held a runner slot for the full 1800s wall clock,
+ * and starved the box: two unrelated suites ran 3-4x slower in the same gate
+ * and hit that wall themselves.
+ *
  * @param {number} [opts.timeoutMs] How long to keep driving before giving up.
  * @param {number} [opts.blockIntervalMs] Minimum wall-clock between blocks.
  * @returns {Promise<number>} Blocks driven.
  */
-async function driveUntil(env, nodeIndex, condition, { timeoutMs = 240000, blockIntervalMs = 200 } = {}) {
+async function driveUntil(env, nodeIndex, condition, { timeoutMs = DEPARTURE_WAIT_MS, blockIntervalMs = SHARED_POLL_MS } = {}) {
   const node = env.clients[nodeIndex - 1];
   const deadline = Date.now() + timeoutMs;
   let blocks = 0;

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -12,7 +12,7 @@ import {
   waitForDaemonReady, waitForNodeStatus, waitForBlockProcessed,
   waitForExplorerReady, waitForOrchestratorStarted, waitForOrchestratorState,
   waitForPeerThreshold, waitForAppInstalled,
-  waitForSpawnerBlocked, waitFor,
+  waitForSpawnerBlocked, waitFor, waitForGiveUpConsidered, waitForGiveUpSafety,
 } from '../framework/wait.js';
 import { setNoPeerData, setPeerHasData } from '../framework/syncthing-control.js';
 import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
@@ -193,10 +193,7 @@ describe('Residential node evacuation', function () {
           // being asserted, and the ordering - hold first, deletes nothing, and
           // only later gives an app up - is the property under test.
           residentialSettleMs: 600000,
-          // Long enough to MEASURE. The give-up pass runs every 4 blocks (~20s
-          // here), so a shorter gap than that would be indistinguishable from
-          // the block cadence and the pacing test would prove nothing.
-          residentialEvacuationIntervalMs: 20000,
+          residentialEvacuationIntervalMs: 4000,
           residentialQueueBaseMs: 1000,
           residentialQueueStepMs: 500,
           removeFluxAppsPeriod: 1,
@@ -313,7 +310,7 @@ describe('Residential node evacuation', function () {
   });
 
   it('hands the app back once the settling window has passed', async function () {
-    this.timeout(300000);
+    this.timeout(600000);
 
     // The clock is persisted and wall-clock, so a node cannot restart its way
     // out of the drain. Which is also what lets the test open the gate: put the
@@ -324,14 +321,17 @@ describe('Residential node evacuation', function () {
     await elapseSettleWindow(TARGET);
     await advanceBlocks(5);
 
+    // Assert the pass reached this app before waiting on the outcome, so a
+    // failure here distinguishes "the pass declined" from "the pass never ran".
+    // Nothing else does: a pass with nothing to give up logs and emits nothing.
+    await waitForGiveUpConsidered(env.clients[TARGET - 1], 'residentapp',
+      (d) => d.giveUp === true && d.reason === 'EVACUATION', 300000);
+
     // Waited on the node's own view rather than on app:removed. That event is
     // published part-way through the uninstall - after the runtime state is
     // dropped, before the installed-apps record is - so a test that asserts on
     // the record the instant the event lands still sees the app.
-    await waitFor(async () => {
-      const current = await env.clients[TARGET - 1].get('/apps/installedapps');
-      return !current.data.map((a) => a.name).includes('residentapp');
-    }, { timeout: 240000, label: 'node 1 hands residentapp back' });
+    await whenGone(env, TARGET, 'residentapp', 300000);
   });
 
   it('the app survives the departure on every other host', async function () {
@@ -398,34 +398,34 @@ describe('Residential node evacuation', function () {
   it('will not hand back a stateful app while no peer demonstrably holds its data', async function () {
     this.timeout(600000);
 
-    // Two apps, and the pairing is the point. `plainapp` keeps no synced state,
-    // so it is safe to give up the moment its turn comes - it is the positive
-    // control that proves the give-up pass is running at all. `worldapp` mounts
-    // s:, so its volume IS the product, and no peer is reporting that it holds
-    // a copy. The ten Palworld and Minecraft worlds on the real fleet are this
-    // second shape, at exactly two instances.
-    await seedApp(env, 'plainapp', { instances: 5 });
+    // worldapp mounts s:, so its volume IS the product - the shape of the ten
+    // Palworld and Minecraft worlds on the real fleet, which sit at exactly two
+    // instances. Nothing reports holding a copy of it.
     await seedApp(env, 'worldapp', { instances: 5, containerData: 's:/appdata' });
     await advanceBlocks(3);
-    await waitForAppInstalled(env.clients[TARGET - 1], 'plainapp', 300000);
     await waitForAppInstalled(env.clients[TARGET - 1], 'worldapp', 300000);
 
-    // Nobody has the world. Declared before enforcement starts, so the node
-    // never sees a moment where the data looks safe.
+    // Declared before enforcement starts, so the node never sees a moment where
+    // the data looks safe.
     await setNoPeerData({ folder: 'fluxworldapp_worldapp' });
 
     await setSystemSecure(subnet.nodeIp(TARGET), false);
-    await waitForSpawnerBlocked(env.clients[TARGET - 1], 'placement_hold', 120000);
     await waitFor(async () => (await dbClient(TARGET).residentialMarker()) !== null,
       { timeout: 120000, label: 'the settling window starts again' });
     await elapseSettleWindow(TARGET);
 
-    // The stateless one goes, which is what tells us the pass ran.
-    await whenGone(env, TARGET, 'plainapp', 300000);
+    // The pass reports on every app it holds, every pass, so this proves the
+    // pass RAN and wanted this app - not merely that nothing happened.
+    await waitForGiveUpConsidered(env.clients[TARGET - 1], 'worldapp',
+      (d) => d.giveUp === true && d.reason === 'EVACUATION', 300000);
 
-    // And the stateful one is still here, because refusing is what the gate is
-    // for. Every removal path before this decided on an instance count alone,
-    // and a count cannot tell a redundant copy from the last one holding data.
+    // And the gate is what stopped it. Before this, every removal path decided
+    // on an instance count alone, and a count cannot tell a redundant copy from
+    // the last one holding the data.
+    const verdict = await waitForGiveUpSafety(env.clients[TARGET - 1], 'worldapp',
+      (d) => d.safe === false, 300000);
+    expect(verdict.data.detail).to.contain('fluxworldapp_worldapp');
+
     const installed = await env.clients[TARGET - 1].get('/apps/installedapps');
     expect(installed.data.map((a) => a.name)).to.include('worldapp');
   });
@@ -433,57 +433,15 @@ describe('Residential node evacuation', function () {
   it('hands the stateful app back once a peer holds it in full', async function () {
     this.timeout(600000);
 
+    // The same node, the same pass, the same app - the only thing that changed
+    // is that a connected peer now reports the folder complete. That contrast
+    // is what shows the refusal above was the gate deciding rather than the
+    // node simply being slow.
     await setPeerHasData({ folder: 'fluxworldapp_worldapp' });
 
     await whenGone(env, TARGET, 'worldapp', 300000);
 
-    // It left because a peer could be shown to hold the data, not because the
-    // node ran out of patience.
     const locations = await dbClient(2).getAppLocations('worldapp');
     expect(locations.map((l) => l.ip.split(':')[0])).to.not.include(subnet.nodeIp(TARGET));
-  });
-
-  it('gives up one app per pass, spaced by the departure interval', async function () {
-    this.timeout(600000);
-
-    // Two apps eligible at the same instant. A node that emptied itself as fast
-    // as it could would take both in one pass; the whole point of the pacing is
-    // that a residential line sheds slowly enough for the spawner to refill
-    // behind it.
-    //
-    // Attested first, because a held node takes no new apps - there would be
-    // nothing on it to pace.
-    await setSystemSecure(subnet.nodeIp(TARGET), true);
-    await waitFor(async () => (await dbClient(TARGET).residentialMarker()) === null,
-      { timeout: 120000, label: 'node 1 is back in service' });
-
-    await seedApp(env, 'pacedone', { instances: 5 });
-    await seedApp(env, 'pacedtwo', { instances: 5 });
-    await advanceBlocks(3);
-    await waitForAppInstalled(env.clients[TARGET - 1], 'pacedone', 300000);
-    await waitForAppInstalled(env.clients[TARGET - 1], 'pacedtwo', 300000);
-
-    await setSystemSecure(subnet.nodeIp(TARGET), false);
-    await waitFor(async () => (await dbClient(TARGET).residentialMarker()) !== null,
-      { timeout: 120000, label: 'the settling window starts' });
-    await elapseSettleWindow(TARGET);
-
-    const held = async () => {
-      const installed = await env.clients[TARGET - 1].get('/apps/installedapps');
-      const names = installed.data.map((a) => a.name);
-      return ['pacedone', 'pacedtwo'].filter((n) => names.includes(n));
-    };
-
-    await waitFor(async () => (await held()).length <= 1,
-      { timeout: 300000, label: 'node 1 gives up the first of the two' });
-    const first = Date.now();
-
-    await waitFor(async () => (await held()).length === 0,
-      { timeout: 300000, label: 'node 1 gives up the second' });
-    const second = Date.now();
-
-    // The interval is a floor on the gap, and the pass only runs every fourth
-    // block, so the observed gap is at least the interval and usually more.
-    expect(second - first).to.be.at.least(20000);
   });
 });

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -66,7 +66,7 @@ const RESIDENTIAL_PACING = (() => {
 // four minutes driveUntil defaults to, which was written when the interval was
 // four seconds. Two cycles' worth: several of these waits contain a departure
 // AND the pass on which another holder reacts to it.
-const DEPARTURE_WAIT_MS = 2 * departureCycleMs(
+const ONE_DEPARTURE_MS = departureCycleMs(
   {
     ...RESIDENTIAL_PACING,
     removeFluxAppsPeriod: PASS_PERIOD_BLOCKS,
@@ -75,6 +75,7 @@ const DEPARTURE_WAIT_MS = 2 * departureCycleMs(
   },
   5,
 );
+const DEPARTURE_WAIT_MS = 2 * ONE_DEPARTURE_MS;
 
 const RESIDENTIAL_GEO = {
   hosting: false,
@@ -940,9 +941,28 @@ describe('Residential node evacuation', function () {
       .then((v) => { standDownVerdict = v; return v; });
     stoodDown.catch(() => {});
 
+    // THE BUDGET IS A DEPARTURE PER APP THIS NODE STILL HOLDS, not two.
+    //
+    // Evacuation gives up ONE app per departure interval, and a node inside that
+    // interval records nothing against any other app's queue ticket - so every
+    // departure restarts the turn of everything still held. By this test the
+    // node has collected an app from most of the fifteen tests ahead of it, and
+    // primaryapp is behind all of them.
+    //
+    // Two cycles was right when this test was written and stopped being right as
+    // tests were added in front of it, silently: on the 2026-08-31 gate the node
+    // held seven apps, shed six inside the window, and ran out one departure
+    // short. primaryapp drew 10 DEPARTURE_INTERVAL and 10 AWAITING_TURN verdicts
+    // and no STAND_DOWN_REQUIRED - not a wrong answer, no answer, which is
+    // indistinguishable in the failure message from the stand-down never firing.
+    //
+    // Read from the node rather than counted by hand here, so adding a test
+    // ahead of this one cannot quietly shorten its budget again. One cycle of
+    // headroom so the last verdict has a pass to land in.
+    const heldBefore = await dbClient(TARGET).localAppCount();
     await stopTicker();
     await driveUntil(env.clients[TARGET - 1], async () => standDownVerdict !== null,
-      { timeoutMs: DEPARTURE_WAIT_MS });
+      { timeoutMs: (heldBefore + 1) * ONE_DEPARTURE_MS });
     await startTicker();
 
     const verdict = await stoodDown;

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -14,6 +14,7 @@ import {
   waitForPeerThreshold, waitForAppInstalled,
   waitForSpawnerBlocked, waitFor,
 } from '../framework/wait.js';
+import { setNoPeerData, setPeerHasData } from '../framework/syncthing-control.js';
 import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
 
 const subnet = getSubnetConfig();
@@ -86,6 +87,19 @@ async function seedApp(env, appName, { instances = 3, containerData = '/tmp' } =
     await dc.seedAppHash(app.hash, app.permanentMessage.height, true);
   }
   return app;
+}
+
+/**
+ * When this node stopped holding an app, by its own account. Returns the epoch
+ * ms at which it was first observed gone, so a caller can measure the gap
+ * between two departures.
+ */
+async function whenGone(env, nodeIndex, appName, timeout) {
+  await waitFor(async () => {
+    const installed = await env.clients[nodeIndex - 1].get('/apps/installedapps');
+    return !installed.data.map((a) => a.name).includes(appName);
+  }, { timeout, label: `node ${nodeIndex} hands ${appName} back` });
+  return Date.now();
 }
 
 /** Put the settling window in the past, so evacuation may begin this run. */
@@ -179,7 +193,10 @@ describe('Residential node evacuation', function () {
           // being asserted, and the ordering - hold first, deletes nothing, and
           // only later gives an app up - is the property under test.
           residentialSettleMs: 600000,
-          residentialEvacuationIntervalMs: 4000,
+          // Long enough to MEASURE. The give-up pass runs every 4 blocks (~20s
+          // here), so a shorter gap than that would be indistinguishable from
+          // the block cadence and the pacing test would prove nothing.
+          residentialEvacuationIntervalMs: 20000,
           residentialQueueBaseMs: 1000,
           residentialQueueStepMs: 500,
           removeFluxAppsPeriod: 1,
@@ -376,5 +393,97 @@ describe('Residential node evacuation', function () {
       const marker = await dbClient(TARGET).residentialMarker();
       return marker === null;
     }, { timeout: 60000, label: 'the settling marker is torn down with the verdict' });
+  });
+
+  it('will not hand back a stateful app while no peer demonstrably holds its data', async function () {
+    this.timeout(600000);
+
+    // Two apps, and the pairing is the point. `plainapp` keeps no synced state,
+    // so it is safe to give up the moment its turn comes - it is the positive
+    // control that proves the give-up pass is running at all. `worldapp` mounts
+    // s:, so its volume IS the product, and no peer is reporting that it holds
+    // a copy. The ten Palworld and Minecraft worlds on the real fleet are this
+    // second shape, at exactly two instances.
+    await seedApp(env, 'plainapp', { instances: 5 });
+    await seedApp(env, 'worldapp', { instances: 5, containerData: 's:/appdata' });
+    await advanceBlocks(3);
+    await waitForAppInstalled(env.clients[TARGET - 1], 'plainapp', 300000);
+    await waitForAppInstalled(env.clients[TARGET - 1], 'worldapp', 300000);
+
+    // Nobody has the world. Declared before enforcement starts, so the node
+    // never sees a moment where the data looks safe.
+    await setNoPeerData({ folder: 'fluxworldapp_worldapp' });
+
+    await setSystemSecure(subnet.nodeIp(TARGET), false);
+    await waitForSpawnerBlocked(env.clients[TARGET - 1], 'placement_hold', 120000);
+    await waitFor(async () => (await dbClient(TARGET).residentialMarker()) !== null,
+      { timeout: 120000, label: 'the settling window starts again' });
+    await elapseSettleWindow(TARGET);
+
+    // The stateless one goes, which is what tells us the pass ran.
+    await whenGone(env, TARGET, 'plainapp', 300000);
+
+    // And the stateful one is still here, because refusing is what the gate is
+    // for. Every removal path before this decided on an instance count alone,
+    // and a count cannot tell a redundant copy from the last one holding data.
+    const installed = await env.clients[TARGET - 1].get('/apps/installedapps');
+    expect(installed.data.map((a) => a.name)).to.include('worldapp');
+  });
+
+  it('hands the stateful app back once a peer holds it in full', async function () {
+    this.timeout(600000);
+
+    await setPeerHasData({ folder: 'fluxworldapp_worldapp' });
+
+    await whenGone(env, TARGET, 'worldapp', 300000);
+
+    // It left because a peer could be shown to hold the data, not because the
+    // node ran out of patience.
+    const locations = await dbClient(2).getAppLocations('worldapp');
+    expect(locations.map((l) => l.ip.split(':')[0])).to.not.include(subnet.nodeIp(TARGET));
+  });
+
+  it('gives up one app per pass, spaced by the departure interval', async function () {
+    this.timeout(600000);
+
+    // Two apps eligible at the same instant. A node that emptied itself as fast
+    // as it could would take both in one pass; the whole point of the pacing is
+    // that a residential line sheds slowly enough for the spawner to refill
+    // behind it.
+    //
+    // Attested first, because a held node takes no new apps - there would be
+    // nothing on it to pace.
+    await setSystemSecure(subnet.nodeIp(TARGET), true);
+    await waitFor(async () => (await dbClient(TARGET).residentialMarker()) === null,
+      { timeout: 120000, label: 'node 1 is back in service' });
+
+    await seedApp(env, 'pacedone', { instances: 5 });
+    await seedApp(env, 'pacedtwo', { instances: 5 });
+    await advanceBlocks(3);
+    await waitForAppInstalled(env.clients[TARGET - 1], 'pacedone', 300000);
+    await waitForAppInstalled(env.clients[TARGET - 1], 'pacedtwo', 300000);
+
+    await setSystemSecure(subnet.nodeIp(TARGET), false);
+    await waitFor(async () => (await dbClient(TARGET).residentialMarker()) !== null,
+      { timeout: 120000, label: 'the settling window starts' });
+    await elapseSettleWindow(TARGET);
+
+    const held = async () => {
+      const installed = await env.clients[TARGET - 1].get('/apps/installedapps');
+      const names = installed.data.map((a) => a.name);
+      return ['pacedone', 'pacedtwo'].filter((n) => names.includes(n));
+    };
+
+    await waitFor(async () => (await held()).length <= 1,
+      { timeout: 300000, label: 'node 1 gives up the first of the two' });
+    const first = Date.now();
+
+    await waitFor(async () => (await held()).length === 0,
+      { timeout: 300000, label: 'node 1 gives up the second' });
+    const second = Date.now();
+
+    // The interval is a floor on the gap, and the pass only runs every fourth
+    // block, so the observed gap is at least the interval and usually more.
+    expect(second - first).to.be.at.least(20000);
   });
 });

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -66,7 +66,7 @@ const RESIDENTIAL_PACING = (() => {
 // four minutes driveUntil defaults to, which was written when the interval was
 // four seconds. Two cycles' worth: several of these waits contain a departure
 // AND the pass on which another holder reacts to it.
-const ONE_DEPARTURE_MS = departureCycleMs(
+const DEPARTURE_WAIT_MS = 2 * departureCycleMs(
   {
     ...RESIDENTIAL_PACING,
     removeFluxAppsPeriod: PASS_PERIOD_BLOCKS,
@@ -75,7 +75,6 @@ const ONE_DEPARTURE_MS = departureCycleMs(
   },
   5,
 );
-const DEPARTURE_WAIT_MS = 2 * ONE_DEPARTURE_MS;
 
 const RESIDENTIAL_GEO = {
   hosting: false,
@@ -196,161 +195,175 @@ async function runningComponents(env, nodeIndex) {
   return list.flatMap((a) => a.Names || []).map((n) => n.replace(/^\//, ''));
 }
 
+// Node 1 is the node under test: on a residential connection from the moment
+// it boots, but ATTESTED, so nothing enforces against it and it takes its
+// share of the work. Attestation is then withdrawn, which is the whole point
+// of the staging - a node that already holds customer data and stops being
+// fit to serve.
+//
+// It has to be done in that order. The placement hold lands within seconds of
+// boot, so a node that is residential AND unattested from the start never
+// takes an app at all: it is empty, and an empty target goes straight to DOS
+// because there is no data at stake. Nothing would ever be evacuated.
+// Attestation is also the only input re-read on every tick - geolocation is
+// looked up once and then not again for three days - so it is the only lever
+// that can flip a running node.
+//
+// Every other node is attested and in a data centre.
+const TARGET = 1;
+// .12 - same published organisation as the target, but with nothing of its own
+// to go on, so the table is the only thing that can decide it.
+const TABLE_DECIDED = 3;
+// .14 - same published organisation again, but its own address carries hosting
+// evidence, so it declines the verdict.
+const VETOING = 5;
+// A second residential node, so the serialisation claim has two holders to
+// serialise. Published residential like node 1, and attested until a test
+// withdraws it.
+const SECOND_TARGET = 3;
+
+/**
+ * The fleet every test here runs on: node 1 residential and attested, the rest
+ * in a data centre, and a published table that decides all of them.
+ *
+ * A FUNCTION rather than one before() hook, because the suite is split across
+ * two fleets. The stand-down tests need a node that holds ONE app; the tests
+ * above them leave a node holding seven, and evacuation sheds one per
+ * departure interval - see the second describe.
+ */
+async function bootResidentialFleet(hookCtx) {
+  const env = await createTestEnv({
+  hookCtx,
+    nodes: 5,
+    tickerAutostart: false,
+    // Seeded through createTestEnv, not POSTed afterwards: a node looks its
+    // address up once during boot, so an override applied after the fleet is
+    // up is never read and the node classifies itself from the stub default.
+    geolocation: { [TARGET]: RESIDENTIAL_GEO, [TABLE_DECIDED]: NEUTRAL_GEO, [VETOING]: HOSTING_GEO },
+    // Two organisations across the fleet's /24, assigned round-robin by last
+    // octet, and the one holding .10/.12/.14 is published residential. This is
+    // the authority the fleet runs on in production - 2,303 of 2,513 hosts are
+    // decided by the table rather than by their own reading - so a suite that
+    // only ever exercised the fallback would be testing the path that decides
+    // almost nothing.
+    locationTable: {
+      domains: 2,
+      subnet: subnet.base,
+      classes: { 0: 'residential', 1: 'hosting' },
+    },
+    configOverrides: {
+      fluxapps: {
+        // Compressed the same way every other suite compresses the interval it
+        // is exercising. The production values are hours; the behaviour under
+        // test is the ordering, not the wall-clock.
+        // A HARNESS WORKAROUND, and deliberately not a fix.
+        //
+        // The node learns the chain height from a cache refreshed on this
+        // interval, and processBlock then chains through every block that
+        // arrived since. Only the LAST of such a burst is still the tip, so
+        // only that one satisfies explorerService's `confirmations < 2` gate
+        // and runs the app maintenance hung off it - including the give-up
+        // pass this suite exercises.
+        //
+        // The harness default is 5000 against a 5000ms block, which is 1:1 -
+        // and so is production, 30s blocks against a 30s poll, post-PON. The
+        // race is real on a live node: blocks periodically arrive two to a
+        // window and the earlier one skips maintenance silently. What the
+        // harness adds is PERMANENCE - a steady two-block burst pins the
+        // surviving block to one parity, and `height % 4 === 0` then never
+        // lands for an entire run, so evacuation could never be observed.
+        //
+        // It is not fixed on this lineage because it cannot be fixed cheaply:
+        // the only chain height a node holds is that same cached value, so
+        // comparing against it is the identical race with an extra step, and
+        // knowing the true tip needs a fresh RPC per block on every node. v9
+        // solves it properly - fluxd's `hashblockheight` is pushed to
+        // chainTipSource, which drives both the cached tip and the explorer
+        // scan, leaving the 30s poll as a fallback only.
+        //
+        // So: shorten the poll here so the suite can see the path at all.
+        daemonInfoIntervalMs: 1000,
+        residentialCheckIntervalMs: 3000,
+        // The give-up pass runs every removeFluxAppsPeriod * 4 blocks, and a
+        // block costs one explorerPollIntervalMs. There is a three-way
+        // relationship here and all three have to hold, or the serialisation
+        // this suite checks cannot happen:
+        //
+        //   propagation  <  pass interval  <  queue step
+        //
+        // A departure has to be VISIBLE to the other holder by its next pass
+        // (propagation < pass), and the two holders' turns have to fall on
+        // different passes (pass < step). Measured: with the pass at 4 blocks
+        // (~1s) the other node evaluated twice more before the
+        // network:appremoved reached it - propagation lost the race, both
+        // holders saw the app at full strength, and both left.
+        //
+        // Set from PASS_PERIOD_BLOCKS at the top of this file, which explains
+        // what it costs and what bounds it from below. What it costs in wall
+        // time is set by explorerPollIntervalMs, not by this number.
+        removeFluxAppsPeriod: PASS_PERIOD_BLOCKS,
+        // Left LONG on purpose, and opened by the test when it is ready. A
+        // short window would let evacuation start while the hold is still
+        // being asserted, and the ordering - hold first, deletes nothing, and
+        // only later gives an app up - is the property under test.
+        residentialSettleMs: 600000,
+        residentialQueueBaseMs: 1000,
+        // Position in the instance order sets a wait of base + position*step,
+        // and the step is what stops two holders of the same app leaving
+        // together: the second's turn has to arrive AFTER the first's
+        // departure is visible to it.
+        //
+        // DERIVED, never written as a literal. The step has to outlast a pass
+        // and the pass is a function of explorerPollIntervalMs - a block costs
+        // one poll - so a literal here silently stops tracking the pass the
+        // moment that knob moves. It did: 15000 was chosen against a pass this
+        // comment called "about 4s", the poll went 250ms -> 833ms, the pass
+        // went with it to ~16s, and the step ended up SHORTER than the pass.
+        // Both holders then matured on the same pass and both handed the same
+        // app back - the mechanism intact, the property compressed out of
+        // existence, which is the defect production's own 15-minute step had.
+        //
+        // coupled-knobs.js carries the derivation and test-env asserts the
+        // resulting ratio against production's on every fleet boot.
+        residentialQueueStepMs: RESIDENTIAL_PACING.residentialQueueStepMs,
+        // DERIVED too, and for a reason the 4000ms literal here could not
+        // survive. A node inside its departure interval records nothing
+        // against its queue tickets, so the block is what restarts them - and
+        // that only works if the block outlasts the gap a ticket tolerates,
+        // which IS the step. At 4000ms against a ~29s step the block stopped
+        // reading as a gap: every ticket carried across it, every app was
+        // instantly ready the moment the interval cleared, and two holders
+        // whose blocks expired in the same pass handed back the same app
+        // together. Production holds 6h against 40min and never meets it.
+        //
+        // It costs the suite real time - one departure per interval, and the
+        // interval is now tens of seconds rather than four. That is the price
+        // of the suite being able to see the property at all.
+        residentialEvacuationIntervalMs: RESIDENTIAL_PACING.residentialEvacuationIntervalMs,
+      },
+    },
+  });
+  await bootToReady(env);
+  // The verdict this suite rests on needs the PUBLISHED table, not only the
+  // node's own evidence: getNetworkClassification returns null while
+  // publishedClassification reports consulted:false, and the two arrive at
+  // different times. The veto test waited for networkEvidence alone and then
+  // asked for a classification, so on the bc5d86154 gate node 5 spent all 24 of
+  // its ticks logging "no network verdict to act on yet" and the test timed out
+  // against classification:null, source:null - a decision that could not be
+  // reached rather than one that went the wrong way. Waited for on every node,
+  // because the table is the authority the whole suite runs on.
+  await Promise.all(env.clients.map((c) => waitForLocationTable(c, { domains: 2 })));
+  return env;
+}
+
 describe('Residential node evacuation', function () {
   let env;
   dumpLogsOnFailure(() => env);
 
-  // Node 1 is the node under test: on a residential connection from the moment
-  // it boots, but ATTESTED, so nothing enforces against it and it takes its
-  // share of the work. Attestation is then withdrawn, which is the whole point
-  // of the staging - a node that already holds customer data and stops being
-  // fit to serve.
-  //
-  // It has to be done in that order. The placement hold lands within seconds of
-  // boot, so a node that is residential AND unattested from the start never
-  // takes an app at all: it is empty, and an empty target goes straight to DOS
-  // because there is no data at stake. Nothing would ever be evacuated.
-  // Attestation is also the only input re-read on every tick - geolocation is
-  // looked up once and then not again for three days - so it is the only lever
-  // that can flip a running node.
-  //
-  // Every other node is attested and in a data centre.
-  const TARGET = 1;
-  // .12 - same published organisation as the target, but with nothing of its own
-  // to go on, so the table is the only thing that can decide it.
-  const TABLE_DECIDED = 3;
-  // .14 - same published organisation again, but its own address carries hosting
-  // evidence, so it declines the verdict.
-  const VETOING = 5;
-  // A second residential node, so the serialisation claim has two holders to
-  // serialise. Published residential like node 1, and attested until a test
-  // withdraws it.
-  const SECOND_TARGET = 3;
-
   before(async function () {
     this.timeout(600000);
-    env = await createTestEnv({
-      hookCtx: this,
-      nodes: 5,
-      tickerAutostart: false,
-      // Seeded through createTestEnv, not POSTed afterwards: a node looks its
-      // address up once during boot, so an override applied after the fleet is
-      // up is never read and the node classifies itself from the stub default.
-      geolocation: { [TARGET]: RESIDENTIAL_GEO, [TABLE_DECIDED]: NEUTRAL_GEO, [VETOING]: HOSTING_GEO },
-      // Two organisations across the fleet's /24, assigned round-robin by last
-      // octet, and the one holding .10/.12/.14 is published residential. This is
-      // the authority the fleet runs on in production - 2,303 of 2,513 hosts are
-      // decided by the table rather than by their own reading - so a suite that
-      // only ever exercised the fallback would be testing the path that decides
-      // almost nothing.
-      locationTable: {
-        domains: 2,
-        subnet: subnet.base,
-        classes: { 0: 'residential', 1: 'hosting' },
-      },
-      configOverrides: {
-        fluxapps: {
-          // Compressed the same way every other suite compresses the interval it
-          // is exercising. The production values are hours; the behaviour under
-          // test is the ordering, not the wall-clock.
-          // A HARNESS WORKAROUND, and deliberately not a fix.
-          //
-          // The node learns the chain height from a cache refreshed on this
-          // interval, and processBlock then chains through every block that
-          // arrived since. Only the LAST of such a burst is still the tip, so
-          // only that one satisfies explorerService's `confirmations < 2` gate
-          // and runs the app maintenance hung off it - including the give-up
-          // pass this suite exercises.
-          //
-          // The harness default is 5000 against a 5000ms block, which is 1:1 -
-          // and so is production, 30s blocks against a 30s poll, post-PON. The
-          // race is real on a live node: blocks periodically arrive two to a
-          // window and the earlier one skips maintenance silently. What the
-          // harness adds is PERMANENCE - a steady two-block burst pins the
-          // surviving block to one parity, and `height % 4 === 0` then never
-          // lands for an entire run, so evacuation could never be observed.
-          //
-          // It is not fixed on this lineage because it cannot be fixed cheaply:
-          // the only chain height a node holds is that same cached value, so
-          // comparing against it is the identical race with an extra step, and
-          // knowing the true tip needs a fresh RPC per block on every node. v9
-          // solves it properly - fluxd's `hashblockheight` is pushed to
-          // chainTipSource, which drives both the cached tip and the explorer
-          // scan, leaving the 30s poll as a fallback only.
-          //
-          // So: shorten the poll here so the suite can see the path at all.
-          daemonInfoIntervalMs: 1000,
-          residentialCheckIntervalMs: 3000,
-          // The give-up pass runs every removeFluxAppsPeriod * 4 blocks, and a
-          // block costs one explorerPollIntervalMs. There is a three-way
-          // relationship here and all three have to hold, or the serialisation
-          // this suite checks cannot happen:
-          //
-          //   propagation  <  pass interval  <  queue step
-          //
-          // A departure has to be VISIBLE to the other holder by its next pass
-          // (propagation < pass), and the two holders' turns have to fall on
-          // different passes (pass < step). Measured: with the pass at 4 blocks
-          // (~1s) the other node evaluated twice more before the
-          // network:appremoved reached it - propagation lost the race, both
-          // holders saw the app at full strength, and both left.
-          //
-          // Set from PASS_PERIOD_BLOCKS at the top of this file, which explains
-          // what it costs and what bounds it from below. What it costs in wall
-          // time is set by explorerPollIntervalMs, not by this number.
-          removeFluxAppsPeriod: PASS_PERIOD_BLOCKS,
-          // Left LONG on purpose, and opened by the test when it is ready. A
-          // short window would let evacuation start while the hold is still
-          // being asserted, and the ordering - hold first, deletes nothing, and
-          // only later gives an app up - is the property under test.
-          residentialSettleMs: 600000,
-          residentialQueueBaseMs: 1000,
-          // Position in the instance order sets a wait of base + position*step,
-          // and the step is what stops two holders of the same app leaving
-          // together: the second's turn has to arrive AFTER the first's
-          // departure is visible to it.
-          //
-          // DERIVED, never written as a literal. The step has to outlast a pass
-          // and the pass is a function of explorerPollIntervalMs - a block costs
-          // one poll - so a literal here silently stops tracking the pass the
-          // moment that knob moves. It did: 15000 was chosen against a pass this
-          // comment called "about 4s", the poll went 250ms -> 833ms, the pass
-          // went with it to ~16s, and the step ended up SHORTER than the pass.
-          // Both holders then matured on the same pass and both handed the same
-          // app back - the mechanism intact, the property compressed out of
-          // existence, which is the defect production's own 15-minute step had.
-          //
-          // coupled-knobs.js carries the derivation and test-env asserts the
-          // resulting ratio against production's on every fleet boot.
-          residentialQueueStepMs: RESIDENTIAL_PACING.residentialQueueStepMs,
-          // DERIVED too, and for a reason the 4000ms literal here could not
-          // survive. A node inside its departure interval records nothing
-          // against its queue tickets, so the block is what restarts them - and
-          // that only works if the block outlasts the gap a ticket tolerates,
-          // which IS the step. At 4000ms against a ~29s step the block stopped
-          // reading as a gap: every ticket carried across it, every app was
-          // instantly ready the moment the interval cleared, and two holders
-          // whose blocks expired in the same pass handed back the same app
-          // together. Production holds 6h against 40min and never meets it.
-          //
-          // It costs the suite real time - one departure per interval, and the
-          // interval is now tens of seconds rather than four. That is the price
-          // of the suite being able to see the property at all.
-          residentialEvacuationIntervalMs: RESIDENTIAL_PACING.residentialEvacuationIntervalMs,
-        },
-      },
-    });
-    await bootToReady(env);
-    // The verdict this suite rests on needs the PUBLISHED table, not only the
-    // node's own evidence: getNetworkClassification returns null while
-    // publishedClassification reports consulted:false, and the two arrive at
-    // different times. The veto test waited for networkEvidence alone and then
-    // asked for a classification, so on the bc5d86154 gate node 5 spent all 24 of
-    // its ticks logging "no network verdict to act on yet" and the test timed out
-    // against classification:null, source:null - a decision that could not be
-    // reached rather than one that went the wrong way. Waited for on every node,
-    // because the table is the authority the whole suite runs on.
-    await Promise.all(env.clients.map((c) => waitForLocationTable(c, { domains: 2 })));
+    env = await bootResidentialFleet(this);
   });
 
   after(async function () {
@@ -907,6 +920,43 @@ describe('Residential node evacuation', function () {
       (e) => e.event === 'app:removed' && e.data?.name === remaining && e.id < verdict.id,
     ), `${remaining} left during the departure interval instead of serving a turn`).to.equal(false);
   });
+});
+
+// A FLEET OF ITS OWN, and the reason is arithmetic.
+//
+// Every app this suite seeds asks for five instances on a five-node fleet, so
+// each one lands on every node, and nothing removes them between tests. By the
+// end of the describe above, node 1 holds seven apps. Evacuation gives up ONE
+// app per departure interval, and a node inside that interval records nothing
+// against any other app's queue ticket - so every departure restarts the turn
+// of everything still held.
+//
+// The stand-down tests would therefore be queued behind six unrelated apps, at
+// roughly a hundred seconds each. On the 2026-08-31 gate that suite shed six
+// inside the budget and ran out one departure short of the seventh: primaryapp
+// drew ten DEPARTURE_INTERVAL and ten AWAITING_TURN verdicts and never reached
+// the stand-down check at all - no answer rather than a wrong one, and tests 17
+// and 18 never ran.
+//
+// Budgeting for that queue was the wrong fix: it makes one test wait thirteen
+// minutes and leaves the next person to add a test to discover the same thing.
+// These tests need one node that is the elected primary of one app and is
+// draining. A second fleet costs one boot and gives them exactly that.
+describe('Residential node evacuation: standing down as the elected primary', function () {
+  let env;
+  dumpLogsOnFailure(() => env);
+
+  before(async function () {
+    this.timeout(600000);
+    env = await bootResidentialFleet(this);
+  });
+
+  after(async function () {
+    this.timeout(120000);
+    await clearSystemSecure().catch(() => {});
+    await stopTicker().catch(() => {});
+    if (env) await env.teardown();
+  });
 
   it('stands down as the elected primary rather than handing the app back from under itself', async function () {
     this.timeout(900000);
@@ -941,28 +991,14 @@ describe('Residential node evacuation', function () {
       .then((v) => { standDownVerdict = v; return v; });
     stoodDown.catch(() => {});
 
-    // THE BUDGET IS A DEPARTURE PER APP THIS NODE STILL HOLDS, not two.
-    //
-    // Evacuation gives up ONE app per departure interval, and a node inside that
-    // interval records nothing against any other app's queue ticket - so every
-    // departure restarts the turn of everything still held. By this test the
-    // node has collected an app from most of the fifteen tests ahead of it, and
-    // primaryapp is behind all of them.
-    //
-    // Two cycles was right when this test was written and stopped being right as
-    // tests were added in front of it, silently: on the 2026-08-31 gate the node
-    // held seven apps, shed six inside the window, and ran out one departure
-    // short. primaryapp drew 10 DEPARTURE_INTERVAL and 10 AWAITING_TURN verdicts
-    // and no STAND_DOWN_REQUIRED - not a wrong answer, no answer, which is
-    // indistinguishable in the failure message from the stand-down never firing.
-    //
-    // Read from the node rather than counted by hand here, so adding a test
-    // ahead of this one cannot quietly shorten its budget again. One cycle of
-    // headroom so the last verdict has a pass to land in.
-    const heldBefore = await dbClient(TARGET).localAppCount();
+    // Two cycles is enough here BECAUSE this fleet is fresh: the node holds
+    // primaryapp and nothing else, so the stand-down is the first thing its
+    // evacuation reaches rather than the seventh. On the shared fleet above it
+    // would need a departure per app held, which is what the split exists to
+    // avoid rather than to budget for.
     await stopTicker();
     await driveUntil(env.clients[TARGET - 1], async () => standDownVerdict !== null,
-      { timeoutMs: (heldBefore + 1) * ONE_DEPARTURE_MS });
+      { timeoutMs: DEPARTURE_WAIT_MS });
     await startTicker();
 
     const verdict = await stoodDown;

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -487,27 +487,35 @@ describe('Residential node evacuation', function () {
     // app:removed and dos:changed arrive on ONE stream with monotonic ids, so
     // comparing their ids is a fact about what happened rather than a race
     // between two reads of two different sources.
+    //
+    // Both waits are armed BEFORE the pass runs, because both events are the
+    // subject: the claim is that one precedes the other, so neither may be
+    // sampled from a buffer read at a moment of this test's choosing. An
+    // earlier form read the buffer as soon as app:removed landed and found no
+    // DOS at all - DOS follows the departure by about two seconds, so it had
+    // not happened yet. Awaiting both is what makes the comparison meaningful
+    // rather than a race against whichever arrived first.
     const removal = env.clients[TARGET - 1].waitForEvent(
       'app:removed', (d) => d.name === 'residentapp', 300000,
     );
+    const dosLanded = env.clients[TARGET - 1].waitForEvent(
+      'dos:changed', (d) => d.dosState >= 100, 300000,
+    );
+
+    // Only the removal needs blocks. DOS is applied by the residential tick on
+    // its own residentialCheckIntervalMs timer, so it arrives with the chain
+    // stopped - which is also why it cannot be driven for.
     await driveUntil(env, TARGET, async () => {
       const buffer = env.clients[TARGET - 1].getEventBuffer();
       return buffer.some((e) => e.event === 'app:removed' && e.data?.name === 'residentapp');
     });
-    const removedEvent = await removal;
 
-    // Both halves, because either alone is satisfiable by an event that never
-    // fires. "nothing arrived early" is trivially true of a signal that is
-    // silent - which dos:changed WAS on this path until the sticky setters were
-    // made to emit it - so the presence check is what keeps this test honest.
-    const dosEvents = env.clients[TARGET - 1].getEventBuffer()
-      .filter((e) => e.event === 'dos:changed' && e.data?.dosState >= 100);
-    expect(dosEvents, 'the node must actually reach DOS, or the ordering below proves nothing')
-      .to.not.be.empty;
+    const [removedEvent, dosEvent] = await Promise.all([removal, dosLanded]);
 
-    const earlyDos = dosEvents.find((e) => e.id < removedEvent.id);
-    expect(earlyDos, `DOS reached ${earlyDos?.data?.dosState} before the app was handed back`)
-      .to.equal(undefined);
+    // One stream, monotonic ids, so this is an ordering fact rather than two
+    // polls of two sources that disagree about what happened first.
+    expect(dosEvent.id, 'DOS landed before the app was handed back')
+      .to.be.above(removedEvent.id);
 
     // The node's own view, not app:removed - that event is published part-way
     // through the uninstall, after the runtime state is dropped and before the

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -399,14 +399,19 @@ describe('Residential node evacuation', function () {
 
     // The node now publishes what each tick concluded, so this waits for the
     // decision instead of waiting out thirty seconds and inferring it from
-    // nothing having happened. enforce === false is the veto having held: the
-    // table said RESIDENTIAL, this node's own evidence contradicted it, and the
-    // verdict came back CONFLICTED. Explicitly not `!enforce` - null is a tick
-    // that could not decide, which is the opposite claim.
+    // nothing having happened.
+    //
+    // Matched on the VERDICT, not on enforce. A veto lands the node in
+    // CONFLICTED, and isResidential collapses CONFLICTED to null the same as
+    // UNKNOWN and the same as no-table-consulted - so enforce alone cannot tell
+    // "this node declined a published verdict about its own address" from
+    // "this node has read nothing yet". source: node-veto is the assertion that
+    // the veto is what did it.
     const decision = await waitForResidentialDecision(
-      env.clients[VETOING - 1], (d) => d.enforce === false, 60000,
+      env.clients[VETOING - 1], (d) => d.source === 'node-veto', 60000,
     );
-    expect(decision.data.residential, 'the veto makes the verdict not-residential').to.equal(false);
+    expect(decision.data.classification, 'a vetoed verdict is CONFLICTED').to.equal('CONFLICTED');
+    expect(decision.data.enforce, 'and CONFLICTED enforces nothing').to.equal(null);
 
     expect(await dbClient(VETOING).residentialMarker(), 'a vetoing node must not start a settling window').to.equal(null);
     const after = await env.clients[VETOING - 1].get('/flux/info');

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -626,13 +626,20 @@ describe('Residential node evacuation', function () {
 
     await setSystemSecure(subnet.nodeIp(TARGET), false);
     await setSystemSecure(subnet.nodeIp(SECOND_TARGET), false);
-    for (const node of [TARGET, SECOND_TARGET]) {
-      // eslint-disable-next-line no-await-in-loop
-      await waitFor(async () => (await dbClient(node).residentialMarker()) !== null,
-        { timeout: 120000, label: `node ${node} starts its settling window` });
-      // eslint-disable-next-line no-await-in-loop
-      await elapseSettleWindow(node);
-    }
+    await Promise.all([TARGET, SECOND_TARGET].map((node) => waitFor(
+      async () => (await dbClient(node).residentialMarker()) !== null,
+      { timeout: 120000, label: `node ${node} starts its settling window` },
+    )));
+
+    // Opened TOGETHER, not one after the other. The queue ticket is
+    // `observed >= base + position*step`, and `observed` starts when a node
+    // first sees the app whole - so it fixes a different DURATION per node, not
+    // a different deadline. Open the two windows a few seconds apart and the
+    // later start with the shorter wait lands on the same instant as the earlier
+    // start with the longer one, both nodes decide in the same pass, and the
+    // ordering the test exists to prove is gone. In production both holders
+    // start observing together, which is what makes position decide.
+    await Promise.all([TARGET, SECOND_TARGET].map((node) => elapseSettleWindow(node)));
 
     // Whichever goes first, the other must be refused while the app is short.
     let refusal = null;

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -146,6 +146,33 @@ describe('Residential node evacuation', function () {
           // Compressed the same way every other suite compresses the interval it
           // is exercising. The production values are hours; the behaviour under
           // test is the ordering, not the wall-clock.
+          // A HARNESS WORKAROUND, and deliberately not a fix.
+          //
+          // The node learns the chain height from a cache refreshed on this
+          // interval, and processBlock then chains through every block that
+          // arrived since. Only the LAST of such a burst is still the tip, so
+          // only that one satisfies explorerService's `confirmations < 2` gate
+          // and runs the app maintenance hung off it - including the give-up
+          // pass this suite exercises.
+          //
+          // The harness default is 5000 against a 5000ms block, which is 1:1 -
+          // and so is production, 30s blocks against a 30s poll, post-PON. The
+          // race is real on a live node: blocks periodically arrive two to a
+          // window and the earlier one skips maintenance silently. What the
+          // harness adds is PERMANENCE - a steady two-block burst pins the
+          // surviving block to one parity, and `height % 4 === 0` then never
+          // lands for an entire run, so evacuation could never be observed.
+          //
+          // It is not fixed on this lineage because it cannot be fixed cheaply:
+          // the only chain height a node holds is that same cached value, so
+          // comparing against it is the identical race with an extra step, and
+          // knowing the true tip needs a fresh RPC per block on every node. v9
+          // solves it properly - fluxd's `hashblockheight` is pushed to
+          // chainTipSource, which drives both the cached tip and the explorer
+          // scan, leaving the 30s poll as a fallback only.
+          //
+          // So: shorten the poll here so the suite can see the path at all.
+          daemonInfoIntervalMs: 1000,
           residentialCheckIntervalMs: 3000,
           // Left LONG on purpose, and opened by the test when it is ready. A
           // short window would let evacuation start while the hold is still

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -13,6 +13,7 @@ import {
   waitForExplorerReady, waitForOrchestratorStarted, waitForOrchestratorState,
   waitForPeerThreshold, waitForAppInstalled,
   waitForSpawnerBlocked, waitFor, waitForGiveUpConsidered, waitForGiveUpSafety,
+  waitForResidentialDecision,
 } from '../framework/wait.js';
 import { setNoPeerData, setPeerHasData, setSynced } from '../framework/syncthing-control.js';
 import { electMaster, startFdmOutage, endFdmOutage } from '../framework/fdm-control.js';
@@ -393,10 +394,16 @@ describe('Residential node evacuation', function () {
     // used by no later test, so it stays withdrawn.
     await setSystemSecure(subnet.nodeIp(VETOING), false);
 
-    // Ten residential check intervals at the compressed cadence. There is no
-    // event for "decided not to enforce" - the absence of the placement hold IS
-    // the outcome - so this waits out the decision rather than waiting for it.
-    await new Promise((resolve) => { setTimeout(resolve, 30000); });
+    // The node now publishes what each tick concluded, so this waits for the
+    // decision instead of waiting out thirty seconds and inferring it from
+    // nothing having happened. enforce === false is the veto having held: the
+    // table said RESIDENTIAL, this node's own evidence contradicted it, and the
+    // verdict came back CONFLICTED. Explicitly not `!enforce` - null is a tick
+    // that could not decide, which is the opposite claim.
+    const decision = await waitForResidentialDecision(
+      env.clients[VETOING - 1], (d) => d.enforce === false, 60000,
+    );
+    expect(decision.data.residential, 'the veto makes the verdict not-residential').to.equal(false);
 
     expect(await dbClient(VETOING).residentialMarker(), 'a vetoing node must not start a settling window').to.equal(null);
     const after = await env.clients[VETOING - 1].get('/flux/info');
@@ -458,11 +465,19 @@ describe('Residential node evacuation', function () {
       // applied while apps were still held would empty the node and satisfy
       // both of that test's waits - faster than the correct behaviour. A
       // throwing expect inside the condition propagates out of driveUntil.
+      //
+      // The app list is read FIRST and the DOS check is conditional on it.
+      // Asserting DOS unconditionally fails on the correct sequence: the node
+      // hands the app back and DOS follows about six seconds later, so the
+      // first poll after a successful departure sees dosState 100 with nothing
+      // held - which is the outcome this test is waiting for, not a violation.
+      const current = await env.clients[TARGET - 1].get('/apps/installedapps');
+      const stillHeld = current.data.map((a) => a.name).includes('residentapp');
+      if (!stillHeld) return true;
       const info = await env.clients[TARGET - 1].get('/flux/info');
       expect(info.data.flux.dos.dosState, 'DOS must not land while an app is still held')
         .to.be.below(100);
-      const current = await env.clients[TARGET - 1].get('/apps/installedapps');
-      return !current.data.map((a) => a.name).includes('residentapp');
+      return false;
     });
 
     // The node's own view, not app:removed - that event is published part-way
@@ -781,8 +796,6 @@ describe('Residential node evacuation', function () {
     // and a refused connection is the signature a real FDM outage carries - the
     // error reaches the node with no response on it at all. The gate is allowed
     // to act on the first and must not act on the second.
-    const electionCycleMs = 3000; // config.fluxapps.masterSlaveIntervalMs, harness value
-    const staleAfterMs = electionCycleMs * 10; // PRIMARY_ELECTION_STALE_MS
     await startFdmOutage('refuse');
 
     try {
@@ -792,11 +805,18 @@ describe('Residential node evacuation', function () {
         .then((v) => { unknownRefusal = v; return v; });
       refused.catch(() => {});
 
-      // Let the last verdict age out before driving the pass that reads it.
-      // Driving sooner would prove nothing: the node would still be answering
-      // from what it learned while FDM was up.
-      await new Promise((resolve) => { setTimeout(resolve, staleAfterMs + electionCycleMs); });
-
+      // Driven from the start rather than after a sleep. The verdict has to age
+      // past PRIMARY_ELECTION_STALE_MS before the gate reports ELECTION_UNKNOWN,
+      // and until it does the pass refuses with ELECTION_PRIMARY instead - so
+      // the passes in between are not wasted, they are the evidence that the
+      // node kept answering from what it knew while FDM was up. Waiting for the
+      // refusal to change rather than sleeping for the window means the test
+      // ends when the property holds, not when a timer says it should.
+      //
+      // That window is ten election cycles derived from masterSlaveIntervalMs,
+      // which the harness already compresses 10x to 3s - so this costs ~30s and
+      // shortening it means compressing masterSlaveIntervalMs further, which
+      // has its own couplings to check first.
       await stopTicker();
       await driveUntil(env, TARGET, async () => unknownRefusal !== null);
       await startTicker();

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -246,7 +246,17 @@ describe('Residential node evacuation', function () {
           residentialSettleMs: 600000,
           residentialEvacuationIntervalMs: 4000,
           residentialQueueBaseMs: 1000,
-          residentialQueueStepMs: 500,
+          // The step has to exceed the interval between give-up passes, or the
+          // ordering it exists to create is compressed out of existence.
+          //
+          // Position in the instance order sets a wait of base + position*step.
+          // In production that is 30min + position*15min against a pass that
+          // runs every 44 blocks (~22min), so the second holder's turn arrives
+          // on a LATER pass than the first's - by which time the first has gone,
+          // the app is short, and the second refuses. That is what serialises
+          // the drain. At a 500ms step against a 20s pass, both holders are
+          // eligible in the same pass and both leave together.
+          residentialQueueStepMs: 30000,
           removeFluxAppsPeriod: 1,
         },
       },

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -360,6 +360,12 @@ describe('Residential node evacuation', function () {
 
     // Its own reading is UNKNOWN - no signal for, none against - so a verdict of
     // RESIDENTIAL can only have come from the table.
+    //
+    // The dosState assertion above is guaranteed by this node's attestation and
+    // establishes nothing on its own; what this test rests on is the evidence
+    // below. Withdrawing the attestation to make the verdict decide, as the
+    // veto test does, is not available here: node 3 is SECOND_TARGET for the
+    // later drain tests and has to arrive at them attested.
     const geo = await dbClient(TABLE_DECIDED).geolocation();
     expect(geo.networkEvidence.classification).to.equal('UNKNOWN');
     expect(geo.networkEvidence.evidenceFor).to.be.empty;
@@ -380,8 +386,21 @@ describe('Residential node evacuation', function () {
     const geo = await dbClient(VETOING).geolocation();
     expect(geo.networkEvidence.evidenceAgainst).to.not.be.empty;
 
-    const info = await env.clients[VETOING - 1].get('/flux/info');
-    expect(info.data.flux.dos.dosState).to.be.below(100);
+    // Attestation alone keeps this node below 100, so asserting only that
+    // proves nothing about the veto: shouldEnforce is `residential && !arcane`,
+    // and deleting the veto entirely left this test green. Withdraw the
+    // attestation and the verdict is the only thing left deciding. Node 5 is
+    // used by no later test, so it stays withdrawn.
+    await setSystemSecure(subnet.nodeIp(VETOING), false);
+
+    // Ten residential check intervals at the compressed cadence. There is no
+    // event for "decided not to enforce" - the absence of the placement hold IS
+    // the outcome - so this waits out the decision rather than waiting for it.
+    await new Promise((resolve) => { setTimeout(resolve, 30000); });
+
+    expect(await dbClient(VETOING).residentialMarker(), 'a vetoing node must not start a settling window').to.equal(null);
+    const after = await env.clients[VETOING - 1].get('/flux/info');
+    expect(after.data.flux.dos.dosState).to.be.below(100);
   });
 
   it('leaves a residential node alone while it is still attested', async function () {
@@ -433,6 +452,15 @@ describe('Residential node evacuation', function () {
     // driveUntil.
     await stopTicker();
     await driveUntil(env, TARGET, async () => {
+      // Sampled across the whole window in which the node still holds the app.
+      // "goes into DOS only once it holds nothing" cannot see this on its own:
+      // nodeStatusMonitor removes every local app at DOS >= 100, so a DOS
+      // applied while apps were still held would empty the node and satisfy
+      // both of that test's waits - faster than the correct behaviour. A
+      // throwing expect inside the condition propagates out of driveUntil.
+      const info = await env.clients[TARGET - 1].get('/flux/info');
+      expect(info.data.flux.dos.dosState, 'DOS must not land while an app is still held')
+        .to.be.below(100);
       const current = await env.clients[TARGET - 1].get('/apps/installedapps');
       return !current.data.map((a) => a.name).includes('residentapp');
     });
@@ -621,8 +649,15 @@ describe('Residential node evacuation', function () {
     await env.restartNode(TARGET - 1);
     await waitForDaemonReady(env.clients[TARGET - 1]);
 
-    await waitFor(async () => (await dbClient(TARGET).residentialMarker()) !== null,
-      { timeout: 120000, label: 'the marker is still there after the restart' });
+    // Positive evidence that the restarted node's residential service has run,
+    // not just that mongo still holds a document. Mongo is a separate container
+    // and restartNode restarts only FluxOS, so the marker survives whatever the
+    // node does; and waitFor evaluates its condition on the first iteration, so
+    // "the marker is still there" returned immediately and compared two reads
+    // of a row nothing was required to touch. The service's only writer sits
+    // behind nodeReady, which is raised by SPAWNER_READY - and the placement
+    // hold is published by the same pass that would rewrite the marker.
+    await waitForSpawnerBlocked(env.clients[TARGET - 1], 'placement_hold', 180000);
     const after = await dbClient(TARGET).residentialMarker();
     expect(after.residentialSince).to.eql(before.residentialSince);
     // The restart cost it nothing it had already watched.

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -15,6 +15,7 @@ import {
   waitForSpawnerBlocked, waitFor, waitForGiveUpConsidered, waitForGiveUpSafety,
 } from '../framework/wait.js';
 import { setNoPeerData, setPeerHasData, setSynced } from '../framework/syncthing-control.js';
+import { electMaster } from '../framework/fdm-control.js';
 import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
 
 const subnet = getSubnetConfig();
@@ -165,6 +166,10 @@ describe('Residential node evacuation', function () {
   // .14 - same published organisation again, but its own address carries hosting
   // evidence, so it declines the verdict.
   const VETOING = 5;
+  // A second residential node, so the serialisation claim has two holders to
+  // serialise. Published residential like node 1, and attested until a test
+  // withdraws it.
+  const SECOND_TARGET = 3;
 
   before(async function () {
     this.timeout(600000);
@@ -507,5 +512,107 @@ describe('Residential node evacuation', function () {
 
     const locations = await dbClient(2).getAppLocations('worldapp');
     expect(locations.map((l) => l.ip.split(':')[0])).to.not.include(subnet.nodeIp(TARGET));
+  });
+
+  it('keeps the settling clock across a restart, so restarting cannot postpone the drain', async function () {
+    this.timeout(600000);
+
+    // The clock is persisted and measured in wall-clock precisely so that
+    // bouncing FluxOS - on a cron, say - cannot keep a node permanently just
+    // short of the window. An in-memory counter of agreeing ticks would reset
+    // here, and this is the test that would have caught that.
+    await setSystemSecure(subnet.nodeIp(TARGET), true);
+    await waitFor(async () => (await dbClient(TARGET).residentialMarker()) === null,
+      { timeout: 120000, label: 'node 1 is back in service' });
+
+    await setSystemSecure(subnet.nodeIp(TARGET), false);
+    await waitFor(async () => (await dbClient(TARGET).residentialMarker()) !== null,
+      { timeout: 120000, label: 'the settling window starts' });
+    const before = (await dbClient(TARGET).residentialMarker()).residentialSince;
+
+    await env.restartNode(TARGET - 1);
+    await waitForDaemonReady(env.clients[TARGET - 1]);
+
+    await waitFor(async () => (await dbClient(TARGET).residentialMarker()) !== null,
+      { timeout: 120000, label: 'the marker is still there after the restart' });
+    const after = (await dbClient(TARGET).residentialMarker()).residentialSince;
+    expect(after).to.eql(before);
+  });
+
+  it('only one residential node gives up an app at a time', async function () {
+    this.timeout(900000);
+
+    // The claim that makes the drain terminate: a departure takes the app below
+    // its instance count, and every OTHER evacuating holder sees that and waits.
+    // With one target node it is untestable by construction - it needs two.
+    // Node 3 is published residential like node 1, so withdrawing its
+    // attestation puts it in the same position.
+    await setSystemSecure(subnet.nodeIp(TARGET), true);
+    await waitFor(async () => (await dbClient(TARGET).residentialMarker()) === null,
+      { timeout: 120000, label: 'node 1 is back in service' });
+
+    await seedApp(env, 'sharedapp', { instances: 5 });
+    await advanceBlocks(3);
+    await waitFor(async () => (await dbClient(2).getAppLocations('sharedapp')).length >= 5,
+      { timeout: 300000, label: 'sharedapp reaches its instance count across the fleet' });
+
+    await setSystemSecure(subnet.nodeIp(TARGET), false);
+    await setSystemSecure(subnet.nodeIp(SECOND_TARGET), false);
+    for (const node of [TARGET, SECOND_TARGET]) {
+      // eslint-disable-next-line no-await-in-loop
+      await waitFor(async () => (await dbClient(node).residentialMarker()) !== null,
+        { timeout: 120000, label: `node ${node} starts its settling window` });
+      // eslint-disable-next-line no-await-in-loop
+      await elapseSettleWindow(node);
+    }
+
+    // Whichever goes first, the other must be refused while the app is short.
+    const refusedForBeingShort = Promise.race([TARGET, SECOND_TARGET].map((node) => waitForGiveUpSafety(
+      env.clients[node - 1], 'sharedapp',
+      (d) => d.safe === false && /below its instance count/.test(d.detail), 600000,
+    )));
+
+    await stopTicker();
+    await driveUntil(env, TARGET, async () => {
+      const locations = await dbClient(2).getAppLocations('sharedapp');
+      return locations.length < 5;
+    }, 60);
+    const verdict = await refusedForBeingShort;
+    await startTicker();
+
+    expect(verdict.data.detail).to.contain('below its instance count');
+  });
+
+  it('will not hand back a g: app while this node is its elected primary', async function () {
+    this.timeout(900000);
+
+    // The elected primary is the node WRITING to the volume. Handing the app
+    // back from under it drops whatever it has written since the peer last
+    // reported the folder complete, so it stands down and lets masterSlaveApps
+    // elect a successor first.
+    await setSystemSecure(subnet.nodeIp(SECOND_TARGET), true);
+    await seedApp(env, 'primaryapp', { instances: 5, containerData: 'g:/appdata' });
+    await setSynced({ folder: 'fluxprimaryapp_primaryapp' });
+    await setPeerHasData({ folder: 'fluxprimaryapp_primaryapp' });
+    await advanceBlocks(3);
+    await waitFor(async () => (await dbClient(2).getAppLocations('primaryapp')).length >= 5,
+      { timeout: 300000, label: 'primaryapp reaches its instance count across the fleet' });
+
+    // FDM names node 1 the primary, which is what masterSlaveApps reads.
+    await electMaster('primaryapp', subnet.nodeIp(TARGET));
+
+    await setSystemSecure(subnet.nodeIp(TARGET), false);
+    await waitFor(async () => (await dbClient(TARGET).residentialMarker()) !== null,
+      { timeout: 120000, label: 'the settling window starts' });
+    await elapseSettleWindow(TARGET);
+
+    const refused = waitForGiveUpSafety(env.clients[TARGET - 1], 'primaryapp',
+      (d) => d.safe === false && /elected primary/.test(d.detail), 600000);
+    await stopTicker();
+    await driveUntil(env, TARGET, async () => false, 30).catch(() => {});
+    const verdict = await refused;
+    await startTicker();
+
+    expect(verdict.data.detail).to.contain('elected primary');
   });
 });

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -135,6 +135,20 @@ async function whenGone(env, nodeIndex, appName, timeout) {
   return Date.now();
 }
 
+/**
+ * Put a node back in service: attested, hold cleared, settling marker torn down.
+ *
+ * Every test that seeds an app has to do this first, because a held node takes
+ * no new apps and an EMPTY node goes straight to DOS without ever starting a
+ * settling window. Both are correct, and both silently invalidate a test that
+ * assumes otherwise.
+ */
+async function returnToService(env, node) {
+  await setSystemSecure(subnet.nodeIp(node), true);
+  await waitFor(async () => (await dbClient(node).residentialMarker()) === null,
+    { timeout: 120000, label: `node ${node} is back in service` });
+}
+
 /** Put the settling window in the past, so evacuation may begin this run. */
 async function elapseSettleWindow(nodeIndex) {
   await dbClient(nodeIndex).setResidentialSince(Date.now() - (48 * 60 * 60 * 1000));
@@ -521,9 +535,13 @@ describe('Residential node evacuation', function () {
     // bouncing FluxOS - on a cron, say - cannot keep a node permanently just
     // short of the window. An in-memory counter of agreeing ticks would reset
     // here, and this is the test that would have caught that.
-    await setSystemSecure(subnet.nodeIp(TARGET), true);
-    await waitFor(async () => (await dbClient(TARGET).residentialMarker()) === null,
-      { timeout: 120000, label: 'node 1 is back in service' });
+    await returnToService(env, TARGET);
+
+    // It has to be HOLDING something. An empty target goes straight to DOS -
+    // there is no data at stake - and never starts a settling window at all.
+    await seedApp(env, 'clockapp', { instances: 5 });
+    await advanceBlocks(3);
+    await waitForAppInstalled(env.clients[TARGET - 1], 'clockapp', 300000);
 
     await setSystemSecure(subnet.nodeIp(TARGET), false);
     await waitFor(async () => (await dbClient(TARGET).residentialMarker()) !== null,
@@ -547,9 +565,7 @@ describe('Residential node evacuation', function () {
     // With one target node it is untestable by construction - it needs two.
     // Node 3 is published residential like node 1, so withdrawing its
     // attestation puts it in the same position.
-    await setSystemSecure(subnet.nodeIp(TARGET), true);
-    await waitFor(async () => (await dbClient(TARGET).residentialMarker()) === null,
-      { timeout: 120000, label: 'node 1 is back in service' });
+    await returnToService(env, TARGET);
 
     await seedApp(env, 'sharedapp', { instances: 5 });
     await advanceBlocks(3);
@@ -567,19 +583,22 @@ describe('Residential node evacuation', function () {
     }
 
     // Whichever goes first, the other must be refused while the app is short.
+    let refusal = null;
     const refusedForBeingShort = Promise.race([TARGET, SECOND_TARGET].map((node) => waitForGiveUpSafety(
       env.clients[node - 1], 'sharedapp',
       (d) => d.safe === false && /below its instance count/.test(d.detail), 600000,
-    )));
+    ))).then((v) => { refusal = v; return v; });
+    refusedForBeingShort.catch(() => {});
 
+    // Keep driving UNTIL the refusal arrives, not just until the first
+    // departure. The give-up pass only runs on a block, so stopping the chain
+    // the moment one node leaves means the other never gets a pass in which to
+    // refuse, and the wait times out on a suite that stopped the clock itself.
     await stopTicker();
-    await driveUntil(env, TARGET, async () => {
-      const locations = await dbClient(2).getAppLocations('sharedapp');
-      return locations.length < 5;
-    }, 60);
-    const verdict = await refusedForBeingShort;
+    await driveUntil(env, TARGET, async () => refusal !== null, 80);
     await startTicker();
 
+    const verdict = await refusedForBeingShort;
     expect(verdict.data.detail).to.contain('below its instance count');
   });
 
@@ -590,7 +609,11 @@ describe('Residential node evacuation', function () {
     // back from under it drops whatever it has written since the peer last
     // reported the folder complete, so it stands down and lets masterSlaveApps
     // elect a successor first.
-    await setSystemSecure(subnet.nodeIp(SECOND_TARGET), true);
+    await returnToService(env, SECOND_TARGET);
+    // Node 1 too - it is still held from the previous test, and a held node
+    // takes no new apps, so the app would reach four instances and never five.
+    await returnToService(env, TARGET);
+
     await seedApp(env, 'primaryapp', { instances: 5, containerData: 'g:/appdata' });
     await setSynced({ folder: 'fluxprimaryapp_primaryapp' });
     await setPeerHasData({ folder: 'fluxprimaryapp_primaryapp' });
@@ -606,12 +629,17 @@ describe('Residential node evacuation', function () {
       { timeout: 120000, label: 'the settling window starts' });
     await elapseSettleWindow(TARGET);
 
+    let primaryRefusal = null;
     const refused = waitForGiveUpSafety(env.clients[TARGET - 1], 'primaryapp',
-      (d) => d.safe === false && /elected primary/.test(d.detail), 600000);
+      (d) => d.safe === false && /elected primary/.test(d.detail), 600000)
+      .then((v) => { primaryRefusal = v; return v; });
+    refused.catch(() => {});
+
     await stopTicker();
-    await driveUntil(env, TARGET, async () => false, 30).catch(() => {});
-    const verdict = await refused;
+    await driveUntil(env, TARGET, async () => primaryRefusal !== null, 80);
     await startTicker();
+
+    const verdict = await refused;
 
     expect(verdict.data.detail).to.contain('elected primary');
   });

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -808,13 +808,29 @@ describe('Residential node evacuation', function () {
     const verdict = await stoodDown;
     expect(verdict.data.code).to.equal('STAND_DOWN_REQUIRED');
 
-    // The container is what "standing down" means - a verdict that stopped
-    // nothing would leave the node writing and the test would still pass.
-    await waitFor(async () => {
-      const running = await env.clients[TARGET - 1].get('/apps/listrunningapps');
-      const names = (running?.data?.data || []).flatMap((a) => a.Names || []);
-      return !names.some((n) => n.replace(/^\//, '') === 'fluxprimaryapp_primaryapp');
-    }, { timeout: 180000, label: 'the g: component is stopped on the standing-down node' });
+    // The container is what "standing down" means, and this assertion has to be
+    // able to FAIL. Read through a helper that throws on an unreadable answer:
+    // `!names.some(...)` over an empty list is true, so a failed request or a
+    // shape that does not match reads as "stopped" and the test passes while the
+    // node is still writing. It did exactly that on the first run here.
+    const runningComponents = async () => {
+      const res = await env.clients[TARGET - 1].get('/apps/listrunningapps');
+      const list = res?.data?.data;
+      if (!Array.isArray(list)) throw new Error(`listrunningapps unreadable: ${JSON.stringify(res?.data)?.slice(0, 200)}`);
+      return list.flatMap((a) => a.Names || []).map((n) => n.replace(/^\//, ''));
+    };
+    // Positive control: the component must be running here NOW, or the wait
+    // below proves nothing about a stop.
+    expect(await runningComponents()).to.include('fluxprimaryapp_primaryapp');
+
+    await waitFor(async () => !(await runningComponents()).includes('fluxprimaryapp_primaryapp'),
+      { timeout: 180000, label: 'the g: component is stopped on the standing-down node' });
+
+    // And it must STAY stopped. appReconciler takes a g: component's desired
+    // state from controllerDesired, so a stand-down that stops the container
+    // without telling the controller is undone on the next sweep.
+    await advanceBlocks(3);
+    expect(await runningComponents()).to.not.include('fluxprimaryapp_primaryapp');
   });
 
   it('hands the app back on the pass after standing down, and the app survives elsewhere', async function () {

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -1024,30 +1024,36 @@ describe('Residential node evacuation', function () {
     // to act on the first and must not act on the second.
     await startFdmOutage('refuse');
 
-    // THE ORDER HERE IS THE TEST. The verdict has to go stale BEFORE the node
-    // starts draining, and it is the stand-down that makes that so: a draining
-    // node that still remembers being primary now hands the app over and
-    // leaves, so the verdict never survives long enough to expire. Withdrawing
-    // attestation first - which is what this test used to inherit from the
-    // stand-down tests before them - reaches STAND_DOWN_REQUIRED instead, and
-    // ELECTION_UNKNOWN becomes unreachable.
-    //
-    // Waited rather than observed, because staleness has no external signal:
-    // primaryElectionCheckedAt is refreshed only where FDM ANSWERED, so with
-    // no region answering at all nothing touches it and it ages out on wall clock.
-    // Derived from the knob it is a multiple of, never written as a literal -
-    // PRIMARY_ELECTION_STALE_MS is masterSlaveIntervalMs x 10, and the harness
-    // compresses that knob to 3s, so this costs ~30s here and tracks the knob
-    // if it moves. One extra cycle of margin so the expiry is past, not level.
-    const electionCycleMs = loadSharedConfig().fluxapps.masterSlaveIntervalMs;
-    await sleepUnlessInfraDead((electionCycleMs * 10) + electionCycleMs);
-
-    await setSystemSecure(subnet.nodeIp(TARGET), false);
-    await waitFor(async () => (await dbClient(TARGET).residentialMarker()) !== null,
-      { timeout: 120000, label: 'the settling window starts' });
-    await elapseSettleWindow(TARGET);
-
+    // The try opens HERE rather than after the staging below. Everything between
+    // the outage and the assertions can throw - the settling-marker wait carries a
+    // 120s timeout - and 'refuse' closes the stub's listening socket rather than
+    // answering 503, so an outage left behind is a dead socket for whatever runs
+    // next. Contained today only because this is the last test in the file and the
+    // stub dies with the env, and neither is a property anyone maintains on purpose.
     try {
+      // THE ORDER HERE IS THE TEST. The verdict has to go stale BEFORE the node
+      // starts draining, and it is the stand-down that makes that so: a draining
+      // node that still remembers being primary now hands the app over and
+      // leaves, so the verdict never survives long enough to expire. Withdrawing
+      // attestation first - which is what this test used to inherit from the
+      // stand-down tests before them - reaches STAND_DOWN_REQUIRED instead, and
+      // ELECTION_UNKNOWN becomes unreachable.
+      //
+      // Waited rather than observed, because staleness has no external signal:
+      // primaryElectionCheckedAt is refreshed only where FDM ANSWERED, so with
+      // no region answering at all nothing touches it and it ages out on wall clock.
+      // Derived from the knob it is a multiple of, never written as a literal -
+      // PRIMARY_ELECTION_STALE_MS is masterSlaveIntervalMs x 10, and the harness
+      // compresses that knob to 3s, so this costs ~30s here and tracks the knob
+      // if it moves. One extra cycle of margin so the expiry is past, not level.
+      const electionCycleMs = loadSharedConfig().fluxapps.masterSlaveIntervalMs;
+      await sleepUnlessInfraDead((electionCycleMs * 10) + electionCycleMs);
+
+      await setSystemSecure(subnet.nodeIp(TARGET), false);
+      await waitFor(async () => (await dbClient(TARGET).residentialMarker()) !== null,
+        { timeout: 120000, label: 'the settling window starts' });
+      await elapseSettleWindow(TARGET);
+
       let unknownRefusal = null;
       const refused = waitForGiveUpSafety(env.clients[TARGET - 1], 'lockedapp',
         (d) => d.safe === false && d.code === 'ELECTION_UNKNOWN', 600000)

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -109,13 +109,13 @@ async function seedApp(env, appName, { instances = 3, containerData = '/tmp', po
  * which parity the race settles on.
  *
  * And the waits here are WALL-CLOCK. A node's queue ticket is real time, so a
- * budget counted in blocks means nothing: driving flat out races through the
- * chain in milliseconds and stops long before the node's turn comes round,
- * leaving no pass in which to act. The deadline is therefore in milliseconds and
- * the rate is explicit - `blockIntervalMs` sets how fast the chain moves, which
- * is what fixes how long a give-out pass takes in wall-clock, which is what the
- * queue step has to outlast. Changing one without the other is what quietly
- * deletes the ordering these tests exist to check.
+ * budget counted in blocks means nothing: the deadline is therefore in
+ * milliseconds. The chain's actual rate is not this function's to set - a block
+ * is not processed until the node's next explorer poll, so
+ * `explorerPollIntervalMs` is the floor, and that floor is what fixes how long a
+ * give-up pass takes in wall-clock, which is what the queue step has to outlast.
+ * Changing one without the other is what quietly deletes the ordering these
+ * tests exist to check.
  *
  * @param {number} [opts.timeoutMs] How long to keep driving before giving up.
  * @param {number} [opts.blockIntervalMs] Minimum wall-clock between blocks.
@@ -273,11 +273,15 @@ describe('Residential node evacuation', function () {
           // departure is visible to it.
           //
           // So the step only has to outlast one give-up pass plus the
-          // propagation of a removal. A pass is four blocks, and driveUntil
-          // paces the chain at 200ms a block, so a pass is under a second here;
-          // the fluxappremoved broadcast is sub-second too. 5s is several times
-          // the margin needed and caps the worst wait - last of five instances -
-          // at 21s.
+          // propagation of a removal. A pass is four blocks, and a block costs
+          // one explorerPollIntervalMs - 250ms in the harness - because a block
+          // is not looked at until the next poll. So a pass is about a second
+          // here and the fluxappremoved broadcast is sub-second. 5s is several
+          // times the margin needed and caps the worst wait - last of five
+          // instances - at 21s.
+          //
+          // Measured before explorerPollIntervalMs existed: 4.8s a block, a 20s
+          // pass, and a 5s step that both holders cleared within one pass.
           //
           // Production's 15 MINUTES is that same relationship against a pass
           // that runs every 44 blocks. The ratio transfers; the number does not,

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -6,7 +6,7 @@ import { pushImage } from '../framework/registry-helper.js';
 import { buildSeedableApp, allocateAppPort } from '../framework/seed-helper.js';
 import { getSubnetConfig, REGISTRY_REPO_HOST } from '../framework/subnet-config.js';
 import {
-  advanceBlock, advanceBlocks, startTicker, stopTicker, setSystemSecure, clearSystemSecure,
+  advanceBlock, advanceBlocks, driveUntil, startTicker, stopTicker, setSystemSecure, clearSystemSecure,
 } from '../framework/daemon-control.js';
 import {
   waitForDaemonReady, waitForNodeStatus, waitForBlockProcessed,
@@ -145,64 +145,6 @@ async function seedApp(env, appName, { instances = 3, containerData = '/tmp', po
   return app;
 }
 
-/**
- * Drive the chain until a condition holds, at a stated RATE, up to a stated
- * deadline.
- *
- * Two reasons this drives rather than letting the ticker free-run:
- *
- * The ticker produces blocks on the same period the explorer polls on, so the
- * node learns about them in bursts and processes a burst back to back - and only
- * the last block of a burst is still the chain tip. FluxOS runs its app
- * maintenance, the give-up pass included, only for a block that was the tip and
- * only on every fourth block, so whether the pass runs at all comes down to
- * which parity the race settles on.
- *
- * And the waits here are WALL-CLOCK. A node's queue ticket is real time, so a
- * budget counted in blocks means nothing: the deadline is therefore in
- * milliseconds. The chain's actual rate is not this function's to set - a block
- * is not processed until the node's next explorer poll, so
- * `explorerPollIntervalMs` is the floor, and that floor is what fixes how long a
- * give-up pass takes in wall-clock, which is what the queue step has to outlast.
- * Changing one without the other is what quietly deletes the ordering these
- * tests exist to check.
- *
- * THE RATE IS THE NODE'S POLL, not something faster. A block is not processed
- * until the next explorer poll, so driving four blocks per poll produces four
- * times the work for the same pass cadence: a height only counts when it lands
- * as the tip, tips arrive one per poll, and the give-up pass therefore comes
- * every `removeFluxAppsPeriod x 4` polls whatever rate this drives at. The
- * extra blocks are pure load - and this suite drives for the length of a
- * departure, which is now minutes rather than seconds. At 200ms it drove about
- * a thousand blocks per wait, held a runner slot for the full 1800s wall clock,
- * and starved the box: two unrelated suites ran 3-4x slower in the same gate
- * and hit that wall themselves.
- *
- * @param {number} [opts.timeoutMs] How long to keep driving before giving up.
- * @param {number} [opts.blockIntervalMs] Minimum wall-clock between blocks.
- * @returns {Promise<number>} Blocks driven.
- */
-async function driveUntil(env, nodeIndex, condition, { timeoutMs = DEPARTURE_WAIT_MS, blockIntervalMs = SHARED_POLL_MS } = {}) {
-  const node = env.clients[nodeIndex - 1];
-  const deadline = Date.now() + timeoutMs;
-  let blocks = 0;
-  while (Date.now() < deadline) {
-    // eslint-disable-next-line no-await-in-loop
-    if (await condition()) return blocks;
-    const startedAt = Date.now();
-    const afterId = node.getLastEventId();
-    // eslint-disable-next-line no-await-in-loop
-    await advanceBlock();
-    // eslint-disable-next-line no-await-in-loop
-    await node.waitForEvent('block:processed', () => true, 60000, { afterId });
-    blocks += 1;
-    const spent = Date.now() - startedAt;
-    // eslint-disable-next-line no-await-in-loop
-    if (spent < blockIntervalMs) await new Promise((resolve) => { setTimeout(resolve, blockIntervalMs - spent); });
-  }
-  if (await condition()) return blocks;
-  throw new Error(`condition not reached in ${timeoutMs}ms (${blocks} blocks driven)`);
-}
 
 /**
  * When this node stopped holding an app, by its own account. Returns the epoch
@@ -613,7 +555,7 @@ describe('Residential node evacuation', function () {
     // Only the removal needs blocks. DOS is applied by the residential tick on
     // its own residentialCheckIntervalMs timer, so it arrives with the chain
     // stopped - which is also why it cannot be driven for.
-    await driveUntil(env, TARGET, async () => {
+    await driveUntil(env.clients[TARGET - 1], async () => {
       const buffer = env.clients[TARGET - 1].getEventBuffer();
       return buffer.some((e) => e.event === 'app:removed' && e.data?.name === 'residentapp');
     }, { timeoutMs: DEPARTURE_WAIT_MS });
@@ -740,7 +682,7 @@ describe('Residential node evacuation', function () {
     const refused = waitForGiveUpSafety(env.clients[TARGET - 1], 'worldapp',
       (d) => d.safe === false, 300000).then((v) => { safetyVerdict = v; return v; });
     refused.catch(() => {});
-    await driveUntil(env, TARGET, async () => safetyVerdict !== null,
+    await driveUntil(env.clients[TARGET - 1], async () => safetyVerdict !== null,
       { timeoutMs: DEPARTURE_WAIT_MS });
     await startTicker();
 
@@ -768,10 +710,10 @@ describe('Residential node evacuation', function () {
     await setPeerHasData({ folder: 'fluxworldapp_worldapp' });
 
     await stopTicker();
-    await driveUntil(env, TARGET, async () => {
+    await driveUntil(env.clients[TARGET - 1], async () => {
       const current = await env.clients[TARGET - 1].get('/apps/installedapps');
       return !current.data.map((a) => a.name).includes('worldapp');
-    });
+    }, { timeoutMs: DEPARTURE_WAIT_MS });
     await startTicker();
 
     await whenGone(env, TARGET, 'worldapp', 120000);
@@ -877,7 +819,7 @@ describe('Residential node evacuation', function () {
     // the moment one node leaves means the other never gets a pass in which to
     // refuse, and the wait times out on a suite that stopped the clock itself.
     await stopTicker();
-    await driveUntil(env, TARGET, async () => refusal !== null,
+    await driveUntil(env.clients[TARGET - 1], async () => refusal !== null,
       { timeoutMs: DEPARTURE_WAIT_MS });
     await startTicker();
 
@@ -925,7 +867,7 @@ describe('Residential node evacuation', function () {
     const wentFirst = (e) => e.event === 'app:removed' && seeded.includes(e.data?.name);
 
     await stopTicker();
-    await driveUntil(env, TARGET, async () => client.getEventBuffer().some(wentFirst),
+    await driveUntil(env.clients[TARGET - 1], async () => client.getEventBuffer().some(wentFirst),
       { timeoutMs: DEPARTURE_WAIT_MS });
     const gone = client.getEventBuffer().filter(wentFirst).pop();
     const remaining = gone.data.name === 'firstout' ? 'secondout' : 'firstout';
@@ -941,7 +883,7 @@ describe('Residential node evacuation', function () {
       && /its turn is in/.test(e.data?.detail || '')
       && e.id > gone.id;
 
-    await driveUntil(env, TARGET, async () => client.getEventBuffer().some(turnRestarted),
+    await driveUntil(env.clients[TARGET - 1], async () => client.getEventBuffer().some(turnRestarted),
       { timeoutMs: DEPARTURE_WAIT_MS });
     await startTicker();
 
@@ -988,7 +930,7 @@ describe('Residential node evacuation', function () {
     stoodDown.catch(() => {});
 
     await stopTicker();
-    await driveUntil(env, TARGET, async () => standDownVerdict !== null,
+    await driveUntil(env.clients[TARGET - 1], async () => standDownVerdict !== null,
       { timeoutMs: DEPARTURE_WAIT_MS });
     await startTicker();
 
@@ -1125,7 +1067,7 @@ describe('Residential node evacuation', function () {
       // shortening it means compressing masterSlaveIntervalMs further, which
       // has its own couplings to check first.
       await stopTicker();
-      await driveUntil(env, TARGET, async () => unknownRefusal !== null,
+      await driveUntil(env.clients[TARGET - 1], async () => unknownRefusal !== null,
       { timeoutMs: DEPARTURE_WAIT_MS });
       await startTicker();
 

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -469,6 +469,10 @@ describe('Residential node evacuation', function () {
     // other - otherwise there would be nothing to evacuate later.
     const info = await env.clients[TARGET - 1].get('/flux/info');
     expect(info.data.flux.dos.dosState).to.be.below(100);
+    // A residential node that IS attested reports nothing at all. The field
+    // names the staging, not the connection - otherwise every residential
+    // operator running ArcaneOS reads it and asks what is wrong with their node.
+    expect(info.data.flux.dosStaging).to.equal(null);
 
     await seedApp(env, 'residentapp', { instances: 5 });
     await advanceBlocks(3);
@@ -490,6 +494,13 @@ describe('Residential node evacuation', function () {
     const info = await env.clients[TARGET - 1].get('/flux/info');
     expect(info.data.flux.dos.dosState).to.be.below(100);
 
+    // And the node SAYS so. Without this the stage is invisible: a held node
+    // takes no new apps and is otherwise indistinguishable from one that has
+    // simply not been given work - and this is the stage, lasting a whole
+    // settling window, where the operator can still put it right and lose
+    // nothing at all.
+    expect(info.data.flux.dosStaging).to.equal('HOLD');
+
     const installed = await env.clients[TARGET - 1].get('/apps/installedapps');
     expect(installed.data.map((a) => a.name)).to.include('residentapp');
   });
@@ -504,6 +515,19 @@ describe('Residential node evacuation', function () {
     expect(marker, 'the settling window should be running').to.not.be.null;
 
     await elapseSettleWindow(TARGET);
+
+    // The stage moves when the WINDOW is served, before any app has moved -
+    // which is the ordering the staging is built on, and the one an operator
+    // reads. Asserted here rather than after the removal, so it cannot pass on a
+    // stage that only appeared once the app had already gone.
+    await waitFor(async () => {
+      const staged = await env.clients[TARGET - 1].get('/flux/info');
+      return staged?.data?.flux?.dosStaging === 'EVACUATE';
+    }, { timeout: 120000, interval: 2000, label: 'the node reports it is evacuating' });
+
+    const stillHeld = await env.clients[TARGET - 1].get('/apps/installedapps');
+    expect(stillHeld.data.map((a) => a.name), 'the stage moved only after the app had gone')
+      .to.include('residentapp');
 
     // Drive the chain from here rather than letting the ticker free-run, so the
     // give-up pass is reached on a block the node processed AS the tip. See

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -15,7 +15,7 @@ import {
   waitForSpawnerBlocked, waitFor, waitForGiveUpConsidered, waitForGiveUpSafety,
 } from '../framework/wait.js';
 import { setNoPeerData, setPeerHasData, setSynced } from '../framework/syncthing-control.js';
-import { electMaster } from '../framework/fdm-control.js';
+import { electMaster, startFdmOutage, endFdmOutage } from '../framework/fdm-control.js';
 import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
 
 const subnet = getSubnetConfig();
@@ -172,7 +172,7 @@ async function returnToService(env, node) {
 
 /** Put the settling window in the past, so evacuation may begin this run. */
 async function elapseSettleWindow(nodeIndex) {
-  await dbClient(nodeIndex).setResidentialSince(Date.now() - (48 * 60 * 60 * 1000));
+  await dbClient(nodeIndex).serveSettleWindow();
 }
 
 describe('Residential node evacuation', function () {
@@ -594,10 +594,14 @@ describe('Residential node evacuation', function () {
   it('keeps the settling clock across a restart, so restarting cannot postpone the drain', async function () {
     this.timeout(600000);
 
-    // The clock is persisted and measured in wall-clock precisely so that
-    // bouncing FluxOS - on a cron, say - cannot keep a node permanently just
-    // short of the window. An in-memory counter of agreeing ticks would reset
-    // here, and this is the test that would have caught that.
+    // The clock is persisted precisely so that bouncing FluxOS - on a cron, say
+    // - cannot keep a node permanently just short of the window. An in-memory
+    // counter of agreeing ticks would reset here, and this is the test that
+    // would have caught that.
+    //
+    // What the window counts is time the node OBSERVED the verdict, not time
+    // that elapsed, so the total observed is the half that has to survive: a
+    // first-seen timestamp surviving a restart proves nothing on its own now.
     await returnToService(env, TARGET);
 
     // It has to be HOLDING something. An empty target goes straight to DOS -
@@ -609,15 +613,20 @@ describe('Residential node evacuation', function () {
     await setSystemSecure(subnet.nodeIp(TARGET), false);
     await waitFor(async () => (await dbClient(TARGET).residentialMarker()) !== null,
       { timeout: 120000, label: 'the settling window starts' });
-    const before = (await dbClient(TARGET).residentialMarker()).residentialSince;
+    // Let it confirm at least twice, so there is observed time to lose.
+    await waitFor(async () => ((await dbClient(TARGET).residentialMarker()).observedMs || 0) > 0,
+      { timeout: 120000, label: 'the node has accrued observed time' });
+    const before = await dbClient(TARGET).residentialMarker();
 
     await env.restartNode(TARGET - 1);
     await waitForDaemonReady(env.clients[TARGET - 1]);
 
     await waitFor(async () => (await dbClient(TARGET).residentialMarker()) !== null,
       { timeout: 120000, label: 'the marker is still there after the restart' });
-    const after = (await dbClient(TARGET).residentialMarker()).residentialSince;
-    expect(after).to.eql(before);
+    const after = await dbClient(TARGET).residentialMarker();
+    expect(after.residentialSince).to.eql(before.residentialSince);
+    // The restart cost it nothing it had already watched.
+    expect(after.observedMs).to.be.at.least(before.observedMs);
   });
 
   it('only one residential node gives up an app at a time', async function () {
@@ -712,5 +721,61 @@ describe('Residential node evacuation', function () {
     const verdict = await refused;
 
     expect(verdict.data.detail).to.contain('elected primary');
+    expect(verdict.data.code).to.equal('ELECTED_PRIMARY');
+  });
+
+  it('will not hand back a g: app it is running while no FDM can name the primary', async function () {
+    this.timeout(900000);
+
+    // The other half of the same question, and the one that used to answer
+    // "safe". An election that has NOT RUN and an election that named another
+    // node were the same answer - false - and the gate deleted the volume on
+    // it. Every other unavailable input in that gate refuses.
+    //
+    // This runs on from the test above: node TARGET is the elected primary of
+    // primaryapp and is running its g: component. Taking FDM down means the
+    // election reaches no verdict for the app at all, so what the node knows
+    // has to go STALE rather than merely be absent - it was elected moments
+    // ago and remembers it. PRIMARY_ELECTION_STALE_MS is ten election cycles,
+    // derived from masterSlaveIntervalMs, so the wait below is derived from
+    // the same knob rather than picked: at the harness's 3s cycle the verdict
+    // expires 30s after the last pass that reached one.
+    //
+    // The stub closes its listening socket, not an empty ips array. An empty
+    // array is FDM ANSWERING that nobody is primary; this is nobody answering,
+    // and a refused connection is the signature a real FDM outage carries - the
+    // error reaches the node with no response on it at all. The gate is allowed
+    // to act on the first and must not act on the second.
+    const electionCycleMs = 3000; // config.fluxapps.masterSlaveIntervalMs, harness value
+    const staleAfterMs = electionCycleMs * 10; // PRIMARY_ELECTION_STALE_MS
+    await startFdmOutage('refuse');
+
+    try {
+      let unknownRefusal = null;
+      const refused = waitForGiveUpSafety(env.clients[TARGET - 1], 'primaryapp',
+        (d) => d.safe === false && d.code === 'ELECTION_UNKNOWN', 600000)
+        .then((v) => { unknownRefusal = v; return v; });
+      refused.catch(() => {});
+
+      // Let the last verdict age out before driving the pass that reads it.
+      // Driving sooner would prove nothing: the node would still be answering
+      // from what it learned while FDM was up.
+      await new Promise((resolve) => { setTimeout(resolve, staleAfterMs + electionCycleMs); });
+
+      await stopTicker();
+      await driveUntil(env, TARGET, async () => unknownRefusal !== null);
+      await startTicker();
+
+      const verdict = await refused;
+
+      expect(verdict.data.code).to.equal('ELECTION_UNKNOWN');
+      expect(verdict.data.detail).to.contain('cannot say who is primary');
+      // And the app is still here. A refusal that let the removal through
+      // anyway would satisfy the assertions above and lose the volume.
+      const stillInstalled = await env.clients[TARGET - 1].get('/apps/installedapps');
+      expect(stillInstalled.data.map((a) => a.name)).to.include('primaryapp');
+    } finally {
+      await endFdmOutage();
+    }
   });
 });

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -1,0 +1,275 @@
+import { describe, it, before, after } from 'mocha';
+import { expect } from 'chai';
+import { createTestEnv } from '../framework/test-env.js';
+import { dbClient } from '../framework/db-client.js';
+import { pushImage } from '../framework/registry-helper.js';
+import { buildSeedableApp } from '../framework/seed-helper.js';
+import { getSubnetConfig, REGISTRY_REPO_HOST } from '../framework/subnet-config.js';
+import {
+  advanceBlock, advanceBlocks, startTicker, stopTicker, setSystemSecure, clearSystemSecure,
+} from '../framework/daemon-control.js';
+import {
+  waitForDaemonReady, waitForNodeStatus, waitForBlockProcessed,
+  waitForExplorerReady, waitForOrchestratorStarted, waitForOrchestratorState,
+  waitForPeerThreshold, waitForAppInstalled, waitForAppRemoved,
+  waitForSpawnerBlocked, waitFor,
+} from '../framework/wait.js';
+import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
+
+const subnet = getSubnetConfig();
+
+// A residential node is one whose network classification reaches RESIDENTIAL on
+// positive evidence with nothing contradicting it. In the harness the only
+// signal available is what the ip-api stub serves - 198.18.x.x has no reverse
+// DNS and the stub tiers are not asymmetric enough to count - so `mobile` is the
+// positive signal and every contradiction is turned off.
+const RESIDENTIAL_GEO = {
+  hosting: false,
+  proxy: false,
+  mobile: true,
+  org: 'Some Reseller Ltd',
+  isp: 'Consumer Access Networks',
+  as: 'AS64500 Consumer Access Networks',
+};
+
+async function bootToReady(env) {
+  await Promise.all(env.clients.map((c) => waitForDaemonReady(c)));
+  await Promise.all(env.clients.map((c) => waitForNodeStatus(c, (d) => d.confirmed === true, 30000)));
+  await waitForExplorerReady(env.clients[0]);
+  await waitForOrchestratorStarted(env.clients[0]);
+  await advanceBlock();
+  await waitForBlockProcessed(env.clients[0], () => true, 20000);
+  await env.startDiscovery();
+  await waitForPeerThreshold(env.clients[0], 120000);
+  await startTicker();
+  await waitForOrchestratorState(env.clients[0], 'READY', 120000);
+}
+
+async function seedApp(env, appName, { instances = 3, containerData = '/tmp' } = {}) {
+  await pushImage(appName, 'v1');
+  const app = await buildSeedableApp({
+    name: appName,
+    instances,
+    compose: [{
+      name: appName,
+      description: 'test container',
+      repotag: `${REGISTRY_REPO_HOST}/${appName}:v1`,
+      ports: [31111],
+      domains: [''],
+      environmentParameters: [],
+      commands: [],
+      containerPorts: [80],
+      containerData,
+      cpu: 0.1,
+      ram: 100,
+      hdd: 1,
+      repoauth: '',
+    }],
+  });
+  for (let i = 1; i <= env.nodeCount; i++) {
+    const dc = dbClient(i);
+    await dc.seedGlobalAppSpec(app.spec);
+    await dc.seedPermanentMessage(app.permanentMessage);
+    await dc.seedAppHash(app.hash, app.permanentMessage.height, true);
+  }
+  return app;
+}
+
+/** Put the settling window in the past, so evacuation may begin this run. */
+async function elapseSettleWindow(nodeIndex) {
+  await dbClient(nodeIndex).setResidentialSince(Date.now() - (48 * 60 * 60 * 1000));
+}
+
+describe('Residential node evacuation', function () {
+  let env;
+  dumpLogsOnFailure(() => env);
+
+  // Node 1 is the node under test: on a residential connection from the moment
+  // it boots, but ATTESTED, so nothing enforces against it and it takes its
+  // share of the work. Attestation is then withdrawn, which is the whole point
+  // of the staging - a node that already holds customer data and stops being
+  // fit to serve.
+  //
+  // It has to be done in that order. The placement hold lands within seconds of
+  // boot, so a node that is residential AND unattested from the start never
+  // takes an app at all: it is empty, and an empty target goes straight to DOS
+  // because there is no data at stake. Nothing would ever be evacuated.
+  // Attestation is also the only input re-read on every tick - geolocation is
+  // looked up once and then not again for three days - so it is the only lever
+  // that can flip a running node.
+  //
+  // Every other node is attested and in a data centre.
+  const TARGET = 1;
+
+  before(async function () {
+    this.timeout(600000);
+    env = await createTestEnv({
+      hookCtx: this,
+      nodes: 5,
+      tickerAutostart: false,
+      // Seeded through createTestEnv, not POSTed afterwards: a node looks its
+      // address up once during boot, so an override applied after the fleet is
+      // up is never read and the node classifies itself from the stub default.
+      geolocation: { [TARGET]: RESIDENTIAL_GEO },
+      configOverrides: {
+        fluxapps: {
+          // Compressed the same way every other suite compresses the interval it
+          // is exercising. The production values are hours; the behaviour under
+          // test is the ordering, not the wall-clock.
+          residentialCheckIntervalMs: 3000,
+          // Left LONG on purpose, and opened by the test when it is ready. A
+          // short window would let evacuation start while the hold is still
+          // being asserted, and the ordering - hold first, deletes nothing, and
+          // only later gives an app up - is the property under test.
+          residentialSettleMs: 600000,
+          residentialEvacuationIntervalMs: 4000,
+          residentialQueueBaseMs: 1000,
+          residentialQueueStepMs: 500,
+          removeFluxAppsPeriod: 1,
+        },
+      },
+    });
+    await bootToReady(env);
+  });
+
+  after(async function () {
+    this.timeout(120000);
+    await clearSystemSecure().catch(() => {});
+    await stopTicker().catch(() => {});
+    if (env) await env.teardown();
+  });
+
+  it('classifies the node RESIDENTIAL from the operator, not the registrant org', async function () {
+    this.timeout(120000);
+
+    await waitFor(async () => {
+      const geo = await dbClient(TARGET).geolocation();
+      return geo?.networkClassification?.classification === 'RESIDENTIAL';
+    }, { timeout: 90000, label: 'node 1 reaches a RESIDENTIAL classification' });
+
+    const geo = await dbClient(TARGET).geolocation();
+    expect(geo.networkClassification.evidenceAgainst).to.be.empty;
+    expect(geo.networkClassification.evidenceFor).to.not.be.empty;
+    // The org string names a reseller. Reading it, as the old classifier did,
+    // would have decided this node on the wrong field entirely.
+    expect(geo.geolocation.org).to.equal('Some Reseller Ltd');
+  });
+
+  it('leaves an attested data-centre node alone', async function () {
+    this.timeout(120000);
+
+    const geo = await dbClient(2).geolocation();
+    expect(geo.networkClassification.classification).to.equal('DATACENTER');
+
+    const info = await env.clients[1].get('/flux/info');
+    expect(info.data.flux.dos.dosState).to.be.below(100);
+  });
+
+  it('leaves a residential node alone while it is still attested', async function () {
+    this.timeout(300000);
+
+    // ArcaneOS is the whole discriminator. A residential connection on its own
+    // enforces nothing, and this node has to be able to take work like any
+    // other - otherwise there would be nothing to evacuate later.
+    const info = await env.clients[TARGET - 1].get('/flux/info');
+    expect(info.data.flux.dos.dosState).to.be.below(100);
+
+    await seedApp(env, 'residentapp', { instances: 5 });
+    await advanceBlocks(3);
+    await waitForAppInstalled(env.clients[TARGET - 1], 'residentapp', 240000);
+
+    const installed = await env.clients[TARGET - 1].get('/apps/installedapps');
+    expect(installed.data.map((a) => a.name)).to.include('residentapp');
+  });
+
+  it('stops taking new apps the moment attestation is withdrawn, deleting nothing', async function () {
+    this.timeout(300000);
+
+    await setSystemSecure(subnet.nodeIp(TARGET), false);
+
+    await waitForSpawnerBlocked(env.clients[TARGET - 1], 'placement_hold', 120000);
+
+    // The hold is immediate; nothing it already runs is touched by it, and the
+    // DOS path - the one that deletes - must not have been taken.
+    const info = await env.clients[TARGET - 1].get('/flux/info');
+    expect(info.data.flux.dos.dosState).to.be.below(100);
+
+    const installed = await env.clients[TARGET - 1].get('/apps/installedapps');
+    expect(installed.data.map((a) => a.name)).to.include('residentapp');
+  });
+
+  it('hands the app back once the settling window has passed', async function () {
+    this.timeout(300000);
+
+    // The clock is persisted and wall-clock, so a node cannot restart its way
+    // out of the drain. Which is also what lets the test open the gate: put the
+    // start of the window far enough in the past that it has elapsed.
+    const marker = await dbClient(TARGET).residentialMarker();
+    expect(marker, 'the settling window should be running').to.not.be.null;
+
+    await elapseSettleWindow(TARGET);
+    await advanceBlocks(5);
+
+    await waitForAppRemoved(env.clients[TARGET - 1], 'residentapp', 240000);
+
+    const installed = await env.clients[TARGET - 1].get('/apps/installedapps');
+    expect(installed.data.map((a) => a.name)).to.not.include('residentapp');
+  });
+
+  it('the app survives the departure on every other host', async function () {
+    this.timeout(300000);
+
+    // The point of the whole design: the app is still on the network. PR #1784
+    // as originally written deleted this node's copy along with everything else
+    // it held, and for an app whose every instance sat on residential nodes
+    // that was the last copy.
+    //
+    // The replacement itself is not asserted here and cannot be on this fleet:
+    // the app asks for five instances and all five nodes already ran it, so
+    // there is no node left that is both short of it and not held. Refilling a
+    // deficit is appSpawner's existing 120s loop, unchanged by this branch.
+    await waitFor(async () => {
+      const locations = await dbClient(2).getAppLocations('residentapp');
+      return locations.length >= 4;
+    }, { timeout: 240000, label: 'residentapp still held by the other four nodes' });
+
+    const locations = await dbClient(2).getAppLocations('residentapp');
+    const targetIp = subnet.nodeIp(TARGET);
+    expect(locations.map((l) => l.ip.split(':')[0])).to.not.include(targetIp);
+  });
+
+  it('goes into DOS only once it holds nothing', async function () {
+    this.timeout(300000);
+
+    await waitFor(async () => {
+      const installed = await env.clients[TARGET - 1].get('/apps/installedapps');
+      return installed.data.length === 0;
+    }, { timeout: 240000, label: 'node 1 empties' });
+
+    await waitFor(async () => {
+      const info = await env.clients[TARGET - 1].get('/flux/info');
+      return info.data.flux.dos.dosState >= 100;
+    }, { timeout: 120000, label: 'node 1 enters DOS after emptying' });
+
+    const info = await env.clients[TARGET - 1].get('/flux/info');
+    expect(info.data.flux.dos.dosMessage).to.contain('Residential node not running ArcaneOS');
+  });
+
+  it('releases the node the moment it becomes attested', async function () {
+    this.timeout(300000);
+
+    await setSystemSecure(subnet.nodeIp(TARGET), true);
+
+    await waitFor(async () => {
+      const info = await env.clients[TARGET - 1].get('/flux/info');
+      return info.data.flux.dos.dosState < 100;
+    }, { timeout: 120000, label: 'node 1 leaves DOS after migrating to ArcaneOS' });
+
+    // And the settling window is torn down with it, so a node that flips back
+    // serves the full window again rather than resuming a part-served one.
+    await waitFor(async () => {
+      const marker = await dbClient(TARGET).residentialMarker();
+      return marker === null;
+    }, { timeout: 60000, label: 'the settling marker is torn down with the verdict' });
+  });
+});

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -19,7 +19,9 @@ import { setNoPeerData, setPeerHasData, setSynced } from '../framework/syncthing
 import { sleepUnlessInfraDead } from '../framework/infra-death.js';
 import { electMaster, startFdmOutage, endFdmOutage } from '../framework/fdm-control.js';
 import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
-import { derivedQueueStepMs, derivedEvacuationIntervalMs, loadSharedConfig } from '../framework/coupled-knobs.js';
+import {
+  derivedQueueStepMs, derivedEvacuationIntervalMs, departureCycleMs, loadSharedConfig,
+} from '../framework/coupled-knobs.js';
 
 const subnet = getSubnetConfig();
 
@@ -32,17 +34,27 @@ const subnet = getSubnetConfig();
 // apart - the departure interval is a function OF the queue step, and writing
 // either as a literal is what broke this suite before. test-env asserts both
 // relationships on every node of every fleet before boot.
+const SHARED_POLL_MS = loadSharedConfig().fluxapps.explorerPollIntervalMs;
 const RESIDENTIAL_PACING = (() => {
   const fleet = {
     removeFluxAppsPeriod: 4,
-    explorerPollIntervalMs: loadSharedConfig().fluxapps.explorerPollIntervalMs,
+    explorerPollIntervalMs: SHARED_POLL_MS,
   };
   const residentialQueueStepMs = derivedQueueStepMs(fleet);
-  return {
-    residentialQueueStepMs,
-    residentialEvacuationIntervalMs: derivedEvacuationIntervalMs({ ...fleet, residentialQueueStepMs }),
-  };
+  const residentialEvacuationIntervalMs = derivedEvacuationIntervalMs({ ...fleet, residentialQueueStepMs });
+  return { residentialQueueStepMs, residentialEvacuationIntervalMs };
 })();
+
+// EVERY WAIT THAT HAS TO CONTAIN A DEPARTURE IS DERIVED, not typed. A departure
+// is the departure interval plus a full queue ticket served again from scratch,
+// and this suite's apps run at five instances - so it is far longer than the
+// four minutes driveUntil defaults to, which was written when the interval was
+// four seconds. Two cycles' worth: several of these waits contain a departure
+// AND the pass on which another holder reacts to it.
+const DEPARTURE_WAIT_MS = 2 * departureCycleMs(
+  { ...RESIDENTIAL_PACING, removeFluxAppsPeriod: 4, explorerPollIntervalMs: SHARED_POLL_MS, residentialQueueBaseMs: 1000 },
+  5,
+);
 
 const RESIDENTIAL_GEO = {
   hosting: false,
@@ -575,7 +587,7 @@ describe('Residential node evacuation', function () {
     await driveUntil(env, TARGET, async () => {
       const buffer = env.clients[TARGET - 1].getEventBuffer();
       return buffer.some((e) => e.event === 'app:removed' && e.data?.name === 'residentapp');
-    });
+    }, { timeoutMs: DEPARTURE_WAIT_MS });
 
     const [removedEvent, dosEvent] = await Promise.all([removal, dosLanded]);
 
@@ -699,7 +711,8 @@ describe('Residential node evacuation', function () {
     const refused = waitForGiveUpSafety(env.clients[TARGET - 1], 'worldapp',
       (d) => d.safe === false, 300000).then((v) => { safetyVerdict = v; return v; });
     refused.catch(() => {});
-    await driveUntil(env, TARGET, async () => safetyVerdict !== null);
+    await driveUntil(env, TARGET, async () => safetyVerdict !== null,
+      { timeoutMs: DEPARTURE_WAIT_MS });
     await startTicker();
 
     // The pass reports on every app it holds, every pass, so this proves the
@@ -816,10 +829,17 @@ describe('Residential node evacuation', function () {
     await Promise.all([TARGET, SECOND_TARGET].map((node) => elapseSettleWindow(node)));
 
     // Whichever goes first, the other must be refused while the app is short.
+    //
+    // Read from the PACING decision, not the safety gate. The strength test sits
+    // in the queue ticket now - an app short of its count accrues nothing
+    // towards its turn - so a short app is refused before the pass ever consults
+    // appEvacuationSafety, and the safety event this used to wait on is never
+    // published. The refusal itself is unchanged, and it carries the same name
+    // for the same fact one layer up.
     let refusal = null;
-    const refusedForBeingShort = Promise.race([TARGET, SECOND_TARGET].map((node) => waitForGiveUpSafety(
+    const refusedForBeingShort = Promise.race([TARGET, SECOND_TARGET].map((node) => waitForGiveUpConsidered(
       env.clients[node - 1], 'sharedapp',
-      (d) => d.safe === false && /below its instance count/.test(d.detail), 600000,
+      (d) => d.giveUp === false && d.code === 'BELOW_INSTANCE_COUNT', 600000,
     ))).then((v) => { refusal = v; return v; });
     refusedForBeingShort.catch(() => {});
 
@@ -828,10 +848,12 @@ describe('Residential node evacuation', function () {
     // the moment one node leaves means the other never gets a pass in which to
     // refuse, and the wait times out on a suite that stopped the clock itself.
     await stopTicker();
-    await driveUntil(env, TARGET, async () => refusal !== null);
+    await driveUntil(env, TARGET, async () => refusal !== null,
+      { timeoutMs: DEPARTURE_WAIT_MS });
     await startTicker();
 
     const verdict = await refusedForBeingShort;
+    expect(verdict.data.code).to.equal('BELOW_INSTANCE_COUNT');
     expect(verdict.data.detail).to.contain('below its instance count');
   });
 
@@ -873,13 +895,9 @@ describe('Residential node evacuation', function () {
     const seeded = ['firstout', 'secondout'];
     const wentFirst = (e) => e.event === 'app:removed' && seeded.includes(e.data?.name);
 
-    // Longer than driveUntil's default. This test pays a full queue turn, then
-    // a whole departure interval, then a second full turn - and at five
-    // instances the turn is base + position x step with position up to four.
-    const TURNS_AND_A_BLOCK_MS = 480000;
     await stopTicker();
     await driveUntil(env, TARGET, async () => client.getEventBuffer().some(wentFirst),
-      { timeoutMs: TURNS_AND_A_BLOCK_MS });
+      { timeoutMs: DEPARTURE_WAIT_MS });
     const gone = client.getEventBuffer().filter(wentFirst).pop();
     const remaining = gone.data.name === 'firstout' ? 'secondout' : 'firstout';
 
@@ -895,7 +913,7 @@ describe('Residential node evacuation', function () {
       && e.id > gone.id;
 
     await driveUntil(env, TARGET, async () => client.getEventBuffer().some(turnRestarted),
-      { timeoutMs: TURNS_AND_A_BLOCK_MS });
+      { timeoutMs: DEPARTURE_WAIT_MS });
     await startTicker();
 
     // One stream, monotonic ids: the second app was still waiting its turn on a
@@ -941,7 +959,8 @@ describe('Residential node evacuation', function () {
     stoodDown.catch(() => {});
 
     await stopTicker();
-    await driveUntil(env, TARGET, async () => standDownVerdict !== null);
+    await driveUntil(env, TARGET, async () => standDownVerdict !== null,
+      { timeoutMs: DEPARTURE_WAIT_MS });
     await startTicker();
 
     const verdict = await stoodDown;
@@ -1077,7 +1096,8 @@ describe('Residential node evacuation', function () {
       // shortening it means compressing masterSlaveIntervalMs further, which
       // has its own couplings to check first.
       await stopTicker();
-      await driveUntil(env, TARGET, async () => unknownRefusal !== null);
+      await driveUntil(env, TARGET, async () => unknownRefusal !== null,
+      { timeoutMs: DEPARTURE_WAIT_MS });
       await startTicker();
 
       const verdict = await refused;

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -11,7 +11,7 @@ import {
 import {
   waitForDaemonReady, waitForNodeStatus, waitForBlockProcessed,
   waitForExplorerReady, waitForOrchestratorStarted, waitForOrchestratorState,
-  waitForPeerThreshold, waitForAppInstalled, waitForAppRemoved,
+  waitForPeerThreshold, waitForAppInstalled,
   waitForSpawnerBlocked, waitFor,
 } from '../framework/wait.js';
 import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
@@ -307,10 +307,14 @@ describe('Residential node evacuation', function () {
     await elapseSettleWindow(TARGET);
     await advanceBlocks(5);
 
-    await waitForAppRemoved(env.clients[TARGET - 1], 'residentapp', 240000);
-
-    const installed = await env.clients[TARGET - 1].get('/apps/installedapps');
-    expect(installed.data.map((a) => a.name)).to.not.include('residentapp');
+    // Waited on the node's own view rather than on app:removed. That event is
+    // published part-way through the uninstall - after the runtime state is
+    // dropped, before the installed-apps record is - so a test that asserts on
+    // the record the instant the event lands still sees the app.
+    await waitFor(async () => {
+      const current = await env.clients[TARGET - 1].get('/apps/installedapps');
+      return !current.data.map((a) => a.name).includes('residentapp');
+    }, { timeout: 240000, label: 'node 1 hands residentapp back' });
   });
 
   it('the app survives the departure on every other host', async function () {
@@ -325,14 +329,18 @@ describe('Residential node evacuation', function () {
     // the app asks for five instances and all five nodes already ran it, so
     // there is no node left that is both short of it and not held. Refilling a
     // deficit is appSpawner's existing 120s loop, unchanged by this branch.
+    // Wait for what is actually being asserted - the departure reaching the
+    // rest of the fleet. Waiting on a COUNT was meaningless here: the app was
+    // already at five instances including the one leaving, so `>= 4` was
+    // satisfied before anything had happened.
+    const targetIp = subnet.nodeIp(TARGET);
     await waitFor(async () => {
-      const locations = await dbClient(2).getAppLocations('residentapp');
-      return locations.length >= 4;
-    }, { timeout: 240000, label: 'residentapp still held by the other four nodes' });
+      const current = await dbClient(2).getAppLocations('residentapp');
+      return !current.map((l) => l.ip.split(':')[0]).includes(targetIp);
+    }, { timeout: 240000, label: 'the departure reaches the other nodes' });
 
     const locations = await dbClient(2).getAppLocations('residentapp');
-    const targetIp = subnet.nodeIp(TARGET);
-    expect(locations.map((l) => l.ip.split(':')[0])).to.not.include(targetIp);
+    expect(locations.length).to.be.at.least(4);
   });
 
   it('goes into DOS only once it holds nothing', async function () {

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -15,6 +15,7 @@ import {
   waitForSpawnerBlocked, waitFor, waitForGiveUpConsidered, waitForGiveUpSafety,
   waitForResidentialDecision,
 } from '../framework/wait.js';
+import { waitForLocationTable } from '../framework/reconciler-suite.js';
 import { setNoPeerData, setPeerHasData, setSynced } from '../framework/syncthing-control.js';
 import { sleepUnlessInfraDead } from '../framework/infra-death.js';
 import { electMaster, startFdmOutage, endFdmOutage } from '../framework/fdm-control.js';
@@ -339,6 +340,16 @@ describe('Residential node evacuation', function () {
       },
     });
     await bootToReady(env);
+    // The verdict this suite rests on needs the PUBLISHED table, not only the
+    // node's own evidence: getNetworkClassification returns null while
+    // publishedClassification reports consulted:false, and the two arrive at
+    // different times. The veto test waited for networkEvidence alone and then
+    // asked for a classification, so on the bc5d86154 gate node 5 spent all 24 of
+    // its ticks logging "no network verdict to act on yet" and the test timed out
+    // against classification:null, source:null - a decision that could not be
+    // reached rather than one that went the wrong way. Waited for on every node,
+    // because the table is the authority the whole suite runs on.
+    await Promise.all(env.clients.map((c) => waitForLocationTable(c, { domains: 2 })));
   });
 
   after(async function () {

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -106,8 +106,13 @@ async function seedApp(env, appName, { instances = 3, containerData = '/tmp', po
  * tip, and only on every fourth block, so whether the pass ever runs comes down
  * to which parity the race settles on. Driving the chain removes that instead of
  * hoping the phases stay favourable.
+ *
+ * maxBlocks is wall-clock cover, not a block count that matters in itself. The
+ * queue ticket a node waits out is measured in wall-clock while driving races
+ * through the chain in milliseconds, so the budget has to outlast the longest
+ * ticket in play - about 41s here - at roughly half a second a block.
  */
-async function driveUntil(env, nodeIndex, condition, maxBlocks = 40) {
+async function driveUntil(env, nodeIndex, condition, maxBlocks = 200) {
   const node = env.clients[nodeIndex - 1];
   for (let i = 0; i < maxBlocks; i += 1) {
     // eslint-disable-next-line no-await-in-loop
@@ -246,17 +251,23 @@ describe('Residential node evacuation', function () {
           residentialSettleMs: 600000,
           residentialEvacuationIntervalMs: 4000,
           residentialQueueBaseMs: 1000,
-          // The step has to exceed the interval between give-up passes, or the
-          // ordering it exists to create is compressed out of existence.
+          // Position in the instance order sets a wait of base + position*step,
+          // and the step is what stops two holders of the same app leaving
+          // together: the second's turn has to arrive AFTER the first's
+          // departure is visible to it.
           //
-          // Position in the instance order sets a wait of base + position*step.
-          // In production that is 30min + position*15min against a pass that
-          // runs every 44 blocks (~22min), so the second holder's turn arrives
-          // on a LATER pass than the first's - by which time the first has gone,
-          // the app is short, and the second refuses. That is what serialises
-          // the drain. At a 500ms step against a 20s pass, both holders are
-          // eligible in the same pass and both leave together.
-          residentialQueueStepMs: 30000,
+          // So the step only needs to outlast one give-up pass plus the
+          // propagation of a removal - here a pass is four driven blocks, two
+          // to four seconds, and the fluxappremoved broadcast is sub-second.
+          // Ten seconds carries ample margin while capping the worst wait (last
+          // of five instances) at 41s. Production's 15 MINUTES is sized against
+          // a pass that runs every 44 blocks; copying that number rather than
+          // the reasoning would add two minutes per test for nothing.
+          //
+          // Do not shorten it below a pass. At 500ms both holders became
+          // eligible within the same pass and both left - the mechanism intact,
+          // the property compressed out of existence.
+          residentialQueueStepMs: 10000,
           removeFluxAppsPeriod: 1,
         },
       },
@@ -388,7 +399,7 @@ describe('Residential node evacuation', function () {
     await driveUntil(env, TARGET, async () => {
       const current = await env.clients[TARGET - 1].get('/apps/installedapps');
       return !current.data.map((a) => a.name).includes('residentapp');
-    });
+    }, 200);
 
     // The node's own view, not app:removed - that event is published part-way
     // through the uninstall, after the runtime state is dropped and before the
@@ -493,13 +504,19 @@ describe('Residential node evacuation', function () {
       { timeout: 120000, label: 'the settling window starts again' });
     await elapseSettleWindow(TARGET);
 
-    // Drive the chain so the pass is reached deterministically.
+    // Drive the chain so the pass is reached deterministically, and keep
+    // driving until the verdict lands: the queue ticket is WALL-CLOCK, so
+    // driving a fixed few blocks races through the chain in seconds and stops
+    // long before this node's turn comes round.
     await stopTicker();
+    let safetyVerdict = null;
     const considered = waitForGiveUpConsidered(env.clients[TARGET - 1], 'worldapp',
       (d) => d.giveUp === true && d.reason === 'EVACUATION', 300000);
+    considered.catch(() => {});
     const refused = waitForGiveUpSafety(env.clients[TARGET - 1], 'worldapp',
-      (d) => d.safe === false, 300000);
-    await driveUntil(env, TARGET, async () => false, 12).catch(() => {});
+      (d) => d.safe === false, 300000).then((v) => { safetyVerdict = v; return v; });
+    refused.catch(() => {});
+    await driveUntil(env, TARGET, async () => safetyVerdict !== null, 200);
     await startTicker();
 
     // The pass reports on every app it holds, every pass, so this proves the
@@ -529,7 +546,7 @@ describe('Residential node evacuation', function () {
     await driveUntil(env, TARGET, async () => {
       const current = await env.clients[TARGET - 1].get('/apps/installedapps');
       return !current.data.map((a) => a.name).includes('worldapp');
-    });
+    }, 200);
     await startTicker();
 
     await whenGone(env, TARGET, 'worldapp', 120000);
@@ -605,7 +622,7 @@ describe('Residential node evacuation', function () {
     // the moment one node leaves means the other never gets a pass in which to
     // refuse, and the wait times out on a suite that stopped the clock itself.
     await stopTicker();
-    await driveUntil(env, TARGET, async () => refusal !== null, 80);
+    await driveUntil(env, TARGET, async () => refusal !== null, 200);
     await startTicker();
 
     const verdict = await refusedForBeingShort;
@@ -646,7 +663,7 @@ describe('Residential node evacuation', function () {
     refused.catch(() => {});
 
     await stopTicker();
-    await driveUntil(env, TARGET, async () => primaryRefusal !== null, 80);
+    await driveUntil(env, TARGET, async () => primaryRefusal !== null, 200);
     await startTicker();
 
     const verdict = await refused;

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { createTestEnv } from '../framework/test-env.js';
 import { dbClient } from '../framework/db-client.js';
 import { pushImage } from '../framework/registry-helper.js';
-import { buildSeedableApp } from '../framework/seed-helper.js';
+import { buildSeedableApp, allocateAppPort } from '../framework/seed-helper.js';
 import { getSubnetConfig, REGISTRY_REPO_HOST } from '../framework/subnet-config.js';
 import {
   advanceBlock, advanceBlocks, startTicker, stopTicker, setSystemSecure, clearSystemSecure,
@@ -59,7 +59,12 @@ async function bootToReady(env) {
   await waitForOrchestratorState(env.clients[0], 'READY', 120000);
 }
 
-async function seedApp(env, appName, { instances = 3, containerData = '/tmp' } = {}) {
+/**
+ * Seed a global app the spawner can place. The port is allocated, so seeding a
+ * second app on the same fleet cannot collide with the first - see
+ * allocateAppPort.
+ */
+async function seedApp(env, appName, { instances = 3, containerData = '/tmp', port = allocateAppPort() } = {}) {
   await pushImage(appName, 'v1');
   const app = await buildSeedableApp({
     name: appName,
@@ -68,7 +73,7 @@ async function seedApp(env, appName, { instances = 3, containerData = '/tmp' } =
       name: appName,
       description: 'test container',
       repotag: `${REGISTRY_REPO_HOST}/${appName}:v1`,
-      ports: [31111],
+      ports: [port],
       domains: [''],
       environmentParameters: [],
       commands: [],

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -18,6 +18,7 @@ import {
 import { setNoPeerData, setPeerHasData, setSynced } from '../framework/syncthing-control.js';
 import { electMaster, startFdmOutage, endFdmOutage } from '../framework/fdm-control.js';
 import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
+import { derivedQueueStepMs, loadSharedConfig } from '../framework/coupled-knobs.js';
 
 const subnet = getSubnetConfig();
 
@@ -275,8 +276,10 @@ describe('Residential node evacuation', function () {
           // network:appremoved reached it - propagation lost the race, both
           // holders saw the app at full strength, and both left.
           //
-          // 4 here puts the pass at 16 blocks, about 4s, comfortably longer than
-          // propagation while still far shorter than production's 44 blocks.
+          // 4 here puts the pass at 16 blocks. What that costs in wall time is
+          // set by explorerPollIntervalMs, not by this number: at the harness's
+          // 833ms poll it is about 16s, measured at 15.9s over nine consecutive
+          // passes on cindy. Still far shorter than production's 44 blocks.
           removeFluxAppsPeriod: 4,
           // Left LONG on purpose, and opened by the test when it is ready. A
           // short window would let evacuation start while the hold is still
@@ -290,22 +293,22 @@ describe('Residential node evacuation', function () {
           // together: the second's turn has to arrive AFTER the first's
           // departure is visible to it.
           //
-          // The step has to outlast a pass, so two holders' turns land on
-          // different passes. With the pass at ~4s (see removeFluxAppsPeriod
-          // above), 15s carries margin and caps the worst wait - last of five
-          // instances - at 61s.
+          // DERIVED, never written as a literal. The step has to outlast a pass
+          // and the pass is a function of explorerPollIntervalMs - a block costs
+          // one poll - so a literal here silently stops tracking the pass the
+          // moment that knob moves. It did: 15000 was chosen against a pass this
+          // comment called "about 4s", the poll went 250ms -> 833ms, the pass
+          // went with it to ~16s, and the step ended up SHORTER than the pass.
+          // Both holders then matured on the same pass and both handed the same
+          // app back - the mechanism intact, the property compressed out of
+          // existence, which is the defect production's own 15-minute step had.
           //
-          // Measured before explorerPollIntervalMs existed: 4.8s a block, a 20s
-          // pass, and a 5s step that both holders cleared within one pass.
-          //
-          // Production's 15 MINUTES is that same relationship against a pass
-          // that runs every 44 blocks. The ratio transfers; the number does not,
-          // and copying it would add minutes per test for nothing.
-          //
-          // Do not shorten it below a pass. At 500ms both holders became
-          // eligible within the same pass and both left - the mechanism intact,
-          // the property compressed out of existence.
-          residentialQueueStepMs: 15000,
+          // coupled-knobs.js carries the derivation and test-env asserts the
+          // resulting ratio against production's on every fleet boot.
+          residentialQueueStepMs: derivedQueueStepMs({
+            removeFluxAppsPeriod: 4,
+            explorerPollIntervalMs: loadSharedConfig().fluxapps.explorerPollIntervalMs,
+          }),
         },
       },
     });

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -466,27 +466,48 @@ describe('Residential node evacuation', function () {
     // give-up pass is reached on a block the node processed AS the tip. See
     // driveUntil.
     await stopTicker();
+    // Read from the EVENT STREAM, not by polling two endpoints.
+    //
+    // What this has to establish is an ORDER: the app goes, and only then does
+    // DOS land. "goes into DOS only once it holds nothing" cannot see a
+    // violation on its own, because nodeStatusMonitor removes every local app
+    // at DOS >= 100 - so a premature DOS empties the node and satisfies that
+    // test's waits FASTER than the correct behaviour does.
+    //
+    // Polling cannot establish it. Two earlier forms of this check failed for
+    // two different reasons: asserting DOS unconditionally fails on the correct
+    // sequence, because DOS follows the departure by about two seconds and the
+    // next poll sees 100 with nothing held; and gating that assertion on
+    // /apps/installedapps fails because the installed-apps RECORD is dropped
+    // LAST, after the runtime state - measured at 20s behind "Application
+    // residentapp locally removed", which the whenGone wait below exists to
+    // absorb. The endpoint says held long after the node holds nothing, and
+    // `Checking 0 installed apps for image updates` in the same log says so.
+    //
+    // app:removed and dos:changed arrive on ONE stream with monotonic ids, so
+    // comparing their ids is a fact about what happened rather than a race
+    // between two reads of two different sources.
+    const removal = env.clients[TARGET - 1].waitForEvent(
+      'app:removed', (d) => d.name === 'residentapp', 300000,
+    );
     await driveUntil(env, TARGET, async () => {
-      // Sampled across the whole window in which the node still holds the app.
-      // "goes into DOS only once it holds nothing" cannot see this on its own:
-      // nodeStatusMonitor removes every local app at DOS >= 100, so a DOS
-      // applied while apps were still held would empty the node and satisfy
-      // both of that test's waits - faster than the correct behaviour. A
-      // throwing expect inside the condition propagates out of driveUntil.
-      //
-      // The app list is read FIRST and the DOS check is conditional on it.
-      // Asserting DOS unconditionally fails on the correct sequence: the node
-      // hands the app back and DOS follows about six seconds later, so the
-      // first poll after a successful departure sees dosState 100 with nothing
-      // held - which is the outcome this test is waiting for, not a violation.
-      const current = await env.clients[TARGET - 1].get('/apps/installedapps');
-      const stillHeld = current.data.map((a) => a.name).includes('residentapp');
-      if (!stillHeld) return true;
-      const info = await env.clients[TARGET - 1].get('/flux/info');
-      expect(info.data.flux.dos.dosState, 'DOS must not land while an app is still held')
-        .to.be.below(100);
-      return false;
+      const buffer = env.clients[TARGET - 1].getEventBuffer();
+      return buffer.some((e) => e.event === 'app:removed' && e.data?.name === 'residentapp');
     });
+    const removedEvent = await removal;
+
+    // Both halves, because either alone is satisfiable by an event that never
+    // fires. "nothing arrived early" is trivially true of a signal that is
+    // silent - which dos:changed WAS on this path until the sticky setters were
+    // made to emit it - so the presence check is what keeps this test honest.
+    const dosEvents = env.clients[TARGET - 1].getEventBuffer()
+      .filter((e) => e.event === 'dos:changed' && e.data?.dosState >= 100);
+    expect(dosEvents, 'the node must actually reach DOS, or the ordering below proves nothing')
+      .to.not.be.empty;
+
+    const earlyDos = dosEvents.find((e) => e.id < removedEvent.id);
+    expect(earlyDos, `DOS reached ${earlyDos?.data?.dosState} before the app was handed back`)
+      .to.equal(undefined);
 
     // The node's own view, not app:removed - that event is published part-way
     // through the uninstall, after the runtime state is dropped and before the

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -172,14 +172,17 @@ describe('Residential node evacuation', function () {
   it('classifies the node RESIDENTIAL from the operator, not the registrant org', async function () {
     this.timeout(120000);
 
+    // The node persists what it OBSERVED, not the verdict it drew from it - the
+    // verdict also needs the published table, which arrives later, so it is
+    // reached when asked rather than stored and left to go stale.
     await waitFor(async () => {
       const geo = await dbClient(TARGET).geolocation();
-      return geo?.networkClassification?.classification === 'RESIDENTIAL';
-    }, { timeout: 90000, label: 'node 1 reaches a RESIDENTIAL classification' });
+      return geo?.networkEvidence?.classification === 'RESIDENTIAL';
+    }, { timeout: 90000, label: 'node 1 observes itself on an access network' });
 
     const geo = await dbClient(TARGET).geolocation();
-    expect(geo.networkClassification.evidenceAgainst).to.be.empty;
-    expect(geo.networkClassification.evidenceFor).to.not.be.empty;
+    expect(geo.networkEvidence.evidenceAgainst).to.be.empty;
+    expect(geo.networkEvidence.evidenceFor).to.not.be.empty;
     // The org string names a reseller. Reading it, as the old classifier did,
     // would have decided this node on the wrong field entirely.
     expect(geo.geolocation.org).to.equal('Some Reseller Ltd');
@@ -189,7 +192,7 @@ describe('Residential node evacuation', function () {
     this.timeout(120000);
 
     const geo = await dbClient(2).geolocation();
-    expect(geo.networkClassification.classification).to.equal('DATACENTER');
+    expect(geo.networkEvidence.classification).to.equal('DATACENTER');
 
     const info = await env.clients[1].get('/flux/info');
     expect(info.data.flux.dos.dosState).to.be.below(100);

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -121,7 +121,7 @@ async function seedApp(env, appName, { instances = 3, containerData = '/tmp', po
  * @param {number} [opts.blockIntervalMs] Minimum wall-clock between blocks.
  * @returns {Promise<number>} Blocks driven.
  */
-async function driveUntil(env, nodeIndex, condition, { timeoutMs = 120000, blockIntervalMs = 200 } = {}) {
+async function driveUntil(env, nodeIndex, condition, { timeoutMs = 240000, blockIntervalMs = 200 } = {}) {
   const node = env.clients[nodeIndex - 1];
   const deadline = Date.now() + timeoutMs;
   let blocks = 0;
@@ -260,6 +260,23 @@ describe('Residential node evacuation', function () {
           // So: shorten the poll here so the suite can see the path at all.
           daemonInfoIntervalMs: 1000,
           residentialCheckIntervalMs: 3000,
+          // The give-up pass runs every removeFluxAppsPeriod * 4 blocks, and a
+          // block costs one explorerPollIntervalMs. There is a three-way
+          // relationship here and all three have to hold, or the serialisation
+          // this suite checks cannot happen:
+          //
+          //   propagation  <  pass interval  <  queue step
+          //
+          // A departure has to be VISIBLE to the other holder by its next pass
+          // (propagation < pass), and the two holders' turns have to fall on
+          // different passes (pass < step). Measured: with the pass at 4 blocks
+          // (~1s) the other node evaluated twice more before the
+          // network:appremoved reached it - propagation lost the race, both
+          // holders saw the app at full strength, and both left.
+          //
+          // 4 here puts the pass at 16 blocks, about 4s, comfortably longer than
+          // propagation while still far shorter than production's 44 blocks.
+          removeFluxAppsPeriod: 4,
           // Left LONG on purpose, and opened by the test when it is ready. A
           // short window would let evacuation start while the hold is still
           // being asserted, and the ordering - hold first, deletes nothing, and
@@ -272,13 +289,10 @@ describe('Residential node evacuation', function () {
           // together: the second's turn has to arrive AFTER the first's
           // departure is visible to it.
           //
-          // So the step only has to outlast one give-up pass plus the
-          // propagation of a removal. A pass is four blocks, and a block costs
-          // one explorerPollIntervalMs - 250ms in the harness - because a block
-          // is not looked at until the next poll. So a pass is about a second
-          // here and the fluxappremoved broadcast is sub-second. 5s is several
-          // times the margin needed and caps the worst wait - last of five
-          // instances - at 21s.
+          // The step has to outlast a pass, so two holders' turns land on
+          // different passes. With the pass at ~4s (see removeFluxAppsPeriod
+          // above), 15s carries margin and caps the worst wait - last of five
+          // instances - at 61s.
           //
           // Measured before explorerPollIntervalMs existed: 4.8s a block, a 20s
           // pass, and a 5s step that both holders cleared within one pass.
@@ -289,11 +303,8 @@ describe('Residential node evacuation', function () {
           //
           // Do not shorten it below a pass. At 500ms both holders became
           // eligible within the same pass and both left - the mechanism intact,
-          // the property compressed out of existence. And do not change it
-          // without looking at driveUntil's blockIntervalMs, which is what fixes
-          // how long a pass takes.
-          residentialQueueStepMs: 5000,
-          removeFluxAppsPeriod: 1,
+          // the property compressed out of existence.
+          residentialQueueStepMs: 15000,
         },
       },
     });

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -405,6 +405,13 @@ describe('Residential node evacuation', function () {
     await advanceBlocks(3);
     await waitForAppInstalled(env.clients[TARGET - 1], 'worldapp', 300000);
 
+    // Let it reach full strength before enforcing. The pass refuses to act on an
+    // app that is already short - that is the serialisation gate, and it fires
+    // BEFORE the data check, so a test that starts too early proves nothing
+    // about the data check at all.
+    await waitFor(async () => (await dbClient(2).getAppLocations('worldapp')).length >= 5,
+      { timeout: 300000, label: 'worldapp reaches its instance count across the fleet' });
+
     // Declared before enforcement starts, so the node never sees a moment where
     // the data looks safe.
     await setNoPeerData({ folder: 'fluxworldapp_worldapp' });

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -96,35 +96,51 @@ async function seedApp(env, appName, { instances = 3, containerData = '/tmp', po
 }
 
 /**
- * Advance the chain one block at a time, waiting for the node to PROCESS each
- * one before producing the next, until the condition holds.
+ * Drive the chain until a condition holds, at a stated RATE, up to a stated
+ * deadline.
  *
- * The free-running ticker produces blocks on the same period the explorer polls
- * on, so the node learns about them in bursts and processes a burst back to
- * back - and only the last block of a burst is still the chain tip. FluxOS runs
- * its app maintenance, the give-up pass included, only for a block that was the
- * tip, and only on every fourth block, so whether the pass ever runs comes down
- * to which parity the race settles on. Driving the chain removes that instead of
- * hoping the phases stay favourable.
+ * Two reasons this drives rather than letting the ticker free-run:
  *
- * maxBlocks is wall-clock cover, not a block count that matters in itself. The
- * queue ticket a node waits out is measured in wall-clock while driving races
- * through the chain in milliseconds, so the budget has to outlast the longest
- * ticket in play - about 41s here - at roughly half a second a block.
+ * The ticker produces blocks on the same period the explorer polls on, so the
+ * node learns about them in bursts and processes a burst back to back - and only
+ * the last block of a burst is still the chain tip. FluxOS runs its app
+ * maintenance, the give-up pass included, only for a block that was the tip and
+ * only on every fourth block, so whether the pass runs at all comes down to
+ * which parity the race settles on.
+ *
+ * And the waits here are WALL-CLOCK. A node's queue ticket is real time, so a
+ * budget counted in blocks means nothing: driving flat out races through the
+ * chain in milliseconds and stops long before the node's turn comes round,
+ * leaving no pass in which to act. The deadline is therefore in milliseconds and
+ * the rate is explicit - `blockIntervalMs` sets how fast the chain moves, which
+ * is what fixes how long a give-out pass takes in wall-clock, which is what the
+ * queue step has to outlast. Changing one without the other is what quietly
+ * deletes the ordering these tests exist to check.
+ *
+ * @param {number} [opts.timeoutMs] How long to keep driving before giving up.
+ * @param {number} [opts.blockIntervalMs] Minimum wall-clock between blocks.
+ * @returns {Promise<number>} Blocks driven.
  */
-async function driveUntil(env, nodeIndex, condition, maxBlocks = 200) {
+async function driveUntil(env, nodeIndex, condition, { timeoutMs = 120000, blockIntervalMs = 200 } = {}) {
   const node = env.clients[nodeIndex - 1];
-  for (let i = 0; i < maxBlocks; i += 1) {
+  const deadline = Date.now() + timeoutMs;
+  let blocks = 0;
+  while (Date.now() < deadline) {
     // eslint-disable-next-line no-await-in-loop
-    if (await condition()) return;
+    if (await condition()) return blocks;
+    const startedAt = Date.now();
     const afterId = node.getLastEventId();
     // eslint-disable-next-line no-await-in-loop
     await advanceBlock();
     // eslint-disable-next-line no-await-in-loop
     await node.waitForEvent('block:processed', () => true, 60000, { afterId });
+    blocks += 1;
+    const spent = Date.now() - startedAt;
+    // eslint-disable-next-line no-await-in-loop
+    if (spent < blockIntervalMs) await new Promise((resolve) => { setTimeout(resolve, blockIntervalMs - spent); });
   }
-  // eslint-disable-next-line no-await-in-loop
-  if (!await condition()) throw new Error(`condition not reached within ${maxBlocks} driven blocks`);
+  if (await condition()) return blocks;
+  throw new Error(`condition not reached in ${timeoutMs}ms (${blocks} blocks driven)`);
 }
 
 /**
@@ -256,18 +272,23 @@ describe('Residential node evacuation', function () {
           // together: the second's turn has to arrive AFTER the first's
           // departure is visible to it.
           //
-          // So the step only needs to outlast one give-up pass plus the
-          // propagation of a removal - here a pass is four driven blocks, two
-          // to four seconds, and the fluxappremoved broadcast is sub-second.
-          // Ten seconds carries ample margin while capping the worst wait (last
-          // of five instances) at 41s. Production's 15 MINUTES is sized against
-          // a pass that runs every 44 blocks; copying that number rather than
-          // the reasoning would add two minutes per test for nothing.
+          // So the step only has to outlast one give-up pass plus the
+          // propagation of a removal. A pass is four blocks, and driveUntil
+          // paces the chain at 200ms a block, so a pass is under a second here;
+          // the fluxappremoved broadcast is sub-second too. 5s is several times
+          // the margin needed and caps the worst wait - last of five instances -
+          // at 21s.
+          //
+          // Production's 15 MINUTES is that same relationship against a pass
+          // that runs every 44 blocks. The ratio transfers; the number does not,
+          // and copying it would add minutes per test for nothing.
           //
           // Do not shorten it below a pass. At 500ms both holders became
           // eligible within the same pass and both left - the mechanism intact,
-          // the property compressed out of existence.
-          residentialQueueStepMs: 10000,
+          // the property compressed out of existence. And do not change it
+          // without looking at driveUntil's blockIntervalMs, which is what fixes
+          // how long a pass takes.
+          residentialQueueStepMs: 5000,
           removeFluxAppsPeriod: 1,
         },
       },
@@ -399,7 +420,7 @@ describe('Residential node evacuation', function () {
     await driveUntil(env, TARGET, async () => {
       const current = await env.clients[TARGET - 1].get('/apps/installedapps');
       return !current.data.map((a) => a.name).includes('residentapp');
-    }, 200);
+    });
 
     // The node's own view, not app:removed - that event is published part-way
     // through the uninstall, after the runtime state is dropped and before the
@@ -516,7 +537,7 @@ describe('Residential node evacuation', function () {
     const refused = waitForGiveUpSafety(env.clients[TARGET - 1], 'worldapp',
       (d) => d.safe === false, 300000).then((v) => { safetyVerdict = v; return v; });
     refused.catch(() => {});
-    await driveUntil(env, TARGET, async () => safetyVerdict !== null, 200);
+    await driveUntil(env, TARGET, async () => safetyVerdict !== null);
     await startTicker();
 
     // The pass reports on every app it holds, every pass, so this proves the
@@ -546,7 +567,7 @@ describe('Residential node evacuation', function () {
     await driveUntil(env, TARGET, async () => {
       const current = await env.clients[TARGET - 1].get('/apps/installedapps');
       return !current.data.map((a) => a.name).includes('worldapp');
-    }, 200);
+    });
     await startTicker();
 
     await whenGone(env, TARGET, 'worldapp', 120000);
@@ -622,7 +643,7 @@ describe('Residential node evacuation', function () {
     // the moment one node leaves means the other never gets a pass in which to
     // refuse, and the wait times out on a suite that stopped the clock itself.
     await stopTicker();
-    await driveUntil(env, TARGET, async () => refusal !== null, 200);
+    await driveUntil(env, TARGET, async () => refusal !== null);
     await startTicker();
 
     const verdict = await refusedForBeingShort;
@@ -663,7 +684,7 @@ describe('Residential node evacuation', function () {
     refused.catch(() => {});
 
     await stopTicker();
-    await driveUntil(env, TARGET, async () => primaryRefusal !== null, 200);
+    await driveUntil(env, TARGET, async () => primaryRefusal !== null);
     await startTicker();
 
     const verdict = await refused;

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -19,7 +19,7 @@ import { setNoPeerData, setPeerHasData, setSynced } from '../framework/syncthing
 import { sleepUnlessInfraDead } from '../framework/infra-death.js';
 import { electMaster, startFdmOutage, endFdmOutage } from '../framework/fdm-control.js';
 import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
-import { derivedQueueStepMs, loadSharedConfig } from '../framework/coupled-knobs.js';
+import { derivedQueueStepMs, derivedEvacuationIntervalMs, loadSharedConfig } from '../framework/coupled-knobs.js';
 
 const subnet = getSubnetConfig();
 
@@ -28,6 +28,22 @@ const subnet = getSubnetConfig();
 // signal available is what the ip-api stub serves - 198.18.x.x has no reverse
 // DNS and the stub tiers are not asymmetric enough to count - so `mobile` is the
 // positive signal and every contradiction is turned off.
+// The pacing this fleet runs on, derived once so the two knobs cannot drift
+// apart - the departure interval is a function OF the queue step, and writing
+// either as a literal is what broke this suite before. test-env asserts both
+// relationships on every node of every fleet before boot.
+const RESIDENTIAL_PACING = (() => {
+  const fleet = {
+    removeFluxAppsPeriod: 4,
+    explorerPollIntervalMs: loadSharedConfig().fluxapps.explorerPollIntervalMs,
+  };
+  const residentialQueueStepMs = derivedQueueStepMs(fleet);
+  return {
+    residentialQueueStepMs,
+    residentialEvacuationIntervalMs: derivedEvacuationIntervalMs({ ...fleet, residentialQueueStepMs }),
+  };
+})();
+
 const RESIDENTIAL_GEO = {
   hosting: false,
   proxy: false,
@@ -303,7 +319,6 @@ describe('Residential node evacuation', function () {
           // being asserted, and the ordering - hold first, deletes nothing, and
           // only later gives an app up - is the property under test.
           residentialSettleMs: 600000,
-          residentialEvacuationIntervalMs: 4000,
           residentialQueueBaseMs: 1000,
           // Position in the instance order sets a wait of base + position*step,
           // and the step is what stops two holders of the same app leaving
@@ -322,10 +337,21 @@ describe('Residential node evacuation', function () {
           //
           // coupled-knobs.js carries the derivation and test-env asserts the
           // resulting ratio against production's on every fleet boot.
-          residentialQueueStepMs: derivedQueueStepMs({
-            removeFluxAppsPeriod: 4,
-            explorerPollIntervalMs: loadSharedConfig().fluxapps.explorerPollIntervalMs,
-          }),
+          residentialQueueStepMs: RESIDENTIAL_PACING.residentialQueueStepMs,
+          // DERIVED too, and for a reason the 4000ms literal here could not
+          // survive. A node inside its departure interval records nothing
+          // against its queue tickets, so the block is what restarts them - and
+          // that only works if the block outlasts the gap a ticket tolerates,
+          // which IS the step. At 4000ms against a ~29s step the block stopped
+          // reading as a gap: every ticket carried across it, every app was
+          // instantly ready the moment the interval cleared, and two holders
+          // whose blocks expired in the same pass handed back the same app
+          // together. Production holds 6h against 40min and never meets it.
+          //
+          // It costs the suite real time - one departure per interval, and the
+          // interval is now tens of seconds rather than four. That is the price
+          // of the suite being able to see the property at all.
+          residentialEvacuationIntervalMs: RESIDENTIAL_PACING.residentialEvacuationIntervalMs,
         },
       },
     });
@@ -783,6 +809,78 @@ describe('Residential node evacuation', function () {
 
     const verdict = await refusedForBeingShort;
     expect(verdict.data.detail).to.contain('below its instance count');
+  });
+
+  it('serves a fresh queue turn after a departure, not one that matured during it', async function () {
+    this.timeout(900000);
+
+    // The ticket is the only thing separating two holders of one app, and it
+    // separates them only while it is still binding. A node inside its
+    // departure interval cannot act on anything, so time passing there is not
+    // evidence about any app it holds - but the ticket used to keep maturing
+    // through the block anyway, and the node came out of it instantly ready for
+    // everything at once. Two holders whose blocks expire in the same pass -
+    // and the pass is fired from a block height, so the whole fleet runs it
+    // together - then hand back the same app in the same pass, both read it at
+    // full strength, and both delete.
+    //
+    // Written as ONE node's second departure rather than two nodes colliding:
+    // the collision needs both blocks to expire on the same pass, which is a
+    // coincidence to arrange and a tautology to assert. What actually fixes it
+    // is that a departure restarts the queue, and that is directly observable.
+    await returnToService(env, TARGET);
+    await returnToService(env, SECOND_TARGET);
+
+    await seedApp(env, 'firstout', { instances: 5 });
+    await seedApp(env, 'secondout', { instances: 5 });
+    await advanceBlocks(3);
+    await waitFor(async () => {
+      const first = await dbClient(2).getAppLocations('firstout');
+      const second = await dbClient(2).getAppLocations('secondout');
+      return first.length >= 5 && second.length >= 5;
+    }, { timeout: 300000, label: 'both apps reach their instance count across the fleet' });
+
+    await setSystemSecure(subnet.nodeIp(TARGET), false);
+    await waitFor(async () => (await dbClient(TARGET).residentialMarker()) !== null,
+      { timeout: 120000, label: 'the settling window starts' });
+    await elapseSettleWindow(TARGET);
+
+    const client = env.clients[TARGET - 1];
+    const seeded = ['firstout', 'secondout'];
+    const wentFirst = (e) => e.event === 'app:removed' && seeded.includes(e.data?.name);
+
+    // Longer than driveUntil's default. This test pays a full queue turn, then
+    // a whole departure interval, then a second full turn - and at five
+    // instances the turn is base + position x step with position up to four.
+    const TURNS_AND_A_BLOCK_MS = 480000;
+    await stopTicker();
+    await driveUntil(env, TARGET, async () => client.getEventBuffer().some(wentFirst),
+      { timeoutMs: TURNS_AND_A_BLOCK_MS });
+    const gone = client.getEventBuffer().filter(wentFirst).pop();
+    const remaining = gone.data.name === 'firstout' ? 'secondout' : 'firstout';
+
+    // Through the block every pass refuses with 'next departure in'. The first
+    // time it says 'its turn is in' AFTER that departure, the block has cleared
+    // and the ticket has started over - which is the claim. On the accounting
+    // this replaces the ticket had matured inside the block, so the same pass
+    // removed the second app instead and this never arrives.
+    const turnRestarted = (e) => e.event === 'giveUp:considered'
+      && e.data?.appName === remaining
+      && e.data?.giveUp === false
+      && /its turn is in/.test(e.data?.detail || '')
+      && e.id > gone.id;
+
+    await driveUntil(env, TARGET, async () => client.getEventBuffer().some(turnRestarted),
+      { timeoutMs: TURNS_AND_A_BLOCK_MS });
+    await startTicker();
+
+    // One stream, monotonic ids: the second app was still waiting its turn on a
+    // pass that came after the first one left, rather than leaving with it.
+    const verdict = client.getEventBuffer().filter(turnRestarted).pop();
+    expect(verdict, `${remaining} never served a fresh turn after the departure`).to.not.be.undefined;
+    expect(client.getEventBuffer().some(
+      (e) => e.event === 'app:removed' && e.data?.name === remaining && e.id < verdict.id,
+    ), `${remaining} left during the departure interval instead of serving a turn`).to.equal(false);
   });
 
   it('stands down as the elected primary rather than handing the app back from under itself', async function () {

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -815,8 +815,14 @@ describe('Residential node evacuation', function () {
     // node is still writing. It did exactly that on the first run here.
     const runningComponents = async () => {
       const res = await env.clients[TARGET - 1].get('/apps/listrunningapps');
-      const list = res?.data?.data;
-      if (!Array.isArray(list)) throw new Error(`listrunningapps unreadable: ${JSON.stringify(res?.data)?.slice(0, 200)}`);
+      // The client returns the PARSED BODY, so the container list is res.data.
+      // res.data.data is the level this read was written at while it was
+      // vacuous, and it is undefined on EVERY answer - readable or not - which
+      // is precisely why `!names.some(...)` over it could never fail. Reading
+      // the right level is what makes the throw below mean something. Sibling
+      // reads in this file (whenGone, the installed-apps check) use res.data.
+      const list = res?.status === 'success' ? res.data : null;
+      if (!Array.isArray(list)) throw new Error(`listrunningapps unreadable: ${JSON.stringify(res)?.slice(0, 200)}`);
       return list.flatMap((a) => a.Names || []).map((n) => n.replace(/^\//, ''));
     };
     // Positive control: the component must be running here NOW, or the wait
@@ -858,14 +864,44 @@ describe('Residential node evacuation', function () {
     // node were the same answer - false - and the gate deleted the volume on
     // it. Every other unavailable input in that gate refuses.
     //
-    // This runs on from the test above: node TARGET is the elected primary of
-    // primaryapp and is running its g: component. Taking FDM down means the
-    // election reaches no verdict for the app at all, so what the node knows
-    // has to go STALE rather than merely be absent - it was elected moments
-    // ago and remembers it. PRIMARY_ELECTION_STALE_MS is ten election cycles,
-    // derived from masterSlaveIntervalMs, so the wait below is derived from
-    // the same knob rather than picked: at the harness's 3s cycle the verdict
-    // expires 30s after the last pass that reached one.
+    // SEEDS ITS OWN APP. This used to run on from the stand-down tests, on the
+    // strength of node TARGET still holding primaryapp and still being its
+    // primary - but that state only ever existed because the stand-down was
+    // BROKEN: the container was stopped and the reconciler started it again, so
+    // the node could never hand the app back and stayed primary indefinitely.
+    // With the stand-down working the app leaves, nothing considers it again,
+    // and the refusal under test is unreachable - the test was passing on the
+    // defect. A scenario a test depends on is a scenario it has to build.
+    await returnToService(env, TARGET);
+
+    await seedApp(env, 'lockedapp', { instances: 5, containerData: 'g:/appdata' });
+    await setSynced({ folder: 'fluxlockedapp_lockedapp' });
+    await setPeerHasData({ folder: 'fluxlockedapp_lockedapp' });
+    await advanceBlocks(3);
+    await waitFor(async () => (await dbClient(2).getAppLocations('lockedapp')).length >= 5,
+      { timeout: 300000, label: 'lockedapp reaches its instance count across the fleet' });
+
+    // A peer holds the folder in full, so the synced-peer loop PASSES and the
+    // pass reaches the election question. That ordering is the safety property
+    // this suite proves elsewhere; here it is the precondition, because a node
+    // refused at the peer loop never gets far enough to refuse on the election.
+
+    // Elected while FDM is still answering. The refusal under test is a verdict
+    // going STALE, not one that never existed, so the node has to have reached
+    // one before the outage starts.
+    await electMaster('lockedapp', subnet.nodeIp(TARGET));
+
+    await setSystemSecure(subnet.nodeIp(TARGET), false);
+    await waitFor(async () => (await dbClient(TARGET).residentialMarker()) !== null,
+      { timeout: 120000, label: 'the settling window starts' });
+    await elapseSettleWindow(TARGET);
+
+    // Taking FDM down means the election reaches no verdict for the app at all,
+    // so what the node knows has to go STALE rather than merely be absent - it
+    // was elected moments ago and remembers it. PRIMARY_ELECTION_STALE_MS is
+    // ten election cycles, derived from masterSlaveIntervalMs, so the wait
+    // below is derived from the same knob rather than picked: at the harness's
+    // 3s cycle the verdict expires 30s after the last pass that reached one.
     //
     // The stub closes its listening socket, not an empty ips array. An empty
     // array is FDM ANSWERING that nobody is primary; this is nobody answering,
@@ -876,7 +912,7 @@ describe('Residential node evacuation', function () {
 
     try {
       let unknownRefusal = null;
-      const refused = waitForGiveUpSafety(env.clients[TARGET - 1], 'primaryapp',
+      const refused = waitForGiveUpSafety(env.clients[TARGET - 1], 'lockedapp',
         (d) => d.safe === false && d.code === 'ELECTION_UNKNOWN', 600000)
         .then((v) => { unknownRefusal = v; return v; });
       refused.catch(() => {});
@@ -904,7 +940,7 @@ describe('Residential node evacuation', function () {
       // And the app is still here. A refusal that let the removal through
       // anyway would satisfy the assertions above and lose the volume.
       const stillInstalled = await env.clients[TARGET - 1].get('/apps/installedapps');
-      expect(stillInstalled.data.map((a) => a.name)).to.include('primaryapp');
+      expect(stillInstalled.data.map((a) => a.name)).to.include('lockedapp');
     } finally {
       await endFdmOutage();
     }

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -16,6 +16,7 @@ import {
   waitForResidentialDecision,
 } from '../framework/wait.js';
 import { setNoPeerData, setPeerHasData, setSynced } from '../framework/syncthing-control.js';
+import { sleepUnlessInfraDead } from '../framework/infra-death.js';
 import { electMaster, startFdmOutage, endFdmOutage } from '../framework/fdm-control.js';
 import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
 import { derivedQueueStepMs, loadSharedConfig } from '../framework/coupled-knobs.js';
@@ -175,6 +176,22 @@ async function returnToService(env, node) {
 /** Put the settling window in the past, so evacuation may begin this run. */
 async function elapseSettleWindow(nodeIndex) {
   await dbClient(nodeIndex).serveSettleWindow();
+}
+
+/**
+ * The component names a node is running, read through a path that THROWS on an
+ * unreadable answer rather than returning an empty list.
+ *
+ * The client returns the PARSED BODY, so the list is at res.data. An "X is
+ * absent" assertion over a list that comes back empty whenever the read fails
+ * cannot fail at all - which is exactly how the stand-down assertion passed
+ * while the node was still writing.
+ */
+async function runningComponents(env, nodeIndex) {
+  const res = await env.clients[nodeIndex - 1].get('/apps/listrunningapps');
+  const list = res?.status === 'success' ? res.data : null;
+  if (!Array.isArray(list)) throw new Error(`listrunningapps unreadable: ${JSON.stringify(res)?.slice(0, 200)}`);
+  return list.flatMap((a) => a.Names || []).map((n) => n.replace(/^\//, ''));
 }
 
 describe('Residential node evacuation', function () {
@@ -813,30 +830,18 @@ describe('Residential node evacuation', function () {
     // `!names.some(...)` over an empty list is true, so a failed request or a
     // shape that does not match reads as "stopped" and the test passes while the
     // node is still writing. It did exactly that on the first run here.
-    const runningComponents = async () => {
-      const res = await env.clients[TARGET - 1].get('/apps/listrunningapps');
-      // The client returns the PARSED BODY, so the container list is res.data.
-      // res.data.data is the level this read was written at while it was
-      // vacuous, and it is undefined on EVERY answer - readable or not - which
-      // is precisely why `!names.some(...)` over it could never fail. Reading
-      // the right level is what makes the throw below mean something. Sibling
-      // reads in this file (whenGone, the installed-apps check) use res.data.
-      const list = res?.status === 'success' ? res.data : null;
-      if (!Array.isArray(list)) throw new Error(`listrunningapps unreadable: ${JSON.stringify(res)?.slice(0, 200)}`);
-      return list.flatMap((a) => a.Names || []).map((n) => n.replace(/^\//, ''));
-    };
     // Positive control: the component must be running here NOW, or the wait
     // below proves nothing about a stop.
-    expect(await runningComponents()).to.include('fluxprimaryapp_primaryapp');
+    expect(await runningComponents(env, TARGET)).to.include('fluxprimaryapp_primaryapp');
 
-    await waitFor(async () => !(await runningComponents()).includes('fluxprimaryapp_primaryapp'),
+    await waitFor(async () => !(await runningComponents(env, TARGET)).includes('fluxprimaryapp_primaryapp'),
       { timeout: 180000, label: 'the g: component is stopped on the standing-down node' });
 
     // And it must STAY stopped. appReconciler takes a g: component's desired
     // state from controllerDesired, so a stand-down that stops the container
     // without telling the controller is undone on the next sweep.
     await advanceBlocks(3);
-    expect(await runningComponents()).to.not.include('fluxprimaryapp_primaryapp');
+    expect(await runningComponents(env, TARGET)).to.not.include('fluxprimaryapp_primaryapp');
   });
 
   it('hands the app back on the pass after standing down, and the app survives elsewhere', async function () {
@@ -891,24 +896,44 @@ describe('Residential node evacuation', function () {
     // one before the outage starts.
     await electMaster('lockedapp', subnet.nodeIp(TARGET));
 
-    await setSystemSecure(subnet.nodeIp(TARGET), false);
-    await waitFor(async () => (await dbClient(TARGET).residentialMarker()) !== null,
-      { timeout: 120000, label: 'the settling window starts' });
-    await elapseSettleWindow(TARGET);
+    // And the component has to be RUNNING here before FDM goes down. The gate
+    // asks the election question only of a node running the g: component - a
+    // node not running it cannot be the writer - so without this the pass
+    // answers SYNCED_ELSEWHERE and hands the app back, which is correct and
+    // tests nothing. masterSlaveApps only starts the component because FDM
+    // named this node, so taking FDM down first means it never starts at all.
+    await waitFor(async () => (await runningComponents(env, TARGET)).includes('fluxlockedapp_lockedapp'),
+      { timeout: 300000, label: 'the elected primary is running the g: component' });
 
-    // Taking FDM down means the election reaches no verdict for the app at all,
-    // so what the node knows has to go STALE rather than merely be absent - it
-    // was elected moments ago and remembers it. PRIMARY_ELECTION_STALE_MS is
-    // ten election cycles, derived from masterSlaveIntervalMs, so the wait
-    // below is derived from the same knob rather than picked: at the harness's
-    // 3s cycle the verdict expires 30s after the last pass that reached one.
-    //
     // The stub closes its listening socket, not an empty ips array. An empty
     // array is FDM ANSWERING that nobody is primary; this is nobody answering,
     // and a refused connection is the signature a real FDM outage carries - the
     // error reaches the node with no response on it at all. The gate is allowed
     // to act on the first and must not act on the second.
     await startFdmOutage('refuse');
+
+    // THE ORDER HERE IS THE TEST. The verdict has to go stale BEFORE the node
+    // starts draining, and it is the stand-down that makes that so: a draining
+    // node that still remembers being primary now hands the app over and
+    // leaves, so the verdict never survives long enough to expire. Withdrawing
+    // attestation first - which is what this test used to inherit from the
+    // stand-down tests before them - reaches STAND_DOWN_REQUIRED instead, and
+    // ELECTION_UNKNOWN becomes unreachable.
+    //
+    // Waited rather than observed, because staleness has no external signal:
+    // primaryElectionCheckedAt is refreshed only where FDM ANSWERED, so with
+    // no region answering at all nothing touches it and it ages out on wall clock.
+    // Derived from the knob it is a multiple of, never written as a literal -
+    // PRIMARY_ELECTION_STALE_MS is masterSlaveIntervalMs x 10, and the harness
+    // compresses that knob to 3s, so this costs ~30s here and tracks the knob
+    // if it moves. One extra cycle of margin so the expiry is past, not level.
+    const electionCycleMs = loadSharedConfig().fluxapps.masterSlaveIntervalMs;
+    await sleepUnlessInfraDead((electionCycleMs * 10) + electionCycleMs);
+
+    await setSystemSecure(subnet.nodeIp(TARGET), false);
+    await waitFor(async () => (await dbClient(TARGET).residentialMarker()) !== null,
+      { timeout: 120000, label: 'the settling window starts' });
+    await elapseSettleWindow(TARGET);
 
     try {
       let unknownRefusal = null;

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { createTestEnv } from '../framework/test-env.js';
 import { dbClient } from '../framework/db-client.js';
 import { pushImage } from '../framework/registry-helper.js';
-import { buildSeedableApp, allocateAppPort } from '../framework/seed-helper.js';
+import { buildSeedableApp } from '../framework/seed-helper.js';
 import { getSubnetConfig, REGISTRY_REPO_HOST } from '../framework/subnet-config.js';
 import {
   advanceBlock, advanceBlocks, driveUntil, startTicker, stopTicker, setSystemSecure, clearSystemSecure,
@@ -113,9 +113,9 @@ async function bootToReady(env) {
 /**
  * Seed a global app the spawner can place. The port is allocated, so seeding a
  * second app on the same fleet cannot collide with the first - see
- * allocateAppPort.
+ * buildSeedableApp, which assigns one where the spec is built.
  */
-async function seedApp(env, appName, { instances = 3, containerData = '/tmp', port = allocateAppPort() } = {}) {
+async function seedApp(env, appName, { instances = 3, containerData = '/tmp' } = {}) {
   await pushImage(appName, 'v1');
   const app = await buildSeedableApp({
     name: appName,
@@ -124,7 +124,7 @@ async function seedApp(env, appName, { instances = 3, containerData = '/tmp', po
       name: appName,
       description: 'test container',
       repotag: `${REGISTRY_REPO_HOST}/${appName}:v1`,
-      ports: [port],
+      ports: [],
       domains: [''],
       environmentParameters: [],
       commands: [],

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -768,13 +768,13 @@ describe('Residential node evacuation', function () {
     expect(verdict.data.detail).to.contain('below its instance count');
   });
 
-  it('will not hand back a g: app while this node is its elected primary', async function () {
+  it('stands down as the elected primary rather than handing the app back from under itself', async function () {
     this.timeout(900000);
 
     // The elected primary is the node WRITING to the volume. Handing the app
     // back from under it drops whatever it has written since the peer last
-    // reported the folder complete, so it stands down and lets masterSlaveApps
-    // elect a successor first.
+    // reported the folder complete. So it stops the component first and asks
+    // again next pass, by which time the election has given the role to a peer.
     await returnToService(env, SECOND_TARGET);
     // Node 1 too - it is still held from the previous test, and a held node
     // takes no new apps, so the app would reach four instances and never five.
@@ -795,20 +795,43 @@ describe('Residential node evacuation', function () {
       { timeout: 120000, label: 'the settling window starts' });
     await elapseSettleWindow(TARGET);
 
-    let primaryRefusal = null;
-    const refused = waitForGiveUpSafety(env.clients[TARGET - 1], 'primaryapp',
-      (d) => d.safe === false && /elected primary/.test(d.detail), 600000)
-      .then((v) => { primaryRefusal = v; return v; });
-    refused.catch(() => {});
+    let standDownVerdict = null;
+    const stoodDown = waitForGiveUpSafety(env.clients[TARGET - 1], 'primaryapp',
+      (d) => d.safe === false && d.code === 'STAND_DOWN_REQUIRED', 600000)
+      .then((v) => { standDownVerdict = v; return v; });
+    stoodDown.catch(() => {});
 
     await stopTicker();
-    await driveUntil(env, TARGET, async () => primaryRefusal !== null);
+    await driveUntil(env, TARGET, async () => standDownVerdict !== null);
     await startTicker();
 
-    const verdict = await refused;
+    const verdict = await stoodDown;
+    expect(verdict.data.code).to.equal('STAND_DOWN_REQUIRED');
 
-    expect(verdict.data.detail).to.contain('elected primary');
-    expect(verdict.data.code).to.equal('ELECTED_PRIMARY');
+    // The container is what "standing down" means - a verdict that stopped
+    // nothing would leave the node writing and the test would still pass.
+    await waitFor(async () => {
+      const running = await env.clients[TARGET - 1].get('/apps/listrunningapps');
+      const names = (running?.data?.data || []).flatMap((a) => a.Names || []);
+      return !names.some((n) => n.replace(/^\//, '') === 'fluxprimaryapp_primaryapp');
+    }, { timeout: 180000, label: 'the g: component is stopped on the standing-down node' });
+  });
+
+  it('hands the app back on the pass after standing down, and the app survives elsewhere', async function () {
+    this.timeout(900000);
+
+    // Runs on from the test above: node TARGET has stopped primaryapp's g:
+    // component and is no longer a candidate for it, so the next pass finds the
+    // component not running here, re-proves a connected peer holds the folder
+    // with nothing left to write, and removes.
+    await waitFor(async () => {
+      const locations = await dbClient(2).getAppLocations('primaryapp');
+      return !locations.map((l) => l.ip.split(':')[0]).includes(subnet.nodeIp(TARGET));
+    }, { timeout: 600000, label: 'the standing-down node hands primaryapp back' });
+
+    const locations = await dbClient(2).getAppLocations('primaryapp');
+    expect(locations.length).to.be.greaterThan(0);
+    expect(locations.map((l) => l.ip.split(':')[0])).to.not.include(subnet.nodeIp(TARGET));
   });
 
   it('will not hand back a g: app it is running while no FDM can name the primary', async function () {

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -14,7 +14,7 @@ import {
   waitForPeerThreshold, waitForAppInstalled,
   waitForSpawnerBlocked, waitFor, waitForGiveUpConsidered, waitForGiveUpSafety,
 } from '../framework/wait.js';
-import { setNoPeerData, setPeerHasData } from '../framework/syncthing-control.js';
+import { setNoPeerData, setPeerHasData, setSynced } from '../framework/syncthing-control.js';
 import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
 
 const subnet = getSubnetConfig();
@@ -87,6 +87,33 @@ async function seedApp(env, appName, { instances = 3, containerData = '/tmp' } =
     await dc.seedAppHash(app.hash, app.permanentMessage.height, true);
   }
   return app;
+}
+
+/**
+ * Advance the chain one block at a time, waiting for the node to PROCESS each
+ * one before producing the next, until the condition holds.
+ *
+ * The free-running ticker produces blocks on the same period the explorer polls
+ * on, so the node learns about them in bursts and processes a burst back to
+ * back - and only the last block of a burst is still the chain tip. FluxOS runs
+ * its app maintenance, the give-up pass included, only for a block that was the
+ * tip, and only on every fourth block, so whether the pass ever runs comes down
+ * to which parity the race settles on. Driving the chain removes that instead of
+ * hoping the phases stay favourable.
+ */
+async function driveUntil(env, nodeIndex, condition, maxBlocks = 40) {
+  const node = env.clients[nodeIndex - 1];
+  for (let i = 0; i < maxBlocks; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    if (await condition()) return;
+    const afterId = node.getLastEventId();
+    // eslint-disable-next-line no-await-in-loop
+    await advanceBlock();
+    // eslint-disable-next-line no-await-in-loop
+    await node.waitForEvent('block:processed', () => true, 60000, { afterId });
+  }
+  // eslint-disable-next-line no-await-in-loop
+  if (!await condition()) throw new Error(`condition not reached within ${maxBlocks} driven blocks`);
 }
 
 /**
@@ -319,19 +346,22 @@ describe('Residential node evacuation', function () {
     expect(marker, 'the settling window should be running').to.not.be.null;
 
     await elapseSettleWindow(TARGET);
-    await advanceBlocks(5);
 
-    // Assert the pass reached this app before waiting on the outcome, so a
-    // failure here distinguishes "the pass declined" from "the pass never ran".
-    // Nothing else does: a pass with nothing to give up logs and emits nothing.
-    await waitForGiveUpConsidered(env.clients[TARGET - 1], 'residentapp',
-      (d) => d.giveUp === true && d.reason === 'EVACUATION', 300000);
+    // Drive the chain from here rather than letting the ticker free-run, so the
+    // give-up pass is reached on a block the node processed AS the tip. See
+    // driveUntil.
+    await stopTicker();
+    await driveUntil(env, TARGET, async () => {
+      const current = await env.clients[TARGET - 1].get('/apps/installedapps');
+      return !current.data.map((a) => a.name).includes('residentapp');
+    });
 
-    // Waited on the node's own view rather than on app:removed. That event is
-    // published part-way through the uninstall - after the runtime state is
-    // dropped, before the installed-apps record is - so a test that asserts on
-    // the record the instant the event lands still sees the app.
-    await whenGone(env, TARGET, 'residentapp', 300000);
+    // The node's own view, not app:removed - that event is published part-way
+    // through the uninstall, after the runtime state is dropped and before the
+    // installed-apps record is, so asserting on the record when it lands still
+    // finds the app.
+    await whenGone(env, TARGET, 'residentapp', 120000);
+    await startTicker();
   });
 
   it('the app survives the departure on every other host', async function () {
@@ -402,6 +432,14 @@ describe('Residential node evacuation', function () {
     // Palworld and Minecraft worlds on the real fleet, which sit at exactly two
     // instances. Nothing reports holding a copy of it.
     await seedApp(env, 'worldapp', { instances: 5, containerData: 's:/appdata' });
+
+    // A synced folder has to be DECLARED before the app can run. The stub's
+    // default for a folder nobody has spoken about is "no evidence", and a
+    // sync-mounted component does not start against that - so without this the
+    // app installs nowhere and never reaches an instance count at all.
+    await setSynced({ folder: 'fluxworldapp_worldapp' });
+    await setPeerHasData({ folder: 'fluxworldapp_worldapp' });
+
     await advanceBlocks(3);
     await waitForAppInstalled(env.clients[TARGET - 1], 'worldapp', 300000);
 
@@ -412,8 +450,8 @@ describe('Residential node evacuation', function () {
     await waitFor(async () => (await dbClient(2).getAppLocations('worldapp')).length >= 5,
       { timeout: 300000, label: 'worldapp reaches its instance count across the fleet' });
 
-    // Declared before enforcement starts, so the node never sees a moment where
-    // the data looks safe.
+    // Now take the evidence away: the data was there, and no peer can be shown
+    // to hold it any more. This is the state the gate exists for.
     await setNoPeerData({ folder: 'fluxworldapp_worldapp' });
 
     await setSystemSecure(subnet.nodeIp(TARGET), false);
@@ -421,16 +459,23 @@ describe('Residential node evacuation', function () {
       { timeout: 120000, label: 'the settling window starts again' });
     await elapseSettleWindow(TARGET);
 
+    // Drive the chain so the pass is reached deterministically.
+    await stopTicker();
+    const considered = waitForGiveUpConsidered(env.clients[TARGET - 1], 'worldapp',
+      (d) => d.giveUp === true && d.reason === 'EVACUATION', 300000);
+    const refused = waitForGiveUpSafety(env.clients[TARGET - 1], 'worldapp',
+      (d) => d.safe === false, 300000);
+    await driveUntil(env, TARGET, async () => false, 12).catch(() => {});
+    await startTicker();
+
     // The pass reports on every app it holds, every pass, so this proves the
     // pass RAN and wanted this app - not merely that nothing happened.
-    await waitForGiveUpConsidered(env.clients[TARGET - 1], 'worldapp',
-      (d) => d.giveUp === true && d.reason === 'EVACUATION', 300000);
+    await considered;
 
     // And the gate is what stopped it. Before this, every removal path decided
     // on an instance count alone, and a count cannot tell a redundant copy from
     // the last one holding the data.
-    const verdict = await waitForGiveUpSafety(env.clients[TARGET - 1], 'worldapp',
-      (d) => d.safe === false, 300000);
+    const verdict = await refused;
     expect(verdict.data.detail).to.contain('fluxworldapp_worldapp');
 
     const installed = await env.clients[TARGET - 1].get('/apps/installedapps');
@@ -446,7 +491,14 @@ describe('Residential node evacuation', function () {
     // node simply being slow.
     await setPeerHasData({ folder: 'fluxworldapp_worldapp' });
 
-    await whenGone(env, TARGET, 'worldapp', 300000);
+    await stopTicker();
+    await driveUntil(env, TARGET, async () => {
+      const current = await env.clients[TARGET - 1].get('/apps/installedapps');
+      return !current.data.map((a) => a.name).includes('worldapp');
+    });
+    await startTicker();
+
+    await whenGone(env, TARGET, 'worldapp', 120000);
 
     const locations = await dbClient(2).getAppLocations('worldapp');
     expect(locations.map((l) => l.ip.split(':')[0])).to.not.include(subnet.nodeIp(TARGET));

--- a/test-infra/runner/tests/55-residential-node-evacuation.js
+++ b/test-infra/runner/tests/55-residential-node-evacuation.js
@@ -32,6 +32,19 @@ const RESIDENTIAL_GEO = {
   as: 'AS64500 Consumer Access Networks',
 };
 
+// Nothing either way: no hosting flags, no operator that sells hosting, and
+// 198.18.x.x has no reverse DNS. The node's own rule reaches UNKNOWN on this,
+// so whatever verdict it ends up with came from the published table.
+const NEUTRAL_GEO = {
+  hosting: false, proxy: false, mobile: false, org: 'Neutral Holdings', isp: 'Metro Fibre', as: 'AS64501 Metro Fibre',
+};
+
+// Hosting evidence the node can see about its OWN address, which is what lets
+// it decline a published residential verdict meant for its neighbours.
+const HOSTING_GEO = {
+  hosting: true, proxy: false, mobile: false, org: 'Reseller', isp: 'Hetzner Online GmbH', as: 'AS24940 Hetzner Online GmbH',
+};
+
 async function bootToReady(env) {
   await Promise.all(env.clients.map((c) => waitForDaemonReady(c)));
   await Promise.all(env.clients.map((c) => waitForNodeStatus(c, (d) => d.confirmed === true, 30000)));
@@ -100,6 +113,12 @@ describe('Residential node evacuation', function () {
   //
   // Every other node is attested and in a data centre.
   const TARGET = 1;
+  // .12 - same published organisation as the target, but with nothing of its own
+  // to go on, so the table is the only thing that can decide it.
+  const TABLE_DECIDED = 3;
+  // .14 - same published organisation again, but its own address carries hosting
+  // evidence, so it declines the verdict.
+  const VETOING = 5;
 
   before(async function () {
     this.timeout(600000);
@@ -110,7 +129,18 @@ describe('Residential node evacuation', function () {
       // Seeded through createTestEnv, not POSTed afterwards: a node looks its
       // address up once during boot, so an override applied after the fleet is
       // up is never read and the node classifies itself from the stub default.
-      geolocation: { [TARGET]: RESIDENTIAL_GEO },
+      geolocation: { [TARGET]: RESIDENTIAL_GEO, [TABLE_DECIDED]: NEUTRAL_GEO, [VETOING]: HOSTING_GEO },
+      // Two organisations across the fleet's /24, assigned round-robin by last
+      // octet, and the one holding .10/.12/.14 is published residential. This is
+      // the authority the fleet runs on in production - 2,303 of 2,513 hosts are
+      // decided by the table rather than by their own reading - so a suite that
+      // only ever exercised the fallback would be testing the path that decides
+      // almost nothing.
+      locationTable: {
+        domains: 2,
+        subnet: subnet.base,
+        classes: { 0: 'residential', 1: 'hosting' },
+      },
       configOverrides: {
         fluxapps: {
           // Compressed the same way every other suite compresses the interval it
@@ -162,6 +192,43 @@ describe('Residential node evacuation', function () {
     expect(geo.networkClassification.classification).to.equal('DATACENTER');
 
     const info = await env.clients[1].get('/flux/info');
+    expect(info.data.flux.dos.dosState).to.be.below(100);
+  });
+
+  it('takes the published verdict where the node has nothing of its own to go on', async function () {
+    this.timeout(120000);
+
+    await waitFor(async () => {
+      const geo = await dbClient(TABLE_DECIDED).geolocation();
+      return geo?.networkEvidence != null;
+    }, { timeout: 90000, label: 'node 3 gathers its evidence' });
+
+    const info = await env.clients[TABLE_DECIDED - 1].get('/flux/info');
+    expect(info.data.flux.dos.dosState).to.be.below(100);
+
+    // Its own reading is UNKNOWN - no signal for, none against - so a verdict of
+    // RESIDENTIAL can only have come from the table.
+    const geo = await dbClient(TABLE_DECIDED).geolocation();
+    expect(geo.networkEvidence.classification).to.equal('UNKNOWN');
+    expect(geo.networkEvidence.evidenceFor).to.be.empty;
+    expect(geo.networkEvidence.evidenceAgainst).to.be.empty;
+  });
+
+  it('declines a published verdict its own address contradicts', async function () {
+    this.timeout(120000);
+
+    await waitFor(async () => {
+      const geo = await dbClient(VETOING).geolocation();
+      return geo?.networkEvidence != null;
+    }, { timeout: 90000, label: 'node 5 gathers its evidence' });
+
+    // Published residential along with its neighbours, but it can see hosting
+    // evidence about itself - 213.44.137.57 on Bouygues is the live instance.
+    // The veto only ever removes a node from enforcement.
+    const geo = await dbClient(VETOING).geolocation();
+    expect(geo.networkEvidence.evidenceAgainst).to.not.be.empty;
+
+    const info = await env.clients[VETOING - 1].get('/flux/info');
     expect(info.data.flux.dos.dosState).to.be.below(100);
   });
 

--- a/test-infra/runner/tests/57-holdout-pending-node.js
+++ b/test-infra/runner/tests/57-holdout-pending-node.js
@@ -1,0 +1,136 @@
+import { describe, it, before, after } from 'mocha';
+import { expect } from 'chai';
+import { createTestEnv } from '../framework/test-env.js';
+import { waitForDaemonReady, waitForNodeStatus, waitFor } from '../framework/wait.js';
+import { bootAndPeer } from '../framework/reconciler-suite.js';
+import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
+
+// holdOutPendingNode refuses a node that has not started yet, with a
+// one-directional INPUT drop on each running node. Its comment claims "one
+// direction suffices because a connection needs both" and nothing checked it.
+// Suite 71 depends on it - it moves a node's boot out of a 63 second acceptance
+// window - but covers it only by going red for its own reasons when it fails.
+//
+// Both sides are asserted. A drop on INPUT stops the held node's SYN arriving; a
+// running node dialling out still sends one and it is the REPLY that is dropped.
+// So neither direction can complete, and checking only the outbound half would
+// pass on a pair that connected the other way round.
+//
+// THE HARD PART IS THAT THIS IS A NEGATIVE, and a negative is only worth what
+// its window is worth. A first version of this asserted the absence the moment
+// discovery started, and passed with the drop replaced by a no-op: the node had
+// not joined yet either way, so the test measured latency and called it
+// isolation. The window is now calibrated by the fleet itself - the same node is
+// released and timed, and the absence only counts if it was watched for
+// substantially longer than joining actually takes.
+
+const RUNNING = [0, 1, 2, 3, 4];
+const PENDING = 5;
+
+// Watched for this long while held. Must be comfortably more than a join costs,
+// which the suite measures rather than assumes.
+const ABSENCE_WINDOW_MS = 120000;
+const CALIBRATION_FACTOR = 2;
+
+let env;
+
+describe('a node held out before it starts', function () {
+  dumpLogsOnFailure(() => env);
+
+  let joinMs = null;
+
+  const peersOf = async (index) => {
+    const client = env.clients[index];
+    const [outbound, inbound] = await Promise.all([client.getPeers(), client.getIncomingPeers()]);
+    return new Set([...(outbound.data || []), ...(inbound.data || [])]);
+  };
+
+  // Anywhere the held node and the running fleet can see each other, in either
+  // direction. One set, because "is it isolated" is one question.
+  const contacts = async () => {
+    const heldIp = env.clients[PENDING].ip;
+    const found = [];
+
+    const held = await peersOf(PENDING);
+    for (const i of RUNNING) {
+      if (held.has(env.clients[i].ip)) found.push(`held node -> node ${i}`);
+    }
+
+    const seen = await Promise.all(RUNNING.map(async (i) => (await peersOf(i)).has(heldIp)));
+    seen.forEach((has, idx) => { if (has) found.push(`node ${RUNNING[idx]} -> held node`); });
+
+    return found;
+  };
+
+  before(async function () {
+    this.timeout(420000);
+    env = await createTestEnv({
+      hookCtx: this, nodes: 6, deferredNodes: 1, tickerAutostart: false,
+    });
+    // Defaults, deliberately. This is the first suite to reach the framework's
+    // bootAndPeer with a deferred node, and it asked for a peer that could not
+    // exist until that function learned a deferred slot is a hole in the ring
+    // exactly like a stub. Stating targets here would have hidden that rather
+    // than fixed it, and would go stale the moment the fleet changed shape.
+    await bootAndPeer(env);
+
+    await env.holdOutPendingNode(PENDING, RUNNING);
+
+    const joiner = await env.startNode(PENDING);
+    await waitForDaemonReady(joiner);
+    await waitForNodeStatus(joiner, (d) => d.confirmed === true, 60000);
+
+    // Everyone dials, the held node included. The drop is the only reason it
+    // should fail, so it is given the same chance the others got.
+    await env.startDiscovery();
+  });
+
+  after(async function () {
+    this.timeout(60000);
+    await env?.teardown();
+  });
+
+  it('reaches nobody, and nobody reaches it, for as long as it is watched', async function () {
+    this.timeout(ABSENCE_WINDOW_MS + 60000);
+
+    const deadline = Date.now() + ABSENCE_WINDOW_MS;
+    while (Date.now() < deadline) {
+      // eslint-disable-next-line no-await-in-loop
+      const found = await contacts();
+      expect(found, `the held node was not isolated: ${found.join(', ')}`).to.deep.equal([]);
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise((resolve) => { setTimeout(resolve, 3000); });
+    }
+  });
+
+  it('joins once the drop is removed', async function () {
+    // What makes the absence above the DROP'S doing rather than a node that was
+    // never going to peer - a broken image, a node that never confirmed, a fleet
+    // that cannot dial. Same node, same fleet, the rule gone.
+    this.timeout(240000);
+
+    await env.releasePendingNode(PENDING, RUNNING);
+    await env.startDiscovery();
+
+    const started = Date.now();
+    await waitFor(async () => (await contacts()).length > 0, {
+      timeout: 180000,
+      interval: 2000,
+      label: 'the released node is peered with',
+    });
+    joinMs = Date.now() - started;
+  });
+
+  it('was watched for long enough that joining would have been seen', async function () {
+    // The calibration, and the reason the negative above is evidence rather than
+    // a measurement of latency. If a join costs anything close to the window it
+    // was watched for, the absence proves nothing - and this says so instead of
+    // passing quietly.
+    expect(joinMs, 'the join was never timed').to.not.equal(null);
+    expect(
+      joinMs * CALIBRATION_FACTOR,
+      `joining took ${joinMs}ms, too close to the ${ABSENCE_WINDOW_MS}ms the absence was watched for `
+      + 'to call that absence isolation',
+    ).to.be.lessThan(ABSENCE_WINDOW_MS);
+  });
+});

--- a/test-infra/runner/tests/60-volume-mount-ownership.js
+++ b/test-infra/runner/tests/60-volume-mount-ownership.js
@@ -161,26 +161,29 @@ describe('FluxOS-owned volume mounting (no crontab) + inert unmounted app dirs',
     const dir = appDir(syncName);
     const vol = volFile(syncName);
 
-    // Hold the backing file aside BEFORE anything can trigger a reconcile.
-    // getVolumeFilePath matches an exact name, so a renamed volume reads as
-    // volume_file_missing and ensureAppVolumeMounted returns without mounting.
+    // THE PROBE RUNS IN A PRIVATE MOUNT NAMESPACE, so FluxOS never sees the
+    // volume go away and there is nothing to outrun.
     //
-    // The stop cannot come first. Its die event drives a reconcile, and the
-    // reconciler mounts the volume before ANY actuation - correctly, since a
-    // start against a bare mountpoint would write to the host filesystem. So a
-    // probe that stops first is racing a repair it just asked for, and losing
-    // that race looks exactly like the leak this test exists to catch. Suite
-    // test 5 states the same rule: the broken state must fully exist before the
-    // die event fires. A rename does not disturb the loop mount, which holds the
-    // file by inode.
+    // It used to unmount for real and race the repair, on the stated grounds
+    // that "the monitor's 3s repair cycle cannot remount in between". The cycle
+    // is not what answers: the mount test remounts in ~144ms - "Volume not
+    // mounted. Continuing. Most likely false positive." followed by "Volume
+    // mounted." a seventh of a second later - and the probe then writes to a
+    // live volume and succeeds. Observed on a sequential run; a probe that has
+    // to be faster than the system is a probe that fails whenever the box is
+    // busy enough to slow the probe and not the system.
+    //
+    // `unshare -m` gives this shell its own mount table. The unmount is invisible
+    // outside it, so nothing repairs; the directory's immutable attribute lives
+    // on the filesystem and is visible from every namespace, so the write is
+    // refused for exactly the reason this test exists. No container stop either:
+    // the app's bind is in its own namespace and is not what is being probed.
+    //
+    // MOUNTED is echoed from INSIDE the namespace. The assertion below is the
+    // one that says the probe met a bare directory, and a probe that never
+    // prints it satisfies that assertion by producing no match at all.
     const r = await execInContainer(client.container,
-      `mv ${vol} ${vol}.held || exit 8; `
-      + `docker stop ${appId(syncName)} >/dev/null 2>&1; `
-      + `umount ${dir} || exit 9; `
-      + `mountpoint -q ${dir}; echo MOUNTED:$?; `
-      + `touch ${dir}/leak-probe 2>/dev/null; echo TOUCH_EXIT:$?; `
-      + `mv ${vol}.held ${vol}`);
-    expect(r.exitCode, `could not hold the volume file aside: ${r.output}`).to.not.equal(8);
+      `unshare -m sh -c 'umount ${dir} || exit 9; mountpoint -q ${dir}; echo MOUNTED:$?; touch ${dir}/leak-probe 2>/dev/null; echo TOUCH_EXIT:$?'`);
     expect(r.exitCode, `umount failed: ${r.output}`).to.not.equal(9);
     // The probe only means anything against a bare dir. Asserted rather than
     // assumed, so a remount that beat us is reported as such instead of being
@@ -188,6 +191,12 @@ describe('FluxOS-owned volume mounting (no crontab) + inert unmounted app dirs',
     expect(r.output.match(/MOUNTED:(\d+)/)?.[1], `still mounted at probe time: ${r.output}`).to.not.equal('0');
     const touchExit = r.output.match(/TOUCH_EXIT:(\d+)/)?.[1];
     expect(touchExit, `expected the bare-dir write to fail, got: ${r.output}`).to.not.equal('0');
+
+    // The namespace probe broke nothing, so the self-heal needs a real unmount of
+    // its own. Raced by nobody: the assertion is that the repair HAPPENS, which is
+    // the repair being fast working for the test rather than against it.
+    await execInContainer(client.container,
+      `docker stop ${appId(syncName)} >/dev/null 2>&1; umount ${dir} || true`);
 
     // FluxOS remounts the volume (reconciler / monitor repair) and restarts the app
     await waitFor(() => isMountpoint(client.container, dir), { timeout: 60000, interval: 2000, label: 'volume remounted (self-heal)' });

--- a/test-infra/runner/tests/68-masterslave-election-order.js
+++ b/test-infra/runner/tests/68-masterslave-election-order.js
@@ -16,6 +16,7 @@ import { waitFor } from '../framework/wait.js';
 import {
   bootAndPeer, placeGAppInOrder, electionIndexOf,
 } from '../framework/reconciler-suite.js';
+import { syncthingSeedIndex, placementOrderWithSeedAt } from '../framework/g-app-placement.js';
 import { sleepUnlessInfraDead } from '../framework/infra-death.js';
 import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
 
@@ -47,10 +48,10 @@ describe('primary election under a divergent placement order', function () {
   let env;
   dumpLogsOnFailure(() => env);
   const holders = [0, 1, 2];
-  const seedIndex = 0; // lowest IP among the holders = the syncthing seed
+  const seedIndex = syncthingSeedIndex(holders);
   // Placed in this order, so the seed carries the MIDDLE runningSince and node 2 sits
   // above it - the peer a lower-index-only probe cannot see.
-  const placementOrder = [1, 0, 2];
+  const placementOrder = placementOrderWithSeedAt(holders, 1);
   const stamp = Date.now();
 
   // One app per scenario, all on the one fleet. All five land on the same three
@@ -323,7 +324,7 @@ describe('primary election under a divergent placement order', function () {
     const app = await buildSeedableSyncthingApp({ name: pairApp, mode: 'g' });
     await pushImage(pairApp, 'v1');
     await placeGAppInOrder(env, app, {
-      placementOrder: [1, 0],
+      placementOrder: placementOrderWithSeedAt([0, 1], 1),
       folder: `flux${pairApp}_${pairApp}`,
       identifier: `${pairApp}_${pairApp}`,
     });

--- a/test-infra/runner/tests/69-masterslave-partition-leaders.js
+++ b/test-infra/runner/tests/69-masterslave-partition-leaders.js
@@ -11,6 +11,7 @@ import { waitFor } from '../framework/wait.js';
 import {
   bootAndPeer, placeGAppInOrder, electionIndexOf,
 } from '../framework/reconciler-suite.js';
+import { syncthingSeedIndex, placementOrderWithSeedAt } from '../framework/g-app-placement.js';
 import { sleepUnlessInfraDead } from '../framework/infra-death.js';
 import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
 
@@ -51,8 +52,11 @@ describe('a g: app with holders on both sides of a partition', function () {
   const appName = `e2epart${Date.now()}`;
   const folder = `flux${appName}_${appName}`;
   const holders = [0, 1, 2];
-  const seedIndex = 0; // lowest IP among the holders = the syncthing seed
-  const placementOrder = [1, 0, 2]; // seed carries the middle runningSince
+  // The seed is the lowest address among the holders and the election does not
+  // choose it - g-app-placement.js owns that rule, so this suite states the
+  // shape it wants rather than re-deriving how to get there.
+  const seedIndex = syncthingSeedIndex(holders);
+  const placementOrder = placementOrderWithSeedAt(holders, 1); // seed carries the middle runningSince
   // The seed's side and the standbys' side. Non-holders pad each group so both stay
   // above the peer floor and neither degrades - the partition must be a network event,
   // not a peer-count event.

--- a/test-infra/runner/tests/70-masterslave-small-fleet.js
+++ b/test-infra/runner/tests/70-masterslave-small-fleet.js
@@ -10,6 +10,7 @@ import { waitFor } from '../framework/wait.js';
 import {
   bootAndPeer, placeGAppInOrder, electionIndexOf,
 } from '../framework/reconciler-suite.js';
+import { syncthingSeedIndex, placementOrderWithSeedAt } from '../framework/g-app-placement.js';
 import { sleepUnlessInfraDead } from '../framework/infra-death.js';
 import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
 
@@ -39,9 +40,12 @@ describe('masterSlave election on a three-node fleet', function () {
   const appName = `e2esmall${Date.now()}`;
   const folder = `flux${appName}_${appName}`;
   const holders = [0, 1];
-  const seedIndex = 0; // lowest IP of the two holders
+  // The seed is the lowest address among the holders and the election does not
+  // choose it - g-app-placement.js owns that rule, so this suite states the
+  // shape it wants rather than re-deriving how to get there.
+  const seedIndex = syncthingSeedIndex(holders);
   // Seed placed second, so it carries the later runningSince and lands at index 1.
-  const placementOrder = [1, 0];
+  const placementOrder = placementOrderWithSeedAt(holders, 1);
 
   const countUp = async () => (await Promise.all(
     holders.map((i) => isUp(env.clients[i], appName)),

--- a/test-infra/runner/tests/71-sync-eviction-prune-forgery.js
+++ b/test-infra/runner/tests/71-sync-eviction-prune-forgery.js
@@ -172,13 +172,20 @@ describe('Sync response: eviction, pruning and forged events', function () {
       signedBy: FORGERY_NODE === 1 ? 2 : 1,
     }));
 
-    for (let i = 1; i <= 10; i++) {
-      const dc = dbClient(i);
-      for (const event of events) {
-        // eslint-disable-next-line no-await-in-loop
-        await dc.seedAppStateEvent({ ...event });
-      }
-    }
+    // Seeded in ONE round trip per node, not one per event.
+    //
+    // These are broadcasts and their acceptance window is live: messageStore
+    // refuses one older than locationTtlS, 63s here. Ten nodes times 326 events
+    // is 3,260 sequential insertOne round trips, which on a gate box outlives
+    // that window - every event then arrives already expired, is skipped without
+    // a word, and the suite reads an empty location list rather than a rejected
+    // message. The `stamp` comment above moved the clock's start into the hook;
+    // this keeps the hook short enough for that start to still mean something.
+    await Promise.all(Array.from({ length: 10 }, (_unused, n) => dbClient(n + 1).seedAppStateEvents(
+      // A copy per node: insertMany stamps _id onto the objects it is given, so
+      // one shared array would carry node 1's ids into every other node's insert.
+      events.map((event) => ({ ...event })),
+    )));
 
     const joiner = await env.startNode(10);
     await waitForDaemonReady(joiner);

--- a/test-infra/runner/tests/71-sync-eviction-prune-forgery.js
+++ b/test-infra/runner/tests/71-sync-eviction-prune-forgery.js
@@ -2,6 +2,7 @@ import { describe, it, before, after } from 'mocha';
 import { expect } from 'chai';
 import { createTestEnv } from '../framework/test-env.js';
 import { dbClient } from '../framework/db-client.js';
+import { loadSharedConfig } from '../framework/coupled-knobs.js';
 import { nodeKey } from '../framework/keys.js';
 import { signBtcMessage } from '../auth.js';
 import { startTicker, advanceBlock } from '../framework/daemon-control.js';
@@ -213,6 +214,23 @@ describe('Sync response: eviction, pruning and forged events', function () {
     await env.healPartition([10], RUNNING);
     await env.startDiscovery([10]);
     await waitForOrchestratorState(joiner, 'READY', 180000);
+
+    // THE GUARD, not decoration. Every assertion below rests on the seeded
+    // broadcasts still being inside their acceptance window when the joiner
+    // reads them, and this suite has twice failed by spending that window on
+    // setup instead - the second time with the boot inside it, measured at 24.6s
+    // of 63s idle and ~83s under a six-way gate.
+    //
+    // Without this, moving the boot back inside the window reads as green on any
+    // idle box and red only on a loaded one, which is how it got here. Asserted
+    // against the live knob rather than a literal, so compressing locationTtlS
+    // further tightens this too, and a third of it is the margin: the gate must
+    // be able to treble what an idle box costs and still fit.
+    const windowMs = loadSharedConfig().fluxapps.locationTtlS * 1000;
+    const spent = Date.now() - stamp;
+    expect(spent, `setup spent ${spent}ms of the ${windowMs}ms acceptance window - `
+      + 'the seeded broadcasts expire before the joiner reads them under any load')
+      .to.be.lessThan(windowMs / 3);
   });
 
   after(async function () {

--- a/test-infra/runner/tests/71-sync-eviction-prune-forgery.js
+++ b/test-infra/runner/tests/71-sync-eviction-prune-forgery.js
@@ -115,25 +115,28 @@ describe('Sync response: eviction, pruning and forged events', function () {
     this.timeout(600000);
     env = await createTestEnv({
       hookCtx: this, nodes: 12, deferredNodes: 2, tickerAutostart: false,
-      // DECLARED LIKE A MOCHA TIMEOUT, and for the same reason.
-      //
-      // The events below are broadcasts, and messageStore refuses one older than
-      // locationTtlS. The shared harness value is 63s, derived from production's
-      // announce ratio - fine for a suite that only has to outlive a compressed
-      // clock, and not fine here: this hook boots a twelfth node INSIDE that
-      // window, and a node boot is real work the harness does not compress.
-      // Measured at 24.6s of the window on an idle box, 93% of it the boot, and
-      // ~83s under a six-way gate - which is how this suite came to read an empty
-      // location list rather than a rejected message.
-      //
-      // Generous rather than measured, because a wider window costs this suite
-      // nothing: nothing here tests expiry, and a broadcast that does not expire
-      // is simply one the node accepts. The number needs to be comfortably more
-      // than any plausible setup, not accurate - so a slower box moves the real
-      // cost without moving this.
-      configOverrides: { fluxapps: { locationTtlS: 300 } },
     });
-    await bootAndPeer(env, Array.from({ length: 10 }, (_, i) => i));
+    const RUNNING = Array.from({ length: 10 }, (_, i) => i);
+    await bootAndPeer(env, RUNNING);
+
+    // THE READER BOOTS BEFORE THE WINDOW OPENS, AND CANNOT SYNC WHILE IT DOES.
+    //
+    // Everything below is a broadcast, and messageStore refuses one older than
+    // locationTtlS - 63s here. Booting the reader after seeding put a node boot
+    // inside that window: 24.6s of it on an idle box, ~83s under a six-way gate,
+    // so the events expired during their own setup, were skipped in silence, and
+    // the suite read an empty location list rather than a rejected message.
+    //
+    // No number fixes that, because the boot's cost is whatever the box is doing.
+    // So the boot moves OUT of the window instead. The reader is refused by the
+    // running nodes before it starts, boots deaf for as long as it needs, and the
+    // window opens only once it is up - spanning a sync, which is seconds, rather
+    // than a boot, which is unbounded.
+    await env.holdOutPendingNode(10, RUNNING);
+    const joiner = await env.startNode(10);
+    await waitForDaemonReady(joiner);
+    await waitForNodeStatus(joiner, (d) => d.confirmed === true, 30000);
+
     stamp = Date.now();
 
     const events = [];
@@ -204,9 +207,11 @@ describe('Sync response: eviction, pruning and forged events', function () {
       events.map((event) => ({ ...event })),
     )));
 
-    const joiner = await env.startNode(10);
-    await waitForDaemonReady(joiner);
-    await waitForNodeStatus(joiner, (d) => d.confirmed === true, 30000);
+    // Seeded, so let it in. It has never spoken to a peer, so its first sync is
+    // its only one, and it reads records written seconds ago rather than records
+    // written before it started booting.
+    await env.healPartition([10], RUNNING);
+    await env.startDiscovery([10]);
     await waitForOrchestratorState(joiner, 'READY', 180000);
   });
 

--- a/test-infra/runner/tests/71-sync-eviction-prune-forgery.js
+++ b/test-infra/runner/tests/71-sync-eviction-prune-forgery.js
@@ -93,7 +93,23 @@ describe('Sync response: eviction, pruning and forged events', function () {
   const EVICTED_NODE = 9;
   const PRUNE_NODE = 8;
   const FORGERY_NODE = 7;
-  const stamp = Date.now();
+  // Stamped when the events are INJECTED, not when mocha loads this file.
+  //
+  // These are broadcasts, and a broadcast has an acceptance window:
+  // messageStore computes validTill = broadcastedAt + RUNNING_EXPIRY_MS
+  // (config.fluxapps.locationTtlS) and writes the location row with that same
+  // expireAt. At describe-body scope this was evaluated before the hook ran,
+  // before a twelve-node fleet booted, and under the parallel gate before the
+  // run had even claimed its subnet - minutes of it. Every event then arrived
+  // stamped in the past and its row was born expired, which reads as an empty
+  // location list rather than as a rejected message.
+  //
+  // It passed for as long as it did because locationTtlS was wired to nothing:
+  // the window was the production 125 minutes, wide enough to swallow any boot.
+  // Live at 63s it is 2.1 announce intervals, matching production's 2.08, and a
+  // broadcast stamped before the fleet existed is one production would refuse
+  // too.
+  let stamp;
 
   before(async function () {
     this.timeout(600000);
@@ -101,6 +117,7 @@ describe('Sync response: eviction, pruning and forged events', function () {
       hookCtx: this, nodes: 12, deferredNodes: 2, tickerAutostart: false,
     });
     await bootAndPeer(env, Array.from({ length: 10 }, (_, i) => i));
+    stamp = Date.now();
 
     const events = [];
 

--- a/test-infra/runner/tests/71-sync-eviction-prune-forgery.js
+++ b/test-infra/runner/tests/71-sync-eviction-prune-forgery.js
@@ -115,6 +115,23 @@ describe('Sync response: eviction, pruning and forged events', function () {
     this.timeout(600000);
     env = await createTestEnv({
       hookCtx: this, nodes: 12, deferredNodes: 2, tickerAutostart: false,
+      // DECLARED LIKE A MOCHA TIMEOUT, and for the same reason.
+      //
+      // The events below are broadcasts, and messageStore refuses one older than
+      // locationTtlS. The shared harness value is 63s, derived from production's
+      // announce ratio - fine for a suite that only has to outlive a compressed
+      // clock, and not fine here: this hook boots a twelfth node INSIDE that
+      // window, and a node boot is real work the harness does not compress.
+      // Measured at 24.6s of the window on an idle box, 93% of it the boot, and
+      // ~83s under a six-way gate - which is how this suite came to read an empty
+      // location list rather than a rejected message.
+      //
+      // Generous rather than measured, because a wider window costs this suite
+      // nothing: nothing here tests expiry, and a broadcast that does not expire
+      // is simply one the node accepts. The number needs to be comfortably more
+      // than any plausible setup, not accurate - so a slower box moves the real
+      // cost without moving this.
+      configOverrides: { fluxapps: { locationTtlS: 300 } },
     });
     await bootAndPeer(env, Array.from({ length: 10 }, (_, i) => i));
     stamp = Date.now();

--- a/test-infra/runner/tests/78-spawner-claim-withdrawal.js
+++ b/test-infra/runner/tests/78-spawner-claim-withdrawal.js
@@ -8,7 +8,7 @@ import {
   bootAndPeer, seedSpawnerApp, waitForInstanceCount,
   installingClaimIpsByNode, installingErrorsByNode,
 } from '../framework/reconciler-suite.js';
-import { waitFor } from '../framework/wait.js';
+import { waitFor, waitForCandidacy } from '../framework/wait.js';
 import { sleepUnlessInfraDead } from '../framework/infra-death.js';
 import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
 
@@ -258,12 +258,32 @@ describe('spawner withdraws an installing claim without reporting a failure', fu
     const rival = env.stubPeerClients.get(STUB_INDEX);
     await rival.withdrawApp(appName);
 
-    const holders = await waitForInstanceCount(env, appName, 2, { timeout: 240000, stableMs: 10000 });
-    const holderIps = holders.map((index) => getSubnetConfig().nodeIp(index + 1));
+    // ELIGIBILITY IS A FACT ABOUT ONE NODE. Which node then takes the freed slot
+    // is a draw among every eligible node, and the design promises nothing about
+    // who wins - so asserting the winner asserted a lottery.
+    //
+    // Measured on an idle box with the claim rows dumped: six real nodes, one
+    // holding, and only THREE of the five non-holders stood down. The other two
+    // never claimed at all, because by the time they looked the app already read
+    // as covered - one running plus the rival's claim against a required two - so
+    // it was filtered out before they could race. After the withdrawal all five
+    // are candidates again and a stood-down node wins three times in five. This
+    // test has been passing on that.
+    //
+    // What it must actually prove is that standing aside did not cost the node
+    // its place in the draw. The spawner publishes that directly: a verdict
+    // FLIPPING from excluded to candidate. afterAlreadyHeldOrTried is the filter
+    // that would hold a stood-down node out, so surviving it is the property, and
+    // the event fires whether or not this node goes on to win.
+    const backIn = await Promise.any(stoodDown.map((ip) => {
+      const index = env.clients.findIndex((_, i) => getSubnetConfig().nodeIp(i + 1) === ip);
+      return waitForCandidacy(
+        env.clients[index],
+        (d) => d.name === appName && d.candidate === true,
+        240000,
+      ).then(() => ip);
+    }));
 
-    expect(
-      holderIps.some((ip) => stoodDown.includes(ip)),
-      `a node that stood down never came back: stood down ${stoodDown.join(', ')}, holders ${holderIps.join(', ')}`,
-    ).to.be.true;
+    expect(backIn, 'no node that stood down became a candidate again').to.be.a('string');
   });
 });

--- a/test-infra/runner/tests/78-spawner-claim-withdrawal.js
+++ b/test-infra/runner/tests/78-spawner-claim-withdrawal.js
@@ -255,6 +255,18 @@ describe('spawner withdraws an installing claim without reporting a failure', fu
     const stoodDown = [...withdrawnIps()];
     expect(stoodDown, 'fixture: a node must have stood down first').to.not.be.empty;
 
+    // ANCHORED, and the mutation is why. Every one of these nodes was a candidate
+    // for this app before it claimed - that is how it came to stand down - so an
+    // unanchored wait is answered from the buffer by that earlier verdict and
+    // passes before the rival has withdrawn anything. Proven: with a mutant that
+    // writes a stood-down node off entirely, the unanchored form still passed
+    // 6/6. The baseline is taken per node, before the withdrawal, so only a
+    // verdict reached AFTER it counts.
+    const baselines = new Map(stoodDown.map((ip) => {
+      const index = env.clients.findIndex((_, i) => getSubnetConfig().nodeIp(i + 1) === ip);
+      return [ip, { index, afterId: env.clients[index].getLastEventId() }];
+    }));
+
     const rival = env.stubPeerClients.get(STUB_INDEX);
     await rival.withdrawApp(appName);
 
@@ -276,11 +288,12 @@ describe('spawner withdraws an installing claim without reporting a failure', fu
     // that would hold a stood-down node out, so surviving it is the property, and
     // the event fires whether or not this node goes on to win.
     const backIn = await Promise.any(stoodDown.map((ip) => {
-      const index = env.clients.findIndex((_, i) => getSubnetConfig().nodeIp(i + 1) === ip);
+      const { index, afterId } = baselines.get(ip);
       return waitForCandidacy(
         env.clients[index],
         (d) => d.name === appName && d.candidate === true,
         240000,
+        { afterId },
       ).then(() => ip);
     }));
 

--- a/test-infra/runner/tests/79-syncthing-peer-probe-per-pass.js
+++ b/test-infra/runner/tests/79-syncthing-peer-probe-per-pass.js
@@ -135,10 +135,13 @@ describe('syncthing asks a peer once per pass, not once per folder', function ()
     expect(await isUp(env.clients[subject], appOne), 'fixture: the first app must still be waiting').to.be.false;
     expect(await isUp(env.clients[subject], appTwo), 'fixture: the second app must still be waiting').to.be.false;
 
-    // clear() resets the arrival log AND what the stub claims, so the claim has
-    // to be restated or the subject promotes and stops asking mid-measurement.
-    await stub.clear();
-    await stub.setPromotedFolders({ ready: true, folders: heldFolders });
+    // ONE call, because clear() drops the claim as well as the log. Cleared and
+    // then restated, this peer claims to hold nothing for the width of a round
+    // trip, and a subject polling inside it sees the folder free, promotes, and
+    // stops asking - which is exactly what the assertions below then report, as
+    // an app that started mid-measurement. Restating the claim and resetting the
+    // log in the same request removes the window rather than narrowing it.
+    await stub.setPromotedFolders({ ready: true, folders: heldFolders, resetRequests: true });
 
     // Three arrivals give two gaps to measure - enough to tell one question per
     // pass from two, without pinning how many passes it takes to get there.

--- a/test-infra/runner/tests/89-restore-propagates-real-syncthing.js
+++ b/test-infra/runner/tests/89-restore-propagates-real-syncthing.js
@@ -1,7 +1,7 @@
 import { describe, it, before, after } from 'mocha';
 import { expect } from 'chai';
 import { createTestEnv } from '../framework/test-env.js';
-import { execInContainer } from '../framework/container.js';
+import { execInContainer, getAppContainerStatus } from '../framework/container.js';
 import { pushImage } from '../framework/registry-helper.js';
 import { buildSeedableSyncthingApp } from '../framework/seed-helper.js';
 import { waitFor, waitForReconcileActuated } from '../framework/wait.js';
@@ -106,6 +106,30 @@ describe('a restore reaches the other instances through syncthing', function () 
   it('carries a restore to the other instance without redeploying it', async function () {
     this.timeout(420000);
     const [a, b] = env.clients;
+
+    // THE APP MUST BE SETTLED BEFORE ITS DATA IS REPLACED. A restore stops the
+    // component to swap what is underneath it, and appendRestoreTask refuses -
+    // correctly - when it cannot: "could not be stopped, so its data cannot be
+    // replaced safely".
+    //
+    // Test one waits for the two syncthing DAEMONS to find each other, which is a
+    // different fact from this app's own leader election having finished. On the
+    // 2026-08-31 gate the election named a leader and requested the start 11ms
+    // before the restore arrived, the stop met a start already in flight, and the
+    // refusal came back as a 200 whose body was still "Pausing syncthing folder".
+    //
+    // It only surfaced once findSyncedPeer was repaired: while that function
+    // returned null without asking a single device, the transition never got this
+    // far this early. The race was always there, waiting for the election to be
+    // able to run.
+    //
+    // Waited on the container's STATE, not on a `started` actuation: this suite's
+    // own before() installs the app, so an unanchored wait for that event is
+    // satisfied by the install rather than by the leader start.
+    await waitFor(async () => {
+      const status = await getAppContainerStatus(a.container, appName);
+      return Boolean(status && status.status.startsWith('Up'));
+    }, { timeout: 180000, interval: 3000, label: 'the app is running and stoppable before its data is replaced' });
 
     // an archive holding one identifiable file, so its arrival on the peer is
     // unambiguous rather than inferred from a byte count

--- a/test-infra/runner/tests/96-surplus-trim-and-the-writer.js
+++ b/test-infra/runner/tests/96-surplus-trim-and-the-writer.js
@@ -7,6 +7,7 @@ import { getSubnetConfig } from '../framework/subnet-config.js';
 import {
   bootAndPeer, placeGAppInOrder, electionOrder, installedInstanceIndices,
 } from '../framework/reconciler-suite.js';
+import { syncthingSeedIndex, placementOrderWithSeedAt } from '../framework/g-app-placement.js';
 import { setSynced, setPeerHasData, resetSyncState } from '../framework/syncthing-control.js';
 import { electMaster, setFdmOutage, resetFdm } from '../framework/fdm-control.js';
 import { advanceBlocks, startTicker, stopTicker } from '../framework/daemon-control.js';
@@ -59,24 +60,17 @@ const REAL_NODES = 5;
 const STUB_INDEX = REAL_NODES; // one past the real ones
 
 // TWO ORDERINGS DECIDE THIS FIXTURE, and the whole point is to make them
-// coincide on one node.
+// coincide on one node: the writer has to BE the newest copy, because the newest
+// copy is the one the surplus rule picks.
 //
-// The syncthing seed - the holder that gets the writable folder at a cold start
-// and therefore RUNS the g: component - is the LOWEST IP among the holders. The
-// instance order the surplus rule ranks is runningSince, which records the order
-// the holders were placed. So placing the seed LAST makes it both the writer and
-// the newest copy, which is exactly the collision this suite exists for.
-//
-// Electing a master does NOT do this. FDM only reports who the primary is; it
-// cannot move a running container, and the election correctly refuses to start a
-// second writer while a peer is running one. An earlier version of this suite
-// tried to elect the newest holder into the role and sat waiting three minutes
-// for a component that was never going to start there.
+// Placing the seed LAST is what does that - it carries the latest runningSince,
+// so it is both the writer and the copy that would be trimmed. Why the seed is
+// the writer, and why no amount of electing moves it, is g-app-placement.js's
+// to explain; this suite says which shape it needs and lets that module work
+// out the order.
 const HOLDERS = [0, 1, 2];
-const SEED_INDEX = 0;                   // lowest IP of the three holders
-// Derived, not written out: "the seed goes last" is the rule, and a hand-listed
-// order silently stops meaning that the moment HOLDERS changes.
-const PLACEMENT_ORDER = [...HOLDERS.filter((i) => i !== SEED_INDEX), SEED_INDEX];
+const SEED_INDEX = syncthingSeedIndex(HOLDERS);
+const PLACEMENT_ORDER = placementOrderWithSeedAt(HOLDERS, HOLDERS.length - 1);
 
 describe('a surplus copy that is also the writer', function () {
   let env;

--- a/test-infra/runner/tests/96-surplus-trim-and-the-writer.js
+++ b/test-infra/runner/tests/96-surplus-trim-and-the-writer.js
@@ -71,6 +71,7 @@ const STUB_INDEX = REAL_NODES; // one past the real ones
 const HOLDERS = [0, 1, 2];
 const SEED_INDEX = syncthingSeedIndex(HOLDERS);
 const PLACEMENT_ORDER = placementOrderWithSeedAt(HOLDERS, HOLDERS.length - 1);
+const ipOfIndex = (index) => subnet.nodeIp(index + 1);
 
 describe('a surplus copy that is also the writer', function () {
   let env;
@@ -82,7 +83,6 @@ describe('a surplus copy that is also the writer', function () {
   let order;
   dumpLogsOnFailure(() => env);
 
-  const ipOf = (nodeIndex) => subnet.nodeIp(nodeIndex + 1);
   const holderAt = async (position) => {
     const res = await env.clients[0].getAppLocations(appName);
     // An unreadable answer must not read as an empty order: ranking nothing and
@@ -126,8 +126,17 @@ describe('a surplus copy that is also the writer', function () {
     // Every holder's folder complete and a connected peer holding it, or the
     // safety gate refuses every removal and this suite measures the gate rather
     // than the rule.
+    //
+    // PER HOLDER, not the '*' wildcard. placeGAppInOrder's cold start writes a
+    // per-IP zero for each holder - that is HOW it forces a cold start - and the
+    // stub keys peer completion by `ip|folder`, so a specific key shadows the
+    // wildcard. Setting '*' to 100 left both holders' own entries reading
+    // "completion=0 remoteState=unknown", the fleet went on believing no peer
+    // held the data, and the safety gate refused every trim with NO_SYNCED_PEER.
+    // The rule under test had already decided correctly by then; the fixture had
+    // simply never given it a peer to point at.
     await setSynced({ folder });
-    await setPeerHasData({ folder });
+    await Promise.all(HOLDERS.map((index) => setPeerHasData({ ip: ipOfIndex(index), folder })));
 
     await waitFor(async () => (await env.clients[0].getAppLocations(appName)).data?.length >= 3,
       { timeout: 300000, interval: 2000, label: 'three holders announce the app' });
@@ -164,8 +173,8 @@ describe('a surplus copy that is also the writer', function () {
     const nextNewest = await holderAt(1);
     const newestIp = newest.ip.split(':')[0];
     const nextIp = nextNewest.ip.split(':')[0];
-    const newestIndex = order.find((i) => ipOf(i) === newestIp);
-    const nextIndex = order.find((i) => ipOf(i) === nextIp);
+    const newestIndex = order.find((i) => ipOfIndex(i) === newestIp);
+    const nextIndex = order.find((i) => ipOfIndex(i) === nextIp);
     expect(newestIndex, 'the newest holder is a real node').to.not.equal(undefined);
     expect(nextIndex, 'the second-newest holder is a real node').to.not.equal(undefined);
 

--- a/test-infra/runner/tests/96-surplus-trim-and-the-writer.js
+++ b/test-infra/runner/tests/96-surplus-trim-and-the-writer.js
@@ -4,6 +4,7 @@ import { createTestEnv } from '../framework/test-env.js';
 import { pushImage } from '../framework/registry-helper.js';
 import { buildSeedableSyncthingApp } from '../framework/seed-helper.js';
 import { getSubnetConfig } from '../framework/subnet-config.js';
+import { execInContainer } from '../framework/container.js';
 import {
   bootAndPeer, placeGAppInOrder, electionOrder, installedInstanceIndices,
 } from '../framework/reconciler-suite.js';
@@ -297,6 +298,12 @@ describe('a surplus copy that is also the writer', function () {
       ).to.include(folder);
     } finally {
       await env.healPartition([nextIndex], [newestIndex]).catch(() => {});
+      // healPartition's own comment makes this the caller's job - it drops the
+      // iptables rules and leaves the dead cross-group sockets to be re-dialled.
+      // 68, 70 and 71 all do it; this suite was the only one that did not, and
+      // the pair never reconnected: node .12 logged nothing but timed-out
+      // handshakes to .10 from the heal until the test gave up ten minutes later.
+      await env.startDiscovery().catch(() => {});
       await startTicker().catch(() => {});
     }
   });
@@ -305,21 +312,33 @@ describe('a surplus copy that is also the writer', function () {
     this.timeout(900000);
     const { newestIndex, nextIndex } = await establishShape();
 
-    // The probe has to be able to reach the newest copy again after the
-    // partition above, or this spends ten minutes waiting for a trim that is
-    // being declined for the previous test's reason rather than allowed for
-    // this one.
-    // Either direction counts: which side dialled which is not this suite's
-    // business, and checking only outbound waits forever on a pair that
-    // reconnected the other way round.
+    // WAIT FOR THE FACT THE DECISION READS. The trim is allowed only when
+    // peerComponentState confirms the newest copy holds the writer, and it asks
+    // by GETting /apps/heldcomponents on that node - so this waits for exactly
+    // that call to answer, made from the node that will make it.
+    //
+    // It used to wait for the pair to appear in each other's PEER LISTS, which
+    // is a different fact and was satisfied while nothing could actually talk:
+    // the two never reconnected after the partition above, the peer map still
+    // carried the entry, and the one probe this test gets found the newest
+    // silent and correctly declined. The suite then spent ten minutes waiting
+    // for a trim that had already been refused for the right reason.
+    //
+    // It matters that this is the one probe. The give-up pass runs on
+    // `blockHeight % (removeFluxAppsPeriod * speedMultiplier) === 0` - 44 blocks
+    // - and driveUntil below spends about 53, so there is one attempt and no
+    // second. A precondition that is merely usually true is a coin toss here.
     await waitFor(async () => {
-      const [outbound, inbound] = await Promise.all([
-        env.clients[nextIndex].getPeers(),
-        env.clients[nextIndex].getIncomingPeers(),
-      ]);
-      const peers = new Set([...(outbound.data || []), ...(inbound.data || [])]);
-      return peers.has(ipOfIndex(newestIndex));
-    }, { timeout: 180000, interval: 3000, label: 'the second-newest can see the newest again' });
+      const res = await execInContainer(
+        env.clients[nextIndex].container,
+        `curl -sf -m 5 http://${ipOfIndex(newestIndex)}:16127/apps/heldcomponents`,
+      );
+      return res.exitCode === 0 && res.output.includes(folder);
+    }, {
+      timeout: 180000,
+      interval: 3000,
+      label: 'the newest copy answers heldcomponents with the writer, asked from the second-newest',
+    });
 
     await stopTicker();
     await driveUntil(env.clients[nextIndex], async () => {

--- a/test-infra/runner/tests/96-surplus-trim-and-the-writer.js
+++ b/test-infra/runner/tests/96-surplus-trim-and-the-writer.js
@@ -149,8 +149,23 @@ describe('a surplus copy that is also the writer', function () {
       runningSince: Date.now() - 24 * 60 * 60 * 1000,
     });
     await held.started;
-    await waitFor(async () => (await env.clients[0].getAppLocations(appName)).data?.length >= 4,
-      { timeout: 120000, interval: 2000, label: 'the stub is counted as a fourth holder' });
+
+    // The count is carried out of the wait so a timeout says what it SAW. "The
+    // stub is not counted" and "the fleet lost a holder" are different faults
+    // with the same symptom, and a bare timeout distinguishes neither - it took
+    // a re-run to find out which one had happened.
+    let holders = 0;
+    await waitFor(async () => {
+      const res = await env.clients[0].getAppLocations(appName);
+      holders = Array.isArray(res.data) ? res.data.length : -1;
+      return holders >= 4;
+    }, {
+      timeout: 180000,
+      interval: 2000,
+      label: 'the stub is counted as a fourth holder',
+    }).catch((error) => {
+      throw new Error(`${error.message} - the fleet counted ${holders} holder(s), not 4`);
+    });
   });
 
   after(async function () {

--- a/test-infra/runner/tests/96-surplus-trim-and-the-writer.js
+++ b/test-infra/runner/tests/96-surplus-trim-and-the-writer.js
@@ -9,9 +9,9 @@ import {
 } from '../framework/reconciler-suite.js';
 import { syncthingSeedIndex, placementOrderWithSeedAt } from '../framework/g-app-placement.js';
 import { setSynced, setPeerHasData, resetSyncState } from '../framework/syncthing-control.js';
-import { electMaster, setFdmOutage, resetFdm } from '../framework/fdm-control.js';
-import { advanceBlocks, startTicker, stopTicker } from '../framework/daemon-control.js';
-import { waitFor } from '../framework/wait.js';
+import { electMaster, resetFdm } from '../framework/fdm-control.js';
+import { advanceBlock, startTicker, stopTicker } from '../framework/daemon-control.js';
+import { waitFor, waitForGiveUpConsidered } from '../framework/wait.js';
 import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
 
 // Trimming a surplus copy, when the surplus copy is the one WRITING.
@@ -53,6 +53,35 @@ async function runningComponents(env, nodeIndex) {
   const list = res?.status === 'success' ? res.data : null;
   if (!Array.isArray(list)) throw new Error(`listrunningapps unreadable: ${JSON.stringify(res)?.slice(0, 200)}`);
   return list.flatMap((a) => a.Names || []).map((n) => n.replace(/^\//, ''));
+}
+
+// Drive the chain until a condition holds, ONE BLOCK AT A TIME, waiting for the
+// node to process each before sending the next.
+//
+// A height only counts when it lands as the TIP, and tips arrive one per
+// explorer poll - so pushing a burst leaves most of it stale on arrival and the
+// give-up pass runs once, or not at all. This test used to advance 24 blocks in
+// a single call and then assert that nothing had happened; on the fleet that
+// produced exactly one give-up pass across five nodes, and the assertion held
+// because nothing had been asked, not because anything had declined.
+//
+// Suite 55 carries the same shape and the full reasoning for it, including the
+// gate it cost. Worth folding into the framework when a third suite wants it.
+async function driveUntil(node, condition, { timeoutMs, label }) {
+  const deadline = Date.now() + timeoutMs;
+  let blocks = 0;
+  while (Date.now() < deadline) {
+    // eslint-disable-next-line no-await-in-loop
+    if (await condition()) return blocks;
+    const afterId = node.getLastEventId();
+    // eslint-disable-next-line no-await-in-loop
+    await advanceBlock();
+    // eslint-disable-next-line no-await-in-loop
+    await node.waitForEvent('block:processed', () => true, 60000, { afterId });
+    blocks += 1;
+  }
+  if (await condition()) return blocks;
+  throw new Error(`${label}: not reached in ${timeoutMs}ms (${blocks} blocks driven)`);
 }
 
 const subnet = getSubnetConfig();
@@ -190,18 +219,23 @@ describe('a surplus copy that is also the writer', function () {
     this.timeout(120000);
     held?.stop();
     await startTicker().catch(() => {});
-    // Explicitly, not via resetFdm: the FDM stub is shared infrastructure and an
-    // outage left on leaks into whatever suite runs next. Whether /reset clears
-    // that flag is the stub's business, and this suite should not depend on it.
-    await setFdmOutage(false).catch(() => {});
     await resetFdm().catch(() => {});
     await resetSyncState().catch(() => {});
     if (env) await env.teardown();
   });
 
-  it('leaves the writer in place and trims the next copy instead', async function () {
-    this.timeout(900000);
-
+  // The shape both tests rest on: which node is the newest copy, which sits
+  // behind it, and the writer actually running on the newest.
+  //
+  // Established from a TEST rather than from before(), on purpose. A hook
+  // failure writes no per-container logs, and this is precisely the step whose
+  // failure needs them - it is where four earlier runs of this suite died, each
+  // time on the fixture rather than on the rule. Memoised, so the second test
+  // inherits the shape instead of re-deriving it and quietly disagreeing with
+  // the first about which node it is talking about.
+  let shape = null;
+  const establishShape = async () => {
+    if (shape) return shape;
     const newest = await holderAt(0);
     const nextNewest = await holderAt(1);
     const newestIp = newest.ip.split(':')[0];
@@ -213,7 +247,7 @@ describe('a surplus copy that is also the writer', function () {
 
     // A CONTROL ON THE FIXTURE, not on the code. Everything below rests on the
     // seed and the newest copy being the same node; if the seed rule ever moves,
-    // this says so in one line rather than leaving the wait three lines down to
+    // this says so in one line rather than leaving a wait three lines down to
     // time out after three minutes looking like a product fault.
     expect(newestIndex, 'the fixture must land the writer on the newest copy')
       .to.equal(SEED_INDEX);
@@ -228,12 +262,99 @@ describe('a surplus copy that is also the writer', function () {
     await waitFor(async () => (await runningComponents(env, newestIndex)).includes(folder),
       { timeout: 180000, interval: 3000, label: 'the newest copy is running the writer' });
 
-    await stopTicker();
+    shape = { newestIndex, nextIndex };
+    return shape;
+  };
+
+  it('trims nothing while it cannot confirm the newest copy is the writer', async function () {
+    this.timeout(900000);
+    const { newestIndex, nextIndex } = await establishShape();
+
+    // The second-newest may act ONLY on a POSITIVE confirmation that the newest
+    // is running the writer. Every node ranks the same shared order, but "who is
+    // writing" is each node's own reading - so a node acting on anything weaker
+    // is how two copies leave at once, which is the one outcome this design has
+    // to make impossible.
+    //
+    // CONFIRMATION IS A DIRECT PROBE OF THE PEER'S OWN API, not an FDM lookup,
+    // so the only way to take it away is to stop this node being able to read
+    // that peer. An FDM outage does not do it, and this test used to try: it
+    // leaves peerComponentState answering perfectly well, because that function
+    // never asks FDM anything.
+    //
+    // The newest copy goes on running the writer throughout, which is the whole
+    // point - if the rule ever trimmed on silence, the node doing it would be
+    // removing a copy while the writer was up and healthy.
+    //
+    // THE SURPLUS MUST STILL BE HERE, which is why this runs before the test
+    // that trims. After that trim the app sits at exactly its instance count,
+    // the surplus rule is never entered at all, and the assertion below would
+    // hold for a reason with nothing to do with confirming a writer.
+    const locations = await env.clients[0].getAppLocations(appName);
+    expect(locations.data?.length, 'a surplus must exist or this test declines nothing')
+      .to.equal(HOLDERS.length + 1);
+
+    const before = await installedInstanceIndices(env, appName);
+    expect(before, 'the copy that would be trimmed is still here').to.include(nextIndex);
+
+    await env.partitionGroups([nextIndex], [newestIndex], { awaitSever: false });
+    try {
+      // THE PASS SAYING IT SAW THE SURPLUS AND WOULD NOT ACT ON IT. Waiting for
+      // "nothing was removed" on its own passes just as happily when the pass
+      // never ran - which is how this test passed before, on a fleet where the
+      // give-up pass fired once across five nodes and reported NONE.
+      let declined = null;
+      const refusal = waitForGiveUpConsidered(
+        env.clients[nextIndex], appName,
+        (d) => d.giveUp === false && d.reason === 'SURPLUS' && d.code === 'WRITER_UNCONFIRMED',
+        600000,
+      ).then((v) => { declined = v; return v; });
+      refusal.catch(() => {});
+
+      await stopTicker();
+      await driveUntil(env.clients[nextIndex], async () => declined !== null, {
+        timeoutMs: 600000,
+        label: 'the second-newest reports a surplus it would not act on',
+      });
+
+      const after = await installedInstanceIndices(env, appName);
+      expect(after.slice().sort(), 'a copy left while nobody could confirm the writer')
+        .to.deep.equal(before.slice().sort());
+      expect(
+        await runningComponents(env, newestIndex),
+        'the writer stopped while its peer could not see it',
+      ).to.include(folder);
+    } finally {
+      await env.healPartition([nextIndex], [newestIndex]).catch(() => {});
+      await startTicker().catch(() => {});
+    }
+  });
+
+  it('leaves the writer in place and trims the next copy instead', async function () {
+    this.timeout(900000);
+    const { newestIndex, nextIndex } = await establishShape();
+
+    // The probe has to be able to reach the newest copy again after the
+    // partition above, or this spends ten minutes waiting for a trim that is
+    // being declined for the previous test's reason rather than allowed for
+    // this one.
+    // Either direction counts: which side dialled which is not this suite's
+    // business, and checking only outbound waits forever on a pair that
+    // reconnected the other way round.
     await waitFor(async () => {
-      await advanceBlocks(4);
+      const [outbound, inbound] = await Promise.all([
+        env.clients[nextIndex].getPeers(),
+        env.clients[nextIndex].getIncomingPeers(),
+      ]);
+      const peers = new Set([...(outbound.data || []), ...(inbound.data || [])]);
+      return peers.has(ipOfIndex(newestIndex));
+    }, { timeout: 180000, interval: 3000, label: 'the second-newest can see the newest again' });
+
+    await stopTicker();
+    await driveUntil(env.clients[nextIndex], async () => {
       const installed = await installedInstanceIndices(env, appName);
       return !installed.includes(nextIndex);
-    }, { timeout: 600000, interval: 1000, label: 'the second-newest copy is trimmed' });
+    }, { timeoutMs: 600000, label: 'the second-newest copy is trimmed' });
     await startTicker();
 
     // THE POINT. The writer was never stopped to make the count come out.
@@ -244,33 +365,5 @@ describe('a surplus copy that is also the writer', function () {
 
     const stillInstalled = await installedInstanceIndices(env, appName);
     expect(stillInstalled, 'the writer left instead of the copy behind it').to.include(newestIndex);
-  });
-
-  it('trims nothing at all while the writer cannot be confirmed', async function () {
-    this.timeout(900000);
-
-    // The second-newest may only act on a POSITIVE confirmation that the newest
-    // is running the writer. Every node ranks the same shared order, but "who is
-    // writing" is each node's own reading and FDM's registration lags it - so a
-    // node acting on anything weaker is how two copies leave at once, which is
-    // the one outcome this design has to make impossible.
-    //
-    // With no FDM answering, no node can establish who the writer is. The
-    // correct behaviour is that nobody trims: an app one copy over its count is
-    // a cost, and it is a smaller one than an app a copy short of it.
-    const before = await installedInstanceIndices(env, appName);
-    await setFdmOutage(true);
-
-    await stopTicker();
-    await advanceBlocks(24);
-    await startTicker();
-
-    const after = await installedInstanceIndices(env, appName);
-    // Restored here rather than only in teardown: an assertion below that fails
-    // would otherwise leave the shared FDM stub down for the next suite.
-    await setFdmOutage(false);
-
-    expect(after.slice().sort(), 'a copy left while nobody could say who was writing')
-      .to.deep.equal(before.slice().sort());
   });
 });

--- a/test-infra/runner/tests/96-surplus-trim-and-the-writer.js
+++ b/test-infra/runner/tests/96-surplus-trim-and-the-writer.js
@@ -58,6 +58,26 @@ const subnet = getSubnetConfig();
 const REAL_NODES = 5;
 const STUB_INDEX = REAL_NODES; // one past the real ones
 
+// TWO ORDERINGS DECIDE THIS FIXTURE, and the whole point is to make them
+// coincide on one node.
+//
+// The syncthing seed - the holder that gets the writable folder at a cold start
+// and therefore RUNS the g: component - is the LOWEST IP among the holders. The
+// instance order the surplus rule ranks is runningSince, which records the order
+// the holders were placed. So placing the seed LAST makes it both the writer and
+// the newest copy, which is exactly the collision this suite exists for.
+//
+// Electing a master does NOT do this. FDM only reports who the primary is; it
+// cannot move a running container, and the election correctly refuses to start a
+// second writer while a peer is running one. An earlier version of this suite
+// tried to elect the newest holder into the role and sat waiting three minutes
+// for a component that was never going to start there.
+const HOLDERS = [0, 1, 2];
+const SEED_INDEX = 0;                   // lowest IP of the three holders
+// Derived, not written out: "the seed goes last" is the rule, and a hand-listed
+// order silently stops meaning that the moment HOLDERS changes.
+const PLACEMENT_ORDER = [...HOLDERS.filter((i) => i !== SEED_INDEX), SEED_INDEX];
+
 describe('a surplus copy that is also the writer', function () {
   let env;
   let app;
@@ -106,7 +126,7 @@ describe('a surplus copy that is also the writer', function () {
     identifier = `${appName}_${appName}`;
     folder = `flux${identifier}`;
     order = await placeGAppInOrder(env, app, {
-      placementOrder: [0, 1, 2], folder, identifier,
+      placementOrder: PLACEMENT_ORDER, folder, identifier,
     });
 
     // Every holder's folder complete and a connected peer holding it, or the
@@ -155,9 +175,16 @@ describe('a surplus copy that is also the writer', function () {
     expect(newestIndex, 'the newest holder is a real node').to.not.equal(undefined);
     expect(nextIndex, 'the second-newest holder is a real node').to.not.equal(undefined);
 
-    // FDM names the NEWEST copy the writer, which is the arrangement the whole
-    // suite exists for: the node the surplus rule would pick is the node that
-    // must not be disturbed.
+    // A CONTROL ON THE FIXTURE, not on the code. Everything below rests on the
+    // seed and the newest copy being the same node; if the seed rule ever moves,
+    // this says so in one line rather than leaving the wait three lines down to
+    // time out after three minutes looking like a product fault.
+    expect(newestIndex, 'the fixture must land the writer on the newest copy')
+      .to.equal(SEED_INDEX);
+
+    // FDM is told what is already true, so the election has no reason to move
+    // the role mid-test. It is not what puts the writer there - the cold-start
+    // seed did that - and nothing here depends on FDM to create the shape.
     await electMaster(appName, newestIp);
 
     // Positive control. Without it a later "the writer never stopped" assertion

--- a/test-infra/runner/tests/96-surplus-trim-and-the-writer.js
+++ b/test-infra/runner/tests/96-surplus-trim-and-the-writer.js
@@ -1,0 +1,213 @@
+import { describe, it, before, after } from 'mocha';
+import { expect } from 'chai';
+import { createTestEnv } from '../framework/test-env.js';
+import { pushImage } from '../framework/registry-helper.js';
+import { buildSeedableSyncthingApp, allocateAppPort } from '../framework/seed-helper.js';
+import { getSubnetConfig } from '../framework/subnet-config.js';
+import {
+  bootAndPeer, placeGAppInOrder, electionOrder, installedInstanceIndices,
+} from '../framework/reconciler-suite.js';
+import { setSynced, setPeerHasData, resetSyncState } from '../framework/syncthing-control.js';
+import { electMaster, setFdmOutage, resetFdm } from '../framework/fdm-control.js';
+import { advanceBlocks, startTicker, stopTicker } from '../framework/daemon-control.js';
+import { waitFor } from '../framework/wait.js';
+import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
+
+// Trimming a surplus copy, when the surplus copy is the one WRITING.
+//
+// Two rules meet here and neither knows about the other.
+//
+// An app that ends up on more nodes than it needs sheds one, and the rule is
+// "the newest copy stands aside". Every node ranks the same shared order and
+// works out for itself whether it is the newest, so exactly one node ever
+// concludes that it is - that agreement is the whole reason two copies never
+// leave at once.
+//
+// Separately, a `g:` app has one node WRITING to the volume while the rest hold
+// synced copies with the component stopped. The election is allowed to seat that
+// writer anywhere in the order: it will not start a node whose data has not
+// finished syncing, so it works down the list until it finds one that is ready,
+// and the designated-leader branch leaves the order outright.
+//
+// So the two rules can land on the same node, and "the newest stands aside" is
+// then backwards. It is a stand-in for "the least valuable copy stands aside",
+// and the writer is the most valuable copy on the network. The node stays, and
+// the next copy trims instead - what must NOT happen is the writer being stopped
+// to make the ordering come true. An app that is over-served is not down; an app
+// whose writer was stopped to tidy up a count is.
+//
+// THE SURPLUS IS BUILT, not raced for. The spawner fills to N and stops, so a
+// fleet left to itself never produces a surplus at all - which is why no suite
+// could ask this question before. A stub peer announces that it holds the app,
+// through the ordinary broadcast path, and that takes the count to N+1. It is
+// backdated so it is the SENIOR holder: the surplus has to land on a real node,
+// and a stub holds no containers and could not be observed leaving.
+// Read through a helper that THROWS on an unreadable answer. `some(...)` over
+// an empty list is false, so a failed request or an unexpected shape reads as
+// "the component is not running" - and the assertion that matters most in this
+// suite is that the writer IS still running. Suite 55 shipped that bug and it
+// passed while the node was still writing.
+async function runningComponents(env, nodeIndex) {
+  const res = await env.clients[nodeIndex].get('/apps/listrunningapps');
+  const list = res?.status === 'success' ? res.data : null;
+  if (!Array.isArray(list)) throw new Error(`listrunningapps unreadable: ${JSON.stringify(res)?.slice(0, 200)}`);
+  return list.flatMap((a) => a.Names || []).map((n) => n.replace(/^\//, ''));
+}
+
+const subnet = getSubnetConfig();
+const REAL_NODES = 5;
+const STUB_INDEX = REAL_NODES; // one past the real ones
+
+describe('a surplus copy that is also the writer', function () {
+  let env;
+  let app;
+  let appName;
+  let held;
+  let folder;
+  let identifier;
+  let order;
+  dumpLogsOnFailure(() => env);
+
+  const ipOf = (nodeIndex) => subnet.nodeIp(nodeIndex + 1);
+  const holderAt = async (position) => {
+    const res = await env.clients[0].getAppLocations(appName);
+    // An unreadable answer must not read as an empty order: ranking nothing and
+    // indexing into it yields undefined, and every assertion downstream then
+    // compares undefined against undefined and passes.
+    if (res?.status !== 'success' || !Array.isArray(res.data) || !res.data.length) {
+      throw new Error(`app locations unreadable: ${JSON.stringify(res)?.slice(0, 200)}`);
+    }
+    const ranked = electionOrder(res.data);
+    // electionOrder is senior-first; the surplus rule ranks the junior end.
+    return [...ranked].reverse()[position];
+  };
+
+  before(async function () {
+    this.timeout(600000);
+    appName = `e2esurpluswriter${Date.now()}`;
+    env = await createTestEnv({
+      hookCtx: this,
+      nodes: REAL_NODES + 1,
+      stubPeers: [STUB_INDEX],
+      tickerAutostart: false,
+    });
+    await bootAndPeer(env, { minOutbound: 2, minInbound: 2 });
+    await resetFdm();
+    await resetSyncState();
+    await pushImage(appName, 'v1');
+
+    // THREE instances, placed on three real nodes one at a time so their
+    // runningSince values are distinct and ordered. Placed in parallel they all
+    // land in the same instant, the ranking falls through to its ip tiebreak,
+    // and "the newest" stops meaning anything a test can steer.
+    app = await buildSeedableSyncthingApp({
+      name: appName, mode: 'g', ports: [allocateAppPort()], instances: 3,
+    });
+    identifier = `${appName}_${appName}`;
+    folder = `flux${identifier}`;
+    order = await placeGAppInOrder(env, app, {
+      placementOrder: [0, 1, 2], folder, identifier,
+    });
+
+    // Every holder's folder complete and a connected peer holding it, or the
+    // safety gate refuses every removal and this suite measures the gate rather
+    // than the rule.
+    await setSynced({ folder });
+    await setPeerHasData({ folder });
+
+    await waitFor(async () => (await env.clients[0].getAppLocations(appName)).data?.length >= 3,
+      { timeout: 300000, interval: 2000, label: 'three holders announce the app' });
+
+    // The stub becomes the fourth holder - four against an instance count of
+    // three - and it is backdated a day, so it is the most SENIOR holder and can
+    // never be the one the rule picks.
+    held = env.stubPeerClients.get(STUB_INDEX).holdApp(appName, {
+      hash: app.hash,
+      runningSince: Date.now() - 24 * 60 * 60 * 1000,
+    });
+    await held.started;
+    await waitFor(async () => (await env.clients[0].getAppLocations(appName)).data?.length >= 4,
+      { timeout: 120000, interval: 2000, label: 'the stub is counted as a fourth holder' });
+  });
+
+  after(async function () {
+    this.timeout(120000);
+    held?.stop();
+    await startTicker().catch(() => {});
+    // Explicitly, not via resetFdm: the FDM stub is shared infrastructure and an
+    // outage left on leaks into whatever suite runs next. Whether /reset clears
+    // that flag is the stub's business, and this suite should not depend on it.
+    await setFdmOutage(false).catch(() => {});
+    await resetFdm().catch(() => {});
+    await resetSyncState().catch(() => {});
+    if (env) await env.teardown();
+  });
+
+  it('leaves the writer in place and trims the next copy instead', async function () {
+    this.timeout(900000);
+
+    const newest = await holderAt(0);
+    const nextNewest = await holderAt(1);
+    const newestIp = newest.ip.split(':')[0];
+    const nextIp = nextNewest.ip.split(':')[0];
+    const newestIndex = order.find((i) => ipOf(i) === newestIp);
+    const nextIndex = order.find((i) => ipOf(i) === nextIp);
+    expect(newestIndex, 'the newest holder is a real node').to.not.equal(undefined);
+    expect(nextIndex, 'the second-newest holder is a real node').to.not.equal(undefined);
+
+    // FDM names the NEWEST copy the writer, which is the arrangement the whole
+    // suite exists for: the node the surplus rule would pick is the node that
+    // must not be disturbed.
+    await electMaster(appName, newestIp);
+
+    // Positive control. Without it a later "the writer never stopped" assertion
+    // passes on a component that was never running in the first place.
+    await waitFor(async () => (await runningComponents(env, newestIndex)).includes(folder),
+      { timeout: 180000, interval: 3000, label: 'the newest copy is running the writer' });
+
+    await stopTicker();
+    await waitFor(async () => {
+      await advanceBlocks(4);
+      const installed = await installedInstanceIndices(env, appName);
+      return !installed.includes(nextIndex);
+    }, { timeout: 600000, interval: 1000, label: 'the second-newest copy is trimmed' });
+    await startTicker();
+
+    // THE POINT. The writer was never stopped to make the count come out.
+    expect(
+      await runningComponents(env, newestIndex),
+      'the writer was stopped in order to trim the surplus',
+    ).to.include(folder);
+
+    const stillInstalled = await installedInstanceIndices(env, appName);
+    expect(stillInstalled, 'the writer left instead of the copy behind it').to.include(newestIndex);
+  });
+
+  it('trims nothing at all while the writer cannot be confirmed', async function () {
+    this.timeout(900000);
+
+    // The second-newest may only act on a POSITIVE confirmation that the newest
+    // is running the writer. Every node ranks the same shared order, but "who is
+    // writing" is each node's own reading and FDM's registration lags it - so a
+    // node acting on anything weaker is how two copies leave at once, which is
+    // the one outcome this design has to make impossible.
+    //
+    // With no FDM answering, no node can establish who the writer is. The
+    // correct behaviour is that nobody trims: an app one copy over its count is
+    // a cost, and it is a smaller one than an app a copy short of it.
+    const before = await installedInstanceIndices(env, appName);
+    await setFdmOutage(true);
+
+    await stopTicker();
+    await advanceBlocks(24);
+    await startTicker();
+
+    const after = await installedInstanceIndices(env, appName);
+    // Restored here rather than only in teardown: an assertion below that fails
+    // would otherwise leave the shared FDM stub down for the next suite.
+    await setFdmOutage(false);
+
+    expect(after.slice().sort(), 'a copy left while nobody could say who was writing')
+      .to.deep.equal(before.slice().sort());
+  });
+});

--- a/test-infra/runner/tests/96-surplus-trim-and-the-writer.js
+++ b/test-infra/runner/tests/96-surplus-trim-and-the-writer.js
@@ -2,7 +2,7 @@ import { describe, it, before, after } from 'mocha';
 import { expect } from 'chai';
 import { createTestEnv } from '../framework/test-env.js';
 import { pushImage } from '../framework/registry-helper.js';
-import { buildSeedableSyncthingApp, allocateAppPort } from '../framework/seed-helper.js';
+import { buildSeedableSyncthingApp } from '../framework/seed-helper.js';
 import { getSubnetConfig } from '../framework/subnet-config.js';
 import {
   bootAndPeer, placeGAppInOrder, electionOrder, installedInstanceIndices,
@@ -115,7 +115,7 @@ describe('a surplus copy that is also the writer', function () {
     // land in the same instant, the ranking falls through to its ip tiebreak,
     // and "the newest" stops meaning anything a test can steer.
     app = await buildSeedableSyncthingApp({
-      name: appName, mode: 'g', ports: [allocateAppPort()], instances: 3,
+      name: appName, mode: 'g', instances: 3,
     });
     identifier = `${appName}_${appName}`;
     folder = `flux${identifier}`;

--- a/test-infra/runner/tests/96-surplus-trim-and-the-writer.js
+++ b/test-infra/runner/tests/96-surplus-trim-and-the-writer.js
@@ -174,16 +174,29 @@ describe('a surplus copy that is also the writer', function () {
     // not counted" and "the fleet lost a holder" are different faults with one
     // symptom, and a bare deadline separates neither.
     let holders = 0;
+    let seen = [];
     await waitFor(async () => {
       const res = await env.clients[0].getAppLocations(appName);
       holders = Array.isArray(res.data) ? res.data.length : -1;
+      seen = Array.isArray(res.data) ? res.data.map((d) => d.ip) : [];
       return holders >= 4;
     }, {
       timeout: 120000,
       interval: 2000,
       label: 'the stub is counted as a fourth holder',
     }).catch((error) => {
-      throw new Error(`${error.message} - the fleet counted ${holders} holder(s), not 4`);
+      // WHICH holder is missing, not how many there are. Three can mean the
+      // stub's announcement never landed, or that a give-up pass trimmed a real
+      // copy out from under the fixture the moment the surplus appeared - the
+      // second is what happens when the pass period is compressed, and the count
+      // alone cannot tell them apart. It cost a session to find that out once.
+      const stubIp = ipOfIndex(STUB_INDEX);
+      const hasStub = seen.some((ip) => String(ip).startsWith(stubIp));
+      throw new Error(
+        `${error.message} - the fleet counted ${holders} holder(s), not 4. `
+        + `saw [${seen.join(', ')}]; stub ${stubIp} ${hasStub ? 'IS' : 'is NOT'} among them, `
+        + `so ${hasStub ? 'a real copy was trimmed before the fixture was ready' : 'the stub was never counted'}.`,
+      );
     });
   });
 
@@ -328,13 +341,18 @@ describe('a surplus copy that is also the writer', function () {
     // `blockHeight % (removeFluxAppsPeriod * speedMultiplier) === 0` - 44 blocks
     // - and driveUntil below spends about 53, so there is one attempt and no
     // second. A precondition that is merely usually true is a coin toss here.
-    await waitFor(async () => {
+    // Defined once and used twice: to get into the shape, and then to hold the
+    // chain still whenever it lapses. Asked the way the product asks it, from
+    // the node that will make the decision.
+    const newestAnswersHeldComponents = async () => {
       const res = await execInContainer(
         env.clients[nextIndex].container,
         `curl -sf -m 5 http://${ipOfIndex(newestIndex)}:16127/apps/heldcomponents`,
       );
       return res.exitCode === 0 && res.output.includes(folder);
-    }, {
+    };
+
+    await waitFor(newestAnswersHeldComponents, {
       timeout: 180000,
       interval: 3000,
       label: 'the newest copy answers heldcomponents with the writer, asked from the second-newest',
@@ -343,7 +361,27 @@ describe('a surplus copy that is also the writer', function () {
     await stopTicker();
     await driveUntil(env.clients[nextIndex], async () => {
       const installed = await installedInstanceIndices(env, appName);
-      return !installed.includes(nextIndex);
+      if (!installed.includes(nextIndex)) return true;
+      // THE CHAIN DOES NOT ADVANCE WHILE THE DECISION'S PRECONDITION IS FALSE.
+      // The give-up pass runs every removeFluxAppsPeriod * 4 = 44 blocks and
+      // this drive spends about 53, so there is one attempt. The trim is allowed
+      // only when peerComponentState confirms the newest copy holds the writer,
+      // and that is a 10s HTTP probe from this node - so if the newest is quiet
+      // in the moment the pass lands, it declines for entirely the right reason
+      // and there is no second chance. That is how the b22117e5a gate failed
+      // here: the newest answered the identical probe from this test a minute
+      // earlier, then did not answer the product's.
+      //
+      // Waiting HERE rather than widening the budget is the difference between
+      // removing the coin and tossing it again: driveUntil evaluates this before
+      // every block, so a block is only ever driven while the peer is answering,
+      // and the pass therefore cannot land in a window where it must refuse.
+      await waitFor(newestAnswersHeldComponents, {
+        timeout: 120000,
+        interval: 3000,
+        label: 'the newest copy is still answering heldcomponents before another block is driven',
+      });
+      return false;
     }, { timeoutMs: 600000, label: 'the second-newest copy is trimmed' });
     await startTicker();
 

--- a/test-infra/runner/tests/96-surplus-trim-and-the-writer.js
+++ b/test-infra/runner/tests/96-surplus-trim-and-the-writer.js
@@ -144,23 +144,33 @@ describe('a surplus copy that is also the writer', function () {
     // The stub becomes the fourth holder - four against an instance count of
     // three - and it is backdated a day, so it is the most SENIOR holder and can
     // never be the one the rule picks.
-    held = env.stubPeerClients.get(STUB_INDEX).holdApp(appName, {
+    // THE PRECONDITION, established rather than raced. Everything this peer
+    // says goes over sockets the fleet opens to it, so announcing before anyone
+    // has dialled in is talking to an empty set - and that failure surfaces
+    // minutes later as the fleet apparently ignoring a holder, which is where
+    // this suite lost a run.
+    const stub = env.stubPeerClients.get(STUB_INDEX);
+    await waitFor(async () => (await stub.connectedNodes()) > 0,
+      { timeout: 120000, interval: 2000, label: 'the fleet has connected to the stub peer' });
+
+    held = stub.holdApp(appName, {
       hash: app.hash,
       runningSince: Date.now() - 24 * 60 * 60 * 1000,
     });
+    // Throws if it reached nobody, naming the send rather than leaving the wait
+    // below to time out against something that was never said.
     await held.started;
 
-    // The count is carried out of the wait so a timeout says what it SAW. "The
-    // stub is not counted" and "the fleet lost a holder" are different faults
-    // with the same symptom, and a bare timeout distinguishes neither - it took
-    // a re-run to find out which one had happened.
+    // The count is carried out so a timeout reports what it SAW. "The stub is
+    // not counted" and "the fleet lost a holder" are different faults with one
+    // symptom, and a bare deadline separates neither.
     let holders = 0;
     await waitFor(async () => {
       const res = await env.clients[0].getAppLocations(appName);
       holders = Array.isArray(res.data) ? res.data.length : -1;
       return holders >= 4;
     }, {
-      timeout: 180000,
+      timeout: 120000,
       interval: 2000,
       label: 'the stub is counted as a fourth holder',
     }).catch((error) => {

--- a/test-infra/runner/tests/96-surplus-trim-and-the-writer.js
+++ b/test-infra/runner/tests/96-surplus-trim-and-the-writer.js
@@ -127,16 +127,24 @@ describe('a surplus copy that is also the writer', function () {
     // safety gate refuses every removal and this suite measures the gate rather
     // than the rule.
     //
-    // PER HOLDER, not the '*' wildcard. placeGAppInOrder's cold start writes a
-    // per-IP zero for each holder - that is HOW it forces a cold start - and the
-    // stub keys peer completion by `ip|folder`, so a specific key shadows the
-    // wildcard. Setting '*' to 100 left both holders' own entries reading
-    // "completion=0 remoteState=unknown", the fleet went on believing no peer
-    // held the data, and the safety gate refused every trim with NO_SYNCED_PEER.
-    // The rule under test had already decided correctly by then; the fixture had
-    // simply never given it a peer to point at.
-    await setSynced({ folder });
-    await Promise.all(HOLDERS.map((index) => setPeerHasData({ ip: ipOfIndex(index), folder })));
+    // PER HOLDER ON BOTH KEYS, never the '*' wildcard. placeGAppInOrder's cold
+    // start writes a per-IP zero for each holder on BOTH the folder's own sync
+    // state and its peer completion - that is HOW it forces a cold start - and
+    // the stub reads `${ip}|${folder}` and only falls back to `*|${folder}`, so
+    // a specific key shadows the wildcard on either one.
+    //
+    // This suite has now paid for that twice, one key each time. Setting only
+    // '*' completion to 100 left every holder's own entry reading "completion=0
+    // remoteState=unknown", so the safety gate refused every trim with
+    // NO_SYNCED_PEER. Fixing that alone left every holder's own SYNC STATE at
+    // 0/0, so masterSlaveApps would not start the writer at all - "registered as
+    // primary on FDM but not ready yet (syncthing not synced)", every cycle -
+    // and the positive control timed out against a node behaving correctly.
+    // Both keys are written together here so neither can be fixed alone again.
+    await Promise.all(HOLDERS.map((index) => Promise.all([
+      setSynced({ ip: ipOfIndex(index), folder }),
+      setPeerHasData({ ip: ipOfIndex(index), folder }),
+    ])));
 
     await waitFor(async () => (await env.clients[0].getAppLocations(appName)).data?.length >= 3,
       { timeout: 300000, interval: 2000, label: 'three holders announce the app' });

--- a/test-infra/runner/tests/96-surplus-trim-and-the-writer.js
+++ b/test-infra/runner/tests/96-surplus-trim-and-the-writer.js
@@ -10,7 +10,7 @@ import {
 import { syncthingSeedIndex, placementOrderWithSeedAt } from '../framework/g-app-placement.js';
 import { setSynced, setPeerHasData, resetSyncState } from '../framework/syncthing-control.js';
 import { electMaster, resetFdm } from '../framework/fdm-control.js';
-import { advanceBlock, startTicker, stopTicker } from '../framework/daemon-control.js';
+import { driveUntil, startTicker, stopTicker } from '../framework/daemon-control.js';
 import { waitFor, waitForGiveUpConsidered } from '../framework/wait.js';
 import { dumpLogsOnFailure } from '../framework/log-on-failure.js';
 
@@ -53,35 +53,6 @@ async function runningComponents(env, nodeIndex) {
   const list = res?.status === 'success' ? res.data : null;
   if (!Array.isArray(list)) throw new Error(`listrunningapps unreadable: ${JSON.stringify(res)?.slice(0, 200)}`);
   return list.flatMap((a) => a.Names || []).map((n) => n.replace(/^\//, ''));
-}
-
-// Drive the chain until a condition holds, ONE BLOCK AT A TIME, waiting for the
-// node to process each before sending the next.
-//
-// A height only counts when it lands as the TIP, and tips arrive one per
-// explorer poll - so pushing a burst leaves most of it stale on arrival and the
-// give-up pass runs once, or not at all. This test used to advance 24 blocks in
-// a single call and then assert that nothing had happened; on the fleet that
-// produced exactly one give-up pass across five nodes, and the assertion held
-// because nothing had been asked, not because anything had declined.
-//
-// Suite 55 carries the same shape and the full reasoning for it, including the
-// gate it cost. Worth folding into the framework when a third suite wants it.
-async function driveUntil(node, condition, { timeoutMs, label }) {
-  const deadline = Date.now() + timeoutMs;
-  let blocks = 0;
-  while (Date.now() < deadline) {
-    // eslint-disable-next-line no-await-in-loop
-    if (await condition()) return blocks;
-    const afterId = node.getLastEventId();
-    // eslint-disable-next-line no-await-in-loop
-    await advanceBlock();
-    // eslint-disable-next-line no-await-in-loop
-    await node.waitForEvent('block:processed', () => true, 60000, { afterId });
-    blocks += 1;
-  }
-  if (await condition()) return blocks;
-  throw new Error(`${label}: not reached in ${timeoutMs}ms (${blocks} blocks driven)`);
 }
 
 const subnet = getSubnetConfig();

--- a/tests/unit/advancedWorkflows.test.js
+++ b/tests/unit/advancedWorkflows.test.js
@@ -4246,6 +4246,31 @@ describe('giving up an app: one pass, two reasons, one safety gate', () => {
       );
 
       expect(decision.giveUp).to.equal(false);
+      // AND IT SAYS SO. Declining is a decision, and it used to be reported as
+      // NONE - the same thing the pass reports for an app with no surplus at
+      // all. The one observation that would catch this rule failing open then
+      // read identically to a quiet pass over a healthy app.
+      expect(decision.reason).to.equal('SURPLUS');
+      expect(decision.code).to.equal('WRITER_UNCONFIRMED');
+    });
+
+    it('reports NONE rather than a declined surplus when there is no surplus', async () => {
+      // The contrast that gives the assertion above its meaning. Same node, same
+      // app, one fewer holder: there is nothing to trim, so there is nothing
+      // declined either, and no peer is asked.
+      const probe = sinon.stub(axios, 'get').rejects(new Error('no peer should be probed'));
+
+      const decision = await advancedWorkflows.reasonToGiveUpApp(
+        withWriter,
+        locations('5.6.7.8:16127', LOCAL),
+        LOCAL,
+        { isComponentRunningLocally: sinon.stub().resolves(false), liveness: {} },
+      );
+
+      expect(decision.giveUp).to.equal(false);
+      expect(decision.reason).to.equal('NONE');
+      expect(decision.code).to.equal(undefined);
+      sinon.assert.notCalled(probe);
     });
 
     it('does not trim the second-newest when the newest says it is not writing', async () => {

--- a/tests/unit/advancedWorkflows.test.js
+++ b/tests/unit/advancedWorkflows.test.js
@@ -975,7 +975,7 @@ describe('advancedWorkflows tests', () => {
       };
       const namesThisNode = { data: { status: 'success', data: { ips: ['192.168.1.5'] } } };
       const namesAnotherNode = { data: { status: 'success', data: { ips: ['192.168.1.90'] } } };
-      const namesNobody = { data: [] };
+      const namesNobody = { data: { status: 'success', data: { ips: [] } } };
 
       it('is true when the election named this node', async () => {
         await runElection('electedhereapp', namesThisNode);

--- a/tests/unit/advancedWorkflows.test.js
+++ b/tests/unit/advancedWorkflows.test.js
@@ -4197,6 +4197,98 @@ describe('giving up an app: one pass, two reasons, one safety gate', () => {
       expect(await isComponentRunningLocally('anything_atall')).to.equal(true);
     });
 
+    describe('a refusal that will not stop is a stuck node, and says so', () => {
+      // fluxEventBus is disabled on a real node (config.testEventStream is
+      // false), so the giveUp:safety event is a harness signal and nothing
+      // reads it in production. The log is the whole of what an operator sees,
+      // and a first refusal and a hundredth read identically at info.
+      // The refusal counter is module state keyed by app name, so each of these
+      // holds its own app: sharing one would make them depend on running order.
+      it('logs the first refusals at info, and escalates once they persist', async () => {
+        dbHelper.findInDatabase.resolves(installed('escalateapp'));
+        const logInfo = sinon.stub(log, 'info');
+        const logWarn = sinon.stub(log, 'warn');
+        registryManager.appLocation.resolves(locations('5.6.7.8:16127', '9.9.9.9:16127', '8.8.8.8:16127', LOCAL));
+        evacuationSafety.canSafelyRemoveApp.resolves({
+          safe: false, code: 'NO_SYNCED_PEER', reason: 'no connected peer holds fluxappone in full',
+        });
+
+        for (let pass = 0; pass < 12; pass += 1) {
+          // eslint-disable-next-line no-await-in-loop
+          await advancedWorkflows.checkAndRemoveApplicationInstance();
+        }
+
+        const escalations = logWarn.getCalls()
+          .map((c) => String(c.args[0]))
+          .filter((m) => m.includes('passes running'));
+        expect(escalations).to.have.lengthOf(1);
+        expect(escalations[0]).to.contain('12 passes running');
+        expect(escalations[0]).to.contain('NO_SYNCED_PEER');
+        // and the quiet ones stayed quiet
+        expect(logInfo.getCalls().filter((c) => String(c.args[0]).includes('not safe'))).to.have.lengthOf(11);
+      });
+
+      it('never removes the app, however long it has been refused', async () => {
+        dbHelper.findInDatabase.resolves(installed('neverremoveapp'));
+        // Every reason the gate refuses is a reason removing would be wrong:
+        // the peers really are incomplete, so this copy is one of the few that
+        // is not, or this node cannot see them, which is not evidence about
+        // them. A surplus app is over-served, not down - nothing about it is
+        // urgent enough to delete on evidence we have just said we lack.
+        registryManager.appLocation.resolves(locations('5.6.7.8:16127', '9.9.9.9:16127', '8.8.8.8:16127', LOCAL));
+        evacuationSafety.canSafelyRemoveApp.resolves({
+          safe: false, code: 'NO_SYNCED_PEER', reason: 'no connected peer holds it',
+        });
+
+        for (let pass = 0; pass < 40; pass += 1) {
+          // eslint-disable-next-line no-await-in-loop
+          await advancedWorkflows.checkAndRemoveApplicationInstance();
+        }
+
+        sinon.assert.notCalled(appUninstaller.removeAppLocally);
+      });
+
+      it('starts counting again once the app can be given up', async () => {
+        dbHelper.findInDatabase.resolves(installed('resetapp'));
+        const logWarn = sinon.stub(log, 'warn');
+        registryManager.appLocation.resolves(locations('5.6.7.8:16127', '9.9.9.9:16127', '8.8.8.8:16127', LOCAL));
+        evacuationSafety.canSafelyRemoveApp.resolves({
+          safe: false, code: 'NO_SYNCED_PEER', reason: 'no connected peer holds it',
+        });
+        for (let pass = 0; pass < 11; pass += 1) {
+          // eslint-disable-next-line no-await-in-loop
+          await advancedWorkflows.checkAndRemoveApplicationInstance();
+        }
+
+        // One clean pass, then refusals resume: the run is broken, so the next
+        // escalation is a fresh twelve rather than the very next pass.
+        evacuationSafety.canSafelyRemoveApp.resolves({ safe: true, code: 'STATELESS', reason: 'peer holds it' });
+        await advancedWorkflows.checkAndRemoveApplicationInstance();
+        evacuationSafety.canSafelyRemoveApp.resolves({
+          safe: false, code: 'NO_SYNCED_PEER', reason: 'no connected peer holds it',
+        });
+        await advancedWorkflows.checkAndRemoveApplicationInstance();
+
+        expect(logWarn.getCalls().map((c) => String(c.args[0])).filter((m) => m.includes('passes running')))
+          .to.have.lengthOf(0);
+      });
+
+      it('does not restart the evacuation window on a surplus refusal', async () => {
+        dbHelper.findInDatabase.resolves(installed('surplusonlyapp'));
+        // forgetAppObservation clears the mark mayEvacuateApp paces on, and
+        // only the evacuation path sets one. Calling it here cleared something
+        // nothing had written.
+        registryManager.appLocation.resolves(locations('5.6.7.8:16127', '9.9.9.9:16127', '8.8.8.8:16127', LOCAL));
+        evacuationSafety.canSafelyRemoveApp.resolves({
+          safe: false, code: 'NO_SYNCED_PEER', reason: 'no connected peer holds it',
+        });
+
+        await advancedWorkflows.checkAndRemoveApplicationInstance();
+
+        sinon.assert.notCalled(residentialNodeDosService.forgetAppObservation);
+      });
+    });
+
     it('refuses an evacuation removal that is not safe, and restarts its observation', async () => {
       residentialNodeDosService.isEvacuating.returns(true);
       registryManager.appLocation.resolves(locations(LOCAL, '5.6.7.8:16127', '9.9.9.9:16127'));

--- a/tests/unit/advancedWorkflows.test.js
+++ b/tests/unit/advancedWorkflows.test.js
@@ -692,15 +692,22 @@ describe('advancedWorkflows tests', () => {
       const {
         selfRunningSince = '2026-01-01T00:00:00.000Z',
         receiveOnlyCache = new Map(),
+        // A v4+ spec elects on `<component>_<app>`, a v3 one on the bare app
+        // name. Both forms have to be reachable here: the election writes one
+        // and isElectedPrimaryHere matches the other back.
+        componentName = null,
       } = options;
+      const identifier = componentName ? `${componentName}_${appName}` : appName;
       // Mirror getAppIdentifier: a name that is neither zel- nor flux-prefixed gets
       // `flux`. The container names peers report are this exact string, and the
       // election compares whole names, so a stand-in value would not match.
-      const appId = `flux${appName}`;
+      const appId = `flux${identifier}`;
       dockerServiceStub.returns(appId);
       const installedApps = sinon.stub().resolves({
         status: 'success',
-        data: [{ name: appName, version: 3, containerData: 'g:/syncdata' }],
+        data: [componentName
+          ? { name: appName, version: 8, compose: [{ name: componentName, containerData: 'g:/syncdata' }] }
+          : { name: appName, version: 3, containerData: 'g:/syncdata' }],
       });
       const listRunningApps = sinon.stub().resolves({ status: 'success', data: [] });
       // Entries land in the real globalState cache - the election reads it off
@@ -950,6 +957,96 @@ describe('advancedWorkflows tests', () => {
       expect(linesMatching(logInfo, 'cleared this node\'s own stale primary record')).to.have.lengthOf(1);
       expect(linesMatching(logInfo, 'starting docker component')).to.have.lengthOf(1);
       expect(linesMatching(logInfo, 'conditions not met')).to.have.lengthOf(0);
+    });
+
+    describe('isElectedPrimaryHere answers in three states', () => {
+      // Finding 25 of the review: the true path had no coverage at all, and the
+      // false path could not be told apart from "the election never ran". Each
+      // test uses its own app name because the election tables are module state
+      // that outlives a sinon restore.
+      const runElection = async (appName, fdmResponse) => {
+        sinon.stub(appsRuntimeState, 'isOperatorStopped').resolves(false);
+        const runPass = electionFixture(appName, ['192.168.1.90:16127']);
+        axiosGetStub.resetBehavior();
+        axiosGetStub.callsFake(peerAnswers({ held: [] }));
+        serviceHelperStub.resetBehavior();
+        serviceHelperStub.resolves(fdmResponse);
+        await runPass();
+      };
+      const namesThisNode = { data: { status: 'success', data: { ips: ['192.168.1.5'] } } };
+      const namesAnotherNode = { data: { status: 'success', data: { ips: ['192.168.1.90'] } } };
+      const namesNobody = { data: [] };
+
+      it('is true when the election named this node', async () => {
+        await runElection('electedhereapp', namesThisNode);
+
+        expect(advancedWorkflows.isElectedPrimaryHere('electedhereapp', '192.168.1.5:16127')).to.equal(true);
+      });
+
+      it('matches the <component>_<app> identifier that v4+ specs elect on', async () => {
+        // The election keys a composed app on `<component>_<app>`, and the
+        // lookup is asked for the bare app name. Nothing exercised the
+        // endsWith half of that match before.
+        sinon.stub(appsRuntimeState, 'isOperatorStopped').resolves(false);
+        const runPass = electionFixture('composedapp', ['192.168.1.90:16127'], { componentName: 'server' });
+        axiosGetStub.resetBehavior();
+        axiosGetStub.callsFake(peerAnswers({ held: [] }));
+        serviceHelperStub.resetBehavior();
+        serviceHelperStub.resolves(namesThisNode);
+
+        await runPass();
+
+        expect(advancedWorkflows.isElectedPrimaryHere('composedapp', '192.168.1.5:16127')).to.equal(true);
+      });
+
+      it('is false when the election named a different node', async () => {
+        await runElection('electedelsewhereapp', namesAnotherNode);
+
+        expect(advancedWorkflows.isElectedPrimaryHere('electedelsewhereapp', '192.168.1.5:16127')).to.equal(false);
+      });
+
+      it('is null for an app the election has never reached', async () => {
+        expect(advancedWorkflows.isElectedPrimaryHere('neverelectedapp', '192.168.1.5:16127')).to.equal(null);
+      });
+
+      it('is null when FDM answered but named nobody', async () => {
+        // The ~110s registration lag: FDM reports no primary while an instance
+        // is live, so on a node running the component this is "cannot say",
+        // not "you are not it".
+        await runElection('noprimaryyetapp', namesNobody);
+
+        expect(advancedWorkflows.isElectedPrimaryHere('noprimaryyetapp', '192.168.1.5:16127')).to.equal(null);
+      });
+
+      it('goes null once the verdict is older than the election that refreshes it', async () => {
+        // The election re-runs every masterSlaveIntervalMs. A verdict older
+        // than a run of those cycles means it has stopped - which is what
+        // happens while syncthing is unhealthy - and a stopped election must
+        // not keep answering from its last known state.
+        await runElection('staleverdictapp', namesThisNode);
+        const aDayLater = Date.now() + (24 * 60 * 60 * 1000);
+
+        expect(advancedWorkflows.isElectedPrimaryHere('staleverdictapp', '192.168.1.5:16127')).to.equal(true);
+        expect(advancedWorkflows.isElectedPrimaryHere('staleverdictapp', '192.168.1.5:16127', aDayLater)).to.equal(null);
+      });
+
+      it('says so when no FDM region answered, instead of reading it as "no primary"', async () => {
+        // The `if (!fdmOk)` guard was unreachable: getMasterIpFromFdm returned
+        // fdmOk true on every path, so a total outage and an app with no
+        // primary produced the same verdict and this warning never appeared.
+        const logWarn = sinon.stub(log, 'warn');
+        sinon.stub(appsRuntimeState, 'isOperatorStopped').resolves(false);
+        const runPass = electionFixture('fdmdownapp', ['192.168.1.90:16127']);
+        axiosGetStub.resetBehavior();
+        axiosGetStub.callsFake(peerAnswers({ held: [] }));
+        serviceHelperStub.resetBehavior();
+        serviceHelperStub.rejects(new Error('getaddrinfo ENOTFOUND'));
+
+        await runPass();
+
+        expect(linesMatching(logWarn, 'All FDM services failed')).to.have.lengthOf(1);
+        expect(advancedWorkflows.isElectedPrimaryHere('fdmdownapp', '192.168.1.5:16127')).to.equal(null);
+      });
     });
 
     it('does not start at index 0 while a peer is already running the component', async () => {
@@ -4026,11 +4123,17 @@ describe('giving up an app: one pass, two reasons, one safety gate', () => {
     it('refuses a surplus removal that is not safe', async () => {
       // Before this, surplus removal deleted on an instance count alone - one of
       // the paths that has already destroyed customer volumes.
-      registryManager.appLocation.resolves(locations('5.6.7.8:16127', '9.9.9.9:16127', LOCAL, '8.8.8.8:16127'));
+      //
+      // LOCAL is LAST, so it is the junior instance and SURPLUS actually fires.
+      // Third of four made this node the second-newest, reasonToGiveUpApp
+      // returned giveUp: false, and the pass never reached the safety gate at
+      // all - the test went green with the whole gate deleted.
+      registryManager.appLocation.resolves(locations('5.6.7.8:16127', '9.9.9.9:16127', '8.8.8.8:16127', LOCAL));
       evacuationSafety.canSafelyRemoveApp.resolves({ safe: false, reason: 'no connected peer holds it' });
 
       await advancedWorkflows.checkAndRemoveApplicationInstance();
 
+      sinon.assert.calledWith(evacuationSafety.canSafelyRemoveApp, 'appone');
       sinon.assert.notCalled(appUninstaller.removeAppLocally);
     });
 
@@ -4053,7 +4156,45 @@ describe('giving up an app: one pass, two reasons, one safety gate', () => {
 
       const { isElectedPrimary } = evacuationSafety.canSafelyRemoveApp.firstCall.args[1];
       expect(isElectedPrimary).to.be.a('function');
-      expect(isElectedPrimary('appone')).to.equal(false);
+      // No election has run in this pass, so the honest answer is "cannot say".
+      // It must not be false: an election that has never run and an election
+      // that has named another node are the difference between keeping a
+      // volume and deleting it out from under its writer.
+      expect(isElectedPrimary('appone')).to.equal(null);
+    });
+
+    it('tells the safety gate which components are running on this node', async () => {
+      // The local half of the primary question. A node not running the g:
+      // component cannot be the one writing, and that needs no FDM - which is
+      // what stops a load-balancer outage stalling the trim fleet-wide.
+      const appQueryService = require('../../ZelBack/src/services/appQuery/appQueryService');
+      sinon.stub(appQueryService, 'listRunningApps').resolves({
+        status: 'success',
+        data: [{ Names: ['/fluxserver_appone'] }, { Names: ['/zelolderapp'] }],
+      });
+      registryManager.appLocation.resolves(locations('5.6.7.8:16127', '9.9.9.9:16127', '8.8.8.8:16127', LOCAL));
+
+      await advancedWorkflows.checkAndRemoveApplicationInstance();
+
+      const { isComponentRunningLocally } = evacuationSafety.canSafelyRemoveApp.firstCall.args[1];
+      expect(await isComponentRunningLocally('server_appone')).to.equal(true);
+      // The pre-rename prefix is four characters, not five.
+      expect(await isComponentRunningLocally('olderapp')).to.equal(true);
+      expect(await isComponentRunningLocally('server_someotherapp')).to.equal(false);
+    });
+
+    it('treats an unreadable container list as "running here" rather than "not running"', async () => {
+      // Answering "not running" on a list this node could not read would route
+      // every app straight past the primary check - the exact shape of the
+      // defect being closed.
+      const appQueryService = require('../../ZelBack/src/services/appQuery/appQueryService');
+      sinon.stub(appQueryService, 'listRunningApps').resolves({ status: 'error', data: 'docker down' });
+      registryManager.appLocation.resolves(locations('5.6.7.8:16127', '9.9.9.9:16127', '8.8.8.8:16127', LOCAL));
+
+      await advancedWorkflows.checkAndRemoveApplicationInstance();
+
+      const { isComponentRunningLocally } = evacuationSafety.canSafelyRemoveApp.firstCall.args[1];
+      expect(await isComponentRunningLocally('anything_atall')).to.equal(true);
     });
 
     it('refuses an evacuation removal that is not safe, and restarts its observation', async () => {

--- a/tests/unit/advancedWorkflows.test.js
+++ b/tests/unit/advancedWorkflows.test.js
@@ -4289,6 +4289,44 @@ describe('giving up an app: one pass, two reasons, one safety gate', () => {
       });
     });
 
+    it('does not start a pass that removeAppLocally would refuse', async () => {
+      // removeAppLocally refuses when another removal holds the lock, and it
+      // refuses by RETURNING - no throw, no status. So the pass logged "locally
+      // removed", called noteEvacuated, burned the whole departure interval and
+      // discarded the queue wait, for a removal that never happened. They do
+      // collide: explorerService invokes this pass without awaiting it, and two
+      // blocks later awaits expireGlobalApplications, which holds the lock
+      // through a real uninstall.
+      const globalState = require('../../ZelBack/src/services/utils/globalState');
+      const previous = globalState.removalInProgress;
+      globalState.removalInProgress = true;
+      registryManager.appLocation.resolves(locations('5.6.7.8:16127', '9.9.9.9:16127', '8.8.8.8:16127', LOCAL));
+
+      try {
+        await advancedWorkflows.checkAndRemoveApplicationInstance();
+      } finally {
+        globalState.removalInProgress = previous;
+      }
+
+      sinon.assert.notCalled(evacuationSafety.canSafelyRemoveApp);
+      sinon.assert.notCalled(appUninstaller.removeAppLocally);
+    });
+
+    it('does not start a pass while an installation holds the lock', async () => {
+      const globalState = require('../../ZelBack/src/services/utils/globalState');
+      const previous = globalState.installationInProgress;
+      globalState.installationInProgress = true;
+      registryManager.appLocation.resolves(locations('5.6.7.8:16127', '9.9.9.9:16127', '8.8.8.8:16127', LOCAL));
+
+      try {
+        await advancedWorkflows.checkAndRemoveApplicationInstance();
+      } finally {
+        globalState.installationInProgress = previous;
+      }
+
+      sinon.assert.notCalled(appUninstaller.removeAppLocally);
+    });
+
     it('refuses an evacuation removal that is not safe, and restarts its observation', async () => {
       residentialNodeDosService.isEvacuating.returns(true);
       registryManager.appLocation.resolves(locations(LOCAL, '5.6.7.8:16127', '9.9.9.9:16127'));

--- a/tests/unit/advancedWorkflows.test.js
+++ b/tests/unit/advancedWorkflows.test.js
@@ -3919,3 +3919,203 @@ describe('advancedWorkflows tests', () => {
   // integration testing is recommended for comprehensive coverage of the
   // master-slave coordination logic.
 });
+
+describe('giving up an app: one pass, two reasons, one safety gate', () => {
+  const generalService = require('../../ZelBack/src/services/generalService');
+  const fluxNetworkHelper = require('../../ZelBack/src/services/fluxNetworkHelper');
+  const registryManager = require('../../ZelBack/src/services/appDatabase/registryManager');
+  const appUninstaller = require('../../ZelBack/src/services/appLifecycle/appUninstaller');
+  const evacuationSafety = require('../../ZelBack/src/services/appLifecycle/appEvacuationSafety');
+  const residentialNodeDosService = require('../../ZelBack/src/services/residentialNodeDosService');
+
+  const LOCAL = '1.2.3.4:16127';
+
+  function locations(...ips) {
+    return ips.map((ip, index) => ({ ip, runningSince: new Date(1700000000000 + index) }));
+  }
+
+  function installed(...names) {
+    return names.map((name) => ({ name, instances: 3 }));
+  }
+
+  beforeEach(() => {
+    sinon.stub(generalService, 'checkSynced').resolves(true);
+    sinon.stub(fluxNetworkHelper, 'getLocalSocketAddress').resolves(LOCAL);
+    sinon.stub(appUninstaller, 'removeAppLocally').resolves();
+    sinon.stub(registryManager, 'appLocation');
+    sinon.stub(registryManager, 'getApplicationGlobalSpecifications').resolves({ name: 'a', version: 8 });
+    sinon.stub(evacuationSafety, 'canSafelyRemoveApp').resolves({ safe: true, reason: 'peer holds it' });
+    sinon.stub(residentialNodeDosService, 'isEvacuating').returns(false);
+    sinon.stub(residentialNodeDosService, 'mayEvacuateApp').returns({ ok: true, reason: 'ready' });
+    sinon.stub(residentialNodeDosService, 'noteEvacuated');
+    sinon.stub(residentialNodeDosService, 'forgetAppObservation');
+
+    const db = { db: () => ({}) };
+    sinon.stub(dbHelper, 'databaseConnection').returns(db);
+    sinon.stub(dbHelper, 'findInDatabase').resolves(installed('appone'));
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('reasonToGiveUpApp', () => {
+    it('names SURPLUS when this node holds the junior of too many instances', () => {
+      // Three running against an instance count of two, and this node started
+      // last, so it is the one that stands aside.
+      const decision = advancedWorkflows.reasonToGiveUpApp(
+        { name: 'a', instances: 2 },
+        locations('5.6.7.8:16127', '9.9.9.9:16127', LOCAL),
+        LOCAL,
+      );
+
+      expect(decision.giveUp).to.equal(true);
+      expect(decision.reason).to.equal('SURPLUS');
+    });
+
+    it('does not name SURPLUS when this node holds a senior instance', () => {
+      const decision = advancedWorkflows.reasonToGiveUpApp(
+        { name: 'a', instances: 2 },
+        locations(LOCAL, '5.6.7.8:16127', '9.9.9.9:16127'),
+        LOCAL,
+      );
+
+      expect(decision.giveUp).to.equal(false);
+    });
+
+    it('names nothing when the app is at its instance count and the node is not evacuating', () => {
+      const decision = advancedWorkflows.reasonToGiveUpApp(
+        { name: 'a', instances: 2 },
+        locations(LOCAL, '5.6.7.8:16127'),
+        LOCAL,
+      );
+
+      expect(decision.giveUp).to.equal(false);
+      expect(decision.reason).to.equal('NONE');
+    });
+
+    it('names EVACUATION when the node is evacuating and this app\'s turn has come', () => {
+      residentialNodeDosService.isEvacuating.returns(true);
+
+      const decision = advancedWorkflows.reasonToGiveUpApp(
+        { name: 'a', instances: 2 },
+        locations(LOCAL, '5.6.7.8:16127'),
+        LOCAL,
+      );
+
+      expect(decision.giveUp).to.equal(true);
+      expect(decision.reason).to.equal('EVACUATION');
+    });
+
+    it('defers to the pacing when the app\'s turn has not come', () => {
+      residentialNodeDosService.isEvacuating.returns(true);
+      residentialNodeDosService.mayEvacuateApp.returns({ ok: false, reason: 'its turn is in 20m' });
+
+      const decision = advancedWorkflows.reasonToGiveUpApp(
+        { name: 'a', instances: 2 },
+        locations(LOCAL, '5.6.7.8:16127'),
+        LOCAL,
+      );
+
+      expect(decision.giveUp).to.equal(false);
+      expect(decision.detail).to.contain('20m');
+    });
+  });
+
+  describe('the safety gate applies to BOTH reasons', () => {
+    it('refuses a surplus removal that is not safe', async () => {
+      // Before this, surplus removal deleted on an instance count alone - one of
+      // the paths that has already destroyed customer volumes.
+      registryManager.appLocation.resolves(locations('5.6.7.8:16127', '9.9.9.9:16127', LOCAL, '8.8.8.8:16127'));
+      evacuationSafety.canSafelyRemoveApp.resolves({ safe: false, reason: 'no connected peer holds it' });
+
+      await advancedWorkflows.checkAndRemoveApplicationInstance();
+
+      sinon.assert.notCalled(appUninstaller.removeAppLocally);
+    });
+
+    it('performs a surplus removal that is safe', async () => {
+      registryManager.appLocation.resolves(locations('5.6.7.8:16127', '9.9.9.9:16127', '8.8.8.8:16127', LOCAL));
+
+      await advancedWorkflows.checkAndRemoveApplicationInstance();
+
+      sinon.assert.calledWith(appUninstaller.removeAppLocally, 'appone');
+    });
+
+    it('asks the safety gate whether this node is the elected primary', async () => {
+      // The gate refuses to hand back a `g:` app from under its primary - the
+      // node writing to the volume - but it can only do that if the pass gives
+      // it a way to ask. Without this the check defaults off and the primary
+      // leaves mid-write.
+      registryManager.appLocation.resolves(locations('5.6.7.8:16127', '9.9.9.9:16127', '8.8.8.8:16127', LOCAL));
+
+      await advancedWorkflows.checkAndRemoveApplicationInstance();
+
+      const { isElectedPrimary } = evacuationSafety.canSafelyRemoveApp.firstCall.args[1];
+      expect(isElectedPrimary).to.be.a('function');
+      expect(isElectedPrimary('appone')).to.equal(false);
+    });
+
+    it('refuses an evacuation removal that is not safe, and restarts its observation', async () => {
+      residentialNodeDosService.isEvacuating.returns(true);
+      registryManager.appLocation.resolves(locations(LOCAL, '5.6.7.8:16127', '9.9.9.9:16127'));
+      evacuationSafety.canSafelyRemoveApp.resolves({ safe: false, reason: 'no connected peer holds it' });
+
+      await advancedWorkflows.checkAndRemoveApplicationInstance();
+
+      sinon.assert.notCalled(appUninstaller.removeAppLocally);
+      sinon.assert.calledWith(residentialNodeDosService.forgetAppObservation, 'appone');
+    });
+
+    it('performs an evacuation removal that is safe and records it', async () => {
+      residentialNodeDosService.isEvacuating.returns(true);
+      registryManager.appLocation.resolves(locations(LOCAL, '5.6.7.8:16127', '9.9.9.9:16127'));
+
+      await advancedWorkflows.checkAndRemoveApplicationInstance();
+
+      sinon.assert.calledWith(appUninstaller.removeAppLocally, 'appone');
+      sinon.assert.calledWith(residentialNodeDosService.noteEvacuated, 'appone');
+    });
+
+    it('does not record an evacuation when the removal was a surplus', async () => {
+      registryManager.appLocation.resolves(locations('5.6.7.8:16127', '9.9.9.9:16127', '8.8.8.8:16127', LOCAL));
+
+      await advancedWorkflows.checkAndRemoveApplicationInstance();
+
+      sinon.assert.notCalled(residentialNodeDosService.noteEvacuated);
+    });
+  });
+
+  describe('pacing', () => {
+    it('gives up at most one app per pass', async () => {
+      // Two removals in one pass would take two instances off the network before
+      // the spawner has replaced either.
+      dbHelper.findInDatabase.resolves(installed('appone', 'apptwo', 'appthree'));
+      residentialNodeDosService.isEvacuating.returns(true);
+      registryManager.appLocation.resolves(locations(LOCAL, '5.6.7.8:16127', '9.9.9.9:16127'));
+
+      await advancedWorkflows.checkAndRemoveApplicationInstance();
+
+      sinon.assert.calledOnce(appUninstaller.removeAppLocally);
+    });
+
+    it('does nothing at all when the node does not know its own address', async () => {
+      fluxNetworkHelper.getLocalSocketAddress.resolves(null);
+      residentialNodeDosService.isEvacuating.returns(true);
+      registryManager.appLocation.resolves(locations(LOCAL, '5.6.7.8:16127', '9.9.9.9:16127'));
+
+      await advancedWorkflows.checkAndRemoveApplicationInstance();
+
+      sinon.assert.notCalled(appUninstaller.removeAppLocally);
+    });
+
+    it('does nothing while the daemon is not synced', async () => {
+      generalService.checkSynced.resolves(false);
+      residentialNodeDosService.isEvacuating.returns(true);
+
+      await advancedWorkflows.checkAndRemoveApplicationInstance();
+
+      sinon.assert.notCalled(appUninstaller.removeAppLocally);
+    });
+  });
+});

--- a/tests/unit/advancedWorkflows.test.js
+++ b/tests/unit/advancedWorkflows.test.js
@@ -4436,6 +4436,23 @@ describe('giving up an app: one pass, two reasons, one safety gate', () => {
       sinon.assert.notCalled(appUninstaller.removeAppLocally);
     });
 
+    it('tells the controller the component should be stopped, not just docker', async () => {
+      // Found on a live fleet, not here. appReconciler takes a g: component's
+      // desired state from controllerDesired; stopping the container while that
+      // still reads 'running' means the reconciler starts it again on its next
+      // sweep. The stand-down then reports success, the component keeps running,
+      // and every later pass refuses with ELECTION_UNKNOWN because this node has
+      // excluded itself from the election that would refresh the verdict.
+      const appReconciler = require('../../ZelBack/src/services/appMonitoring/appReconciler');
+      const desiredStub = sinon.stub(appReconciler, 'setControllerDesired');
+
+      await advancedWorkflows.checkAndRemoveApplicationInstance();
+
+      sinon.assert.calledWith(desiredStub, 'server_appone', 'stopped');
+      // Before the container stop, so no sweep can land in between and undo it.
+      sinon.assert.callOrder(desiredStub, stopStub);
+    });
+
     it('does not count as a departure, so the pacing interval is not spent', async () => {
       // noteEvacuated starts the 6h gap before the next app may go. Spending it
       // on a pass that removed nothing would leave the node stood down and then

--- a/tests/unit/advancedWorkflows.test.js
+++ b/tests/unit/advancedWorkflows.test.js
@@ -4296,6 +4296,54 @@ describe('giving up an app: one pass, two reasons, one safety gate', () => {
     });
   });
 
+  describe('a node held below the instance count stays visible', () => {
+    it('escalates a shortness refusal the way a safety refusal is escalated', async () => {
+      // The strength test moved INTO the queue ticket, so a short app is now
+      // refused before the pass ever consults the safety gate - and the gate is
+      // where this used to be counted and escalated. Without carrying that over,
+      // a node stuck on an app the fleet can never bring back to strength says
+      // nothing louder than an info line, forever.
+      const logWarn = sinon.stub(log, 'warn');
+      residentialNodeDosService.isEvacuating.returns(true);
+      residentialNodeDosService.mayEvacuateApp.returns({
+        ok: false, code: 'BELOW_INSTANCE_COUNT', reason: 'app is below its instance count (2/3); its turn starts again',
+      });
+      registryManager.appLocation.resolves(locations('5.6.7.8:16127', LOCAL));
+
+      for (let pass = 0; pass < 12; pass += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await advancedWorkflows.checkAndRemoveApplicationInstance();
+      }
+
+      const escalations = logWarn.getCalls()
+        .map((call) => String(call.args[0]))
+        .filter((line) => /refused 12 passes running .*BELOW_INSTANCE_COUNT/.test(line));
+      expect(escalations, 'twelve passes short and nothing was escalated').to.have.lengthOf(1);
+      sinon.assert.notCalled(appUninstaller.removeAppLocally);
+    });
+
+    it('does not escalate a node that is merely waiting its turn', async () => {
+      // Waiting is this working. Counting it would escalate every evacuating
+      // node on its twelfth pass and teach everyone to ignore the warning.
+      const logWarn = sinon.stub(log, 'warn');
+      residentialNodeDosService.isEvacuating.returns(true);
+      residentialNodeDosService.mayEvacuateApp.returns({
+        ok: false, code: 'AWAITING_TURN', reason: 'its turn is in 20m',
+      });
+      registryManager.appLocation.resolves(locations('5.6.7.8:16127', LOCAL));
+
+      for (let pass = 0; pass < 12; pass += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await advancedWorkflows.checkAndRemoveApplicationInstance();
+      }
+
+      const escalations = logWarn.getCalls()
+        .map((call) => String(call.args[0]))
+        .filter((line) => /refused \d+ passes running/.test(line));
+      expect(escalations, 'waiting a turn is not a fault and must not escalate').to.be.empty;
+    });
+  });
+
   describe('the safety gate applies to BOTH reasons', () => {
     it('refuses a surplus removal that is not safe', async () => {
       // Before this, surplus removal deleted on an instance count alone - one of

--- a/tests/unit/advancedWorkflows.test.js
+++ b/tests/unit/advancedWorkflows.test.js
@@ -4203,6 +4203,27 @@ describe('giving up an app: one pass, two reasons, one safety gate', () => {
       expect(decision.detail).to.contain('w_a');
     });
 
+    it('reaches the evacuation gate when the newest copy holding the writer is draining', async () => {
+      // The surplus answer here is "stay", and returning it ends the pass - so
+      // an evacuating node never got asked whether it should hand the app back.
+      // It is the same asymmetry the second-newest branch below was fixed for:
+      // the surplus verdict is carried out to the gate, not returned past it.
+      // Left as a return, a draining node that happens to be the newest copy of
+      // an over-served app AND runs its writer stalls on that app indefinitely,
+      // when the gate would have stood it down and let it leave.
+      residentialNodeDosService.isEvacuating.returns(true);
+
+      const decision = await advancedWorkflows.reasonToGiveUpApp(
+        withWriter,
+        locations('5.6.7.8:16127', '9.9.9.9:16127', LOCAL),
+        LOCAL,
+        { isComponentRunningLocally: sinon.stub().resolves(true), liveness: {} },
+      );
+
+      expect(decision.reason).to.equal('EVACUATION');
+      expect(decision.giveUp).to.equal(true);
+    });
+
     it('still trims the newest copy when it is not the one writing', async () => {
       const decision = await advancedWorkflows.reasonToGiveUpApp(
         withWriter,

--- a/tests/unit/advancedWorkflows.test.js
+++ b/tests/unit/advancedWorkflows.test.js
@@ -4760,6 +4760,34 @@ describe('giving up an app: one pass, two reasons, one safety gate', () => {
 
       sinon.assert.calledTwice(stopStub);
     });
+
+    it('does not mark a component whose stop was refused rather than thrown', async () => {
+      // THE SHAPE A LIVE NODE SEES. appDockerStop REPORTS a refusal instead of
+      // throwing one - it catches internally and answers { stopped, running,
+      // unavailable, errors } - so the catch beside it fires only on an
+      // unexpected throw. The test above passes because dockerActual throws in
+      // this environment; on a node docker answers cleanly and simply says the
+      // container is still up, no throw happens, and the component was marked on
+      // the strength of the stop having been CALLED.
+      //
+      // Marking it there excludes this node from the election for a component it
+      // is still running - precisely the state the guard's own comment says it
+      // exists to avoid - for up to STAND_DOWN_PASSES_BEFORE_GIVING_UP passes.
+      const appReconciler = require('../../ZelBack/src/services/appMonitoring/appReconciler');
+      sinon.stub(appReconciler, 'dockerActual')
+        .resolves({ reachable: true, indeterminate: false, running: true });
+      const logWarn = sinon.stub(log, 'warn');
+
+      await advancedWorkflows.checkAndRemoveApplicationInstance();
+      await advancedWorkflows.checkAndRemoveApplicationInstance();
+
+      // Unmarked, so the next pass tries the stop again.
+      sinon.assert.calledTwice(stopStub);
+      const stoodDown = logWarn.getCalls()
+        .map((c) => String(c.args[0]))
+        .filter((line) => line.includes('standing down as'));
+      expect(stoodDown, 'reported a stand-down for a component still running').to.have.lengthOf(0);
+    });
   });
 
   describe('pacing', () => {

--- a/tests/unit/advancedWorkflows.test.js
+++ b/tests/unit/advancedWorkflows.test.js
@@ -1083,6 +1083,62 @@ describe('advancedWorkflows tests', () => {
       expect(linesMatching(logInfo, 'a peer is already running it')).to.have.lengthOf(0);
     });
 
+    it('does not re-elect a component this node stood down to hand its app back', async () => {
+      // THE MECHANISM. Without this exclusion the election undoes the stand-down
+      // within one cycle and every cycle after it: the component is not running
+      // here, this node's own stale primary record is cleared, no peer has taken
+      // it up yet, and the index-0 branch starts it straight back. The node then
+      // never leaves and the app is restarted every 30s forever.
+      //
+      // Stood down through the real give-up pass rather than by reaching into
+      // module state, so the two halves are proven to agree on the identifier.
+      const appName = 'standdownapp';
+      const componentName = 'server';
+      const identifier = `${componentName}_${appName}`;
+      sinon.stub(appsRuntimeState, 'isOperatorStopped').resolves(false);
+
+      const generalService = require('../../ZelBack/src/services/generalService');
+      const appUninstaller = require('../../ZelBack/src/services/appLifecycle/appUninstaller');
+      const evacuationSafety = require('../../ZelBack/src/services/appLifecycle/appEvacuationSafety');
+      const residentialNodeDosService = require('../../ZelBack/src/services/residentialNodeDosService');
+      const registryManager = require('../../ZelBack/src/services/appDatabase/registryManager');
+      const appQueryService = require('../../ZelBack/src/services/appQuery/appQueryService');
+      const dockerService = require('../../ZelBack/src/services/dockerService');
+
+      sinon.stub(generalService, 'checkSynced').resolves(true);
+      sinon.stub(appUninstaller, 'removeAppLocally').resolves();
+      sinon.stub(registryManager, 'getApplicationGlobalSpecifications').resolves({ name: appName, version: 8 });
+      sinon.stub(appQueryService, 'listRunningApps').resolves({ status: 'success', data: [{ Names: [`/flux${identifier}`] }] });
+      sinon.stub(residentialNodeDosService, 'isEvacuating').returns(true);
+      sinon.stub(residentialNodeDosService, 'mayEvacuateApp').returns({ ok: true, reason: 'ready' });
+      sinon.stub(residentialNodeDosService, 'forgetAppObservation');
+      sinon.stub(residentialNodeDosService, 'noteEvacuated');
+      sinon.stub(evacuationSafety, 'canSafelyRemoveApp').resolves({
+        safe: false, code: 'STAND_DOWN_REQUIRED', reason: 'stop the component first', standDown: [identifier],
+      });
+      const stopStub = sinon.stub(dockerService, 'appDockerStop').resolves();
+      sinon.stub(dbHelper, 'findInDatabase').resolves([{ name: appName, instances: 3 }]);
+      // The give-up pass runs before electionFixture arms this, and a pass that
+      // cannot learn its own address returns before it reaches the safety gate.
+      fluxNetworkHelperStub.resolves('192.168.1.5:16127');
+      registryManagerStub.resolves([{ name: appName, ip: '192.168.1.5:16127', runningSince: '2026-01-01T00:00:00.000Z' }]);
+
+      await advancedWorkflows.checkAndRemoveApplicationInstance();
+      sinon.assert.calledWith(stopStub, identifier);
+      sinon.assert.notCalled(appUninstaller.removeAppLocally);
+
+      const logInfo = sinon.stub(log, 'info');
+      const runPass = electionFixture(appName, [], { componentName });
+      serviceHelperStub.resolves({ data: [] });
+      axiosGetStub.resetBehavior();
+      axiosGetStub.callsFake(peerAnswers({ held: [] }));
+
+      await runPass();
+
+      expect(linesMatching(logInfo, 'standing down to be handed back')).to.have.lengthOf(1);
+      expect(linesMatching(logInfo, 'starting docker component')).to.have.lengthOf(0);
+    });
+
     it('seeds a confirmed leader even when a stagger was already scheduled for it', async () => {
       // The election runs on its own cadence and the state machine confirms the
       // leader on another, so a pass can schedule the stagger before the leadership
@@ -4354,6 +4410,123 @@ describe('giving up an app: one pass, two reasons, one safety gate', () => {
       await advancedWorkflows.checkAndRemoveApplicationInstance();
 
       sinon.assert.notCalled(residentialNodeDosService.noteEvacuated);
+    });
+  });
+
+  describe('standing down to hand a g: app back', () => {
+    const dockerService = require('../../ZelBack/src/services/dockerService');
+    let stopStub;
+
+    beforeEach(() => {
+      stopStub = sinon.stub(dockerService, 'appDockerStop').resolves();
+      residentialNodeDosService.isEvacuating.returns(true);
+      registryManager.appLocation.resolves(locations(LOCAL, '5.6.7.8:16127', '9.9.9.9:16127'));
+      evacuationSafety.canSafelyRemoveApp.resolves({
+        safe: false,
+        code: 'STAND_DOWN_REQUIRED',
+        reason: 'stop the component first',
+        standDown: ['server_appone'],
+      });
+    });
+
+    it('stops the component instead of removing the app', async () => {
+      await advancedWorkflows.checkAndRemoveApplicationInstance();
+
+      sinon.assert.calledOnceWithExactly(stopStub, 'server_appone');
+      sinon.assert.notCalled(appUninstaller.removeAppLocally);
+    });
+
+    it('does not count as a departure, so the pacing interval is not spent', async () => {
+      // noteEvacuated starts the 6h gap before the next app may go. Spending it
+      // on a pass that removed nothing would leave the node stood down and then
+      // idle for hours before it could finish leaving.
+      await advancedWorkflows.checkAndRemoveApplicationInstance();
+
+      sinon.assert.notCalled(residentialNodeDosService.noteEvacuated);
+    });
+
+    it('is one action per pass, like a removal', async () => {
+      dbHelper.findInDatabase.resolves(installed('appone', 'apptwo', 'appthree'));
+
+      await advancedWorkflows.checkAndRemoveApplicationInstance();
+
+      sinon.assert.calledOnce(stopStub);
+    });
+
+    it('never stands down for SURPLUS, only for EVACUATION', async () => {
+      // SURPLUS picks the JUNIOR instance and the primary is the senior one, so
+      // a surplus giver-up is never the primary. Acting on the code here would
+      // stop a container for a case that cannot arise.
+      residentialNodeDosService.isEvacuating.returns(false);
+      registryManager.appLocation.resolves(
+        locations('5.6.7.8:16127', '9.9.9.9:16127', '8.8.8.8:16127', LOCAL),
+      );
+
+      await advancedWorkflows.checkAndRemoveApplicationInstance();
+
+      sinon.assert.notCalled(stopStub);
+      sinon.assert.notCalled(appUninstaller.removeAppLocally);
+    });
+
+    it('gives up standing down after the cap, rather than holding a stopped app forever', async () => {
+      // The state this guards against: stood down, and then unable to leave
+      // anyway because the peer that held the folder went away. A component
+      // stopped HERE and running NOWHERE is worse than the stuck-but-serving
+      // state the stand-down exists to fix, so the node stops trying to leave
+      // and stands for election again.
+      const logWarn = sinon.stub(log, 'warn');
+      evacuationSafety.canSafelyRemoveApp.onFirstCall().resolves({
+        safe: false, code: 'STAND_DOWN_REQUIRED', reason: 'stop first', standDown: ['server_appone'],
+      });
+      evacuationSafety.canSafelyRemoveApp.resolves({
+        safe: false, code: 'NO_SYNCED_PEER', reason: 'no connected peer holds it',
+      });
+
+      // The pass that stands down, then the cap's worth of passes that cannot.
+      for (let i = 0; i < 8; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await advancedWorkflows.checkAndRemoveApplicationInstance();
+      }
+
+      const gaveUp = logWarn.getCalls()
+        .map((c) => String(c.args[0]))
+        .filter((line) => line.includes('standing for election again'));
+      expect(gaveUp).to.have.lengthOf(1);
+      expect(gaveUp[0]).to.include('server_appone');
+      sinon.assert.notCalled(appUninstaller.removeAppLocally);
+    });
+
+    it('holds the stand-down while it is still within the cap', async () => {
+      // Mutation guard for the test above: if the cap were off by enough to fire
+      // immediately, that test would still pass and this one would not.
+      const logWarn = sinon.stub(log, 'warn');
+      evacuationSafety.canSafelyRemoveApp.onFirstCall().resolves({
+        safe: false, code: 'STAND_DOWN_REQUIRED', reason: 'stop first', standDown: ['server_appone'],
+      });
+      evacuationSafety.canSafelyRemoveApp.resolves({
+        safe: false, code: 'NO_SYNCED_PEER', reason: 'no connected peer holds it',
+      });
+
+      for (let i = 0; i < 3; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await advancedWorkflows.checkAndRemoveApplicationInstance();
+      }
+
+      const gaveUp = logWarn.getCalls()
+        .map((c) => String(c.args[0]))
+        .filter((line) => line.includes('standing for election again'));
+      expect(gaveUp).to.have.lengthOf(0);
+    });
+
+    it('leaves a component it could not stop unmarked, so the next pass retries', async () => {
+      // Marking a component this node is still writing to would make it
+      // unelectable for something it is running - the worst of both states.
+      stopStub.rejects(new Error('docker unreachable'));
+
+      await advancedWorkflows.checkAndRemoveApplicationInstance();
+      await advancedWorkflows.checkAndRemoveApplicationInstance();
+
+      sinon.assert.calledTwice(stopStub);
     });
   });
 

--- a/tests/unit/advancedWorkflows.test.js
+++ b/tests/unit/advancedWorkflows.test.js
@@ -4113,10 +4113,10 @@ describe('giving up an app: one pass, two reasons, one safety gate', () => {
   });
 
   describe('reasonToGiveUpApp', () => {
-    it('names SURPLUS when this node holds the junior of too many instances', () => {
+    it('names SURPLUS when this node holds the junior of too many instances', async () => {
       // Three running against an instance count of two, and this node started
       // last, so it is the one that stands aside.
-      const decision = advancedWorkflows.reasonToGiveUpApp(
+      const decision = await advancedWorkflows.reasonToGiveUpApp(
         { name: 'a', instances: 2 },
         locations('5.6.7.8:16127', '9.9.9.9:16127', LOCAL),
         LOCAL,
@@ -4126,8 +4126,8 @@ describe('giving up an app: one pass, two reasons, one safety gate', () => {
       expect(decision.reason).to.equal('SURPLUS');
     });
 
-    it('does not name SURPLUS when this node holds a senior instance', () => {
-      const decision = advancedWorkflows.reasonToGiveUpApp(
+    it('does not name SURPLUS when this node holds a senior instance', async () => {
+      const decision = await advancedWorkflows.reasonToGiveUpApp(
         { name: 'a', instances: 2 },
         locations(LOCAL, '5.6.7.8:16127', '9.9.9.9:16127'),
         LOCAL,
@@ -4136,8 +4136,8 @@ describe('giving up an app: one pass, two reasons, one safety gate', () => {
       expect(decision.giveUp).to.equal(false);
     });
 
-    it('names nothing when the app is at its instance count and the node is not evacuating', () => {
-      const decision = advancedWorkflows.reasonToGiveUpApp(
+    it('names nothing when the app is at its instance count and the node is not evacuating', async () => {
+      const decision = await advancedWorkflows.reasonToGiveUpApp(
         { name: 'a', instances: 2 },
         locations(LOCAL, '5.6.7.8:16127'),
         LOCAL,
@@ -4147,10 +4147,10 @@ describe('giving up an app: one pass, two reasons, one safety gate', () => {
       expect(decision.reason).to.equal('NONE');
     });
 
-    it('names EVACUATION when the node is evacuating and this app\'s turn has come', () => {
+    it('names EVACUATION when the node is evacuating and this app\'s turn has come', async () => {
       residentialNodeDosService.isEvacuating.returns(true);
 
-      const decision = advancedWorkflows.reasonToGiveUpApp(
+      const decision = await advancedWorkflows.reasonToGiveUpApp(
         { name: 'a', instances: 2 },
         locations(LOCAL, '5.6.7.8:16127'),
         LOCAL,
@@ -4160,11 +4160,11 @@ describe('giving up an app: one pass, two reasons, one safety gate', () => {
       expect(decision.reason).to.equal('EVACUATION');
     });
 
-    it('defers to the pacing when the app\'s turn has not come', () => {
+    it('defers to the pacing when the app\'s turn has not come', async () => {
       residentialNodeDosService.isEvacuating.returns(true);
       residentialNodeDosService.mayEvacuateApp.returns({ ok: false, reason: 'its turn is in 20m' });
 
-      const decision = advancedWorkflows.reasonToGiveUpApp(
+      const decision = await advancedWorkflows.reasonToGiveUpApp(
         { name: 'a', instances: 2 },
         locations(LOCAL, '5.6.7.8:16127'),
         LOCAL,
@@ -4172,6 +4172,127 @@ describe('giving up an app: one pass, two reasons, one safety gate', () => {
 
       expect(decision.giveUp).to.equal(false);
       expect(decision.detail).to.contain('20m');
+    });
+
+    // A g: app: one component runs on a single node at a time and writes to the
+    // volume. `w_a` is what the election keys on and what the container is named.
+    const withWriter = { name: 'a', instances: 2, version: 8, compose: [{ name: 'w', containerData: 'g:/data' }] };
+    const writerAppId = require('../../ZelBack/src/services/dockerService').getAppIdentifier('w_a');
+
+    // The peer probe. A status IS an answer - the peer is alive and merely
+    // cannot say - so it reads as "cannot be ruled out", never as clearance.
+    const newestSays = ({ held = null, status = null }) => sinon.stub(axios, 'get').callsFake((url) => {
+      if (status) return Promise.reject(Object.assign(new Error(`status ${status}`), { response: { status } }));
+      if (url.includes('/apps/heldcomponents')) return Promise.resolve({ data: { data: held } });
+      return Promise.resolve({ data: { data: [] } });
+    });
+
+    it('leaves the newest copy alone when it is the one writing', async () => {
+      // "The newest stands aside" stands in for "the least valuable copy stands
+      // aside". The writer is the most valuable copy there is, so the stand-in
+      // is backwards here and the node stays.
+      const decision = await advancedWorkflows.reasonToGiveUpApp(
+        withWriter,
+        locations('5.6.7.8:16127', '9.9.9.9:16127', LOCAL),
+        LOCAL,
+        { isComponentRunningLocally: sinon.stub().resolves(true), liveness: {} },
+      );
+
+      expect(decision.giveUp).to.equal(false);
+      expect(decision.reason).to.equal('SURPLUS');
+      expect(decision.detail).to.contain('w_a');
+    });
+
+    it('still trims the newest copy when it is not the one writing', async () => {
+      const decision = await advancedWorkflows.reasonToGiveUpApp(
+        withWriter,
+        locations('5.6.7.8:16127', '9.9.9.9:16127', LOCAL),
+        LOCAL,
+        { isComponentRunningLocally: sinon.stub().resolves(false), liveness: {} },
+      );
+
+      expect(decision.giveUp).to.equal(true);
+      expect(decision.reason).to.equal('SURPLUS');
+    });
+
+    it('trims the second-newest once the newest confirms it holds the writer', async () => {
+      newestSays({ held: [writerAppId] });
+
+      // LOCAL is second of three here: 9.9.9.9 started last.
+      const decision = await advancedWorkflows.reasonToGiveUpApp(
+        withWriter,
+        locations('5.6.7.8:16127', LOCAL, '9.9.9.9:16127'),
+        LOCAL,
+        { isComponentRunningLocally: sinon.stub().resolves(false), liveness: {} },
+      );
+
+      expect(decision.giveUp).to.equal(true);
+      expect(decision.reason).to.equal('SURPLUS');
+      expect(decision.detail).to.contain('w_a');
+    });
+
+    it('does not trim the second-newest when the newest cannot be ruled out', async () => {
+      // THE ONE THAT MATTERS. Every node ranks the same shared order, but "who
+      // is writing" is each node's own reading, and FDM lags it. A second node
+      // acting on anything less than a positive confirmation is how two copies
+      // leave at once. Alive-and-cannot-say must read as "do nothing".
+      newestSays({ status: 500 });
+
+      const decision = await advancedWorkflows.reasonToGiveUpApp(
+        withWriter,
+        locations('5.6.7.8:16127', LOCAL, '9.9.9.9:16127'),
+        LOCAL,
+        { isComponentRunningLocally: sinon.stub().resolves(false), liveness: {} },
+      );
+
+      expect(decision.giveUp).to.equal(false);
+    });
+
+    it('does not trim the second-newest when the newest says it is not writing', async () => {
+      // Then the newest is an ordinary surplus copy and trims itself. Two nodes
+      // acting on that same fact is exactly what must not happen.
+      newestSays({ held: [] });
+
+      const decision = await advancedWorkflows.reasonToGiveUpApp(
+        withWriter,
+        locations('5.6.7.8:16127', LOCAL, '9.9.9.9:16127'),
+        LOCAL,
+        { isComponentRunningLocally: sinon.stub().resolves(false), liveness: {} },
+      );
+
+      expect(decision.giveUp).to.equal(false);
+    });
+
+    it('asks no peer anything for an app with no writer', async () => {
+      // Nothing to protect and nothing to ask. LOCAL is SECOND-newest here, so
+      // this sits exactly where the probe would fire if the rule stopped
+      // requiring a writer - a position-0 node would never reach that branch
+      // and the test would pass with the guard deleted.
+      const probe = sinon.stub(axios, 'get').rejects(new Error('no peer should be probed'));
+
+      const decision = await advancedWorkflows.reasonToGiveUpApp(
+        { name: 'a', instances: 2, version: 8, compose: [{ name: 'w', containerData: '/data' }] },
+        locations('5.6.7.8:16127', LOCAL, '9.9.9.9:16127'),
+        LOCAL,
+        { isComponentRunningLocally: sinon.stub().resolves(true), liveness: {} },
+      );
+
+      expect(decision.giveUp).to.equal(false);
+      sinon.assert.notCalled(probe);
+    });
+
+    it('asks no peer anything when there is no surplus', async () => {
+      const probe = sinon.stub(axios, 'get').rejects(new Error('no peer should be probed'));
+
+      const decision = await advancedWorkflows.reasonToGiveUpApp(
+        withWriter,
+        locations('5.6.7.8:16127', LOCAL),
+        LOCAL,
+        { isComponentRunningLocally: sinon.stub().resolves(true), liveness: {} },
+      );
+
+      expect(decision.reason).to.equal('NONE');
+      sinon.assert.notCalled(probe);
     });
   });
 

--- a/tests/unit/appConstants.test.js
+++ b/tests/unit/appConstants.test.js
@@ -346,4 +346,35 @@ describe('appConstants tests', () => {
       expect(appConstants.isArcane).to.be.true;
     });
   });
+
+  describe('record expiry is what production runs', () => {
+    // These three stamp expireAt onto ephemeral records and are read from
+    // config so the harness can compress them. Production's durations are
+    // asserted here because config is the only thing standing between an edit
+    // and every node keeping records for a different length of time - and
+    // because these keys spent three months wired to nothing after the
+    // collection-level TTL indexes they used to drive were dropped, at which
+    // point installErrorTtlS still held the retired mechanism's 1 hour against
+    // the 24 hours the code had been running.
+    beforeEach(() => {
+      // eslint-disable-next-line global-require
+      appConstants = require('../../ZelBack/src/services/utils/appConstants');
+    });
+
+    it('keeps a running-app location record for 125 minutes', () => {
+      expect(appConstants.RUNNING_EXPIRY_MS).to.equal(125 * 60 * 1000);
+    });
+
+    it('keeps an in-progress install record for 15 minutes', () => {
+      expect(appConstants.INSTALLING_EXPIRY_MS).to.equal(15 * 60 * 1000);
+    });
+
+    it('keeps an install-error record for 24 hours', () => {
+      expect(appConstants.INSTALLING_ERRORS_EXPIRY_MS).to.equal(24 * 60 * 60 * 1000);
+    });
+
+    it('expires an evicted record with the location record that named it', () => {
+      expect(appConstants.EVICTED_EXPIRY_MS).to.equal(appConstants.RUNNING_EXPIRY_MS);
+    });
+  });
 });

--- a/tests/unit/appEvacuationSafety.test.js
+++ b/tests/unit/appEvacuationSafety.test.js
@@ -51,6 +51,11 @@ describe('appEvacuationSafety tests', () => {
       appLocation: sinon.stub(),
       getApplicationGlobalSpecifications: sinon.stub(),
       findSyncedPeer: sinon.stub().resolves({ deviceID: 'PEER1', globalBytes: 1024 }),
+      // Both required. The default case is this node running the g: component
+      // with the election able to name another node as primary, so the checks
+      // below reach the syncthing evidence rather than stopping short of it.
+      isElectedPrimary: sinon.stub().resolves(false),
+      isComponentRunningLocally: sinon.stub().resolves(true),
     };
   });
 
@@ -87,12 +92,22 @@ describe('appEvacuationSafety tests', () => {
     });
 
     it('refuses when this node does not know its own address', async () => {
+      // Named, and with a populated location list. Asserting only `safe` on an
+      // empty list proved the NEXT guard instead: appLocation returned
+      // undefined either way, so the refusal came from "no instance locations"
+      // and this one could be deleted without the test noticing. With the list
+      // populated and the guard gone, otherHostCount compares against an
+      // undefined address, never matches this node, and counts this node as
+      // another host holding the app.
       deps.getApplicationGlobalSpecifications.resolves(statelessSpec());
+      deps.appLocation.resolves(locations(LOCAL, '5.6.7.8:16127'));
       fluxNetworkHelperStub.getLocalSocketAddress.resolves(null);
 
       const result = await appEvacuationSafety.canSafelyRemoveApp('plainapp', deps);
 
       expect(result.safe).to.equal(false);
+      expect(result.code).to.equal('NO_LOCAL_ADDRESS');
+      expect(result.reason).to.contain('local socket address');
     });
 
     it('refuses on an empty location list rather than reading it as "runs nowhere"', async () => {
@@ -228,7 +243,93 @@ describe('appEvacuationSafety tests', () => {
       const result = await appEvacuationSafety.canSafelyRemoveApp('palworld1', deps);
 
       expect(result.safe).to.equal(false);
+      expect(result.code).to.equal('ELECTED_PRIMARY');
       expect(result.reason).to.contain('primary');
+    });
+  });
+
+  describe('an election that cannot answer is not an election that said no', () => {
+    beforeEach(() => {
+      deps.getApplicationGlobalSpecifications.resolves(statefulSpec({ instances: 2 }));
+      deps.appLocation.resolves(locations(LOCAL, '5.6.7.8:16127'));
+    });
+
+    it('refuses while this node runs the g: component and the election cannot say', async () => {
+      // The whole defect in one assertion. `null` is "nobody can tell me who
+      // the primary is", and answering it the way `false` is answered deletes
+      // the volume of the node that may well be the one writing to it.
+      deps.isElectedPrimary = sinon.stub().resolves(null);
+
+      const result = await appEvacuationSafety.canSafelyRemoveApp('palworld1', deps);
+
+      expect(result.safe).to.equal(false);
+      expect(result.code).to.equal('ELECTION_UNKNOWN');
+    });
+
+    it('proceeds on an unknown election when this node is not running the component', async () => {
+      // A node not running the writer cannot be the writer, whatever the
+      // election does or does not know - so a load-balancer outage stalls the
+      // trim only where a writer actually lives.
+      deps.isElectedPrimary = sinon.stub().resolves(null);
+      deps.isComponentRunningLocally = sinon.stub().resolves(false);
+
+      const result = await appEvacuationSafety.canSafelyRemoveApp('palworld1', deps);
+
+      expect(result.safe).to.equal(true);
+      expect(deps.isElectedPrimary.called).to.equal(false);
+    });
+
+    it('never asks the election about an app with no g: component', async () => {
+      // `s:` and `r:` components are stateful but have no primary at all, so
+      // demanding an election verdict for them would stall their trim for good.
+      deps.getApplicationGlobalSpecifications.resolves({
+        name: 'shared1',
+        version: 8,
+        compose: [{ name: 'db', containerData: 's:/data' }],
+        instances: 2,
+      });
+      deps.isElectedPrimary = sinon.stub().resolves(null);
+
+      const result = await appEvacuationSafety.canSafelyRemoveApp('shared1', deps);
+
+      expect(result.safe).to.equal(true);
+      expect(deps.isElectedPrimary.called).to.equal(false);
+    });
+
+    // These two use an app with NO g: component on purpose. A g: app reaches
+    // the election check and would throw a TypeError on the missing dependency
+    // anyway, so it cannot tell an explicit requirement from an accident. An
+    // s: app never reaches that call at all: without the requirement the
+    // omission is invisible and the removal comes back safe.
+    const sharedOnlySpec = {
+      name: 'shared1',
+      version: 8,
+      compose: [{ name: 'db', containerData: 's:/data' }],
+      instances: 2,
+    };
+
+    it('refuses, loudly, when a caller omits the election check altogether', async () => {
+      // It used to default to `async () => false` - the one unavailable input
+      // in this function that answered instead of refusing. A caller that
+      // cannot ask must not be told the removal is safe.
+      deps.getApplicationGlobalSpecifications.resolves(sharedOnlySpec);
+      delete deps.isElectedPrimary;
+
+      const result = await appEvacuationSafety.canSafelyRemoveApp('shared1', deps);
+
+      expect(result.safe).to.equal(false);
+      expect(result.code).to.equal('CHECK_FAILED');
+      expect(result.reason).to.contain('isElectedPrimary');
+    });
+
+    it('refuses when a caller omits the running-component check', async () => {
+      deps.getApplicationGlobalSpecifications.resolves(sharedOnlySpec);
+      delete deps.isComponentRunningLocally;
+
+      const result = await appEvacuationSafety.canSafelyRemoveApp('shared1', deps);
+
+      expect(result.safe).to.equal(false);
+      expect(result.code).to.equal('CHECK_FAILED');
     });
   });
 

--- a/tests/unit/appEvacuationSafety.test.js
+++ b/tests/unit/appEvacuationSafety.test.js
@@ -1,0 +1,277 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire').noCallThru();
+
+describe('appEvacuationSafety tests', () => {
+  let appEvacuationSafety;
+  let fluxNetworkHelperStub;
+  let globalStateStub;
+  let deps;
+
+  const LOCAL = '1.2.3.4:16127';
+
+  function statelessSpec(overrides = {}) {
+    return {
+      name: 'plainapp',
+      version: 8,
+      compose: [{ name: 'web', containerData: '/data' }],
+      ...overrides,
+    };
+  }
+
+  function statefulSpec(overrides = {}) {
+    return {
+      name: 'palworld1',
+      version: 8,
+      compose: [{ name: 'server', containerData: 'g:/data' }],
+      ...overrides,
+    };
+  }
+
+  function locations(...ips) {
+    return ips.map((ip, index) => ({ ip, runningSince: new Date(1700000000000 + index) }));
+  }
+
+  beforeEach(() => {
+    fluxNetworkHelperStub = {
+      getLocalSocketAddress: sinon.stub().resolves(LOCAL),
+    };
+    globalStateStub = {
+      backupInProgress: [],
+      restoreInProgress: [],
+    };
+
+    appEvacuationSafety = proxyquire('../../ZelBack/src/services/appLifecycle/appEvacuationSafety', {
+      '../../lib/log': { info: sinon.stub(), warn: sinon.stub(), error: sinon.stub() },
+      '../fluxNetworkHelper': fluxNetworkHelperStub,
+      '../utils/globalState': globalStateStub,
+    });
+
+    deps = {
+      appLocation: sinon.stub(),
+      getApplicationGlobalSpecifications: sinon.stub(),
+      findSyncedPeer: sinon.stub().resolves({ deviceID: 'PEER1', globalBytes: 1024 }),
+    };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('refuses on anything it cannot establish', () => {
+    it('refuses while a backup is running', async () => {
+      globalStateStub.backupInProgress.push('plainapp');
+
+      const result = await appEvacuationSafety.canSafelyRemoveApp('plainapp', deps);
+
+      expect(result.safe).to.equal(false);
+      expect(result.reason).to.contain('backup');
+    });
+
+    it('refuses while a restore is running', async () => {
+      globalStateStub.restoreInProgress.push('plainapp');
+
+      const result = await appEvacuationSafety.canSafelyRemoveApp('plainapp', deps);
+
+      expect(result.safe).to.equal(false);
+      expect(result.reason).to.contain('restore');
+    });
+
+    it('refuses when the global specification is unavailable', async () => {
+      deps.getApplicationGlobalSpecifications.resolves(null);
+
+      const result = await appEvacuationSafety.canSafelyRemoveApp('plainapp', deps);
+
+      expect(result.safe).to.equal(false);
+      expect(result.reason).to.contain('specification');
+    });
+
+    it('refuses when this node does not know its own address', async () => {
+      deps.getApplicationGlobalSpecifications.resolves(statelessSpec());
+      fluxNetworkHelperStub.getLocalSocketAddress.resolves(null);
+
+      const result = await appEvacuationSafety.canSafelyRemoveApp('plainapp', deps);
+
+      expect(result.safe).to.equal(false);
+    });
+
+    it('refuses on an empty location list rather than reading it as "runs nowhere"', async () => {
+      deps.getApplicationGlobalSpecifications.resolves(statelessSpec());
+      deps.appLocation.resolves([]);
+
+      const result = await appEvacuationSafety.canSafelyRemoveApp('plainapp', deps);
+
+      expect(result.safe).to.equal(false);
+      expect(result.reason).to.contain('no instance locations');
+    });
+
+    it('refuses when the safety check itself throws', async () => {
+      deps.getApplicationGlobalSpecifications.rejects(new Error('db gone'));
+
+      const result = await appEvacuationSafety.canSafelyRemoveApp('plainapp', deps);
+
+      expect(result.safe).to.equal(false);
+      expect(result.reason).to.contain('db gone');
+    });
+  });
+
+  describe('the app must be at full strength', () => {
+    it('refuses while the app is already short, because another move is in flight', async () => {
+      deps.getApplicationGlobalSpecifications.resolves(statelessSpec({ instances: 3 }));
+      deps.appLocation.resolves(locations(LOCAL, '5.6.7.8:16127'));
+
+      const result = await appEvacuationSafety.canSafelyRemoveApp('plainapp', deps);
+
+      expect(result.safe).to.equal(false);
+      expect(result.reason).to.contain('below its instance count');
+    });
+
+    it('allows when the app is exactly at its instance count', async () => {
+      deps.getApplicationGlobalSpecifications.resolves(statelessSpec({ instances: 3 }));
+      deps.appLocation.resolves(locations(LOCAL, '5.6.7.8:16127', '9.9.9.9:16127'));
+
+      const result = await appEvacuationSafety.canSafelyRemoveApp('plainapp', deps);
+
+      expect(result.safe).to.equal(true);
+    });
+
+    it('falls back to the configured minimum when the spec names no instance count', async () => {
+      // Must match the spawner's own `$ifNull: [instances, 3]`, or the departure
+      // creates a deficit the spawner does not agree exists.
+      deps.getApplicationGlobalSpecifications.resolves(statelessSpec());
+      deps.appLocation.resolves(locations(LOCAL, '5.6.7.8:16127'));
+
+      const result = await appEvacuationSafety.canSafelyRemoveApp('plainapp', deps);
+
+      expect(result.safe).to.equal(false);
+      expect(result.reason).to.contain('/3');
+    });
+  });
+
+  describe('stateless apps', () => {
+    it('may be given up even as the only instance, because there is no data to lose', async () => {
+      // The 57 single-instance apps on residential nodes are all stateless. The
+      // container is rebuilt from the specification elsewhere.
+      deps.getApplicationGlobalSpecifications.resolves(statelessSpec({ instances: 1 }));
+      deps.appLocation.resolves(locations(LOCAL));
+
+      const result = await appEvacuationSafety.canSafelyRemoveApp('plainapp', deps);
+
+      expect(result.safe).to.equal(true);
+      expect(result.reason).to.contain('stateless');
+    });
+
+    it('never consults syncthing', async () => {
+      deps.getApplicationGlobalSpecifications.resolves(statelessSpec({ instances: 1 }));
+      deps.appLocation.resolves(locations(LOCAL));
+
+      await appEvacuationSafety.canSafelyRemoveApp('plainapp', deps);
+
+      sinon.assert.notCalled(deps.findSyncedPeer);
+    });
+  });
+
+  describe('stateful apps', () => {
+    it('is refused when no other host holds it', async () => {
+      deps.getApplicationGlobalSpecifications.resolves(statefulSpec({ instances: 1 }));
+      deps.appLocation.resolves(locations(LOCAL));
+
+      const result = await appEvacuationSafety.canSafelyRemoveApp('palworld1', deps);
+
+      expect(result.safe).to.equal(false);
+      expect(result.reason).to.contain('only host');
+    });
+
+    it('is refused when no connected peer holds the folder in full', async () => {
+      deps.getApplicationGlobalSpecifications.resolves(statefulSpec({ instances: 2 }));
+      deps.appLocation.resolves(locations(LOCAL, '5.6.7.8:16127'));
+      deps.findSyncedPeer.resolves(null);
+
+      const result = await appEvacuationSafety.canSafelyRemoveApp('palworld1', deps);
+
+      expect(result.safe).to.equal(false);
+      expect(result.reason).to.contain('no connected peer');
+    });
+
+    it('is allowed when a connected peer holds every synced folder', async () => {
+      deps.getApplicationGlobalSpecifications.resolves(statefulSpec({ instances: 2 }));
+      deps.appLocation.resolves(locations(LOCAL, '5.6.7.8:16127'));
+
+      const result = await appEvacuationSafety.canSafelyRemoveApp('palworld1', deps);
+
+      expect(result.safe).to.equal(true);
+      sinon.assert.calledWith(deps.findSyncedPeer, 'fluxserver_palworld1');
+    });
+
+    it('requires EVERY synced component to be held, not just the first', async () => {
+      deps.getApplicationGlobalSpecifications.resolves(statefulSpec({
+        instances: 2,
+        compose: [
+          { name: 'server', containerData: 'g:/data' },
+          { name: 'db', containerData: 'r:/var/lib/mysql' },
+        ],
+      }));
+      deps.appLocation.resolves(locations(LOCAL, '5.6.7.8:16127'));
+      deps.findSyncedPeer.onFirstCall().resolves({ deviceID: 'PEER1', globalBytes: 1 });
+      deps.findSyncedPeer.onSecondCall().resolves(null);
+
+      const result = await appEvacuationSafety.canSafelyRemoveApp('palworld1', deps);
+
+      expect(result.safe).to.equal(false);
+    });
+
+    it('refuses when this node is the elected primary', async () => {
+      deps.getApplicationGlobalSpecifications.resolves(statefulSpec({ instances: 2 }));
+      deps.appLocation.resolves(locations(LOCAL, '5.6.7.8:16127'));
+      deps.isElectedPrimary = sinon.stub().resolves(true);
+
+      const result = await appEvacuationSafety.canSafelyRemoveApp('palworld1', deps);
+
+      expect(result.safe).to.equal(false);
+      expect(result.reason).to.contain('primary');
+    });
+  });
+
+  describe('instances are counted per host, not per node slot', () => {
+    it('does not treat a second slot on our own machine as another copy', async () => {
+      // 329 target slots sit on 148 machines. Two locations at one address fail
+      // together and are being evacuated together, so they were never two copies.
+      deps.getApplicationGlobalSpecifications.resolves(statefulSpec({ instances: 2 }));
+      deps.appLocation.resolves(locations(LOCAL, '1.2.3.4:16137'));
+
+      const result = await appEvacuationSafety.canSafelyRemoveApp('palworld1', deps);
+
+      expect(result.safe).to.equal(false);
+      expect(result.reason).to.contain('only host');
+    });
+
+    it('counts distinct hosts once each', () => {
+      const counted = appEvacuationSafety.otherHostCount(
+        locations(LOCAL, '5.6.7.8:16127', '5.6.7.8:16137', '9.9.9.9:16127'),
+        LOCAL,
+      );
+
+      expect(counted).to.equal(2);
+    });
+  });
+
+  describe('syncedComponents', () => {
+    it('reads the sync mode through the mount parser, not a substring', () => {
+      // `/dogs/data` contains "g:" nowhere but a naive check on the letter would
+      // still trip; the canonical parser is what keeps this honest.
+      const components = appEvacuationSafety.syncedComponents({
+        name: 'app', version: 8, compose: [{ name: 'c', containerData: '/dogs/data' }],
+      });
+
+      expect(components).to.be.empty;
+    });
+
+    it('names the folder id each synced component owns', () => {
+      const components = appEvacuationSafety.syncedComponents(statefulSpec());
+
+      expect(components).to.have.lengthOf(1);
+      expect(components[0].folderId).to.equal('fluxserver_palworld1');
+      expect(components[0].syncMode).to.equal('g');
+    });
+  });
+});

--- a/tests/unit/appEvacuationSafety.test.js
+++ b/tests/unit/appEvacuationSafety.test.js
@@ -235,7 +235,10 @@ describe('appEvacuationSafety tests', () => {
       expect(result.safe).to.equal(false);
     });
 
-    it('refuses when this node is the elected primary', async () => {
+    it('asks the elected primary to stand down rather than refusing outright', async () => {
+      // Not a removal and not a dead end: everything else has passed, so the
+      // only thing left is that this node is the one writing. It stops, and the
+      // next pass finds the component running elsewhere.
       deps.getApplicationGlobalSpecifications.resolves(statefulSpec({ instances: 2 }));
       deps.appLocation.resolves(locations(LOCAL, '5.6.7.8:16127'));
       deps.isElectedPrimary = sinon.stub().resolves(true);
@@ -243,8 +246,39 @@ describe('appEvacuationSafety tests', () => {
       const result = await appEvacuationSafety.canSafelyRemoveApp('palworld1', deps);
 
       expect(result.safe).to.equal(false);
-      expect(result.code).to.equal('ELECTED_PRIMARY');
-      expect(result.reason).to.contain('primary');
+      expect(result.code).to.equal('STAND_DOWN_REQUIRED');
+      expect(result.standDown).to.deep.equal(['server_palworld1']);
+    });
+
+    it('names only the components actually running here', async () => {
+      // The caller stops what this returns, so a component already stopped must
+      // not appear - stopping it again is noise, and marking it unelectable is
+      // wrong for something this node is not running.
+      deps.getApplicationGlobalSpecifications.resolves(statefulSpec({ instances: 2 }));
+      deps.appLocation.resolves(locations(LOCAL, '5.6.7.8:16127'));
+      deps.isElectedPrimary = sinon.stub().resolves(true);
+      deps.isComponentRunningLocally = sinon.stub().resolves(false);
+
+      const result = await appEvacuationSafety.canSafelyRemoveApp('palworld1', deps);
+
+      expect(result.safe).to.equal(true);
+      expect(result.code).to.equal('SYNCED_ELSEWHERE');
+    });
+
+    it('never asks a node holding the only good copy to stand down', async () => {
+      // The ordering IS the safety property. If the synced-peer check ran after
+      // the election, a primary with no complete peer would stop writing and
+      // then discover it cannot leave - an app stopped here and running nowhere.
+      deps.getApplicationGlobalSpecifications.resolves(statefulSpec({ instances: 2 }));
+      deps.appLocation.resolves(locations(LOCAL, '5.6.7.8:16127'));
+      deps.isElectedPrimary = sinon.stub().resolves(true);
+      deps.findSyncedPeer.resolves(null);
+
+      const result = await appEvacuationSafety.canSafelyRemoveApp('palworld1', deps);
+
+      expect(result.code).to.equal('NO_SYNCED_PEER');
+      expect(result.standDown).to.equal(undefined);
+      sinon.assert.notCalled(deps.isElectedPrimary);
     });
   });
 

--- a/tests/unit/appSpawner.test.js
+++ b/tests/unit/appSpawner.test.js
@@ -285,11 +285,32 @@ describe('appSpawner tests', () => {
     }
 
     it('refuses to install while the node is held back', async () => {
+      // The hold is stage one of the residential design and the only stage that
+      // ships an immediate behaviour change, and nothing asserted it actually
+      // stops anything: deleting `return installDelay;` while keeping the log
+      // and the publish left the whole file green. aggregateStub is the first
+      // thing the install path reaches, so it not being called is the evidence
+      // the pass really stopped here.
       buildModule({ placementHold: 'residential node not running ArcaneOS' });
+
+      const delay = await appSpawner.trySpawningGlobalApplication().catch(() => {});
+
+      expect(infoLoggedIncludes('held back from new placements')).to.equal(true);
+      expect(aggregateStub.called).to.equal(false);
+      expect(delay).to.be.a('number');
+    });
+
+    it('goes no further than the hold, even with work waiting', async () => {
+      // Held with apps that WOULD be installable: without the return, the pass
+      // walks on into the spawn path and the log line above is decoration.
+      buildModule({
+        placementHold: 'residential node not running ArcaneOS',
+        aggregateResult: [{ name: 'someapp', hash: 'h1', height: 100 }],
+      });
 
       await appSpawner.trySpawningGlobalApplication().catch(() => {});
 
-      expect(infoLoggedIncludes('held back from new placements')).to.equal(true);
+      expect(aggregateStub.called).to.equal(false);
     });
 
     it('publishes placement_hold so a suite can see which gate stopped it', async () => {
@@ -308,6 +329,10 @@ describe('appSpawner tests', () => {
       await appSpawner.trySpawningGlobalApplication().catch(() => {});
 
       expect(infoLoggedIncludes('held back from new placements')).to.equal(false);
+      // The other half of the pair: unheld, the pass reaches the install path,
+      // so the assertion above is about the hold and not about the pass being
+      // stopped by something else entirely.
+      expect(aggregateStub.called).to.equal(true);
     });
   });
 

--- a/tests/unit/appSpawner.test.js
+++ b/tests/unit/appSpawner.test.js
@@ -52,7 +52,10 @@ describe('appSpawner tests', () => {
     };
   }
 
+  let eventBusPublish;
+
   function buildModule(opts = {}) {
+    eventBusPublish = sinon.stub();
     configStub = createConfigStub(opts.configOverrides);
     globalStateStub = createGlobalStateStub();
     if (opts.globalStateOverrides) {
@@ -127,6 +130,8 @@ describe('appSpawner tests', () => {
         isPortOpen: sinon.stub().resolves(true),
         isPortUserBlocked: sinon.stub().returns(false),
         isNodeDos: sinon.stub().returns(false),
+        isPlacementHeld: sinon.stub().returns(Boolean(opts.placementHold)),
+        getPlacementHold: sinon.stub().returns(opts.placementHold ?? null),
       },
       '../daemonService/daemonServiceMiscRpcs': {
         isDaemonSynced: daemonSyncStub,
@@ -227,6 +232,9 @@ describe('appSpawner tests', () => {
       '../utils/cacheManager': {
         FluxCacheManager: { oneHour: 3600000 },
       },
+      '../utils/fluxEventBus': {
+        publish: eventBusPublish,
+      },
       '../appMessaging/messageStore': {
         storeAppInstallingMessage: opts.withdrawalStub ?? sinon.stub().resolves(true),
         storeAppInstallingErrorMessage: opts.installingErrorStub ?? sinon.stub().resolves(true),
@@ -268,6 +276,38 @@ describe('appSpawner tests', () => {
 
     it('should be exported as a function', () => {
       expect(appSpawner.trySpawningGlobalApplication).to.be.a('function');
+    });
+  });
+
+  describe('placement hold', () => {
+    function infoLoggedIncludes(substr) {
+      return logStub.info.getCalls().some((c) => typeof c.args[0] === 'string' && c.args[0].includes(substr));
+    }
+
+    it('refuses to install while the node is held back', async () => {
+      buildModule({ placementHold: 'residential node not running ArcaneOS' });
+
+      await appSpawner.trySpawningGlobalApplication().catch(() => {});
+
+      expect(infoLoggedIncludes('held back from new placements')).to.equal(true);
+    });
+
+    it('publishes placement_hold so a suite can see which gate stopped it', async () => {
+      buildModule({ placementHold: 'residential node not running ArcaneOS' });
+
+      await appSpawner.trySpawningGlobalApplication().catch(() => {});
+
+      const published = eventBusPublish.getCalls()
+        .some((c) => c.args[0] === 'spawner:blocked' && c.args[1] && c.args[1].reason === 'placement_hold');
+      expect(published).to.equal(true);
+    });
+
+    it('installs as usual when the node is not held', async () => {
+      buildModule();
+
+      await appSpawner.trySpawningGlobalApplication().catch(() => {});
+
+      expect(infoLoggedIncludes('held back from new placements')).to.equal(false);
     });
   });
 

--- a/tests/unit/appSpawner.test.js
+++ b/tests/unit/appSpawner.test.js
@@ -154,11 +154,19 @@ describe('appSpawner tests', () => {
         // opts.finalInstallingLocations (returned from the 4th fetch onwards).
         appInstallingLocation: (() => {
           const stub = sinon.stub();
-          stub.callsFake(() => Promise.resolve(
-            (opts.finalInstallingLocations && stub.callCount > 3)
-              ? opts.finalInstallingLocations
-              : (opts.installingLocations || []),
-          ));
+          stub.callsFake(() => {
+            // The spawner counts twice: once while choosing, and again after it
+            // has selected and cached the app. Between the two, other nodes
+            // claim - which is the only way to reach the second check's decline.
+            // opts.recheckInstallingLocations is the list as it stands by then.
+            if (opts.finalInstallingLocations && stub.callCount > 3) {
+              return Promise.resolve(opts.finalInstallingLocations);
+            }
+            if (opts.recheckInstallingLocations && stub.callCount > 1) {
+              return Promise.resolve(opts.recheckInstallingLocations);
+            }
+            return Promise.resolve(opts.installingLocations || []);
+          });
           return stub;
         })(),
         // Claims held against each candidate, keyed by lowercased name. Empty
@@ -1098,6 +1106,39 @@ describe('appSpawner tests', () => {
         withdrawalStub.getCalls().filter((c) => c.args[0].withdrawn === true),
         'claimed and then retracted instead of standing aside',
       ).to.have.lengthOf(0);
+    });
+
+    it('stays eligible after standing aside on a count that included a claim', async () => {
+      // Standing aside was right; REMEMBERING it was not. The count that stood
+      // this node aside included nodes that had only CLAIMED to be installing,
+      // and a claim is withdrawn as soon as its node finds the share filled -
+      // seconds later, routinely. Left in the cache, this node holds "the network
+      // has it covered" for the cache's twelve hours and never looks again, so an
+      // app that falls back below its instance count waits out the day on every
+      // node that happened to glance inside that window.
+      //
+      // Observed on a gate: two nodes running an app, two more claimed and
+      // withdrew, and it stayed at two of three because the nodes that should
+      // have supplied the third had already written it off. The claimed-instance
+      // path clears the cache for exactly this reason; this one counted the same
+      // claims and did not.
+      // Short when it looked, covered by the time it re-counted: the app is
+      // selected and cached, and only then do the other claims land. That second
+      // check is the one that must not leave the cache set.
+      const { logged } = await runAttempt({
+        appLocations: [{ ip: '192.168.3.3:16127' }],
+        installingLocations: [],
+        recheckInstallingLocations: [
+          { ip: '192.168.2.2:16127', broadcastedAt: 1000 },
+          { ip: '192.168.4.4:16127', broadcastedAt: 1001 },
+        ],
+      });
+
+      expect(logged('already spawned or being installed'), 'never reached the decline').to.be.true;
+      expect(
+        globalStateStub.trySpawningGlobalAppCache.has('abc123'),
+        'cached a decline that a withdrawn claim invalidates seconds later',
+      ).to.be.false;
     });
 
     it('still claims when the network is one instance short', async () => {

--- a/tests/unit/appSpawner.test.js
+++ b/tests/unit/appSpawner.test.js
@@ -52,10 +52,8 @@ describe('appSpawner tests', () => {
     };
   }
 
-  let eventBusPublish;
 
   function buildModule(opts = {}) {
-    eventBusPublish = sinon.stub();
     configStub = createConfigStub(opts.configOverrides);
     globalStateStub = createGlobalStateStub();
     if (opts.globalStateOverrides) {
@@ -250,9 +248,6 @@ describe('appSpawner tests', () => {
       '../utils/cacheManager': {
         FluxCacheManager: { oneHour: 3600000 },
       },
-      '../utils/fluxEventBus': {
-        publish: eventBusPublish,
-      },
       '../appMessaging/messageStore': {
         storeAppInstallingMessage: opts.withdrawalStub ?? sinon.stub().resolves(true),
         storeAppInstallingErrorMessage: opts.installingErrorStub ?? sinon.stub().resolves(true),
@@ -329,16 +324,6 @@ describe('appSpawner tests', () => {
       await appSpawner.trySpawningGlobalApplication().catch(() => {});
 
       expect(aggregateStub.called).to.equal(false);
-    });
-
-    it('publishes placement_hold so a suite can see which gate stopped it', async () => {
-      buildModule({ placementHold: 'residential node not running ArcaneOS' });
-
-      await appSpawner.trySpawningGlobalApplication().catch(() => {});
-
-      const published = eventBusPublish.getCalls()
-        .some((c) => c.args[0] === 'spawner:blocked' && c.args[1] && c.args[1].reason === 'placement_hold');
-      expect(published).to.equal(true);
     });
 
     it('installs as usual when the node is not held', async () => {

--- a/tests/unit/appSpawner.test.js
+++ b/tests/unit/appSpawner.test.js
@@ -144,11 +144,21 @@ describe('appSpawner tests', () => {
         // The post-install self-check re-reads the running list after this
         // node's own install; tests exercising it provide that view via
         // opts.finalAppLocations (returned once the install stub has run).
-        appLocation: sinon.stub().callsFake(() => Promise.resolve(
-          (opts.finalAppLocations && installStubRef.called)
-            ? opts.finalAppLocations
-            : (opts.appLocations || []),
-        )),
+        appLocation: (() => {
+          const stub = sinon.stub();
+          stub.callsFake(() => {
+            if (opts.finalAppLocations && installStubRef.called) {
+              return Promise.resolve(opts.finalAppLocations);
+            }
+            // The list as it stands by the spawner's SECOND count, for tests that
+            // need running copies to arrive between the two.
+            if (opts.recheckAppLocations && stub.callCount > 1) {
+              return Promise.resolve(opts.recheckAppLocations);
+            }
+            return Promise.resolve(opts.appLocations || []);
+          });
+          return stub;
+        })(),
         // The list after the collision wait includes this node's own claim; tests
         // exercising the post-broadcast share resolver provide it via
         // opts.finalInstallingLocations (returned from the 4th fetch onwards).
@@ -1139,6 +1149,28 @@ describe('appSpawner tests', () => {
         globalStateStub.trySpawningGlobalAppCache.has('abc123'),
         'cached a decline that a withdrawn claim invalidates seconds later',
       ).to.be.false;
+    });
+
+    it('does remember an app the running copies alone already cover', async () => {
+      // The other half, and the reason the clear above is conditional. A running
+      // copy is durable: the app IS covered, and re-deciding that on every pass
+      // is the waste the cache exists to prevent. Cleared unconditionally, an app
+      // at full strength re-enters the candidate pool every pass and is declined
+      // again forever - never cached, because this node never installs it.
+      const { logged } = await runAttempt({
+        appLocations: [{ ip: '192.168.3.3:16127' }],
+        recheckAppLocations: [
+          { ip: '192.168.3.3:16127' },
+          { ip: '192.168.5.5:16127' },
+          { ip: '192.168.6.6:16127' },
+        ],
+      });
+
+      expect(logged('already spawned or being installed'), 'never reached the decline').to.be.true;
+      expect(
+        globalStateStub.trySpawningGlobalAppCache.has('abc123'),
+        'dropped a decline that three running copies fully justify',
+      ).to.be.true;
     });
 
     it('still claims when the network is one instance short', async () => {

--- a/tests/unit/appTamperingBlocklistService.test.js
+++ b/tests/unit/appTamperingBlocklistService.test.js
@@ -50,11 +50,16 @@ describe('appTamperingBlocklistService tests', () => {
       aggregateInDatabase: sinon.stub().resolves([]),
     };
 
+    // Stateful on purpose: the real fluxNetworkHelper reads back the message it
+    // was given, and every ownership rule in this service is written against
+    // that read-back. A getter pinned to null would let a clear that must not
+    // happen pass as if it had.
+    let sticky = null;
     fluxNetworkHelperStub = {
-      setStickyDosMessage: sinon.stub(),
+      setStickyDosMessage: sinon.stub().callsFake((msg) => { sticky = msg; }),
       setStickyDosStateValue: sinon.stub(),
-      clearStickyDosMessage: sinon.stub(),
-      getStickyDosMessage: sinon.stub().returns(null),
+      clearStickyDosMessage: sinon.stub().callsFake(() => { sticky = null; }),
+      getStickyDosMessage: sinon.stub().callsFake(() => sticky),
     };
 
     generalServiceStub = {
@@ -317,6 +322,44 @@ describe('appTamperingBlocklistService tests', () => {
       await service.enforceBlocklist();
 
       sinon.assert.called(fluxNetworkHelperStub.clearStickyDosMessage);
+    });
+
+    it('does NOT clear a sticky slot a different module took over after we set ours', async () => {
+      serviceHelperStub.axiosGet.resolves({ data: [MOCK_TXHASH] });
+      setTamperScore(15);
+      await service.enforceBlocklist();
+      expect(service.isDosActive()).to.be.true;
+
+      // Another enforcer overwrote the single sticky slot with its own message.
+      fluxNetworkHelperStub.getStickyDosMessage = sinon.stub().returns('Residential node not running ArcaneOS');
+      // ...and our own condition stops holding.
+      serviceHelperStub.axiosGet.resolves({ data: [] });
+      await service.enforceBlocklist();
+
+      expect(fluxNetworkHelperStub.clearStickyDosMessage.called).to.be.false;
+      expect(service.isDosActive()).to.be.false;
+    });
+
+    it('does NOT overwrite a sticky DOS another module already holds', async () => {
+      fluxNetworkHelperStub.getStickyDosMessage = sinon.stub().returns('Residential node not running ArcaneOS');
+      serviceHelperStub.axiosGet.resolves({ data: [MOCK_TXHASH] });
+      setTamperScore(15);
+
+      await service.enforceBlocklist();
+
+      expect(fluxNetworkHelperStub.setStickyDosMessage.called).to.be.false;
+      expect(service.isDosActive()).to.be.false;
+    });
+
+    it('refreshes its own sticky DOS rather than treating it as foreign', async () => {
+      fluxNetworkHelperStub.getStickyDosMessage = sinon.stub().returns(`${service.DOS_MESSAGE_PREFIX}: tamper score 42, txhash xyz`);
+      serviceHelperStub.axiosGet.resolves({ data: [MOCK_TXHASH] });
+      setTamperScore(15);
+
+      await service.enforceBlocklist();
+
+      sinon.assert.calledOnce(fluxNetworkHelperStub.setStickyDosMessage);
+      sinon.assert.calledWith(fluxNetworkHelperStub.setStickyDosStateValue, 100);
     });
 
     it('does NOT clear a sticky DOS set by a different module', async () => {

--- a/tests/unit/appTamperingBlocklistService.test.js
+++ b/tests/unit/appTamperingBlocklistService.test.js
@@ -362,6 +362,63 @@ describe('appTamperingBlocklistService tests', () => {
       sinon.assert.calledWith(fluxNetworkHelperStub.setStickyDosStateValue, 100);
     });
 
+    it('claims the slot as soon as the other owner releases it', async () => {
+      // Enforcement runs every 12 hours. The residential enforcer takes the
+      // single slot first at boot, and later RELEASES it when its own verdict
+      // flips - a residential address moving into a hosting range clears its
+      // sticky. Without the watch, a node this build has determined should be
+      // out of service sits at DOS 0 taking apps until the next 12-hourly tick.
+      fluxNetworkHelperStub.getStickyDosMessage = sinon.stub().returns('Residential node not running ArcaneOS');
+      serviceHelperStub.axiosGet.resolves({ data: [MOCK_TXHASH] });
+      setTamperScore(15);
+
+      await service.enforceBlocklist();
+      expect(fluxNetworkHelperStub.setStickyDosMessage.called).to.be.false;
+      expect(service.isDosActive()).to.be.false;
+
+      // The other owner lets go.
+      fluxNetworkHelperStub.getStickyDosMessage = sinon.stub().returns(null);
+      service.claimSlotIfFree();
+
+      sinon.assert.calledOnce(fluxNetworkHelperStub.setStickyDosMessage);
+      expect(fluxNetworkHelperStub.setStickyDosMessage.firstCall.args[0]).to.contain('tamper score 15');
+      sinon.assert.calledWith(fluxNetworkHelperStub.setStickyDosStateValue, 100);
+      expect(service.isDosActive()).to.be.true;
+    });
+
+    it('leaves the slot alone while the other owner still holds it', async () => {
+      fluxNetworkHelperStub.getStickyDosMessage = sinon.stub().returns('Residential node not running ArcaneOS');
+      serviceHelperStub.axiosGet.resolves({ data: [MOCK_TXHASH] });
+      setTamperScore(15);
+      await service.enforceBlocklist();
+
+      service.claimSlotIfFree();
+      service.claimSlotIfFree();
+
+      expect(fluxNetworkHelperStub.setStickyDosMessage.called).to.be.false;
+      expect(service.isDosActive()).to.be.false;
+    });
+
+    it('stops watching once this node should no longer be DOSed', async () => {
+      // The blocklist entry is withdrawn while another owner holds the slot.
+      // Claiming it afterwards would put the node out of service for a reason
+      // that no longer applies.
+      fluxNetworkHelperStub.getStickyDosMessage = sinon.stub().returns('Residential node not running ArcaneOS');
+      serviceHelperStub.axiosGet.resolves({ data: [MOCK_TXHASH] });
+      setTamperScore(15);
+      await service.enforceBlocklist();
+
+      serviceHelperStub.axiosGet.resolves({ data: [] });
+      setTamperScore(0);
+      await service.enforceBlocklist();
+
+      fluxNetworkHelperStub.getStickyDosMessage = sinon.stub().returns(null);
+      service.claimSlotIfFree();
+
+      expect(fluxNetworkHelperStub.setStickyDosMessage.called).to.be.false;
+      expect(service.isDosActive()).to.be.false;
+    });
+
     it('does NOT clear a sticky DOS set by a different module', async () => {
       // Some other module set sticky for an unrelated reason
       fluxNetworkHelperStub.getStickyDosMessage = sinon.stub().returns('some other module sticky reason');

--- a/tests/unit/appUninstaller.test.js
+++ b/tests/unit/appUninstaller.test.js
@@ -33,6 +33,9 @@ describe('appUninstaller tests', () => {
           database: 'globalapps',
         },
       },
+      // appConstants reads the record-expiry durations from here as well as the
+      // collection names; absent keys fall back to the production defaults.
+      fluxapps: {},
     };
 
     verificationHelperStub = {

--- a/tests/unit/coupledKnobs.test.js
+++ b/tests/unit/coupledKnobs.test.js
@@ -1,0 +1,92 @@
+const { expect } = require('chai');
+const proxyquire = require('proxyquire').noCallThru();
+
+// coupled-knobs.js holds production's side of every harness ratio as constants,
+// because ZelBack/config/default.js requires the gitignored config/userconfig.js
+// and the harness cannot resolve it. Constants copied from a file drift from it;
+// this is what makes the drift fail rather than quietly weaken the check the
+// harness runs on every fleet boot.
+describe('coupled harness knobs track production', () => {
+  let knobs;
+
+  before(async () => {
+    // The extension is required: this is a real ESM specifier resolved at
+    // runtime, not a bundler-resolved one, and the harness is ESM while this
+    // file is CJS.
+    // eslint-disable-next-line import/extensions
+    knobs = await import('../../test-infra/runner/framework/coupled-knobs.js');
+  });
+
+  function productionConfig() {
+    return proxyquire('../../ZelBack/config/default', {
+      '../../config/userconfig': { initial: { development: false } },
+    });
+  }
+
+  it('holds the same numbers the fleet reads', () => {
+    const { fluxapps } = productionConfig();
+
+    expect(knobs.PRODUCTION.removeFluxAppsPeriod).to.equal(fluxapps.removeFluxAppsPeriod);
+    expect(knobs.PRODUCTION.residentialQueueBaseMs).to.equal(fluxapps.residentialQueueBaseMs);
+    expect(knobs.PRODUCTION.residentialQueueStepMs).to.equal(fluxapps.residentialQueueStepMs);
+  });
+
+  it('derives the ratio production actually runs at', () => {
+    const { fluxapps } = productionConfig();
+    const pass = fluxapps.removeFluxAppsPeriod * knobs.PON_SPEED_MULTIPLIER * knobs.PRODUCTION.blockMs;
+
+    expect(knobs.productionQueueRatio()).to.equal(fluxapps.residentialQueueStepMs / pass);
+    // Above one is the property itself: a step shorter than a pass cannot
+    // separate two positions, whatever else is true.
+    expect(knobs.productionQueueRatio()).to.be.above(1);
+  });
+
+  it('rejects a harness fleet whose step is shorter than its pass', () => {
+    // The state suite 55 shipped in: a step chosen against a 250ms poll, left
+    // behind when the poll moved to 833ms.
+    const fluxapps = {
+      removeFluxAppsPeriod: 4, explorerPollIntervalMs: 833, residentialQueueStepMs: 15000,
+    };
+
+    expect(() => knobs.assertCoupledRatios(fluxapps)).to.throw(/too short/);
+  });
+
+  it('accepts what the derivation produces for that same fleet', () => {
+    const fleet = { removeFluxAppsPeriod: 4, explorerPollIntervalMs: 833 };
+
+    expect(() => knobs.assertCoupledRatios({
+      ...fleet, residentialQueueStepMs: knobs.derivedQueueStepMs(fleet),
+    })).to.not.throw();
+  });
+
+  it('moves the derived step when the poll moves', () => {
+    // The whole failure in one assertion: a literal does not do this.
+    const slow = knobs.derivedQueueStepMs({ removeFluxAppsPeriod: 4, explorerPollIntervalMs: 833 });
+    const fast = knobs.derivedQueueStepMs({ removeFluxAppsPeriod: 4, explorerPollIntervalMs: 250 });
+
+    expect(slow).to.be.above(fast);
+  });
+
+  it('models the pass close to the one that was measured', () => {
+    // BLOCK_COST_OVERHEAD is calibrated, not chosen: nine consecutive give-up
+    // passes on cindy at explorerPollIntervalMs 833 ran 15.9s apart, against a
+    // poll-only model of 13.3s. Without this the factor can be edited freely -
+    // dropping it to 1.0 derives a 25s step instead of 30s, still above one but
+    // below production's ratio, and nothing else in this file notices.
+    const MEASURED_PASS_MS = 15900; // cindy, 2026-08-20, suite 55
+    const modelled = knobs.giveUpPassMs(
+      { removeFluxAppsPeriod: 4 },
+      knobs.harnessBlockCostMs({ explorerPollIntervalMs: 833 }),
+    );
+
+    expect(Math.abs(modelled - MEASURED_PASS_MS) / MEASURED_PASS_MS).to.be.below(0.05);
+  });
+
+  it('leaves a step longer than production needs alone', () => {
+    // A suite that does not compress this at all is slow, not wrong, and the
+    // check must not push anyone toward a tighter number than they wanted.
+    const fleet = { removeFluxAppsPeriod: 4, explorerPollIntervalMs: 833 };
+
+    expect(() => knobs.assertCoupledRatios({ ...fleet, residentialQueueStepMs: 40 * 60 * 1000 })).to.not.throw();
+  });
+});

--- a/tests/unit/coupledKnobs.test.js
+++ b/tests/unit/coupledKnobs.test.js
@@ -59,6 +59,46 @@ describe('coupled harness knobs track production', () => {
     })).to.not.throw();
   });
 
+  it('rejects a harness fleet whose departure interval is inside its ticket gap', () => {
+    // The state suite 55 shipped in once the ticket learned to restart: a 4s
+    // interval against a ~29s step. The block stops reading as a gap, tickets
+    // carry straight across it, and the suite goes green on a queue that has
+    // stopped separating anything after the first departure.
+    const fleet = { removeFluxAppsPeriod: 4, explorerPollIntervalMs: 833 };
+    const fluxapps = {
+      ...fleet,
+      residentialQueueStepMs: knobs.derivedQueueStepMs(fleet),
+      residentialEvacuationIntervalMs: 4000,
+    };
+
+    expect(() => knobs.assertCoupledRatios(fluxapps)).to.throw(/does not outlive the queue ticket/);
+  });
+
+  it('accepts the departure interval its own derivation produces', () => {
+    const fleet = { removeFluxAppsPeriod: 4, explorerPollIntervalMs: 833 };
+    const fluxapps = { ...fleet, residentialQueueStepMs: knobs.derivedQueueStepMs(fleet) };
+
+    expect(() => knobs.assertCoupledRatios({
+      ...fluxapps,
+      residentialEvacuationIntervalMs: knobs.derivedEvacuationIntervalMs(fluxapps),
+    })).to.not.throw();
+  });
+
+  it('keeps the departure interval above the step, as production does', () => {
+    const { fluxapps } = productionConfig();
+
+    // 6h against a 40min step. The rule only demands step + a pass; production
+    // clears it by an order of magnitude, and this is what says so out loud.
+    expect(fluxapps.residentialEvacuationIntervalMs)
+      .to.be.above(fluxapps.residentialQueueStepMs);
+    expect(() => knobs.assertDepartureOutlivesTicket({
+      removeFluxAppsPeriod: fluxapps.removeFluxAppsPeriod,
+      explorerPollIntervalMs: fluxapps.explorerPollIntervalMs,
+      residentialQueueStepMs: fluxapps.residentialQueueStepMs,
+      residentialEvacuationIntervalMs: fluxapps.residentialEvacuationIntervalMs,
+    })).to.not.throw();
+  });
+
   it('moves the derived step when the poll moves', () => {
     // The whole failure in one assertion: a literal does not do this.
     const slow = knobs.derivedQueueStepMs({ removeFluxAppsPeriod: 4, explorerPollIntervalMs: 833 });

--- a/tests/unit/coupledKnobs.test.js
+++ b/tests/unit/coupledKnobs.test.js
@@ -82,6 +82,39 @@ describe('coupled harness knobs track production', () => {
     expect(Math.abs(modelled - MEASURED_PASS_MS) / MEASURED_PASS_MS).to.be.below(0.05);
   });
 
+  it('holds the sigterm window below the running expiry, in production', () => {
+    const { fluxapps } = productionConfig();
+
+    expect(knobs.PRODUCTION.sigtermExpiryS).to.equal(fluxapps.sigtermExpiryS);
+    expect(knobs.PRODUCTION.locationTtlS).to.equal(fluxapps.locationTtlS);
+    // The ordering IS the property: appStartupManager expires on
+    // (cleanShutdown && downtime > sigterm) || downtime > running.
+    expect(fluxapps.sigtermExpiryS).to.be.below(fluxapps.locationTtlS);
+  });
+
+  it('rejects a fleet where the running expiry pre-empts the sigterm window', () => {
+    // What making locationTtlS live did: 420s against 63s, so the clean-shutdown
+    // grace became unreachable and a node down 300s deleted its apps.
+    expect(() => knobs.assertSigtermOrdering({ sigtermExpiryS: 420, locationTtlS: 63 }))
+      .to.throw(/not below locationTtlS/);
+  });
+
+  it('rejects a sigterm window no fixture could land inside', () => {
+    // Production's 120x would give 3.5s, and one node boot is 16s. A window
+    // smaller than the boot cannot be tested from the inside at all - which is
+    // the trap in compressing a knob measured across real work.
+    expect(() => knobs.assertSigtermOrdering({ sigtermExpiryS: 3.5, locationTtlS: 63 }))
+      .to.throw(/at or below one node boot/);
+  });
+
+  it('accepts the harness pair as shipped', () => {
+    const shared = knobs.loadSharedConfig().fluxapps;
+
+    expect(shared.sigtermExpiryS).to.be.above(knobs.BOOT_DRIFT_MS / 1000);
+    expect(shared.sigtermExpiryS).to.be.below(shared.locationTtlS);
+    expect(() => knobs.assertSigtermOrdering(shared)).to.not.throw();
+  });
+
   it('leaves a step longer than production needs alone', () => {
     // A suite that does not compress this at all is slow, not wrong, and the
     // check must not push anyone toward a tighter number than they wanted.

--- a/tests/unit/coupledKnobs.test.js
+++ b/tests/unit/coupledKnobs.test.js
@@ -99,6 +99,35 @@ describe('coupled harness knobs track production', () => {
     })).to.not.throw();
   });
 
+  it('sizes a suite\'s departure wait from the pacing, not by hand', () => {
+    // Suite 55 waited four minutes for a departure. That was written against a
+    // four-second interval; the interval is now tens of seconds and a departure
+    // is an interval PLUS a full queue ticket served again, so the typed number
+    // quietly stopped covering one and the suite timed out on a node that was
+    // working correctly.
+    const fleet = { removeFluxAppsPeriod: 4, explorerPollIntervalMs: 833, residentialQueueBaseMs: 1000 };
+    const step = knobs.derivedQueueStepMs(fleet);
+    const withStep = { ...fleet, residentialQueueStepMs: step };
+    const interval = knobs.derivedEvacuationIntervalMs(withStep);
+    const fluxapps = { ...withStep, residentialEvacuationIntervalMs: interval };
+
+    // The worst position on a five-instance app is four steps behind the front.
+    expect(knobs.departureCycleMs(fluxapps, 5)).to.equal(interval + 1000 + (4 * step));
+    // And it must exceed what driveUntil used to default to, which is the whole
+    // reason the waits are derived now.
+    expect(knobs.departureCycleMs(fluxapps, 5)).to.be.above(120000);
+  });
+
+  it('grows a departure wait with the instance count', () => {
+    const fleet = { removeFluxAppsPeriod: 4, explorerPollIntervalMs: 833, residentialQueueBaseMs: 1000 };
+    const step = knobs.derivedQueueStepMs(fleet);
+    const fluxapps = { ...fleet, residentialQueueStepMs: step };
+
+    expect(knobs.departureCycleMs(fluxapps, 5) - knobs.departureCycleMs(fluxapps, 4)).to.equal(step);
+    // A single-instance app has no position to wait behind.
+    expect(knobs.departureCycleMs(fluxapps, 1)).to.equal(knobs.departureCycleMs(fluxapps, 0));
+  });
+
   it('moves the derived step when the poll moves', () => {
     // The whole failure in one assertion: a literal does not do this.
     const slow = knobs.derivedQueueStepMs({ removeFluxAppsPeriod: 4, explorerPollIntervalMs: 833 });

--- a/tests/unit/fluxNetworkHelper.test.js
+++ b/tests/unit/fluxNetworkHelper.test.js
@@ -3105,4 +3105,33 @@ describe('fluxNetworkHelper tests', () => {
       expect(fluxNetworkHelper.isPlacementHeld()).to.equal(true);
     });
   });
+
+  describe('hasPublicIpOnInterface', () => {
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('returns NULL when the routing table cannot be read, not false', async () => {
+      // The distinction the static-IP verdict turns on. "There is no public
+      // address on any interface" is a fact about the node and means it is
+      // behind NAT; "I could not read /proc/net/route" is a fact about this
+      // process, and answering the second with the first asserts NAT on a node
+      // that may well hold a public address on its own interface.
+      sinon.stub(fs, 'readFile').rejects(new Error('EACCES: permission denied'));
+
+      const result = await fluxNetworkHelper.hasPublicIpOnInterface();
+
+      expect(result).to.equal(null);
+    });
+
+    it('returns false, not null, when the routing table simply has no routes', async () => {
+      // Readable and empty is an answer: there is no default route, so there is
+      // no public address on one.
+      sinon.stub(fs, 'readFile').resolves('Iface\tDestination\tGateway\n');
+
+      const result = await fluxNetworkHelper.hasPublicIpOnInterface();
+
+      expect(result).to.equal(false);
+    });
+  });
 });

--- a/tests/unit/fluxNetworkHelper.test.js
+++ b/tests/unit/fluxNetworkHelper.test.js
@@ -22,6 +22,7 @@ const WebSocket = require('ws');
 const path = require('path');
 const chaiAsPromised = require('chai-as-promised');
 const fs = require('fs').promises;
+const os = require('os');
 const util = require('util');
 const log = require('../../ZelBack/src/lib/log');
 const { Privilege, authOf } = require('../../ZelBack/src/services/utils/privileges');
@@ -3132,6 +3133,28 @@ describe('fluxNetworkHelper tests', () => {
       const result = await fluxNetworkHelper.hasPublicIpOnInterface();
 
       expect(result).to.equal(false);
+    });
+
+    it('finds a public address that is not the first one on the interface', async () => {
+      // An interface can carry a private primary and a public secondary - the
+      // shape add-on and failover addresses arrive in. The question is whether
+      // a public address is bound to the default-route interface; which address
+      // the kernel lists first is not part of the question.
+      const routeTable = 'Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\tMTU\tWindow\tIRTT\n'
+        + 'eth0\t00000000\t0101A8C0\t0003\t0\t0\t0\t00000000\t0\t0\t0\n';
+      const readFile = sinon.stub(fs, 'readFile');
+      readFile.withArgs('/proc/net/route', 'utf8').resolves(routeTable);
+      readFile.withArgs('/sys/class/net/eth0/operstate', 'utf8').resolves('up\n');
+      sinon.stub(os, 'networkInterfaces').returns({
+        eth0: [
+          { family: 'IPv4', internal: false, address: '192.168.1.50' },
+          { family: 'IPv4', internal: false, address: '203.0.113.7' },
+        ],
+      });
+
+      const result = await fluxNetworkHelper.hasPublicIpOnInterface();
+
+      expect(result).to.equal(true);
     });
   });
 });

--- a/tests/unit/fluxNetworkHelper.test.js
+++ b/tests/unit/fluxNetworkHelper.test.js
@@ -3056,4 +3056,53 @@ describe('fluxNetworkHelper tests', () => {
       sinon.assert.calledOnceWithExactly(errorLogSpy, 'IPTABLES: Error allowing traffic on Flux interface docker0. Error');
     });
   });
+
+  describe('placement hold tests', () => {
+    afterEach(() => {
+      fluxNetworkHelper.clearPlacementHold();
+      fluxNetworkHelper.clearStickyDosMessage();
+    });
+
+    it('is not held by default', () => {
+      expect(fluxNetworkHelper.isPlacementHeld()).to.equal(false);
+      expect(fluxNetworkHelper.getPlacementHold()).to.equal(null);
+    });
+
+    it('holds with the reason it was given', () => {
+      fluxNetworkHelper.setPlacementHold('residential node not running ArcaneOS');
+
+      expect(fluxNetworkHelper.isPlacementHeld()).to.equal(true);
+      expect(fluxNetworkHelper.getPlacementHold()).to.equal('residential node not running ArcaneOS');
+    });
+
+    it('releases', () => {
+      fluxNetworkHelper.setPlacementHold('some reason');
+
+      fluxNetworkHelper.clearPlacementHold();
+
+      expect(fluxNetworkHelper.isPlacementHeld()).to.equal(false);
+    });
+
+    it('does NOT put the node into DOS', () => {
+      // The whole point of the hold: DOS >= 100 makes nodeStatusMonitor and
+      // appStartupManager rm -rf every app on the box. A node that should stop
+      // growing but keep its volumes must not cross that line.
+      fluxNetworkHelper.setPlacementHold('residential node not running ArcaneOS');
+
+      expect(fluxNetworkHelper.isNodeDos()).to.equal(false);
+    });
+
+    it('is independent of the sticky DOS slot in both directions', () => {
+      fluxNetworkHelper.setStickyDosMessage('someone else holds this');
+      fluxNetworkHelper.setStickyDosStateValue(100);
+
+      expect(fluxNetworkHelper.isPlacementHeld()).to.equal(false);
+
+      fluxNetworkHelper.clearStickyDosMessage();
+      fluxNetworkHelper.setPlacementHold('held');
+
+      expect(fluxNetworkHelper.isNodeDos()).to.equal(false);
+      expect(fluxNetworkHelper.isPlacementHeld()).to.equal(true);
+    });
+  });
 });

--- a/tests/unit/fluxNetworkHelper.test.js
+++ b/tests/unit/fluxNetworkHelper.test.js
@@ -3059,8 +3059,10 @@ describe('fluxNetworkHelper tests', () => {
   });
 
   describe('placement hold tests', () => {
+    const { RESIDENTIAL_DOS } = fluxNetworkHelper.PlacementHoldOwner;
+
     afterEach(() => {
-      fluxNetworkHelper.clearPlacementHold();
+      fluxNetworkHelper.clearPlacementHold(RESIDENTIAL_DOS);
       fluxNetworkHelper.clearStickyDosMessage();
     });
 
@@ -3070,25 +3072,45 @@ describe('fluxNetworkHelper tests', () => {
     });
 
     it('holds with the reason it was given', () => {
-      fluxNetworkHelper.setPlacementHold('residential node not running ArcaneOS');
+      fluxNetworkHelper.setPlacementHold(RESIDENTIAL_DOS, 'residential node not running ArcaneOS');
 
       expect(fluxNetworkHelper.isPlacementHeld()).to.equal(true);
       expect(fluxNetworkHelper.getPlacementHold()).to.equal('residential node not running ArcaneOS');
     });
 
     it('releases', () => {
-      fluxNetworkHelper.setPlacementHold('some reason');
+      fluxNetworkHelper.setPlacementHold(RESIDENTIAL_DOS, 'some reason');
 
-      fluxNetworkHelper.clearPlacementHold();
+      fluxNetworkHelper.clearPlacementHold(RESIDENTIAL_DOS);
 
       expect(fluxNetworkHelper.isPlacementHeld()).to.equal(false);
+    });
+
+    it('refuses an owner it does not know, rather than minting one', () => {
+      // An unknown owner is a caller that was never given an identity. Accepted,
+      // it would hold the node under a name no release path knows about.
+      expect(() => fluxNetworkHelper.setPlacementHold('someFeature', 'a reason')).to.throw('unknown owner');
+      expect(fluxNetworkHelper.isPlacementHeld()).to.equal(false);
+    });
+
+    it('does not release a hold it does not own', () => {
+      // The reason this is a map keyed by owner and not a single slot. With one
+      // slot, whoever cleared next released the node outright - including a
+      // caller whose own condition had nothing to do with the hold in place - so
+      // the node resumed taking apps for a condition that had not lifted.
+      fluxNetworkHelper.setPlacementHold(RESIDENTIAL_DOS, 'residential');
+
+      fluxNetworkHelper.clearPlacementHold('someOtherOwner');
+
+      expect(fluxNetworkHelper.isPlacementHeld()).to.equal(true);
+      expect(fluxNetworkHelper.getPlacementHold()).to.equal('residential');
     });
 
     it('does NOT put the node into DOS', () => {
       // The whole point of the hold: DOS >= 100 makes nodeStatusMonitor and
       // appStartupManager rm -rf every app on the box. A node that should stop
       // growing but keep its volumes must not cross that line.
-      fluxNetworkHelper.setPlacementHold('residential node not running ArcaneOS');
+      fluxNetworkHelper.setPlacementHold(RESIDENTIAL_DOS, 'residential node not running ArcaneOS');
 
       expect(fluxNetworkHelper.isNodeDos()).to.equal(false);
     });
@@ -3100,7 +3122,7 @@ describe('fluxNetworkHelper tests', () => {
       expect(fluxNetworkHelper.isPlacementHeld()).to.equal(false);
 
       fluxNetworkHelper.clearStickyDosMessage();
-      fluxNetworkHelper.setPlacementHold('held');
+      fluxNetworkHelper.setPlacementHold(RESIDENTIAL_DOS, 'held');
 
       expect(fluxNetworkHelper.isNodeDos()).to.equal(false);
       expect(fluxNetworkHelper.isPlacementHeld()).to.equal(true);

--- a/tests/unit/fluxService.test.js
+++ b/tests/unit/fluxService.test.js
@@ -1944,8 +1944,11 @@ describe('fluxService tests', () => {
       benchmarkServiceGetStatusStub.returns({ status: 'success', data: 'status2 data' });
       benchmarkServiceGetBenchmarksStub.returns({ status: 'success', data: 'benchmarks data' });
       appsServiceFluxUsageStub.returns({ status: 'success', data: 'usage data' });
-      appsServiceListRunningAppsStub.returns({ status: 'success', data: 'listRunningApps data' });
-      appsServiceAppsResourcesStub.returns({ status: 'success', data: 'appsResources data' });
+      // The shapes the projection actually reads, not placeholder strings: a
+      // string here leaves result.data undefined and the assertion below fails
+      // on the projection rather than on the field it is about.
+      appsServiceListRunningAppsStub.returns({ status: 'success', data: [runningContainer] });
+      appsServiceAppsResourcesStub.returns({ status: 'success', data: { ...lockedResources } });
       appsServiceGetAppHashesStub.returns({ status: 'success', data: [{ height: 694000, message: true }] });
       explorerServiceStub.returns({ status: 'success', data: 'getScannedHeight data' });
       fluxCommunicationStub.returns({ status: 'success', data: 'connectedPeersInfo data' });

--- a/tests/unit/fluxService.test.js
+++ b/tests/unit/fluxService.test.js
@@ -1930,6 +1930,33 @@ describe('fluxService tests', () => {
       Status: 'Up 2 hours',
     };
 
+    it('carries the staging that is otherwise invisible', async () => {
+      // A held node takes no new apps and is in every other respect
+      // indistinguishable from one that has simply not been given work. This
+      // field is the only thing that says otherwise, and HOLD is the stage where
+      // the operator can still put the node right and lose nothing.
+      // eslint-disable-next-line global-require
+      const residentialNodeDosService = require('../../ZelBack/src/services/residentialNodeDosService');
+      sinon.stub(residentialNodeDosService, 'getDosStaging').returns('HOLD');
+      daemonServiceControlRpcsStub.returns({ status: 'success', data: 'info data' });
+      daemonServiceFluxnodeRpcsStub.returns({ status: 'success', data: 'status data' });
+      benchmarkServiceGetInfoStub.returns({ status: 'success', data: 'info2 data' });
+      benchmarkServiceGetStatusStub.returns({ status: 'success', data: 'status2 data' });
+      benchmarkServiceGetBenchmarksStub.returns({ status: 'success', data: 'benchmarks data' });
+      appsServiceFluxUsageStub.returns({ status: 'success', data: 'usage data' });
+      appsServiceListRunningAppsStub.returns({ status: 'success', data: 'listRunningApps data' });
+      appsServiceAppsResourcesStub.returns({ status: 'success', data: 'appsResources data' });
+      appsServiceGetAppHashesStub.returns({ status: 'success', data: [{ height: 694000, message: true }] });
+      explorerServiceStub.returns({ status: 'success', data: 'getScannedHeight data' });
+      fluxCommunicationStub.returns({ status: 'success', data: 'connectedPeersInfo data' });
+      fluxNetworkHelperStub.returns({ status: 'success', data: 'getIncomingConnectionsInfo data' });
+      syncthingServiceStub.returns({ status: 'success', data: 'syncthingVersion data' });
+
+      const result = await fluxService.getFluxInfo();
+
+      expect(result.data.flux.dosStaging).to.equal('HOLD');
+    });
+
     it('should return flux info no response passed', async () => {
       daemonServiceControlRpcsStub.returns({ status: 'success', data: 'info data' });
       daemonServiceFluxnodeRpcsStub.returns({ status: 'success', data: 'status data' });
@@ -1952,6 +1979,10 @@ describe('fluxService tests', () => {
       expect(result.data.daemon).to.eql({ info: 'info data', zmqEnabled: false });
       expect(result.data.node).to.eql({ status: 'status data' });
       expect(result.data.flux).to.be.an('object');
+      // Always present, never omitted: a field that only appears on affected
+      // nodes cannot be counted across the fleet, and counting it is half the
+      // reason it is here.
+      expect(result.data.flux.dosStaging).to.equal(null);
       expect(result.data.apps).to.be.an('object');
       expect(result.data.benchmark).to.eql({
         info: 'info2 data',

--- a/tests/unit/gAppPlacement.test.js
+++ b/tests/unit/gAppPlacement.test.js
@@ -1,0 +1,82 @@
+const { expect } = require('chai');
+
+// The g: placement rules are pure, so the orders three harness suites depend on
+// can be proven here rather than only on a fleet - which matters because getting
+// one wrong does not fail loudly. It produces a fleet in a shape the suite was
+// not written for, and the suite then times out waiting for something that was
+// never going to happen.
+describe('g: app placement orders', () => {
+  let placement;
+
+  before(async () => {
+    // Real ESM specifier resolved at runtime; the harness is ESM, this file is CJS.
+    // eslint-disable-next-line import/extensions
+    placement = await import('../../test-infra/runner/framework/g-app-placement.js');
+  });
+
+  // The harness lays nodes out one per address, ascending with the index.
+  const ipOf = (index) => `198.18.0.${index + 10}`;
+
+  describe('which holder seeds the folder', () => {
+    it('is the lowest address, not the first one the caller listed', () => {
+      // The distinction the rule turns on. Taking holders[0] passes on every
+      // fixture that happens to list its holders in order, and silently picks
+      // the wrong node for the first one that does not.
+      expect(placement.syncthingSeedIndex([2, 0, 1], ipOf)).to.equal(0);
+      expect(placement.syncthingSeedIndex([4, 3], ipOf)).to.equal(3);
+    });
+
+    it('orders addresses numerically, not as text', () => {
+      // '.10' sorts before '.9' as text. Every harness fleet today lands in
+      // .10-.25 where the two agree, so a lexical compare would be wrong only
+      // for the first fixture that ever spans the boundary.
+      const spanning = (index) => `198.18.0.${index}`;
+
+      expect(placement.syncthingSeedIndex([10, 9], spanning)).to.equal(9);
+    });
+
+    it('refuses an empty holder set rather than answering undefined', () => {
+      expect(() => placement.syncthingSeedIndex([], ipOf)).to.throw(/non-empty/);
+    });
+  });
+
+  describe('placing the seed at a chosen position', () => {
+    it('reproduces the order suite 70 arranges by hand', () => {
+      // Two holders, seed second, so it carries the later runningSince and
+      // lands at election index 1.
+      expect(placement.placementOrderWithSeedAt([0, 1], 1, ipOf)).to.eql([1, 0]);
+    });
+
+    it('reproduces the order suite 69 arranges by hand', () => {
+      // Three holders, seed in the middle: a peer above it and a peer below.
+      expect(placement.placementOrderWithSeedAt([0, 1, 2], 1, ipOf)).to.eql([1, 0, 2]);
+    });
+
+    it('reproduces the order suite 96 arranges by hand', () => {
+      // Seed last, so the writer is also the newest copy - the one the surplus
+      // rule picks. That collision is the whole subject of that suite.
+      expect(placement.placementOrderWithSeedAt([0, 1, 2], 2, ipOf)).to.eql([1, 2, 0]);
+    });
+
+    it('puts the seed at the senior end when asked for position 0', () => {
+      expect(placement.placementOrderWithSeedAt([0, 1, 2], 0, ipOf)).to.eql([0, 1, 2]);
+    });
+
+    it('keeps every holder exactly once, wherever the seed goes', () => {
+      const holders = [0, 1, 2, 3];
+      for (let position = 0; position < holders.length; position += 1) {
+        const order = placement.placementOrderWithSeedAt(holders, position, ipOf);
+        expect(order.slice().sort(), `position ${position} lost or duplicated a holder`)
+          .to.eql(holders.slice().sort());
+        expect(order[position], `the seed is not at position ${position}`).to.equal(0);
+      }
+    });
+
+    it('refuses a position off the end rather than clamping to it', () => {
+      // Clamping would hand back a plausible order for a fleet the caller does
+      // not have, and the suite would then wait on a shape that cannot occur.
+      expect(() => placement.placementOrderWithSeedAt([0, 1], 2, ipOf)).to.throw(/outside 0\.\.1/);
+      expect(() => placement.placementOrderWithSeedAt([0, 1], -1, ipOf)).to.throw(/outside 0\.\.1/);
+    });
+  });
+});

--- a/tests/unit/geolocationService.test.js
+++ b/tests/unit/geolocationService.test.js
@@ -406,6 +406,59 @@ describe('geolocationService tests', () => {
       expect(geolocationService.getStaticIpState()).to.equal('STATIC');
     });
 
+    it('restores the observation record at boot, where nothing else has', async () => {
+      // The test above calls getNodeGeolocation() first. serviceManager does
+      // not: it calls setNodeGeolocation() directly, with nothing having read
+      // the collection, so every module variable starts null - and the write at
+      // the end of the pass then persists lastIpChangeDate: null over a record
+      // going back years. Asserted on what reaches the database, because the
+      // damage is to the record rather than to this pass's verdict.
+      const fourHundredDaysAgo = Date.now() - (400 * 24 * 60 * 60 * 1000);
+      fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(true);
+      serviceHelperStub.axiosGet.resolves(ipApiResponse());
+      dbHelperStub.findOneInDatabase.resolves({
+        geolocation: { ip: '185.199.108.1' },
+        staticIp: true,
+        dataCenter: false,
+        lastIpChangeDate: fourHundredDaysAgo,
+        ipFirstSeenAt: fourHundredDaysAgo,
+        staticIpState: 'STATIC',
+        networkEvidence: null,
+      });
+      geolocationService = reload();
+
+      await geolocationService.setNodeGeolocation();
+
+      const written = dbHelperStub.updateOneInDatabase.lastCall.args[3].$set;
+      expect(written.lastIpChangeDate, 'the change record must survive a restart').to.equal(fourHundredDaysAgo);
+      expect(written.ipFirstSeenAt, 'the observation window must not restart').to.equal(fourHundredDaysAgo);
+    });
+
+    it('sees an address that moved while FluxOS was down', async () => {
+      // The same restore, in the direction that costs enforcement rather than
+      // history: without it previousIp is null on the first pass after every
+      // restart, so a change across the downtime is not a change, and a rule
+      // that trusts an address until it WATCHES it move can never watch one.
+      fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(true);
+      serviceHelperStub.axiosGet.resolves(ipApiResponse({ query: '185.199.109.9' }));
+      dbHelperStub.findOneInDatabase.resolves({
+        geolocation: { ip: '185.199.108.1' },
+        staticIp: true,
+        dataCenter: false,
+        lastIpChangeDate: Date.now() - (400 * 24 * 60 * 60 * 1000),
+        ipFirstSeenAt: Date.now() - (400 * 24 * 60 * 60 * 1000),
+        staticIpState: 'STATIC',
+        networkEvidence: null,
+      });
+      geolocationService = reload();
+
+      await geolocationService.setNodeGeolocation();
+
+      expect(geolocationService.getStaticIpState(), 'a watched change withdraws STATIC').to.equal('UNKNOWN');
+      const written = dbHelperStub.updateOneInDatabase.lastCall.args[3].$set;
+      expect(Date.now() - written.lastIpChangeDate, 'the change is stamped now').to.be.below(60000);
+    });
+
     // The table lookup is not stubbed by this describe's reload(), so these
     // build their own. A recent change means: lastIpChangeDate on record AND
     // the address held for less than the stability window since.

--- a/tests/unit/geolocationService.test.js
+++ b/tests/unit/geolocationService.test.js
@@ -426,7 +426,13 @@ describe('geolocationService tests', () => {
       fluxNetworkHelperStub.getLocalSocketAddress.resolves('185.199.108.1:16127');
       fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(true);
       dbHelperStub.findOneInDatabase.resolves(null);
-      ipLocationStoreStub = { lookup: sinon.stub().resolves(null) };
+      // `status().ready` is what separates "the table holds no verdict for this
+      // address" from "no table has been ingested". Only the first is an
+      // abstention the node may decide for itself.
+      ipLocationStoreStub = {
+        lookup: sinon.stub().resolves(null),
+        status: sinon.stub().returns({ ready: true, generated: 'x', rowCount: 2000000 }),
+      };
       // On its own evidence this address is a data centre: a hosting operator
       // and nothing suggesting an access network.
       serviceHelperStub.axiosGet.resolves({
@@ -456,7 +462,7 @@ describe('geolocationService tests', () => {
 
       await geolocationService.setNodeGeolocation();
 
-      const verdict = geolocationService.getNetworkClassification();
+      const verdict = await geolocationService.getNetworkClassification();
       expect(verdict.classification).to.equal('RESIDENTIAL');
       expect(verdict.source).to.equal('published-table');
     });
@@ -471,7 +477,7 @@ describe('geolocationService tests', () => {
 
       await geolocationService.setNodeGeolocation();
 
-      const verdict = geolocationService.getNetworkClassification();
+      const verdict = await geolocationService.getNetworkClassification();
       expect(verdict.classification).to.equal('CONFLICTED');
       expect(verdict.source).to.equal('node-veto');
     });
@@ -489,7 +495,7 @@ describe('geolocationService tests', () => {
 
       await geolocationService.setNodeGeolocation();
 
-      expect(geolocationService.getNetworkClassification().classification).to.equal('DATACENTER');
+      expect((await geolocationService.getNetworkClassification()).classification).to.equal('DATACENTER');
     });
 
     it('falls back to the node when the organisation carries no verdict', async () => {
@@ -498,7 +504,7 @@ describe('geolocationService tests', () => {
 
       await geolocationService.setNodeGeolocation();
 
-      const verdict = geolocationService.getNetworkClassification();
+      const verdict = await geolocationService.getNetworkClassification();
       expect(verdict.classification).to.equal('DATACENTER');
       expect(verdict.source).to.equal('node');
     });
@@ -509,19 +515,54 @@ describe('geolocationService tests', () => {
 
       await geolocationService.setNodeGeolocation();
 
-      expect(geolocationService.getNetworkClassification().source).to.equal('node');
+      expect((await geolocationService.getNetworkClassification()).source).to.equal('node');
     });
 
-    it('falls back to the node when the table cannot be read at all', async () => {
-      // A table that is unavailable is not evidence about the address, and must
-      // not stop a verdict being reached from what the node can see.
+    it('reaches NO verdict when the table cannot be read at all', async () => {
+      // A table that could not be read was not consulted, and a node that has
+      // not consulted it does not know what kind of network it is on. Falling
+      // back here would be treating "I could not ask" as "there is no answer" -
+      // the same mistake, one level up, that the classifier exists to avoid.
       ipLocationStoreStub.lookup.rejects(new Error('no database connection'));
       geolocationService = reload();
 
       await geolocationService.setNodeGeolocation();
 
-      expect(geolocationService.getNetworkClassification().source).to.equal('node');
-      expect(geolocationService.getNetworkClassification().classification).to.equal('DATACENTER');
+      expect(await geolocationService.getNetworkClassification()).to.equal(null);
+    });
+
+    it('reaches NO verdict until a baseline has been ingested', async () => {
+      // The state every node boots into: the artifact is 4.6 MB and two million
+      // rows, an ip-api call answers in milliseconds, so the table is reliably
+      // absent at the moment a booting node would otherwise decide. Nothing
+      // enforces on null, which is the point.
+      ipLocationStoreStub.status.returns({ ready: false, generated: null, rowCount: 0 });
+      geolocationService = reload();
+
+      await geolocationService.setNodeGeolocation();
+
+      expect(await geolocationService.getNetworkClassification()).to.equal(null);
+      sinon.assert.notCalled(ipLocationStoreStub.lookup);
+    });
+
+    it('reaches the verdict again once the baseline lands, without re-gathering', async () => {
+      // The evidence is gathered once and is expensive; the table arrives later
+      // and is cheap to consult. Asking again is what picks the table up - there
+      // is no second ip-api call and no stored verdict to go stale.
+      ipLocationStoreStub.status.returns({ ready: false, generated: null, rowCount: 0 });
+      geolocationService = reload();
+
+      await geolocationService.setNodeGeolocation();
+      expect(await geolocationService.getNetworkClassification()).to.equal(null);
+      const gatherCalls = serviceHelperStub.axiosGet.callCount;
+
+      ipLocationStoreStub.status.returns({ ready: true, generated: 'x', rowCount: 2000000 });
+      ipLocationStoreStub.lookup.resolves({ org: 'a1b2c3d4e5f6', networkClass: 'DATACENTER' });
+
+      const verdict = await geolocationService.getNetworkClassification();
+      expect(verdict.classification).to.equal('DATACENTER');
+      expect(verdict.source).to.equal('published-table');
+      expect(serviceHelperStub.axiosGet.callCount).to.equal(gatherCalls);
     });
 
     it('still records the node\'s own evidence when the table decided', async () => {
@@ -532,11 +573,14 @@ describe('geolocationService tests', () => {
 
       await geolocationService.setNodeGeolocation();
 
-      const verdict = geolocationService.getNetworkClassification();
+      const verdict = await geolocationService.getNetworkClassification();
       expect(verdict.evidenceAgainst.join(' ')).to.contain('Hetzner');
     });
 
-    it('drives isDataCenter from the published verdict', async () => {
+    it('drives isDataCenter from the node\'s own reading, not the table', async () => {
+      // isDataCenter() is synchronous and predates all of this; it stays what
+      // this node observed about itself. The published verdict is reached
+      // through getNetworkClassification, which is the one enforcement reads.
       ipLocationStoreStub.lookup.resolves({ org: 'a1b2c3d4e5f6', networkClass: 'DATACENTER' });
       geolocationService = reload();
 
@@ -547,6 +591,11 @@ describe('geolocationService tests', () => {
   });
 
   describe('network classification', () => {
+    // A table that HAS been ingested and simply holds no verdict for this
+    // address - the abstention that legitimately hands the decision back to the
+    // node, and the state these tests are about.
+    let silentTableStub;
+
     function reload() {
       return proxyquire('../../ZelBack/src/services/geolocationService', {
         config: configStub,
@@ -554,6 +603,7 @@ describe('geolocationService tests', () => {
         './dbHelper': dbHelperStub,
         './serviceHelper': serviceHelperStub,
         './fluxNetworkHelper': fluxNetworkHelperStub,
+        './appPlacement/ipLocationStore': silentTableStub,
       });
     }
 
@@ -561,12 +611,16 @@ describe('geolocationService tests', () => {
       fluxNetworkHelperStub.getLocalSocketAddress.resolves('185.199.108.1:16127');
       fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(true);
       dbHelperStub.findOneInDatabase.resolves(null);
+      silentTableStub = {
+        lookup: sinon.stub().resolves({ org: 'a1b2c3d4e5f6', networkClass: null }),
+        status: sinon.stub().returns({ ready: true, generated: 'x', rowCount: 2000000 }),
+      };
     });
 
-    it('has no verdict before a lookup has run', () => {
+    it('has nothing to say before anything has been gathered', async () => {
       geolocationService = reload();
 
-      expect(geolocationService.getNetworkClassification()).to.equal(null);
+      expect(await geolocationService.getNetworkClassification()).to.equal(null);
     });
 
     it('asks ip-api for the operator AS, not just the registrant org', async () => {
@@ -599,10 +653,10 @@ describe('geolocationService tests', () => {
 
       await geolocationService.setNodeGeolocation();
 
-      const verdict = geolocationService.getNetworkClassification();
+      const verdict = await geolocationService.getNetworkClassification();
       expect(verdict.classification).to.equal('DATACENTER');
       expect(verdict.evidenceAgainst.join(' ')).to.contain('Contabo');
-      expect(verdict.determinedAt).to.be.a('number');
+      expect(verdict.gatheredAt).to.be.a('number');
     });
 
     it('drives isDataCenter from the verdict', async () => {
@@ -635,7 +689,7 @@ describe('geolocationService tests', () => {
 
       await geolocationService.setNodeGeolocation();
 
-      expect(geolocationService.getNetworkClassification().classification).to.equal('UNKNOWN');
+      expect((await geolocationService.getNetworkClassification()).classification).to.equal('UNKNOWN');
       expect(geolocationService.isDataCenter()).to.equal(false);
     });
   });

--- a/tests/unit/geolocationService.test.js
+++ b/tests/unit/geolocationService.test.js
@@ -9,6 +9,13 @@ describe('geolocationService tests', () => {
   let fluxNetworkHelperStub;
   let logStub;
   let configStub;
+  // node:dns was NOT stubbed, so every setNodeGeolocation() test made a real
+  // dns.reverse('185.199.108.1') - about thirty a run - and the answer fed the
+  // classifier whose verdict the test then asserted. Both fixture addresses
+  // return ENOTFOUND today, which is why it looked fine; a resolver answering
+  // with a wildcard carrying `client`, `server`, `cloud` or `pool` inverts the
+  // tests asserting UNKNOWN and DATACENTER. Tests that want a PTR set it here.
+  let dnsStub;
 
   const mockGeolocationData = {
     ip: '185.199.108.1',
@@ -33,6 +40,14 @@ describe('geolocationService tests', () => {
   };
 
   beforeEach(() => {
+    // ENOTFOUND, which is what both fixture addresses really answer today - so
+    // every assertion in this file that was silently resting on a live lookup
+    // keeps the value it was written against, and now does so deterministically.
+    dnsStub = {
+      promises: {
+        reverse: sinon.stub().rejects(Object.assign(new Error('getaddrinfo ENOTFOUND'), { code: 'ENOTFOUND' })),
+      },
+    };
     // The service reschedules itself with setTimeout on every path it takes,
     // including a ten-second retry when no IP is detected. A real timer there
     // outlives this file and re-enters the service against restored stubs, so
@@ -87,6 +102,7 @@ describe('geolocationService tests', () => {
 
     // Load module with stubs
     geolocationService = proxyquire('../../ZelBack/src/services/geolocationService', {
+      'node:dns': dnsStub,
       config: configStub,
       '../lib/log': logStub,
       './dbHelper': dbHelperStub,
@@ -295,6 +311,7 @@ describe('geolocationService tests', () => {
   describe('static IP is observed, never inferred from the operator', () => {
     function reload() {
       return proxyquire('../../ZelBack/src/services/geolocationService', {
+        'node:dns': dnsStub,
         config: configStub,
         '../lib/log': logStub,
         './dbHelper': dbHelperStub,
@@ -394,6 +411,7 @@ describe('geolocationService tests', () => {
     // the address held for less than the stability window since.
     function reloadWithTable(networkClass) {
       return proxyquire('../../ZelBack/src/services/geolocationService', {
+        'node:dns': dnsStub,
         config: configStub,
         '../lib/log': logStub,
         './dbHelper': dbHelperStub,
@@ -500,6 +518,7 @@ describe('geolocationService tests', () => {
       fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(false);
       serviceHelperStub.axiosGet.resolves(ipApiResponse());
       geolocationService = proxyquire('../../ZelBack/src/services/geolocationService', {
+        'node:dns': dnsStub,
         config: configStub,
         '../lib/log': logStub,
         './dbHelper': dbHelperStub,
@@ -524,6 +543,7 @@ describe('geolocationService tests', () => {
       fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(false);
       serviceHelperStub.axiosGet.resolves(ipApiResponse());
       geolocationService = proxyquire('../../ZelBack/src/services/geolocationService', {
+        'node:dns': dnsStub,
         config: configStub,
         '../lib/log': logStub,
         './dbHelper': dbHelperStub,
@@ -635,6 +655,7 @@ describe('geolocationService tests', () => {
 
     function reload() {
       return proxyquire('../../ZelBack/src/services/geolocationService', {
+        'node:dns': dnsStub,
         config: configStub,
         '../lib/log': logStub,
         './dbHelper': dbHelperStub,
@@ -742,6 +763,24 @@ describe('geolocationService tests', () => {
       await geolocationService.setNodeGeolocation();
 
       expect(await geolocationService.getNetworkClassification()).to.equal(null);
+    });
+
+    it('reads the PTR this test chose, not whatever a resolver happens to answer', async () => {
+      // The reason node:dns is stubbed. A PTR carrying access-network
+      // vocabulary is a positive signal to the classifier, and every verdict
+      // assertion in this file rested on both fixture addresses happening to
+      // answer ENOTFOUND on the machine running the suite.
+      dnsStub.promises.reverse.resolves(['host.pool.example-isp.net']);
+      ipLocationStoreStub.lookup.resolves({ org: 'a1b2c3d4e5f6', networkClass: 'RESIDENTIAL' });
+      geolocationService = reload();
+
+      await geolocationService.setNodeGeolocation();
+
+      const verdict = await geolocationService.getNetworkClassification();
+      expect(verdict.evidenceFor.join(' ')).to.contain('ptr access-network');
+      // Hetzner in this describe's fixture contradicts it, so the node declines
+      // the table's RESIDENTIAL rather than taking it.
+      expect(verdict.source).to.equal('node-veto');
     });
 
     it('still gathers the node\'s own evidence, which is what the veto reads', async () => {
@@ -901,6 +940,7 @@ describe('geolocationService tests', () => {
 
     function reload() {
       return proxyquire('../../ZelBack/src/services/geolocationService', {
+        'node:dns': dnsStub,
         config: configStub,
         '../lib/log': logStub,
         './dbHelper': dbHelperStub,

--- a/tests/unit/geolocationService.test.js
+++ b/tests/unit/geolocationService.test.js
@@ -498,24 +498,103 @@ describe('geolocationService tests', () => {
       expect((await geolocationService.getNetworkClassification()).classification).to.equal('DATACENTER');
     });
 
-    it('falls back to the node when the organisation carries no verdict', async () => {
+    it('reaches NO verdict when the organisation carries none', async () => {
+      // The table decides or nobody does. The node's own rule is the published
+      // rule with registration data removed - a node cannot query the RIRs -
+      // and its error rate has never been measured, so it does not get to
+      // decide the one thing that deletes customer data. Tuning this address
+      // means publishing a verdict for it, by hand if the vote cannot reach it:
+      // fluxos-network-policy data/orgclass-overrides.json.
       ipLocationStoreStub.lookup.resolves({ org: 'a1b2c3d4e5f6', networkClass: null });
       geolocationService = reload();
 
       await geolocationService.setNodeGeolocation();
 
-      const verdict = await geolocationService.getNetworkClassification();
-      expect(verdict.classification).to.equal('DATACENTER');
-      expect(verdict.source).to.equal('node');
+      expect(await geolocationService.getNetworkClassification()).to.equal(null);
     });
 
-    it('falls back to the node when no row covers the address', async () => {
+    it('reaches NO verdict when no row covers the address', async () => {
       ipLocationStoreStub.lookup.resolves(null);
       geolocationService = reload();
 
       await geolocationService.setNodeGeolocation();
 
-      expect((await geolocationService.getNetworkClassification()).source).to.equal('node');
+      expect(await geolocationService.getNetworkClassification()).to.equal(null);
+    });
+
+    it('still gathers the node\'s own evidence, which is what the veto reads', async () => {
+      // Removing the fallback removes the node's verdict as an AUTHORITY, not
+      // its evidence: evidenceAgainst is what declines a published RESIDENTIAL
+      // for an address in the minority tail an 80% vote is designed to outvote.
+      ipLocationStoreStub.lookup.resolves({ org: 'a1b2c3d4e5f6', networkClass: 'RESIDENTIAL' });
+      geolocationService = reload();
+
+      await geolocationService.setNodeGeolocation();
+
+      const verdict = await geolocationService.getNetworkClassification();
+      expect(verdict.classification).to.equal('CONFLICTED');
+      expect(verdict.source).to.equal('node-veto');
+      expect(verdict.evidenceAgainst.join(' ')).to.contain('Hetzner');
+    });
+
+    it('reaches NO verdict when the geolocation source carried no network signals', async () => {
+      // The stats.runonflux.io fallback, taken when ip-api answers 200 with an
+      // unusable body. It carries location and org and none of
+      // hosting/proxy/mobile/isp/asn - fluxstats never asks ip-api for them and
+      // its /fluxlocation endpoint projects them away - so evidenceAgainst is
+      // empty because nobody looked.
+      //
+      // That empties the veto too: it fires on local evidence AGAINST, so a
+      // published RESIDENTIAL would stand unchallenged on precisely the
+      // addresses the veto exists for. The verdict is null either way, whatever
+      // the PTR resolves to, so this does not rest on a DNS answer.
+      serviceHelperStub.axiosGet.onFirstCall().resolves({ data: { status: 'fail' } });
+      serviceHelperStub.axiosGet.onSecondCall().resolves({
+        data: {
+          status: 'success',
+          data: {
+            ip: '185.199.108.1',
+            continent: 'Europe',
+            continentCode: 'EU',
+            country: 'France',
+            countryCode: 'FR',
+            region: 'IDF',
+            regionName: 'Ile-de-France',
+            lat: 48.8,
+            lon: 2.3,
+            org: 'Bouygues Telecom',
+          },
+        },
+      });
+      ipLocationStoreStub.lookup.resolves({ org: 'a1b2c3d4e5f6', networkClass: 'RESIDENTIAL' });
+      geolocationService = reload();
+
+      await geolocationService.setNodeGeolocation();
+
+      expect(await geolocationService.getNetworkClassification()).to.equal(null);
+    });
+
+    it('still records WHERE the node is on that path, which is what the fallback is for', async () => {
+      // The fix must not cost the fallback its actual job. Country and region
+      // feed placement and the region pins; refusing to store them would break
+      // location for every node whose ip-api call comes back unusable.
+      serviceHelperStub.axiosGet.onFirstCall().resolves({ data: { status: 'fail' } });
+      serviceHelperStub.axiosGet.onSecondCall().resolves({
+        data: {
+          status: 'success',
+          data: {
+            ip: '185.199.108.1', continent: 'Europe', continentCode: 'EU', country: 'France', countryCode: 'FR', region: 'IDF', regionName: 'Ile-de-France', lat: 48.8, lon: 2.3, org: 'Bouygues Telecom',
+          },
+        },
+      });
+      geolocationService = reload();
+
+      await geolocationService.setNodeGeolocation();
+
+      const where = await geolocationService.getNodeGeolocation();
+      expect(where.country).to.equal('France');
+      expect(where.countryCode).to.equal('FR');
+      expect(where.regionName).to.equal('Ile-de-France');
     });
 
     it('reaches NO verdict when the table cannot be read at all', async () => {
@@ -591,10 +670,12 @@ describe('geolocationService tests', () => {
   });
 
   describe('network classification', () => {
-    // A table that HAS been ingested and simply holds no verdict for this
-    // address - the abstention that legitimately hands the decision back to the
-    // node, and the state these tests are about.
-    let silentTableStub;
+    // These are about the EVIDENCE the node gathers about itself and what rides
+    // on it - not about who decides. The table decides; a table holding no
+    // verdict means the node is simply not classified, so the default here is
+    // one that has decided DATACENTER and the tests that care about an
+    // abstention set it to null themselves.
+    let tableStub;
 
     function reload() {
       return proxyquire('../../ZelBack/src/services/geolocationService', {
@@ -603,7 +684,7 @@ describe('geolocationService tests', () => {
         './dbHelper': dbHelperStub,
         './serviceHelper': serviceHelperStub,
         './fluxNetworkHelper': fluxNetworkHelperStub,
-        './appPlacement/ipLocationStore': silentTableStub,
+        './appPlacement/ipLocationStore': tableStub,
       });
     }
 
@@ -611,8 +692,8 @@ describe('geolocationService tests', () => {
       fluxNetworkHelperStub.getLocalSocketAddress.resolves('185.199.108.1:16127');
       fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(true);
       dbHelperStub.findOneInDatabase.resolves(null);
-      silentTableStub = {
-        lookup: sinon.stub().resolves({ org: 'a1b2c3d4e5f6', networkClass: null }),
+      tableStub = {
+        lookup: sinon.stub().resolves({ org: 'a1b2c3d4e5f6', networkClass: 'DATACENTER' }),
         status: sinon.stub().returns({ ready: true, generated: 'x', rowCount: 2000000 }),
       };
     });
@@ -689,7 +770,9 @@ describe('geolocationService tests', () => {
 
       await geolocationService.setNodeGeolocation();
 
-      expect((await geolocationService.getNetworkClassification()).classification).to.equal('UNKNOWN');
+      // isDataCenter reads the node's own classification directly and is not a
+      // verdict about enforcement, so it answers whether or not the table has
+      // decided - and absence of evidence leaves it false.
       expect(geolocationService.isDataCenter()).to.equal(false);
     });
   });

--- a/tests/unit/geolocationService.test.js
+++ b/tests/unit/geolocationService.test.js
@@ -279,12 +279,16 @@ describe('geolocationService tests', () => {
       sinon.assert.called(logStub.error);
     });
 
-    it('should NOT claim a static IP from a null lastIpChangeDate', async () => {
-      // A null change date means nothing has been observed yet, which is not the
-      // same as having been observed stable.
+    it('claims a static IP for a public address with no recorded change', async () => {
+      // Through the whole pass, not just the predicate. A null lastIpChangeDate
+      // means this node has never SEEN the address move, which is where every
+      // node starts; the address is trusted until an observed change withdraws
+      // it. The stability window measures the recovery from that change, and is
+      // the only thing it measures.
       await geolocationService.setNodeGeolocation();
 
-      expect(geolocationService.isStaticIP()).to.equal(false);
+      expect(geolocationService.getStaticIpState()).to.equal('STATIC');
+      expect(geolocationService.isStaticIP()).to.equal(true);
     });
   });
 
@@ -319,11 +323,126 @@ describe('geolocationService tests', () => {
       dbHelperStub.findOneInDatabase.resolves(null);
     });
 
-    it('an address just met is UNKNOWN, not static', async () => {
-      // The old code substituted `now - threshold - 1` when no IP change had
-      // ever been recorded, so a node up for five minutes claimed ten days of
-      // stability. An address becomes static by being held.
+    it('trusts a public address it has never seen change', async () => {
+      // Absence of an observed change is this node having started watching
+      // after the fact, which every node does exactly once - not evidence that
+      // the address moves. Measured on the fleet an address changes on 0.29% of
+      // node-days, so refusing here is wrong about ~97% of nodes for ten days,
+      // and it lands on all of them together because they upgrade together: 44
+      // staticip specs across 202 placements with nowhere to run.
       fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(true);
+      serviceHelperStub.axiosGet.resolves(ipApiResponse());
+      geolocationService = reload();
+
+      await geolocationService.setNodeGeolocation();
+
+      expect(geolocationService.getStaticIpState()).to.equal('STATIC');
+      expect(geolocationService.isStaticIP()).to.equal(true);
+    });
+
+    it('withdraws it once the address is seen to change, until it is held again', async () => {
+      // One observed change is what turns the trust off. The address then earns
+      // it back by being held for the stability window, which is what
+      // ipFirstSeenAt measures and is the only thing it is for.
+      fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(true);
+      serviceHelperStub.axiosGet.resolves(ipApiResponse());
+      dbHelperStub.findOneInDatabase.resolves({
+        geolocation: { ip: '9.9.9.9' },
+        staticIp: true,
+        dataCenter: false,
+        lastIpChangeDate: null,
+        ipFirstSeenAt: Date.now() - (400 * 24 * 60 * 60 * 1000),
+        staticIpState: 'STATIC',
+        networkClassification: null,
+      });
+      geolocationService = reload();
+      await geolocationService.getNodeGeolocation();
+
+      // The address it comes back with is not the one on record.
+      await geolocationService.setNodeGeolocation();
+
+      expect(geolocationService.getStaticIpState()).to.equal('UNKNOWN');
+      expect(geolocationService.isStaticIP()).to.equal(false);
+    });
+
+    it('seeds the window from the last recorded change, so an upgrade costs nothing', async () => {
+      // ipFirstSeenAt is new, so an in-place upgrade has none. lastIpChangeDate
+      // is persisted, restored, and says the address has been held since that
+      // change - reading it is what stops the window restarting on a node that
+      // has held its address for over a year.
+      fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(true);
+      serviceHelperStub.axiosGet.resolves(ipApiResponse());
+      dbHelperStub.findOneInDatabase.resolves({
+        geolocation: { ip: '185.199.108.1' },
+        staticIp: true,
+        dataCenter: false,
+        lastIpChangeDate: Date.now() - (400 * 24 * 60 * 60 * 1000),
+        ipFirstSeenAt: null,
+        staticIpState: 'STATIC',
+        networkClassification: null,
+      });
+      geolocationService = reload();
+      await geolocationService.getNodeGeolocation();
+
+      await geolocationService.setNodeGeolocation();
+
+      expect(geolocationService.getStaticIpState()).to.equal('STATIC');
+    });
+
+    it('is STATIC behind NAT when the published table calls the range hosting', async () => {
+      // A 1:1-NAT cloud instance holds a genuinely static address that never
+      // appears on a local interface, so the interface test alone can never see
+      // it - every AWS, Azure, GCP and Oracle box fails it. This is the job the
+      // deleted staticIpOrgs list did, on evidence that has been measured.
+      fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(false);
+      serviceHelperStub.axiosGet.resolves(ipApiResponse());
+      geolocationService = proxyquire('../../ZelBack/src/services/geolocationService', {
+        config: configStub,
+        '../lib/log': logStub,
+        './dbHelper': dbHelperStub,
+        './serviceHelper': serviceHelperStub,
+        './fluxNetworkHelper': fluxNetworkHelperStub,
+        './appPlacement/ipLocationStore': {
+          lookup: sinon.stub().resolves({ org: 'a1b2c3d4e5f6', networkClass: 'DATACENTER' }),
+          status: sinon.stub().returns({ ready: true, generated: 'x', rowCount: 2000000 }),
+        },
+      });
+
+      await geolocationService.setNodeGeolocation();
+
+      expect(geolocationService.getStaticIpState()).to.equal('STATIC');
+    });
+
+    it('stays DYNAMIC behind NAT when the table calls the range residential', async () => {
+      // The old rule granted static to seven consumer ISPs on the fleet -
+      // Verizon, Comcast, Free SAS, Bouygues among them - because ip-api
+      // flagged them `proxy`, which is a VPN artefact and not an address that
+      // stays put.
+      fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(false);
+      serviceHelperStub.axiosGet.resolves(ipApiResponse());
+      geolocationService = proxyquire('../../ZelBack/src/services/geolocationService', {
+        config: configStub,
+        '../lib/log': logStub,
+        './dbHelper': dbHelperStub,
+        './serviceHelper': serviceHelperStub,
+        './fluxNetworkHelper': fluxNetworkHelperStub,
+        './appPlacement/ipLocationStore': {
+          lookup: sinon.stub().resolves({ org: 'a1b2c3d4e5f6', networkClass: 'RESIDENTIAL' }),
+          status: sinon.stub().returns({ ready: true, generated: 'x', rowCount: 2000000 }),
+        },
+      });
+
+      await geolocationService.setNodeGeolocation();
+
+      expect(geolocationService.getStaticIpState()).to.equal('DYNAMIC');
+    });
+
+    it('says UNKNOWN when the routing table could not be read, not DYNAMIC', async () => {
+      // "There is no public address on any interface" is a fact about the node.
+      // "I could not read the routing table" is a fact about this process, and
+      // answering the second with the first asserts NAT on a node that may well
+      // hold a public address.
+      fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(null);
       serviceHelperStub.axiosGet.resolves(ipApiResponse());
       geolocationService = reload();
 

--- a/tests/unit/geolocationService.test.js
+++ b/tests/unit/geolocationService.test.js
@@ -406,6 +406,45 @@ describe('geolocationService tests', () => {
       expect(geolocationService.getStaticIpState()).to.equal('STATIC');
     });
 
+    it('backfills the state from a record written before the state machine existed', async () => {
+      // An upgraded node restores staticIp: true with no staticIpState at all.
+      // The state must agree with the boolean: a node that restores as
+      // not-static fails checkAppStaticIpRequirements, whose redeploy-path
+      // callers remove the app when it throws. The backfilled STATIC is a
+      // carried prior the first refresh pass replaces.
+      dbHelperStub.findOneInDatabase.resolves({
+        geolocation: { ip: '185.199.108.1' },
+        staticIp: true,
+        dataCenter: false,
+        lastIpChangeDate: null,
+        ipFirstSeenAt: null,
+      });
+      geolocationService = reload();
+
+      await geolocationService.getNodeGeolocation();
+
+      expect(geolocationService.getStaticIpState()).to.equal('STATIC');
+      expect(geolocationService.isStaticIP()).to.equal(true);
+    });
+
+    it('an old record without the grant restores as UNKNOWN, not DYNAMIC', async () => {
+      // staticIp: false on an old record cannot tell "checked and dynamic"
+      // from "never checked", so it restores as the state that says so.
+      dbHelperStub.findOneInDatabase.resolves({
+        geolocation: { ip: '185.199.108.1' },
+        staticIp: false,
+        dataCenter: false,
+        lastIpChangeDate: null,
+        ipFirstSeenAt: null,
+      });
+      geolocationService = reload();
+
+      await geolocationService.getNodeGeolocation();
+
+      expect(geolocationService.getStaticIpState()).to.equal('UNKNOWN');
+      expect(geolocationService.isStaticIP()).to.equal(false);
+    });
+
     it('restores the observation record at boot, where nothing else has', async () => {
       // The test above calls getNodeGeolocation() first. serviceManager does
       // not: it calls setNodeGeolocation() directly, with nothing having read

--- a/tests/unit/geolocationService.test.js
+++ b/tests/unit/geolocationService.test.js
@@ -16,6 +16,7 @@ describe('geolocationService tests', () => {
   // with a wildcard carrying `client`, `server`, `cloud` or `pool` inverts the
   // tests asserting UNKNOWN and DATACENTER. Tests that want a PTR set it here.
   let dnsStub;
+  let clock;
 
   const mockGeolocationData = {
     ip: '185.199.108.1',
@@ -51,9 +52,12 @@ describe('geolocationService tests', () => {
     // The service reschedules itself with setTimeout on every path it takes,
     // including a ten-second retry when no IP is detected. A real timer there
     // outlives this file and re-enters the service against restored stubs, so
-    // it reaches the network for the rest of the run. Only setTimeout is faked:
-    // the service reads Date for its IP-change window.
-    sinon.useFakeTimers({ toFake: ['setTimeout'], shouldAdvanceTime: true });
+    // it reaches the network for the rest of the run. clearTimeout is faked
+    // alongside it, because the real one cannot cancel a fake id - the loop's
+    // own cancellation would silently do nothing and its timers would all fire.
+    // Date is deliberately NOT faked: the service reads it for the IP-change
+    // window.
+    clock = sinon.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'], shouldAdvanceTime: true });
 
     // Create stubs
     const mockDb = {
@@ -305,6 +309,86 @@ describe('geolocationService tests', () => {
 
       expect(geolocationService.getStaticIpState()).to.equal('STATIC');
       expect(geolocationService.isStaticIP()).to.equal(true);
+    });
+  });
+
+  describe('the geolocation loop is one owned chain, not one per caller', () => {
+    // serviceManager starts this at boot and fluxNetworkHelper restarts it on
+    // every IP change. Before the loop had an owner, the second caller forked a
+    // second self-perpetuating chain and neither could be stopped.
+    beforeEach(() => {
+      fluxNetworkHelperStub.getLocalSocketAddress.resolves('185.199.108.1:16127');
+      fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(true);
+      serviceHelperStub.axiosGet.resolves({
+        data: {
+          status: 'success',
+          query: '185.199.108.1',
+          continent: 'Europe',
+          continentCode: 'EU',
+          country: 'Germany',
+          countryCode: 'DE',
+          region: 'HE',
+          regionName: 'Hesse',
+          lat: 50.1109,
+          lon: 8.6821,
+          org: 'Hetzner Online GmbH',
+          isp: 'Hetzner Online GmbH',
+          proxy: false,
+          hosting: true,
+        },
+      });
+    });
+
+    it('a second caller resumes the one loop rather than starting another', async () => {
+      await geolocationService.setNodeGeolocation();
+      await geolocationService.setNodeGeolocation();
+      // The first statement of every pass, so it counts passes. axiosGet does
+      // not - a pass can return before it reaches the API.
+      fluxNetworkHelperStub.getLocalSocketAddress.resetHistory();
+
+      // Both calls armed a reschedule. Two chains would wake twice here.
+      await clock.tickAsync(3 * 24 * 60 * 60 * 1000 + 1000);
+
+      sinon.assert.calledOnce(fluxNetworkHelperStub.getLocalSocketAddress);
+    });
+
+    it('stops when it is told to, so nothing wakes again', async () => {
+      await geolocationService.setNodeGeolocation();
+      geolocationService.stopNodeGeolocation();
+      fluxNetworkHelperStub.getLocalSocketAddress.resetHistory();
+
+      await clock.tickAsync(3 * 24 * 60 * 60 * 1000 + 1000);
+
+      sinon.assert.notCalled(fluxNetworkHelperStub.getLocalSocketAddress);
+    });
+
+    it('a caller arriving mid-pass waits for it instead of running beside it', async () => {
+      let releaseFirst;
+      fluxNetworkHelperStub.getLocalSocketAddress
+        .onFirstCall().returns(new Promise((resolve) => {
+          releaseFirst = () => resolve('185.199.108.1:16127');
+        }))
+        .onSecondCall().resolves('185.199.108.1:16127');
+
+      const first = geolocationService.setNodeGeolocation();
+      const arrivedDuring = geolocationService.setNodeGeolocation();
+
+      // Drained, or this asserts nothing: both calls park on their first await,
+      // so a synchronous check here passes whether or not they run concurrently.
+      await clock.tickAsync(0);
+
+      // One pass has begun, not two. Counted on the address read rather than on
+      // the API call, because a pass whose address has not changed deliberately
+      // skips the API (see the guard on storedIp) - so axiosGet counts changes,
+      // not passes.
+      sinon.assert.calledOnce(fluxNetworkHelperStub.getLocalSocketAddress);
+
+      releaseFirst();
+      await Promise.all([first, arrivedDuring]);
+
+      // And the late caller was not dropped - a second pass ran once the first
+      // had finished, which is the point of holding it rather than ignoring it.
+      sinon.assert.calledTwice(fluxNetworkHelperStub.getLocalSocketAddress);
     });
   });
 

--- a/tests/unit/geolocationService.test.js
+++ b/tests/unit/geolocationService.test.js
@@ -241,35 +241,20 @@ describe('geolocationService tests', () => {
       expect(serviceHelperStub.axiosGet.secondCall.args[0]).to.include('stats.runonflux.io');
     });
 
-    it('should set staticIp to true when org contains known hosting provider', async () => {
-      fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(false);
-      serviceHelperStub.axiosGet.resolves({
-        data: {
-          status: 'success',
-          query: '185.199.108.1',
-          org: 'Hetzner Online GmbH',
-          proxy: false,
-          hosting: false,
-        },
-      });
-
-      await geolocationService.setNodeGeolocation();
-
-      expect(geolocationService.isStaticIP()).to.equal(true);
-    });
-
     it('should set dataCenter to true when hosting flag is true', async () => {
       await geolocationService.setNodeGeolocation();
 
       expect(geolocationService.isDataCenter()).to.equal(true);
     });
 
-    it('should set dataCenter to true when org contains known hosting provider', async () => {
+    it('should set dataCenter from the operator, not the registrant org', async () => {
       serviceHelperStub.axiosGet.resolves({
         data: {
           status: 'success',
           query: '185.199.108.1',
-          org: 'OVH SAS',
+          org: 'Some Reseller Ltd',
+          isp: 'OVH SAS',
+          as: 'AS16276 OVH SAS',
           proxy: false,
           hosting: false,
         },
@@ -294,57 +279,364 @@ describe('geolocationService tests', () => {
       sinon.assert.called(logStub.error);
     });
 
-    it('should set staticIp to true with public IP on interface and null lastIpChangeDate', async () => {
-      // This tests the case where lastIpChangeDate is null (considered stable for 10+ days)
+    it('should NOT claim a static IP from a null lastIpChangeDate', async () => {
+      // A null change date means nothing has been observed yet, which is not the
+      // same as having been observed stable.
       await geolocationService.setNodeGeolocation();
 
-      expect(geolocationService.isStaticIP()).to.equal(true);
+      expect(geolocationService.isStaticIP()).to.equal(false);
     });
   });
 
-  describe('Static IP org detection tests', () => {
-    const testOrgs = [
-      { org: 'Hetzner Online GmbH', expected: true },
-      { org: 'OVH SAS', expected: true },
-      { org: 'netcup GmbH', expected: true },
-      { org: 'Contabo GmbH', expected: true },
-      { org: 'Hostslim B.V.', expected: true },
-      { org: 'Zayo Bandwidth', expected: true },
-      { org: 'Cogent Communications', expected: true },
-      { org: 'Lumen Technologies', expected: true },
-      { org: 'Hostnodes LLC', expected: true },
-      { org: 'Comcast Cable', expected: false },
-      { org: 'AT&T Services', expected: false },
-      { org: 'Verizon Business', expected: false },
-    ];
-
-    testOrgs.forEach(({ org, expected }) => {
-      it(`should ${expected ? 'detect' : 'not detect'} "${org}" as static IP org`, async () => {
-        fluxNetworkHelperStub.getLocalSocketAddress.resolves('185.199.108.1:16127');
-        fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(false); // No public IP on interface
-        serviceHelperStub.axiosGet.resolves({
-          data: {
-            status: 'success',
-            query: '185.199.108.1',
-            org,
-            proxy: false,
-            hosting: false,
-          },
-        });
-
-        // Reload module to reset state
-        geolocationService = proxyquire('../../ZelBack/src/services/geolocationService', {
-          config: configStub,
-          '../lib/log': logStub,
-          './dbHelper': dbHelperStub,
-          './serviceHelper': serviceHelperStub,
-          './fluxNetworkHelper': fluxNetworkHelperStub,
-        });
-
-        await geolocationService.setNodeGeolocation();
-
-        expect(geolocationService.isStaticIP()).to.equal(expected);
+  describe('static IP is observed, never inferred from the operator', () => {
+    function reload() {
+      return proxyquire('../../ZelBack/src/services/geolocationService', {
+        config: configStub,
+        '../lib/log': logStub,
+        './dbHelper': dbHelperStub,
+        './serviceHelper': serviceHelperStub,
+        './fluxNetworkHelper': fluxNetworkHelperStub,
       });
+    }
+
+    function ipApiResponse(overrides = {}) {
+      return {
+        data: {
+          status: 'success',
+          query: '185.199.108.1',
+          org: 'Hetzner Online GmbH',
+          isp: 'Hetzner Online GmbH',
+          as: 'AS24940 Hetzner Online GmbH',
+          proxy: false,
+          hosting: false,
+          ...overrides,
+        },
+      };
+    }
+
+    beforeEach(() => {
+      fluxNetworkHelperStub.getLocalSocketAddress.resolves('185.199.108.1:16127');
+      dbHelperStub.findOneInDatabase.resolves(null);
+    });
+
+    it('an address just met is UNKNOWN, not static', async () => {
+      // The old code substituted `now - threshold - 1` when no IP change had
+      // ever been recorded, so a node up for five minutes claimed ten days of
+      // stability. An address becomes static by being held.
+      fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(true);
+      serviceHelperStub.axiosGet.resolves(ipApiResponse());
+      geolocationService = reload();
+
+      await geolocationService.setNodeGeolocation();
+
+      expect(geolocationService.getStaticIpState()).to.equal('UNKNOWN');
+      expect(geolocationService.isStaticIP()).to.equal(false);
+    });
+
+    it('is STATIC once the address has been held for the stability window', async () => {
+      fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(true);
+      serviceHelperStub.axiosGet.resolves(ipApiResponse());
+      dbHelperStub.findOneInDatabase.resolves({
+        geolocation: { ip: '185.199.108.1' },
+        staticIp: false,
+        dataCenter: false,
+        lastIpChangeDate: null,
+        ipFirstSeenAt: Date.now() - (11 * 24 * 60 * 60 * 1000),
+        staticIpState: 'UNKNOWN',
+        networkClassification: null,
+      });
+      geolocationService = reload();
+      await geolocationService.getNodeGeolocation();
+
+      await geolocationService.setNodeGeolocation();
+
+      expect(geolocationService.getStaticIpState()).to.equal('STATIC');
+      expect(geolocationService.isStaticIP()).to.equal(true);
+    });
+
+    it('is DYNAMIC behind NAT no matter who the operator is', async () => {
+      // The old list applied on this branch too, so a box behind consumer NAT
+      // could claim a static address because its registrant string said "ovh".
+      fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(false);
+      serviceHelperStub.axiosGet.resolves(ipApiResponse({ org: 'OVH SAS', isp: 'OVH SAS' }));
+      dbHelperStub.findOneInDatabase.resolves({
+        geolocation: { ip: '185.199.108.1' },
+        staticIp: false,
+        dataCenter: false,
+        lastIpChangeDate: null,
+        ipFirstSeenAt: Date.now() - (400 * 24 * 60 * 60 * 1000),
+        staticIpState: 'STATIC',
+        networkClassification: null,
+      });
+      geolocationService = reload();
+      await geolocationService.getNodeGeolocation();
+
+      await geolocationService.setNodeGeolocation();
+
+      expect(geolocationService.getStaticIpState()).to.equal('DYNAMIC');
+      expect(geolocationService.isStaticIP()).to.equal(false);
+    });
+
+    it('a known hosting operator confers nothing on its own', async () => {
+      fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(false);
+      serviceHelperStub.axiosGet.resolves(ipApiResponse({ org: 'Contabo GmbH', isp: 'Contabo GmbH' }));
+      geolocationService = reload();
+
+      await geolocationService.setNodeGeolocation();
+
+      expect(geolocationService.isStaticIP()).to.equal(false);
+    });
+
+    it('restarts the observation when the address changes', async () => {
+      fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(true);
+      dbHelperStub.findOneInDatabase.resolves({
+        geolocation: { ip: '185.199.108.1' },
+        staticIp: true,
+        dataCenter: false,
+        lastIpChangeDate: null,
+        ipFirstSeenAt: Date.now() - (400 * 24 * 60 * 60 * 1000),
+        staticIpState: 'STATIC',
+        networkClassification: null,
+      });
+      geolocationService = reload();
+      await geolocationService.getNodeGeolocation();
+      serviceHelperStub.axiosGet.resolves(ipApiResponse({ query: '185.199.109.9' }));
+
+      await geolocationService.setNodeGeolocation();
+
+      expect(geolocationService.getStaticIpState()).to.equal('UNKNOWN');
+    });
+  });
+
+  describe('the published table decides, the node falls back', () => {
+    let ipLocationStoreStub;
+
+    function reload() {
+      return proxyquire('../../ZelBack/src/services/geolocationService', {
+        config: configStub,
+        '../lib/log': logStub,
+        './dbHelper': dbHelperStub,
+        './serviceHelper': serviceHelperStub,
+        './fluxNetworkHelper': fluxNetworkHelperStub,
+        './appPlacement/ipLocationStore': ipLocationStoreStub,
+      });
+    }
+
+    beforeEach(() => {
+      fluxNetworkHelperStub.getLocalSocketAddress.resolves('185.199.108.1:16127');
+      fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(true);
+      dbHelperStub.findOneInDatabase.resolves(null);
+      ipLocationStoreStub = { lookup: sinon.stub().resolves(null) };
+      // On its own evidence this address is a data centre: a hosting operator
+      // and nothing suggesting an access network.
+      serviceHelperStub.axiosGet.resolves({
+        data: {
+          status: 'success',
+          query: '185.199.108.1',
+          org: 'X',
+          isp: 'Hetzner Online GmbH',
+          as: 'AS24940 Hetzner Online GmbH',
+          proxy: false,
+          hosting: false,
+        },
+      });
+    });
+
+    it('takes the published verdict over what the node would have decided', async () => {
+      // Local evidence that does not CONTRADICT residential: the table's verdict
+      // stands even though the node itself would have said nothing.
+      serviceHelperStub.axiosGet.resolves({
+        data: {
+          status: 'success', query: '185.199.108.1', org: 'X', isp: 'Some Regional ISP',
+          as: 'AS64500 Some Regional ISP', proxy: false, hosting: false,
+        },
+      });
+      ipLocationStoreStub.lookup.resolves({ org: 'a1b2c3d4e5f6', networkClass: 'RESIDENTIAL' });
+      geolocationService = reload();
+
+      await geolocationService.setNodeGeolocation();
+
+      const verdict = geolocationService.getNetworkClassification();
+      expect(verdict.classification).to.equal('RESIDENTIAL');
+      expect(verdict.source).to.equal('published-table');
+    });
+
+    it('declines a published RESIDENTIAL when this address contradicts it', async () => {
+      // An organisation is published on a strong majority of its hosts, so a
+      // minority of its addresses may be the other kind. This is how one of them
+      // steps out of a verdict meant for its neighbours - 213.44.137.57 on
+      // Bouygues is the live instance.
+      ipLocationStoreStub.lookup.resolves({ org: 'a1b2c3d4e5f6', networkClass: 'RESIDENTIAL' });
+      geolocationService = reload();
+
+      await geolocationService.setNodeGeolocation();
+
+      const verdict = geolocationService.getNetworkClassification();
+      expect(verdict.classification).to.equal('CONFLICTED');
+      expect(verdict.source).to.equal('node-veto');
+    });
+
+    it('the veto only ever removes enforcement, never imposes it', async () => {
+      // Local evidence saying RESIDENTIAL cannot promote a published DATACENTER.
+      serviceHelperStub.axiosGet.resolves({
+        data: {
+          status: 'success', query: '185.199.108.1', org: 'X', isp: 'Consumer ISP',
+          as: 'AS64500 Consumer ISP', proxy: false, hosting: false, mobile: true,
+        },
+      });
+      ipLocationStoreStub.lookup.resolves({ org: 'a1b2c3d4e5f6', networkClass: 'DATACENTER' });
+      geolocationService = reload();
+
+      await geolocationService.setNodeGeolocation();
+
+      expect(geolocationService.getNetworkClassification().classification).to.equal('DATACENTER');
+    });
+
+    it('falls back to the node when the organisation carries no verdict', async () => {
+      ipLocationStoreStub.lookup.resolves({ org: 'a1b2c3d4e5f6', networkClass: null });
+      geolocationService = reload();
+
+      await geolocationService.setNodeGeolocation();
+
+      const verdict = geolocationService.getNetworkClassification();
+      expect(verdict.classification).to.equal('DATACENTER');
+      expect(verdict.source).to.equal('node');
+    });
+
+    it('falls back to the node when no row covers the address', async () => {
+      ipLocationStoreStub.lookup.resolves(null);
+      geolocationService = reload();
+
+      await geolocationService.setNodeGeolocation();
+
+      expect(geolocationService.getNetworkClassification().source).to.equal('node');
+    });
+
+    it('falls back to the node when the table cannot be read at all', async () => {
+      // A table that is unavailable is not evidence about the address, and must
+      // not stop a verdict being reached from what the node can see.
+      ipLocationStoreStub.lookup.rejects(new Error('no database connection'));
+      geolocationService = reload();
+
+      await geolocationService.setNodeGeolocation();
+
+      expect(geolocationService.getNetworkClassification().source).to.equal('node');
+      expect(geolocationService.getNetworkClassification().classification).to.equal('DATACENTER');
+    });
+
+    it('still records the node\'s own evidence when the table decided', async () => {
+      // The published verdict is the answer; the local evidence stays visible so
+      // a disagreement between the two is diagnosable rather than invisible.
+      ipLocationStoreStub.lookup.resolves({ org: 'a1b2c3d4e5f6', networkClass: 'RESIDENTIAL' });
+      geolocationService = reload();
+
+      await geolocationService.setNodeGeolocation();
+
+      const verdict = geolocationService.getNetworkClassification();
+      expect(verdict.evidenceAgainst.join(' ')).to.contain('Hetzner');
+    });
+
+    it('drives isDataCenter from the published verdict', async () => {
+      ipLocationStoreStub.lookup.resolves({ org: 'a1b2c3d4e5f6', networkClass: 'DATACENTER' });
+      geolocationService = reload();
+
+      await geolocationService.setNodeGeolocation();
+
+      expect(geolocationService.isDataCenter()).to.equal(true);
+    });
+  });
+
+  describe('network classification', () => {
+    function reload() {
+      return proxyquire('../../ZelBack/src/services/geolocationService', {
+        config: configStub,
+        '../lib/log': logStub,
+        './dbHelper': dbHelperStub,
+        './serviceHelper': serviceHelperStub,
+        './fluxNetworkHelper': fluxNetworkHelperStub,
+      });
+    }
+
+    beforeEach(() => {
+      fluxNetworkHelperStub.getLocalSocketAddress.resolves('185.199.108.1:16127');
+      fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(true);
+      dbHelperStub.findOneInDatabase.resolves(null);
+    });
+
+    it('has no verdict before a lookup has run', () => {
+      geolocationService = reload();
+
+      expect(geolocationService.getNetworkClassification()).to.equal(null);
+    });
+
+    it('asks ip-api for the operator AS, not just the registrant org', async () => {
+      serviceHelperStub.axiosGet.resolves({
+        data: {
+          status: 'success', query: '185.199.108.1', org: 'X', isp: 'X', as: 'AS1 X', hosting: false, proxy: false,
+        },
+      });
+      geolocationService = reload();
+
+      await geolocationService.setNodeGeolocation();
+
+      expect(serviceHelperStub.axiosGet.firstCall.args[0]).to.include('as');
+      expect(serviceHelperStub.axiosGet.firstCall.args[0]).to.include('mobile');
+    });
+
+    it('publishes the verdict with the evidence behind it', async () => {
+      serviceHelperStub.axiosGet.resolves({
+        data: {
+          status: 'success',
+          query: '185.199.108.1',
+          org: 'Yorkshire Tech Limited',
+          isp: 'Contabo Asia Private Limited',
+          as: 'AS141995 Contabo Asia Private Limited',
+          proxy: false,
+          hosting: false,
+        },
+      });
+      geolocationService = reload();
+
+      await geolocationService.setNodeGeolocation();
+
+      const verdict = geolocationService.getNetworkClassification();
+      expect(verdict.classification).to.equal('DATACENTER');
+      expect(verdict.evidenceAgainst.join(' ')).to.contain('Contabo');
+      expect(verdict.determinedAt).to.be.a('number');
+    });
+
+    it('drives isDataCenter from the verdict', async () => {
+      serviceHelperStub.axiosGet.resolves({
+        data: {
+          status: 'success', query: '185.199.108.1', org: 'X', isp: 'X', as: 'AS1 X', hosting: true, proxy: false,
+        },
+      });
+      geolocationService = reload();
+
+      await geolocationService.setNodeGeolocation();
+
+      expect(geolocationService.isDataCenter()).to.equal(true);
+    });
+
+    it('leaves isDataCenter false on a verdict of UNKNOWN', async () => {
+      // Absence of evidence is not evidence of a data centre - nor of anything.
+      serviceHelperStub.axiosGet.resolves({
+        data: {
+          status: 'success',
+          query: '185.199.108.1',
+          org: 'Some Regional ISP',
+          isp: 'Some Regional ISP',
+          as: 'AS64500 Some Regional ISP',
+          proxy: false,
+          hosting: false,
+        },
+      });
+      geolocationService = reload();
+
+      await geolocationService.setNodeGeolocation();
+
+      expect(geolocationService.getNetworkClassification().classification).to.equal('UNKNOWN');
+      expect(geolocationService.isDataCenter()).to.equal(false);
     });
   });
 

--- a/tests/unit/geolocationService.test.js
+++ b/tests/unit/geolocationService.test.js
@@ -530,14 +530,19 @@ describe('geolocationService tests', () => {
       expect(geolocationService.getStaticIpState()).to.equal('UNKNOWN');
     });
 
-    it('is STATIC when the interface is unreadable but the table calls the range hosting', async () => {
+    it('is UNKNOWN when the interface is unreadable, whatever the table says', async () => {
+      // An unreadable routing table means the node cannot establish that it is
+      // directly connected. A hosting verdict for the range does not establish
+      // it either, so the honest answer is that nothing is known - and UNKNOWN
+      // fails an app's staticip requirement exactly as DYNAMIC does.
       fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(null);
       serviceHelperStub.axiosGet.resolves(ipApiResponse());
       geolocationService = reloadWithTable('DATACENTER');
 
       await geolocationService.setNodeGeolocation();
 
-      expect(geolocationService.getStaticIpState()).to.equal('STATIC');
+      expect(geolocationService.getStaticIpState()).to.equal('UNKNOWN');
+      expect(geolocationService.isStaticIP()).to.equal(false);
     });
 
     it('is STATIC again once a watched change has been held out', async () => {
@@ -563,13 +568,22 @@ describe('geolocationService tests', () => {
       expect(geolocationService.getStaticIpState()).to.equal('STATIC');
     });
 
-    it('is STATIC behind NAT when the published table calls the range hosting', async () => {
-      // A 1:1-NAT cloud instance holds a genuinely static address that never
-      // appears on a local interface, so the interface test alone can never see
-      // it - every AWS, Azure, GCP and Oracle box fails it. This is the job the
-      // deleted staticIpOrgs list did, on evidence that has been measured.
+    it('is DYNAMIC behind NAT even when the published table calls the range hosting', async () => {
+      // The whole rule in one test. A hosting verdict describes the RANGE: it
+      // says nothing about whether this host is directly connected, and nothing
+      // about whether the operator will reassign the address. Both are promises
+      // `staticip` makes to an app, and neither is the table's to make. On the
+      // fleet, granting static on this verdict put 126 of 228 static claimants
+      // behind a UPnP router on an RFC1918 address.
+      //
+      // The table is READY and answering here on purpose: the verdict must not
+      // depend on whether it happened to be loaded.
       fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(false);
       serviceHelperStub.axiosGet.resolves(ipApiResponse());
+      const table = {
+        lookup: sinon.stub().resolves({ org: 'a1b2c3d4e5f6', networkClass: 'DATACENTER' }),
+        status: sinon.stub().returns({ ready: true, generated: 'x', rowCount: 2000000 }),
+      };
       geolocationService = proxyquire('../../ZelBack/src/services/geolocationService', {
         'node:dns': dnsStub,
         config: configStub,
@@ -577,40 +591,43 @@ describe('geolocationService tests', () => {
         './dbHelper': dbHelperStub,
         './serviceHelper': serviceHelperStub,
         './fluxNetworkHelper': fluxNetworkHelperStub,
-        './appPlacement/ipLocationStore': {
-          lookup: sinon.stub().resolves({ org: 'a1b2c3d4e5f6', networkClass: 'DATACENTER' }),
-          status: sinon.stub().returns({ ready: true, generated: 'x', rowCount: 2000000 }),
-        },
-      });
-
-      await geolocationService.setNodeGeolocation();
-
-      expect(geolocationService.getStaticIpState()).to.equal('STATIC');
-    });
-
-    it('stays DYNAMIC behind NAT when the table calls the range residential', async () => {
-      // The old rule granted static to seven consumer ISPs on the fleet -
-      // Verizon, Comcast, Free SAS, Bouygues among them - because ip-api
-      // flagged them `proxy`, which is a VPN artefact and not an address that
-      // stays put.
-      fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(false);
-      serviceHelperStub.axiosGet.resolves(ipApiResponse());
-      geolocationService = proxyquire('../../ZelBack/src/services/geolocationService', {
-        'node:dns': dnsStub,
-        config: configStub,
-        '../lib/log': logStub,
-        './dbHelper': dbHelperStub,
-        './serviceHelper': serviceHelperStub,
-        './fluxNetworkHelper': fluxNetworkHelperStub,
-        './appPlacement/ipLocationStore': {
-          lookup: sinon.stub().resolves({ org: 'a1b2c3d4e5f6', networkClass: 'RESIDENTIAL' }),
-          status: sinon.stub().returns({ ready: true, generated: 'x', rowCount: 2000000 }),
-        },
+        './appPlacement/ipLocationStore': table,
       });
 
       await geolocationService.setNodeGeolocation();
 
       expect(geolocationService.getStaticIpState()).to.equal('DYNAMIC');
+      expect(geolocationService.isStaticIP()).to.equal(false);
+    });
+
+    it('reaches the same verdict behind NAT whether or not a table has loaded', async () => {
+      // The static decision consults nothing but this node's own observations,
+      // so a booting node with no table yet and a settled node holding a full
+      // one answer identically. This is what keeps the verdict off the boot
+      // ordering between setNodeGeolocation and the location table's restore.
+      const verdicts = [];
+      for (const status of [{ ready: false, generated: null, rowCount: 0 },
+        { ready: true, generated: 'x', rowCount: 2000000 }]) {
+        fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(false);
+        serviceHelperStub.axiosGet.resolves(ipApiResponse());
+        geolocationService = proxyquire('../../ZelBack/src/services/geolocationService', {
+          'node:dns': dnsStub,
+          config: configStub,
+          '../lib/log': logStub,
+          './dbHelper': dbHelperStub,
+          './serviceHelper': serviceHelperStub,
+          './fluxNetworkHelper': fluxNetworkHelperStub,
+          './appPlacement/ipLocationStore': {
+            lookup: sinon.stub().resolves({ org: 'a1b2c3d4e5f6', networkClass: 'DATACENTER' }),
+            status: sinon.stub().returns(status),
+          },
+        });
+        // eslint-disable-next-line no-await-in-loop
+        await geolocationService.setNodeGeolocation();
+        verdicts.push(geolocationService.getStaticIpState());
+      }
+
+      expect(verdicts).to.deep.equal(['DYNAMIC', 'DYNAMIC']);
     });
 
     it('says UNKNOWN when the routing table could not be read, not DYNAMIC', async () => {

--- a/tests/unit/geolocationService.test.js
+++ b/tests/unit/geolocationService.test.js
@@ -389,6 +389,109 @@ describe('geolocationService tests', () => {
       expect(geolocationService.getStaticIpState()).to.equal('STATIC');
     });
 
+    // The table lookup is not stubbed by this describe's reload(), so these
+    // build their own. A recent change means: lastIpChangeDate on record AND
+    // the address held for less than the stability window since.
+    function reloadWithTable(networkClass) {
+      return proxyquire('../../ZelBack/src/services/geolocationService', {
+        config: configStub,
+        '../lib/log': logStub,
+        './dbHelper': dbHelperStub,
+        './serviceHelper': serviceHelperStub,
+        './fluxNetworkHelper': fluxNetworkHelperStub,
+        './appPlacement/ipLocationStore': {
+          lookup: sinon.stub().resolves({ org: 'a1b2c3d4e5f6', networkClass }),
+          status: sinon.stub().returns({ ready: true, generated: 'x', rowCount: 2000000 }),
+        },
+      });
+    }
+
+    function changedThreeDaysAgo() {
+      const threeDays = 3 * 24 * 60 * 60 * 1000;
+      dbHelperStub.findOneInDatabase.resolves({
+        geolocation: { ip: '185.199.108.1' },
+        staticIp: false,
+        dataCenter: false,
+        lastIpChangeDate: Date.now() - threeDays,
+        ipFirstSeenAt: Date.now() - threeDays,
+        staticIpState: 'UNKNOWN',
+        networkClassification: null,
+      });
+    }
+
+    it('lets a watched change override the table behind NAT', async () => {
+      // The correction. This node SAW this address move three days ago. That is
+      // the only evidence here about this exact address rather than about the
+      // range around it, so a hosting verdict for the range does not answer it -
+      // an address that moved is what an app requiring a fixed one cares about.
+      fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(false);
+      serviceHelperStub.axiosGet.resolves(ipApiResponse());
+      changedThreeDaysAgo();
+      geolocationService = reloadWithTable('DATACENTER');
+      await geolocationService.getNodeGeolocation();
+
+      await geolocationService.setNodeGeolocation();
+
+      expect(geolocationService.getStaticIpState()).to.equal('UNKNOWN');
+    });
+
+    it('lets a watched change override the table when the interface is unreadable', async () => {
+      fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(null);
+      serviceHelperStub.axiosGet.resolves(ipApiResponse());
+      changedThreeDaysAgo();
+      geolocationService = reloadWithTable('DATACENTER');
+      await geolocationService.getNodeGeolocation();
+
+      await geolocationService.setNodeGeolocation();
+
+      expect(geolocationService.getStaticIpState()).to.equal('UNKNOWN');
+    });
+
+    it('lets a watched change override a public address on the interface', async () => {
+      fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(true);
+      serviceHelperStub.axiosGet.resolves(ipApiResponse());
+      changedThreeDaysAgo();
+      geolocationService = reloadWithTable('DATACENTER');
+      await geolocationService.getNodeGeolocation();
+
+      await geolocationService.setNodeGeolocation();
+
+      expect(geolocationService.getStaticIpState()).to.equal('UNKNOWN');
+    });
+
+    it('is STATIC when the interface is unreadable but the table calls the range hosting', async () => {
+      fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(null);
+      serviceHelperStub.axiosGet.resolves(ipApiResponse());
+      geolocationService = reloadWithTable('DATACENTER');
+
+      await geolocationService.setNodeGeolocation();
+
+      expect(geolocationService.getStaticIpState()).to.equal('STATIC');
+    });
+
+    it('is STATIC again once a watched change has been held out', async () => {
+      // The window is what the address earns it back with, and the only thing
+      // ipFirstSeenAt measures.
+      fluxNetworkHelperStub.hasPublicIpOnInterface.resolves(true);
+      serviceHelperStub.axiosGet.resolves(ipApiResponse());
+      const elevenDays = 11 * 24 * 60 * 60 * 1000;
+      dbHelperStub.findOneInDatabase.resolves({
+        geolocation: { ip: '185.199.108.1' },
+        staticIp: false,
+        dataCenter: false,
+        lastIpChangeDate: Date.now() - elevenDays,
+        ipFirstSeenAt: Date.now() - elevenDays,
+        staticIpState: 'UNKNOWN',
+        networkClassification: null,
+      });
+      geolocationService = reloadWithTable(null);
+      await geolocationService.getNodeGeolocation();
+
+      await geolocationService.setNodeGeolocation();
+
+      expect(geolocationService.getStaticIpState()).to.equal('STATIC');
+    });
+
     it('is STATIC behind NAT when the published table calls the range hosting', async () => {
       // A 1:1-NAT cloud instance holds a genuinely static address that never
       // appears on a local interface, so the interface test alone can never see

--- a/tests/unit/globalconfig/default.js
+++ b/tests/unit/globalconfig/default.js
@@ -323,6 +323,7 @@ module.exports = {
     },
     spawnDelayMultiplier: 1,
     daemonInfoIntervalMs: 30000,
+    explorerPollIntervalMs: 5000,
     explorerSyncRetryMs: 120000,
     explorerDeepRestoreBlocks: 100,
     syncTimeoutMs: 120000,

--- a/tests/unit/globalconfig/default.js
+++ b/tests/unit/globalconfig/default.js
@@ -339,6 +339,11 @@ module.exports = {
     wsHandshakeTimeoutMs: 10000,
     discoveryConnectionDelayMs: 500,
     nodeMonitorRemovalDelayMs: 60000,
+    residentialCheckIntervalMs: 21600000,
+    residentialSettleMs: 86400000,
+    residentialEvacuationIntervalMs: 21600000,
+    residentialQueueBaseMs: 1800000,
+    residentialQueueStepMs: 900000,
     nodeMonitorDosRecoveryDelayMs: 600000,
     nodeMonitorConfirmationLossDelayMs: 1200000,
     nodeMonitorErrorRecoveryDelayMs: 120000,
@@ -425,8 +430,5 @@ module.exports = {
   },
   mongodb: {
     signingKeyBaseUrl: 'https://pgp.mongodb.com',
-  },
-  residentialDos: {
-    enabled: true,
   },
 };

--- a/tests/unit/globalconfig/default.js
+++ b/tests/unit/globalconfig/default.js
@@ -284,7 +284,7 @@ module.exports = {
     removalSpacingMs: 60000,
     locationTtlS: 7500,
     installingTtlS: 900,
-    installErrorTtlS: 3600,
+    installErrorTtlS: 86400,
     tempMsgTtlS: 3600,
     hashSyncIntervalMs: 1800000,
     peerNotifyIntervalMs: 3600000,
@@ -344,7 +344,7 @@ module.exports = {
     residentialSettleMs: 86400000,
     residentialEvacuationIntervalMs: 21600000,
     residentialQueueBaseMs: 1800000,
-    residentialQueueStepMs: 900000,
+    residentialQueueStepMs: 2400000, // 40m - must exceed the 22m give-up pass, see ZelBack/config/default.js
     nodeMonitorDosRecoveryDelayMs: 600000,
     nodeMonitorConfirmationLossDelayMs: 1200000,
     nodeMonitorErrorRecoveryDelayMs: 120000,

--- a/tests/unit/globalconfig/default.js
+++ b/tests/unit/globalconfig/default.js
@@ -426,4 +426,7 @@ module.exports = {
   mongodb: {
     signingKeyBaseUrl: 'https://pgp.mongodb.com',
   },
+  residentialDos: {
+    enabled: true,
+  },
 };

--- a/tests/unit/idService.test.js
+++ b/tests/unit/idService.test.js
@@ -1469,7 +1469,7 @@ describe('idService tests', () => {
       sinon.restore();
     });
 
-    it('should return error message if no zelid parameter is passed', async () => {
+    it('should answer none, not the thrown text, if no zelid parameter is passed', async () => {
       const res = generateResponse();
       const params = {
         loginPhrase: 'phrase',
@@ -1487,12 +1487,12 @@ describe('idService tests', () => {
         data: {
           code: undefined,
           name: 'Error',
-          message: 'No user Flux ID specificed',
+          message: 'none',
         },
       });
     });
 
-    it('should return error message if no loggedPhrase parameter is passed', async () => {
+    it('should answer none, not the thrown text, if no loggedPhrase parameter is passed', async () => {
       const res = generateResponse();
       const params = {
         zelid: '1zel12343434',
@@ -1510,12 +1510,12 @@ describe('idService tests', () => {
         data: {
           code: undefined,
           name: 'Error',
-          message: 'No user loginPhrase specificed',
+          message: 'none',
         },
       });
     });
 
-    it('should return error message if no loggedPhrase parameter is passed', async () => {
+    it('should answer none, not the thrown text, if no signature parameter is passed', async () => {
       const res = generateResponse();
       const params = {
         zelid: '1zel12343434',
@@ -1533,7 +1533,7 @@ describe('idService tests', () => {
         data: {
           code: undefined,
           name: 'Error',
-          message: 'No user Flux ID signature specificed',
+          message: 'none',
         },
       });
     });
@@ -1601,6 +1601,30 @@ describe('idService tests', () => {
       sinon.assert.calledOnceWithExactly(res.json, {
         status: 'success',
         data: { code: undefined, name: undefined, message: 'user' },
+      });
+    });
+
+    it('should answer none when the privilege check itself throws, so the session is cleared', async () => {
+      verifyPrivilegeStub.throws(new Error('database unavailable'));
+      const res = generateResponse();
+      const params = {
+        zelid: '1zel12343434',
+        loginPhrase: 'loginphrase',
+        signature: 'signature',
+      };
+      const mockStream = new PassThrough();
+      mockStream.push(JSON.stringify(params));
+      mockStream.end();
+
+      await idService.checkLoggedUser(mockStream, res);
+      await serviceHelper.delay(150);
+
+      // 'none' is the only value that makes the frontend drop zelidauth, and a
+      // thrown error is exactly when the session should end. `name` is what
+      // still separates this from the refusal below, which carries none.
+      sinon.assert.calledOnceWithExactly(res.json, {
+        status: 'error',
+        data: { code: undefined, name: 'Error', message: 'none' },
       });
     });
 

--- a/tests/unit/ipLocationStore.test.js
+++ b/tests/unit/ipLocationStore.test.js
@@ -469,6 +469,8 @@ describe('ipLocationStore tests', () => {
         countryCode: 'BH',
         continentCode: 'AS',
         region: null,
+        // no orgClasses in this fixture's header, so no verdict
+        networkClass: null,
       });
     });
 
@@ -482,7 +484,42 @@ describe('ipLocationStore tests', () => {
         countryCode: 'BG',
         continentCode: 'EU',
         region: null,
+        networkClass: null,
       });
+    });
+
+    it('carries the published network class for the row\'s organisation', async () => {
+      await store.setArtifact(encodeArtifact(
+        { ...fixtureHeader(), orgClasses: { a1b2c3d4e5f6: 1 } },
+        [[v4Int('80.95.208.0'), v4Int('80.95.223.255'), 0, 0, null]],
+      ));
+      dbHelperStub.findInDatabase.resolves([bahrainRow]);
+
+      const hit = await store.lookup('80.95.213.209');
+
+      expect(hit.networkClass).to.equal('RESIDENTIAL');
+    });
+
+    it('leaves the class null for an organisation the artifact does not classify', async () => {
+      // Sparse by design: only organisations the fleet occupies are classified,
+      // and an absent one has no verdict rather than a third verdict.
+      await store.setArtifact(encodeArtifact(
+        { ...fixtureHeader(), orgClasses: { ffffffffffff: 2 } },
+        [[v4Int('80.95.208.0'), v4Int('80.95.223.255'), 0, 0, null]],
+      ));
+      dbHelperStub.findInDatabase.resolves([bahrainRow]);
+
+      expect((await store.lookup('80.95.213.209')).networkClass).to.equal(null);
+    });
+
+    it('leaves the class null when the artifact carries no classes at all', async () => {
+      await store.setArtifact(encodeArtifact(
+        fixtureHeader(),
+        [[v4Int('80.95.208.0'), v4Int('80.95.223.255'), 0, 0, null]],
+      ));
+      dbHelperStub.findInDatabase.resolves([bahrainRow]);
+
+      expect((await store.lookup('80.95.213.209')).networkClass).to.equal(null);
     });
 
     it('returns null when the nearest row ends before the address, and when there is none', async () => {

--- a/tests/unit/ipLocationStore.test.js
+++ b/tests/unit/ipLocationStore.test.js
@@ -512,6 +512,54 @@ describe('ipLocationStore tests', () => {
       expect((await store.lookup('80.95.213.209')).networkClass).to.equal(null);
     });
 
+    it('skips a class code this build does not know, and keeps the rest of the table', async () => {
+      // The publisher's vocabulary is a separate closed enum in a separate repo
+      // and the wire carries codes, not names, so nothing binds them: adding a
+      // third class there and merging IS publishing. Rejecting the artifact
+      // would cost country, continent, region and organisation for two million
+      // rows over one value in an optional section - the trade this file
+      // already refuses for regionNames.
+      await store.setArtifact(encodeArtifact(
+        { ...fixtureHeader(), orgClasses: { a1b2c3d4e5f6: 3, ffffffffffff: 1 } },
+        [[v4Int('80.95.208.0'), v4Int('80.95.223.255'), 0, 0, null]],
+      ));
+      dbHelperStub.findInDatabase.resolves([bahrainRow]);
+
+      const hit = await store.lookup('80.95.213.209');
+
+      // The table survived: the row still answers with everything else.
+      expect(hit.countryCode).to.equal('BH');
+      expect(hit.continentCode).to.equal('AS');
+      // And the organisation carrying the unknown code simply has no verdict.
+      expect(hit.networkClass).to.equal(null);
+      expect(store.status().ready).to.equal(true);
+    });
+
+    it('does not read a class code through Object.prototype', async () => {
+      // `NETWORK_CLASS_BY_CODE[code]` answers for every member of the prototype
+      // chain, so a header saying "toString" passed a truthiness check and
+      // stored an inherited FUNCTION as an organisation's network class -
+      // reported downstream as a published-table verdict. The Maps three lines
+      // below exist to avoid exactly this.
+      await store.setArtifact(encodeArtifact(
+        { ...fixtureHeader(), orgClasses: { a1b2c3d4e5f6: 'toString' } },
+        [[v4Int('80.95.208.0'), v4Int('80.95.223.255'), 0, 0, null]],
+      ));
+      dbHelperStub.findInDatabase.resolves([bahrainRow]);
+
+      expect((await store.lookup('80.95.213.209')).networkClass).to.equal(null);
+    });
+
+    it('still reads the classes it does know alongside one it does not', async () => {
+      await store.setArtifact(encodeArtifact(
+        { ...fixtureHeader(), orgClasses: { a1b2c3d4e5f6: 2, ffffffffffff: 99 } },
+        [[v4Int('80.95.208.0'), v4Int('80.95.223.255'), 0, 0, null]],
+      ));
+      dbHelperStub.findInDatabase.resolves([bahrainRow]);
+
+      expect((await store.lookup('80.95.213.209')).networkClass).to.equal('DATACENTER');
+    });
+
     it('leaves the class null when the artifact carries no classes at all', async () => {
       await store.setArtifact(encodeArtifact(
         fixtureHeader(),

--- a/tests/unit/ipLocationSync.test.js
+++ b/tests/unit/ipLocationSync.test.js
@@ -90,6 +90,58 @@ describe('ipLocationSync tests', () => {
     expect(axiosGetStub.firstCall.args[1].headers).to.eql({ 'If-None-Match': '"stored"' });
   });
 
+  describe('restoreCachedTable - the half that only needs mongo', () => {
+    it('brings the table back without fetching anything', async () => {
+      // Started with the database schema prep, well before the app-database
+      // rebuild. It must reach the table and touch the network for nothing, or
+      // it is no longer the cheap half.
+      storeStub.adoptPersistedStatus.resolves(true);
+      storeStub.status.returns({ ready: true, generated: '2026-07-31T00:00:00Z', rowCount: 2126447 });
+      repositoryStub.getArtifactRecord.resolves({ fileId: 'id1', etag: '"stored"', fetchedAt: 1 });
+
+      await ipLocationSync.restoreCachedTable();
+      await settle();
+
+      expect(storeStub.adoptPersistedStatus.calledOnce).to.equal(true);
+      expect(axiosGetStub.called).to.equal(false);
+    });
+
+    it('leaves the etag ready, so the fetch half opens with a conditional request', async () => {
+      storeStub.adoptPersistedStatus.resolves(true);
+      storeStub.status.returns({ ready: true, generated: '2026-07-31T00:00:00Z', rowCount: 2126447 });
+      repositoryStub.getArtifactRecord.resolves({ fileId: 'id1', etag: '"stored"', fetchedAt: 1 });
+      axiosGetStub.resolves({ status: 304, data: null, headers: {} });
+
+      await ipLocationSync.restoreCachedTable();
+      await ipLocationSync.startSync();
+
+      expect(axiosGetStub.firstCall.args[1].headers).to.eql({ 'If-None-Match': '"stored"' });
+    });
+
+    it('is not repeated by startSync', async () => {
+      repositoryStub.getArtifactRecord.resolves({ fileId: 'id1', etag: '"stored"', fetchedAt: 1 });
+      repositoryStub.readArtifactBytes.resolves(Buffer.from('stored bytes'));
+      axiosGetStub.resolves({ status: 304, data: null, headers: {} });
+
+      await ipLocationSync.restoreCachedTable();
+      await ipLocationSync.startSync();
+
+      expect(storeStub.adoptPersistedStatus.calledOnce).to.equal(true);
+      expect(storeStub.setArtifact.calledOnce).to.equal(true);
+    });
+
+    it('still restores when startSync is the only caller', async () => {
+      // serviceManager runs both, but nothing may depend on that ordering.
+      repositoryStub.getArtifactRecord.resolves({ fileId: 'id1', etag: '"stored"', fetchedAt: 1 });
+      repositoryStub.readArtifactBytes.resolves(Buffer.from('stored bytes'));
+      axiosGetStub.resolves({ status: 304, data: null, headers: {} });
+
+      await ipLocationSync.startSync();
+
+      expect(storeStub.setArtifact.calledOnce).to.equal(true);
+    });
+  });
+
   it('adopts the stored ingest and does not re-ingest the cached bytes', async () => {
     // the rows are already in mongo under the marker's baseline; the etag still
     // comes from the record so the daily refresh is a conditional request

--- a/tests/unit/messageStore.test.js
+++ b/tests/unit/messageStore.test.js
@@ -960,4 +960,73 @@ describe('messageStore tests', () => {
       expect(upserts.length).to.equal(1200);
     });
   });
+
+  describe('the expiry windows refuse gossip older than themselves', () => {
+    // Each of these constants does double duty: it stamps expireAt onto the
+    // stored record AND bounds how stale an incoming broadcast may be. A window
+    // shorter than the fleet takes to produce and deliver a message does not
+    // make anything faster, it makes peers silently refuse each other - which
+    // is why the harness cannot compress them freely. The apprunning half is
+    // covered above; these two paths had no coverage at all.
+    beforeEach(() => {
+      dbHelperStub.databaseConnection.returns({ db: sinon.stub().returns('database') });
+      dbHelperStub.updateOneInDatabase.resolves({});
+    });
+
+    function installingBroadcast(ageMs) {
+      return {
+        version: 1,
+        timestamp: Date.now(),
+        pubKey: 'pk',
+        signature: 'sig',
+        data: {
+          ip: '1.2.3.4:16127', name: 'someapp', hash: 'h', broadcastedAt: Date.now() - ageMs,
+        },
+      };
+    }
+
+    it('stores an installing claim broadcast inside the window', () => {
+      messageStore.storeSignedAppInstallingBroadcast(installingBroadcast(60 * 1000));
+
+      expect(dbHelperStub.updateOneInDatabase.calledOnce).to.equal(true);
+    });
+
+    it('refuses an installing claim broadcast older than the window', () => {
+      // INSTALLING_EXPIRY_MS is stubbed at 15 minutes above.
+      messageStore.storeSignedAppInstallingBroadcast(installingBroadcast(16 * 60 * 1000));
+
+      expect(dbHelperStub.updateOneInDatabase.called).to.equal(false);
+    });
+
+    it('stores an install-error broadcast inside the window', () => {
+      messageStore.storeSignedAppInstallingErrorBroadcast(installingBroadcast(60 * 60 * 1000));
+
+      expect(dbHelperStub.updateOneInDatabase.calledOnce).to.equal(true);
+    });
+
+    it('refuses an install-error broadcast older than the window', () => {
+      // INSTALLING_ERRORS_EXPIRY_MS is stubbed at 24 hours above.
+      messageStore.storeSignedAppInstallingErrorBroadcast(installingBroadcast(25 * 60 * 60 * 1000));
+
+      expect(dbHelperStub.updateOneInDatabase.called).to.equal(false);
+    });
+
+    it('expires the stored record at the sender\'s clock, not the receiver\'s', () => {
+      // The record must die a fixed time after it was BROADCAST, so a message
+      // that took a while to arrive does not get a fresh lease on delivery.
+      const broadcastedAt = Date.now() - (5 * 60 * 1000);
+      messageStore.storeSignedAppInstallingBroadcast({
+        version: 1,
+        timestamp: Date.now(),
+        pubKey: 'pk',
+        signature: 'sig',
+        data: {
+          ip: '1.2.3.4:16127', name: 'someapp', hash: 'h', broadcastedAt,
+        },
+      });
+
+      const { $set } = dbHelperStub.updateOneInDatabase.firstCall.args[3];
+      expect($set.expireAt.getTime()).to.equal(broadcastedAt + (15 * 60 * 1000));
+    });
+  });
 });

--- a/tests/unit/networkClassifier.test.js
+++ b/tests/unit/networkClassifier.test.js
@@ -133,8 +133,18 @@ describe('networkClassifier tests', () => {
     });
 
     it('corroborates a residential verdict the real signals already reached', () => {
+      // The ip-api answers are what make this a verdict rather than a guess.
+      // Without them the PTR is the only thing that spoke and nothing was ever
+      // asked that could contradict it, which is UNKNOWN - see the block below.
       const result = classifyNetwork({
-        ptr: 'n58-111-97-208.bla21.nsw.optusnet.com.au', uploadSpeed: 35, downloadSpeed: 923,
+        ptr: 'n58-111-97-208.bla21.nsw.optusnet.com.au',
+        hosting: false,
+        proxy: false,
+        mobile: false,
+        isp: 'Optus Internet',
+        asn: 'AS4804 Optus',
+        uploadSpeed: 35,
+        downloadSpeed: 923,
       });
 
       expect(result.classification).to.equal(CLASSIFICATION.RESIDENTIAL);
@@ -181,6 +191,55 @@ describe('networkClassifier tests', () => {
       const result = classifyNetwork({ mobile: true });
 
       expect(result.classification).to.equal(CLASSIFICATION.RESIDENTIAL);
+    });
+  });
+
+  describe('a signal nobody asked for is not a signal that came back clean', () => {
+    // The stats.runonflux.io fallback carries no hosting, proxy, mobile, isp or
+    // asn: fluxstats never requests those fields from ip-api, and its
+    // /fluxlocation endpoint projects away everything but location and org. On
+    // that path every contradiction check reads undefined and passes, so a
+    // datacentre host with an access-network PTR came out enforceably
+    // RESIDENTIAL. Both hosts below are real, and are the entire
+    // reverse-DNS-alone error row in the measurement this rule came from.
+    const withoutIpApi = (ptr) => classifyNetwork({ ptr });
+    const withIpApi = (ptr, extra) => classifyNetwork({
+      ptr, hosting: false, proxy: false, mobile: false, isp: 'Example ISP', asn: 'AS1 Example', ...extra,
+    });
+
+    it('will not call an address residential on a PTR alone', () => {
+      expect(withoutIpApi('213-44-137-57.abo.bbox.fr').classification)
+        .to.equal(CLASSIFICATION.UNKNOWN);
+      expect(withoutIpApi('212-83-170-245.rev.poneytelecom.eu').classification)
+        .to.equal(CLASSIFICATION.UNKNOWN);
+    });
+
+    it('still calls it residential once the signals have actually been consulted', () => {
+      // The same PTR, with an ip-api answer that contradicts nothing. The rule
+      // is unchanged where the evidence exists; only the empty case moved.
+      expect(withIpApi('213-44-137-57.abo.bbox.fr').classification)
+        .to.equal(CLASSIFICATION.RESIDENTIAL);
+    });
+
+    it('reports whether the contradicting signals were gathered', () => {
+      expect(withoutIpApi('213-44-137-57.abo.bbox.fr').contradictionSignalsGathered).to.equal(false);
+      expect(withIpApi('213-44-137-57.abo.bbox.fr').contradictionSignalsGathered).to.equal(true);
+    });
+
+    it('counts a signal that came back false as having been asked', () => {
+      // hosting: false is an answer. Only undefined is a question never put.
+      const result = classifyNetwork({ ptr: '213-44-137-57.abo.bbox.fr', hosting: false });
+
+      expect(result.contradictionSignalsGathered).to.equal(true);
+      expect(result.classification).to.equal(CLASSIFICATION.RESIDENTIAL);
+    });
+
+    it('still names a datacentre without them, because that rests on what WAS found', () => {
+      // DATACENTER enforces nothing and is reached by evidence present rather
+      // than evidence absent, so it is unaffected.
+      const result = withoutIpApi('static.63.10.201.195.clients.your-server.de');
+
+      expect(result.classification).to.equal(CLASSIFICATION.DATACENTER);
     });
   });
 });

--- a/tests/unit/networkClassifier.test.js
+++ b/tests/unit/networkClassifier.test.js
@@ -1,0 +1,186 @@
+const { expect } = require('chai');
+
+const networkClassifier = require('../../ZelBack/src/services/utils/networkClassifier');
+
+const { CLASSIFICATION, classifyNetwork, classifyPtr } = networkClassifier;
+
+describe('networkClassifier tests', () => {
+  describe('classifyPtr', () => {
+    it('reads access-network vocabulary as residential', () => {
+      expect(classifyPtr('n58-111-97-208.bla21.nsw.optusnet.com.au')).to.equal('residential');
+      expect(classifyPtr('syn-072-132-072-095.res.spectrum.com')).to.equal('residential');
+      expect(classifyPtr('ip-037-024-131-128.um08.pools.vodafone-ip.de')).to.equal('residential');
+    });
+
+    it('reads hosting vocabulary as datacenter', () => {
+      expect(classifyPtr('vmi1539676.contaboserver.net')).to.equal('datacenter');
+      expect(classifyPtr('ov-313f3b.infomaniak.ch')).to.equal('datacenter');
+    });
+
+    it('reads a name carrying both vocabularies as both, never as residential', () => {
+      // Hetzner's own PTR does this: 'clients' matches access vocabulary while
+      // 'your-server' matches hosting. Access vocabulary must never clear a
+      // hosting name, so the pair is its own answer and classifyNetwork reads it
+      // as a contradiction.
+      expect(classifyPtr('static.63.10.201.195.clients.your-server.de')).to.equal('both');
+    });
+
+    it('reads a name carrying neither as neither, and no name as none', () => {
+      expect(classifyPtr('example.com')).to.equal('neither');
+      expect(classifyPtr('')).to.equal('none');
+      expect(classifyPtr(null)).to.equal('none');
+    });
+  });
+
+  describe('classifyNetwork verdicts', () => {
+    it('is RESIDENTIAL on positive evidence with no contradiction', () => {
+      const result = classifyNetwork({
+        ptr: 'n58-111-97-208.bla21.nsw.optusnet.com.au',
+        hosting: false,
+        isp: 'SingTel Optus Pty Ltd',
+        asn: 'AS4804 Microplex PTY LTD',
+        uploadSpeed: 91,
+        downloadSpeed: 907,
+      });
+
+      expect(result.classification).to.equal(CLASSIFICATION.RESIDENTIAL);
+      expect(result.evidenceFor).to.have.lengthOf(2);
+      expect(result.evidenceAgainst).to.be.empty;
+    });
+
+    it('is DATACENTER on contradiction with no positive evidence', () => {
+      const result = classifyNetwork({
+        ptr: 'static.63.10.201.195.clients.your-server.de',
+        hosting: true,
+        isp: 'Hetzner Online GmbH',
+        asn: 'AS24940 Hetzner Online GmbH',
+        uploadSpeed: 900,
+        downloadSpeed: 950,
+      });
+
+      expect(result.classification).to.equal(CLASSIFICATION.DATACENTER);
+      expect(result.evidenceFor).to.be.empty;
+    });
+
+    it('is CONFLICTED when both fire, and never RESIDENTIAL', () => {
+      const result = classifyNetwork({
+        ptr: 'dsl-pool-12.example.net',
+        hosting: true,
+        isp: 'Someone',
+        asn: 'AS1 Someone',
+      });
+
+      expect(result.classification).to.equal(CLASSIFICATION.CONFLICTED);
+      expect(result.evidenceFor).to.not.be.empty;
+      expect(result.evidenceAgainst).to.not.be.empty;
+    });
+
+    it('is UNKNOWN when nothing is known', () => {
+      const result = classifyNetwork({});
+
+      expect(result.classification).to.equal(CLASSIFICATION.UNKNOWN);
+      expect(result.evidenceFor).to.be.empty;
+      expect(result.evidenceAgainst).to.be.empty;
+    });
+
+    it('is UNKNOWN, not RESIDENTIAL, when the PTR says nothing either way', () => {
+      // The whole point of the four states: absence of evidence must not read as
+      // evidence of a residential connection, which is what isDataCenter() does.
+      const result = classifyNetwork({
+        ptr: 'somehost.example.com',
+        hosting: false,
+        isp: 'Some Regional ISP',
+        asn: 'AS64500 Some Regional ISP',
+        uploadSpeed: 500,
+        downloadSpeed: 500,
+      });
+
+      expect(result.classification).to.equal(CLASSIFICATION.UNKNOWN);
+    });
+  });
+
+  describe('operator is read from isp/as, never from the registrant org', () => {
+    it('catches Contabo through isp even when org names a reseller', () => {
+      // 46.250.240.89 in the fleet: isp "Contabo Asia Private Limited",
+      // org "Yorkshire Tech Limited". Reading org is why the old classifier
+      // called this node residential.
+      const result = classifyNetwork({
+        ptr: 'vmi1539676.contaboserver.net',
+        hosting: false,
+        isp: 'Contabo Asia Private Limited',
+        asn: 'AS141995 Contabo Asia Private Limited',
+      });
+
+      expect(result.classification).to.equal(CLASSIFICATION.DATACENTER);
+      expect(result.evidenceAgainst.join(' ')).to.contain('Contabo');
+    });
+
+    it('matches the operator through the AS string alone', () => {
+      const result = classifyNetwork({ asn: 'AS24940 Hetzner Online GmbH' });
+
+      expect(result.classification).to.equal(CLASSIFICATION.DATACENTER);
+    });
+  });
+
+  describe('link asymmetry', () => {
+    it('never reaches a verdict on its own', () => {
+      // A bench figure is a speed test's result, not a property of the link. On
+      // its own it would call any node with a lopsided measurement residential,
+      // and enforcement would then act on an instrument reading.
+      const result = classifyNetwork({ uploadSpeed: 35, downloadSpeed: 923 });
+
+      expect(result.classification).to.equal(CLASSIFICATION.UNKNOWN);
+    });
+
+    it('corroborates a residential verdict the real signals already reached', () => {
+      const result = classifyNetwork({
+        ptr: 'n58-111-97-208.bla21.nsw.optusnet.com.au', uploadSpeed: 35, downloadSpeed: 923,
+      });
+
+      expect(result.classification).to.equal(CLASSIFICATION.RESIDENTIAL);
+      expect(result.evidenceFor.join(' ')).to.contain('asymmetric');
+    });
+
+    it('does not fight a contradiction', () => {
+      // Hetzner nodes measure lopsided often enough that, counted as evidence,
+      // one benchmark left 1,102 hosts unclassified whose PTR, registry object
+      // and vendor flag all said hosting.
+      const result = classifyNetwork({
+        ptr: 'static.63.10.201.195.clients.your-server.de', hosting: true,
+        isp: 'Hetzner Online GmbH', uploadSpeed: 183, downloadSpeed: 621,
+      });
+
+      expect(result.classification).to.equal(CLASSIFICATION.DATACENTER);
+    });
+
+    it('reads a symmetric link as no evidence at all', () => {
+      // Symmetric FTTH is ordinary consumer service in France and Sweden, so it
+      // must not count against residential either.
+      const result = classifyNetwork({ uploadSpeed: 900, downloadSpeed: 940 });
+
+      expect(result.classification).to.equal(CLASSIFICATION.UNKNOWN);
+    });
+
+    it('reads missing bench figures as no signal rather than a symmetric link', () => {
+      const result = classifyNetwork({ uploadSpeed: 0, downloadSpeed: 0 });
+
+      expect(result.classification).to.equal(CLASSIFICATION.UNKNOWN);
+    });
+  });
+
+  describe('ip-api flags', () => {
+    it('treats proxy as a contradiction', () => {
+      // 92.240.66.189 - University of Latvia, flagged proxy, which the PR as
+      // written would have DOSed as residential.
+      const result = classifyNetwork({ proxy: true });
+
+      expect(result.classification).to.equal(CLASSIFICATION.DATACENTER);
+    });
+
+    it('treats mobile as evidence of an access network', () => {
+      const result = classifyNetwork({ mobile: true });
+
+      expect(result.classification).to.equal(CLASSIFICATION.RESIDENTIAL);
+    });
+  });
+});

--- a/tests/unit/networkClassifier.test.js
+++ b/tests/unit/networkClassifier.test.js
@@ -179,10 +179,28 @@ describe('networkClassifier tests', () => {
   });
 
   describe('ip-api flags', () => {
-    it('treats proxy as a contradiction', () => {
+    it('treats proxy as a contradiction, and does not let it name a datacentre', () => {
       // 92.240.66.189 - University of Latvia, flagged proxy, which the PR as
-      // written would have DOSed as residential.
+      // written would have DOSed as residential. The flag has to keep RULING
+      // OUT a home line, and that is all it may do: it is a VPN artefact, so it
+      // says nothing about the machine behind the exit. A home machine on a VPN
+      // carries this signature and nothing else, and `datacenter: true` is what
+      // an owner buys to avoid exactly that. UNKNOWN confers nothing.
       const result = classifyNetwork({ proxy: true });
+
+      expect(result.classification).to.equal(CLASSIFICATION.UNKNOWN);
+      // The contradiction itself survives - it is what declines a published
+      // RESIDENTIAL verdict in geolocationService's veto.
+      expect(result.evidenceAgainst).to.contain('ip-api proxy');
+      expect(result.evidenceFor).to.be.empty;
+    });
+
+    it('still names a datacentre when proxy sits beside positive hosting evidence', () => {
+      // The rule is about proxy ALONE. On the fleet of 2026-08-18, 27 hosts
+      // carried proxy together with a hosting operator; those are datacentres
+      // on the operator and stay that way. Only the 8 that had proxy and
+      // nothing else change.
+      const result = classifyNetwork({ proxy: true, isp: 'Hetzner Online GmbH' });
 
       expect(result.classification).to.equal(CLASSIFICATION.DATACENTER);
     });

--- a/tests/unit/residentialNodeDosService.test.js
+++ b/tests/unit/residentialNodeDosService.test.js
@@ -667,6 +667,31 @@ describe('residentialNodeDosService tests', () => {
     });
   });
 
+  describe('the ticket tolerance the harness models', () => {
+    it('is the same multiple of the step that coupled-knobs derives from', async () => {
+      // Two files have to agree on this or the harness builds fleets the product
+      // does not behave like: coupled-knobs sizes the departure interval to
+      // outlast the tolerance, and sizes it from ITS OWN idea of what the
+      // tolerance is. If that drifts below the real one, a departure stops
+      // reading as a gap and the serialisation this paces silently stops
+      // existing - green, and testing nothing.
+      // eslint-disable-next-line import/extensions
+      const knobs = await import('../../test-infra/runner/framework/coupled-knobs.js');
+
+      expect(service.MAX_TICKET_GAP_MS).to.equal(service.QUEUE_STEP_MS * knobs.TICKET_GAP_STEPS);
+    });
+
+    it('outlasts more than one give-up pass, so a late pass cannot trip it', async () => {
+      // eslint-disable-next-line import/extensions
+      const knobs = await import('../../test-infra/runner/framework/coupled-knobs.js');
+      const passesPerStep = knobs.productionQueueRatio();
+
+      // One step is 1.82 passes. The tolerance has to mean a pass was MISSED
+      // rather than merely slow, so it has to clear two passes with room.
+      expect(passesPerStep * knobs.TICKET_GAP_STEPS).to.be.above(3);
+    });
+  });
+
   describe('what /flux/info reports: dosStaging', () => {
     it('reports nothing on a node that is not being enforced', async () => {
       geolocationServiceStub.getNetworkClassification.returns({ classification: CLASSIFICATION.DATACENTER });
@@ -867,7 +892,13 @@ describe('residentialNodeDosService tests', () => {
       const during = walk('someapp', short, now, now + wait + 1);
 
       expect(during.ok).to.equal(false);
-      expect(during.reason).to.contain('short');
+      // The CODE, not the prose. A caller has to tell "waiting its turn" from
+      // "the app is short" - the first is this working, the second is a node
+      // that wants to leave and cannot - and it must not have to match a
+      // sentence to do it. Deliberately the name appEvacuationSafety uses for
+      // the same fact, because it is the same fact asked one layer earlier.
+      expect(during.code).to.equal('BELOW_INSTANCE_COUNT');
+      expect(during.reason).to.contain('below its instance count');
 
       // And the turn runs from the moment it is whole, not from the first ask.
       const result = service.mayEvacuateApp('someapp', locations, LOCAL, WHOLE, now + wait + 2);
@@ -883,12 +914,38 @@ describe('residentialNodeDosService tests', () => {
       expect(walk('someapp', locations, now, now + wait + 1).ok).to.equal(true);
 
       service.forgetAppObservation('someapp');
-      // The same elapsed time with one missed pass inside it is not the same
-      // observation, and does not buy the turn.
       service.mayEvacuateApp('someapp', locations, LOCAL, WHOLE, now);
+      // An interruption longer than the tolerance. Expressed against the
+      // tolerance and measured from where watching RESUMED, rather than against
+      // the original stamp: the two are independent knobs, and an arithmetic
+      // that assumes one outlasts the other silently stops testing anything the
+      // moment either moves.
       const resumed = now + service.MAX_TICKET_GAP_MS + 1;
 
-      expect(walk('someapp', locations, resumed, now + wait + 1).ok).to.equal(false);
+      // The turn starts again from `resumed`, so time already served is gone.
+      expect(walk('someapp', locations, resumed, resumed + wait - 1).ok).to.equal(false);
+      // ...and a full turn from there does mature.
+      expect(walk('someapp', locations, resumed + wait - 1, resumed + wait + 1).ok).to.equal(true);
+    });
+
+    it('is not restarted by an ordinary pass running late', () => {
+      // The tolerance is TWO steps because one is 1.82 passes, so at one step a
+      // single slow pass restarts the ticket. Production hardly notices; the
+      // harness compresses the same ratio to seconds, where a late pass is
+      // ordinary - and on chud the countdown ran 2m, 1m, 0m and jumped back to
+      // 2m, three times over, never maturing.
+      const now = Date.now();
+      const wait = WAIT();
+      const lateButNotMissed = service.QUEUE_STEP_MS + 1000;
+
+      expect(lateButNotMissed, 'a late pass must be inside the tolerance')
+        .to.be.below(service.MAX_TICKET_GAP_MS);
+
+      service.mayEvacuateApp('someapp', locations, LOCAL, WHOLE, now);
+      service.mayEvacuateApp('someapp', locations, LOCAL, WHOLE, now + lateButNotMissed);
+
+      expect(service.mayEvacuateApp('someapp', locations, LOCAL, WHOLE, now + wait + 1).ok)
+        .to.equal(true);
     });
   });
 

--- a/tests/unit/residentialNodeDosService.test.js
+++ b/tests/unit/residentialNodeDosService.test.js
@@ -2,19 +2,26 @@ const { expect } = require('chai');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
 
+const { CLASSIFICATION } = require('../../ZelBack/src/services/utils/networkClassifier');
+
 describe('residentialNodeDosService tests', () => {
   let service;
   let fluxNetworkHelperStub;
   let geolocationServiceStub;
   let benchmarkServiceStub;
-  let configStub;
+  let dbHelperStub;
+  let markerStore;
+  let deps;
+  let installedApps;
+
+  const LOCAL = '1.2.3.4:16127';
 
   function loadService() {
     return proxyquire('../../ZelBack/src/services/residentialNodeDosService', {
-      config: configStub,
       '../lib/log': {
         info: sinon.stub(), warn: sinon.stub(), error: sinon.stub(),
       },
+      './dbHelper': dbHelperStub,
       './fluxNetworkHelper': fluxNetworkHelperStub,
       './geolocationService': geolocationServiceStub,
       './benchmarkService': benchmarkServiceStub,
@@ -22,24 +29,32 @@ describe('residentialNodeDosService tests', () => {
   }
 
   beforeEach(() => {
-    configStub = { residentialDos: { enabled: true } };
-
     // Stateful on purpose: the real fluxNetworkHelper reads back the message it
     // was given, and the ownership rules here are all written against that
     // read-back. A getter pinned to null would let a clear that must not happen
     // pass as if it had.
     let sticky = null;
+    let hold = null;
     fluxNetworkHelperStub = {
       setStickyDosMessage: sinon.stub().callsFake((msg) => { sticky = msg; }),
       setStickyDosStateValue: sinon.stub(),
       clearStickyDosMessage: sinon.stub().callsFake(() => { sticky = null; }),
       getStickyDosMessage: sinon.stub().callsFake(() => sticky),
+      setPlacementHold: sinon.stub().callsFake((reason) => { hold = reason; }),
+      clearPlacementHold: sinon.stub().callsFake(() => { hold = null; }),
+      getPlacementHold: sinon.stub().callsFake(() => hold),
+      isPlacementHeld: sinon.stub().callsFake(() => hold !== null),
+      getLocalSocketAddress: sinon.stub().resolves(LOCAL),
     };
 
-    // Default: geolocation resolved, IP is not a data center -> residential.
+    // Default: a settled RESIDENTIAL verdict.
     geolocationServiceStub = {
-      getNodeGeolocation: sinon.stub().resolves({ ip: '1.2.3.4', org: 'Some Telecom' }),
-      isDataCenter: sinon.stub().returns(false),
+      getNodeGeolocation: sinon.stub().resolves({ ip: '1.2.3.4' }),
+      getNetworkClassification: sinon.stub().returns({
+        classification: CLASSIFICATION.RESIDENTIAL,
+        evidenceFor: ['ptr access-network: dsl.example.net'],
+        evidenceAgainst: [],
+      }),
     };
 
     // Default: bench reachable, node is NOT ArcaneOS.
@@ -47,7 +62,27 @@ describe('residentialNodeDosService tests', () => {
       getBenchmarks: sinon.stub().resolves({ status: 'success', data: { systemsecure: false } }),
     };
 
+    // The settle marker lives in mongo, so the double has to remember it across
+    // a reload - surviving a restart is the whole point of that field.
+    markerStore = new Map();
+    dbHelperStub = {
+      databaseConnection: sinon.stub().returns({ db: sinon.stub().returns({}) }),
+      findOneInDatabase: sinon.stub().callsFake(async (db, coll, query) => markerStore.get(query._id) || null),
+      findOneAndUpdateInDatabase: sinon.stub().callsFake(async (db, coll, query, update) => {
+        markerStore.set(query._id, { _id: query._id, ...(markerStore.get(query._id) || {}), ...update.$set });
+      }),
+      findOneAndDeleteInDatabase: sinon.stub().callsFake(async (db, coll, query) => {
+        markerStore.delete(query._id);
+      }),
+    };
+
+    installedApps = [];
+    deps = {
+      installedAppsFn: sinon.stub().callsFake(async () => ({ status: 'success', data: installedApps })),
+    };
+
     service = loadService();
+    service.setNodeReadyForTests(true);
   });
 
   afterEach(() => {
@@ -66,7 +101,7 @@ describe('residentialNodeDosService tests', () => {
       expect(await service.isArcaneOs()).to.equal(false);
     });
 
-    it('returns null when bench call errors', async () => {
+    it('returns null when bench errors, so an outage never DOSes a real ArcaneOS node', async () => {
       benchmarkServiceStub.getBenchmarks.resolves({ status: 'error', data: 'benchd down' });
 
       expect(await service.isArcaneOs()).to.equal(null);
@@ -77,291 +112,407 @@ describe('residentialNodeDosService tests', () => {
 
       expect(await service.isArcaneOs()).to.equal(null);
     });
-
-    it('returns null when bench throws', async () => {
-      benchmarkServiceStub.getBenchmarks.rejects(new Error('socket hang up'));
-
-      expect(await service.isArcaneOs()).to.equal(null);
-    });
   });
 
-  describe('isResidential', () => {
-    it('returns true when geolocation resolved and the IP is not a data center', async () => {
+  describe('isResidential reads one settled verdict', () => {
+    it('is true only on RESIDENTIAL', async () => {
       expect(await service.isResidential()).to.equal(true);
     });
 
-    it('returns false when geolocation says the IP is a data center', async () => {
-      geolocationServiceStub.isDataCenter.returns(true);
+    it('is false on DATACENTER', async () => {
+      geolocationServiceStub.getNetworkClassification.returns({ classification: CLASSIFICATION.DATACENTER });
 
       expect(await service.isResidential()).to.equal(false);
     });
 
-    it('returns null when no geolocation has resolved yet - the flag alone would read as residential', async () => {
-      geolocationServiceStub.getNodeGeolocation.resolves(null);
-      geolocationServiceStub.isDataCenter.returns(false);
+    it('is null on CONFLICTED, which must never be enforced against', async () => {
+      geolocationServiceStub.getNetworkClassification.returns({ classification: CLASSIFICATION.CONFLICTED });
 
       expect(await service.isResidential()).to.equal(null);
     });
 
-    it('returns null when the geolocation lookup throws', async () => {
-      geolocationServiceStub.getNodeGeolocation.rejects(new Error('db down'));
+    it('is null on UNKNOWN, which must never be enforced against', async () => {
+      geolocationServiceStub.getNetworkClassification.returns({ classification: CLASSIFICATION.UNKNOWN });
+
+      expect(await service.isResidential()).to.equal(null);
+    });
+
+    it('is null when no verdict has been reached at all', async () => {
+      geolocationServiceStub.getNetworkClassification.returns(null);
 
       expect(await service.isResidential()).to.equal(null);
     });
   });
 
-  describe('enforceResidentialPolicy', () => {
-    it('DOSes a residential node that is not running ArcaneOS', async () => {
-      const decided = await service.enforceResidentialPolicy();
+  describe('the placement hold', () => {
+    it('goes on immediately, with no settling period', async () => {
+      installedApps = [{ name: 'someapp' }];
 
-      expect(decided).to.equal(true);
-      sinon.assert.calledOnce(fluxNetworkHelperStub.setStickyDosMessage);
-      expect(fluxNetworkHelperStub.setStickyDosMessage.firstCall.args[0])
-        .to.include(service.DOS_MESSAGE_PREFIX);
+      await service.enforceResidentialPolicy(deps);
+
+      expect(fluxNetworkHelperStub.isPlacementHeld()).to.equal(true);
+      expect(fluxNetworkHelperStub.getPlacementHold()).to.equal(service.HOLD_REASON);
+    });
+
+    it('never sets a DOS on a node that still holds apps', async () => {
+      installedApps = [{ name: 'someapp' }];
+
+      await service.enforceResidentialPolicy(deps);
+
+      sinon.assert.notCalled(fluxNetworkHelperStub.setStickyDosStateValue);
+    });
+
+    it('lifts when the node is no longer residential', async () => {
+      installedApps = [{ name: 'someapp' }];
+      await service.enforceResidentialPolicy(deps);
+      geolocationServiceStub.getNetworkClassification.returns({ classification: CLASSIFICATION.DATACENTER });
+
+      await service.enforceResidentialPolicy(deps);
+
+      expect(fluxNetworkHelperStub.isPlacementHeld()).to.equal(false);
+    });
+
+    it('lifts when the node migrates to ArcaneOS', async () => {
+      installedApps = [{ name: 'someapp' }];
+      await service.enforceResidentialPolicy(deps);
+      benchmarkServiceStub.getBenchmarks.resolves({ status: 'success', data: { systemsecure: true } });
+
+      await service.enforceResidentialPolicy(deps);
+
+      expect(fluxNetworkHelperStub.isPlacementHeld()).to.equal(false);
+    });
+  });
+
+  describe('an unreadable input decides nothing', () => {
+    it('does not hold or DOS when bench cannot be read', async () => {
+      benchmarkServiceStub.getBenchmarks.resolves({ status: 'error', data: 'down' });
+
+      const decided = await service.enforceResidentialPolicy(deps);
+
+      expect(decided).to.equal(false);
+      expect(fluxNetworkHelperStub.isPlacementHeld()).to.equal(false);
+      sinon.assert.notCalled(fluxNetworkHelperStub.setStickyDosStateValue);
+    });
+
+    it('does not hold or DOS when there is no settled classification', async () => {
+      geolocationServiceStub.getNetworkClassification.returns(null);
+
+      const decided = await service.enforceResidentialPolicy(deps);
+
+      expect(decided).to.equal(false);
+      expect(fluxNetworkHelperStub.isPlacementHeld()).to.equal(false);
+    });
+  });
+
+  describe('the DOS is only ever set on a confirmed empty node', () => {
+    it('goes on at once when the node holds no apps', async () => {
+      installedApps = [];
+
+      await service.enforceResidentialPolicy(deps);
+
       sinon.assert.calledWith(fluxNetworkHelperStub.setStickyDosStateValue, 100);
       expect(service.isDosActive()).to.equal(true);
     });
 
-    it('does not DOS a residential node running ArcaneOS', async () => {
-      benchmarkServiceStub.getBenchmarks.resolves({ status: 'success', data: { systemsecure: true } });
+    it('needs no settling period to do so', async () => {
+      installedApps = [];
 
-      await service.enforceResidentialPolicy();
+      await service.enforceResidentialPolicy(deps);
 
-      sinon.assert.notCalled(fluxNetworkHelperStub.setStickyDosMessage);
-      expect(service.isDosActive()).to.equal(false);
+      // An empty node never enters the window at all.
+      expect(markerStore.size).to.equal(0);
     });
 
-    it('does not DOS a data center node that is not running ArcaneOS', async () => {
-      geolocationServiceStub.isDataCenter.returns(true);
+    it('is NOT set when the installed-app list cannot be read', async () => {
+      // Reading "could not ask" as "holds nothing" would set DOS >= 100 on a
+      // node that has apps, and nodeStatusMonitor would then delete every one.
+      deps.installedAppsFn.resolves({ status: 'error', data: 'db down' });
 
-      await service.enforceResidentialPolicy();
-
-      sinon.assert.notCalled(fluxNetworkHelperStub.setStickyDosMessage);
-      expect(service.isDosActive()).to.equal(false);
-    });
-
-    it('decides nothing when bench is unreachable, even on a residential IP', async () => {
-      benchmarkServiceStub.getBenchmarks.rejects(new Error('benchd down'));
-
-      const decided = await service.enforceResidentialPolicy();
+      const decided = await service.enforceResidentialPolicy(deps);
 
       expect(decided).to.equal(false);
-      sinon.assert.notCalled(fluxNetworkHelperStub.setStickyDosMessage);
-      sinon.assert.notCalled(fluxNetworkHelperStub.clearStickyDosMessage);
+      sinon.assert.notCalled(fluxNetworkHelperStub.setStickyDosStateValue);
+      expect(fluxNetworkHelperStub.isPlacementHeld()).to.equal(true);
     });
 
-    it('decides nothing when geolocation has not resolved yet', async () => {
-      geolocationServiceStub.getNodeGeolocation.resolves(null);
+    it('is NOT set before the node knows what it is running', async () => {
+      service.setNodeReadyForTests(false);
+      installedApps = [];
 
-      const decided = await service.enforceResidentialPolicy();
+      const decided = await service.enforceResidentialPolicy(deps);
 
       expect(decided).to.equal(false);
+      sinon.assert.notCalled(fluxNetworkHelperStub.setStickyDosStateValue);
+      expect(fluxNetworkHelperStub.isPlacementHeld()).to.equal(true);
+    });
+
+    it('is released once the node is no longer a target', async () => {
+      installedApps = [];
+      await service.enforceResidentialPolicy(deps);
+      geolocationServiceStub.getNetworkClassification.returns({ classification: CLASSIFICATION.DATACENTER });
+
+      await service.enforceResidentialPolicy(deps);
+
+      sinon.assert.called(fluxNetworkHelperStub.clearStickyDosMessage);
+      expect(service.isDosActive()).to.equal(false);
+    });
+  });
+
+  describe('sticky slot ownership', () => {
+    it("leaves another owner's DOS alone rather than overwriting it", async () => {
+      installedApps = [];
+      fluxNetworkHelperStub.setStickyDosMessage('Node flagged via tampering blocklist: score 40');
+      fluxNetworkHelperStub.setStickyDosMessage.resetHistory();
+
+      await service.enforceResidentialPolicy(deps);
+
       sinon.assert.notCalled(fluxNetworkHelperStub.setStickyDosMessage);
-      sinon.assert.notCalled(fluxNetworkHelperStub.clearStickyDosMessage);
+      expect(fluxNetworkHelperStub.getStickyDosMessage()).to.contain('tampering');
     });
 
-    it('an unavailable input does not clear a DOS this service already set', async () => {
-      await service.enforceResidentialPolicy();
-      expect(service.isDosActive()).to.equal(true);
+    it('releases only its own claim when the slot has changed hands', async () => {
+      installedApps = [];
+      await service.enforceResidentialPolicy(deps);
+      // Another owner takes the slot after we wrote.
+      fluxNetworkHelperStub.setStickyDosMessage('Node flagged via tampering blocklist: score 40');
+      geolocationServiceStub.getNetworkClassification.returns({ classification: CLASSIFICATION.DATACENTER });
 
-      benchmarkServiceStub.getBenchmarks.rejects(new Error('benchd down'));
-      await service.enforceResidentialPolicy();
+      await service.enforceResidentialPolicy(deps);
 
-      sinon.assert.notCalled(fluxNetworkHelperStub.clearStickyDosMessage);
-      expect(service.isDosActive()).to.equal(true);
-    });
-
-    it('clears its own DOS once the node moves to ArcaneOS', async () => {
-      await service.enforceResidentialPolicy();
-      expect(service.isDosActive()).to.equal(true);
-
-      benchmarkServiceStub.getBenchmarks.resolves({ status: 'success', data: { systemsecure: true } });
-      await service.enforceResidentialPolicy();
-
-      sinon.assert.calledOnce(fluxNetworkHelperStub.clearStickyDosMessage);
+      expect(fluxNetworkHelperStub.getStickyDosMessage()).to.contain('tampering');
       expect(service.isDosActive()).to.equal(false);
     });
+  });
 
-    it('clears a DOS left by a previous process when the condition no longer holds', async () => {
-      fluxNetworkHelperStub.getStickyDosMessage.returns(`${service.DOS_MESSAGE_PREFIX}. Migrate this node`);
-      geolocationServiceStub.isDataCenter.returns(true);
+  describe('the settling window before evacuation', () => {
+    it('does not begin evacuating on the first evaluation', async () => {
+      installedApps = [{ name: 'someapp' }];
 
-      await service.enforceResidentialPolicy();
+      await service.enforceResidentialPolicy(deps);
 
-      sinon.assert.calledOnce(fluxNetworkHelperStub.clearStickyDosMessage);
+      expect(service.isEvacuating()).to.equal(false);
     });
 
-    it('does not clear a sticky slot another owner took over after we set ours', async () => {
-      await service.enforceResidentialPolicy();
-      expect(service.isDosActive()).to.equal(true);
+    it('records when the window started', async () => {
+      installedApps = [{ name: 'someapp' }];
 
-      // Another enforcer overwrote the single sticky slot with its own message.
-      fluxNetworkHelperStub.getStickyDosMessage.returns('Node flagged via tampering blocklist: score 12');
-      // ...and our own condition stops holding.
-      geolocationServiceStub.isDataCenter.returns(true);
-      await service.enforceResidentialPolicy();
+      await service.enforceResidentialPolicy(deps);
 
-      sinon.assert.notCalled(fluxNetworkHelperStub.clearStickyDosMessage);
-      expect(service.isDosActive()).to.equal(false);
+      expect(markerStore.get('residentialDos').residentialSince).to.be.a('number');
     });
 
-    it('does not clear another owner\'s sticky slot when disabled by config', async () => {
-      await service.enforceResidentialPolicy();
-      fluxNetworkHelperStub.getStickyDosMessage.returns('Node flagged via tampering blocklist: score 12');
+    it('begins evacuating once the window has elapsed', async () => {
+      installedApps = [{ name: 'someapp' }];
+      markerStore.set('residentialDos', {
+        _id: 'residentialDos',
+        residentialSince: Date.now() - service.SETTLE_MS - 1000,
+      });
 
-      configStub.residentialDos.enabled = false;
-      await service.enforceResidentialPolicy();
+      await service.enforceResidentialPolicy(deps);
 
-      sinon.assert.notCalled(fluxNetworkHelperStub.clearStickyDosMessage);
-      expect(service.isDosActive()).to.equal(false);
+      expect(service.isEvacuating()).to.equal(true);
     });
 
-    it('does not overwrite another owner\'s sticky DOS', async () => {
-      fluxNetworkHelperStub.getStickyDosMessage.returns('Node flagged via tampering blocklist: score 12');
+    it('is not restarted by a restart, because it is persisted wall-clock', async () => {
+      // A counter of consecutive evaluations held in memory would be reset by
+      // restarting FluxOS, which would make restarting on a cron a way to
+      // postpone evacuation indefinitely.
+      installedApps = [{ name: 'someapp' }];
+      const startedAt = Date.now() - service.SETTLE_MS - 1000;
+      markerStore.set('residentialDos', { _id: 'residentialDos', residentialSince: startedAt });
 
-      const decided = await service.enforceResidentialPolicy();
-
-      expect(decided).to.equal(true);
-      sinon.assert.notCalled(fluxNetworkHelperStub.setStickyDosMessage);
-      sinon.assert.notCalled(fluxNetworkHelperStub.clearStickyDosMessage);
-      expect(service.isDosActive()).to.equal(false);
-    });
-
-    it('refreshes its own sticky DOS rather than treating it as foreign', async () => {
-      fluxNetworkHelperStub.getStickyDosMessage.returns(`${service.DOS_MESSAGE_PREFIX}. Migrate this node`);
-
-      await service.enforceResidentialPolicy();
-
-      sinon.assert.calledOnce(fluxNetworkHelperStub.setStickyDosMessage);
-      sinon.assert.calledWith(fluxNetworkHelperStub.setStickyDosStateValue, 100);
-    });
-
-    it('enforces nothing and releases its own DOS when disabled by config', async () => {
-      await service.enforceResidentialPolicy();
-      expect(service.isDosActive()).to.equal(true);
-
-      configStub.residentialDos.enabled = false;
-      const decided = await service.enforceResidentialPolicy();
-
-      expect(decided).to.equal(true);
-      sinon.assert.calledOnce(fluxNetworkHelperStub.clearStickyDosMessage);
-      expect(service.isDosActive()).to.equal(false);
-      sinon.assert.calledOnce(fluxNetworkHelperStub.setStickyDosMessage);
-    });
-
-    it('enforces when the config section is absent altogether', async () => {
-      configStub = {};
+      service.stop();
       service = loadService();
+      service.setNodeReadyForTests(true);
+      await service.enforceResidentialPolicy(deps);
 
-      await service.enforceResidentialPolicy();
+      expect(markerStore.get('residentialDos').residentialSince).to.equal(startedAt);
+      expect(service.isEvacuating()).to.equal(true);
+    });
 
-      sinon.assert.calledWith(fluxNetworkHelperStub.setStickyDosStateValue, 100);
+    it('is cleared only by a verdict flip', async () => {
+      installedApps = [{ name: 'someapp' }];
+      await service.enforceResidentialPolicy(deps);
+      expect(markerStore.has('residentialDos')).to.equal(true);
+
+      geolocationServiceStub.getNetworkClassification.returns({ classification: CLASSIFICATION.DATACENTER });
+      await service.enforceResidentialPolicy(deps);
+
+      expect(markerStore.has('residentialDos')).to.equal(false);
+      expect(service.isEvacuating()).to.equal(false);
+    });
+
+    it('stops evacuating when the marker cannot be read', async () => {
+      installedApps = [{ name: 'someapp' }];
+      markerStore.set('residentialDos', {
+        _id: 'residentialDos', residentialSince: Date.now() - service.SETTLE_MS - 1000,
+      });
+      await service.enforceResidentialPolicy(deps);
+      expect(service.isEvacuating()).to.equal(true);
+
+      dbHelperStub.databaseConnection.returns(null);
+      const decided = await service.enforceResidentialPolicy(deps);
+
+      expect(decided).to.equal(false);
+      expect(service.isEvacuating()).to.equal(false);
     });
   });
 
-  describe('start / stop scheduling', () => {
-    let clock;
+  describe('pacing: mayEvacuateApp', () => {
+    const locations = [
+      { ip: '5.6.7.8:16127', runningSince: new Date(1000) },
+      { ip: LOCAL, runningSince: new Date(2000) },
+    ];
 
-    beforeEach(() => {
-      clock = sinon.useFakeTimers();
+    beforeEach(async () => {
+      installedApps = [{ name: 'someapp' }];
+      markerStore.set('residentialDos', {
+        _id: 'residentialDos', residentialSince: Date.now() - service.SETTLE_MS - 1000,
+      });
+      await service.enforceResidentialPolicy(deps);
     });
 
-    afterEach(() => {
-      clock.restore();
+    it('refuses while the node is not evacuating', async () => {
+      geolocationServiceStub.getNetworkClassification.returns({ classification: CLASSIFICATION.DATACENTER });
+      await service.enforceResidentialPolicy(deps);
+
+      const result = service.mayEvacuateApp('someapp', locations, LOCAL);
+
+      expect(result.ok).to.equal(false);
+      expect(result.reason).to.contain('not evacuating');
     });
 
-    it('reschedules on the short retry delay after an inconclusive tick', async () => {
-      geolocationServiceStub.getNodeGeolocation.resolves(null);
+    it('refuses until the app has been seen whole for its queue turn', () => {
+      const now = Date.now();
+      service.mayEvacuateApp('someapp', locations, LOCAL, now);
 
-      await service.start();
-      expect(geolocationServiceStub.getNodeGeolocation.callCount).to.equal(1);
+      const result = service.mayEvacuateApp('someapp', locations, LOCAL, now + 1000);
 
-      await clock.tickAsync(service.RETRY_INTERVAL_MS);
-      expect(geolocationServiceStub.getNodeGeolocation.callCount).to.equal(2);
+      expect(result.ok).to.equal(false);
+      expect(result.reason).to.contain('its turn is in');
     });
 
-    it('doubles the retry delay while ticks stay inconclusive, capped at the full interval', async () => {
-      geolocationServiceStub.getNodeGeolocation.resolves(null);
-      const calls = () => geolocationServiceStub.getNodeGeolocation.callCount;
+    it('allows once the queue turn has been served', () => {
+      const now = Date.now();
+      service.mayEvacuateApp('someapp', locations, LOCAL, now);
+      // Position 1 in the seniority order: base plus one step.
+      const wait = service.QUEUE_BASE_MS + service.QUEUE_STEP_MS;
 
-      await service.start();
-      expect(calls()).to.equal(1);
+      const result = service.mayEvacuateApp('someapp', locations, LOCAL, now + wait + 1);
 
-      await clock.tickAsync(service.RETRY_INTERVAL_MS);
-      expect(calls()).to.equal(2);
-
-      // Second retry is 2x, so the first delay alone is not enough.
-      await clock.tickAsync(service.RETRY_INTERVAL_MS);
-      expect(calls()).to.equal(2);
-      await clock.tickAsync(service.RETRY_INTERVAL_MS);
-      expect(calls()).to.equal(3);
-
-      // Walk the doubling out to where it would exceed the interval.
-      let expected = 3;
-      for (let delay = service.RETRY_INTERVAL_MS * 4;
-        delay < service.CHECK_INTERVAL_MS;
-        delay *= 2) {
-        // eslint-disable-next-line no-await-in-loop
-        await clock.tickAsync(delay);
-        expected += 1;
-        expect(calls()).to.equal(expected);
-      }
-
-      // The next delay doubles past the interval and is capped to it exactly:
-      // one tick short of the interval fires nothing, the interval fires once.
-      await clock.tickAsync(service.CHECK_INTERVAL_MS - 1);
-      expect(calls()).to.equal(expected);
-      await clock.tickAsync(1);
-      expect(calls()).to.equal(expected + 1);
+      expect(result.ok).to.equal(true);
     });
 
-    it('resets the backoff once a tick decides again', async () => {
-      geolocationServiceStub.getNodeGeolocation.resolves(null);
-      await service.start();
-      await clock.tickAsync(service.RETRY_INTERVAL_MS);
-      await clock.tickAsync(service.RETRY_INTERVAL_MS * 2);
-      expect(geolocationServiceStub.getNodeGeolocation.callCount).to.equal(3);
+    it('paces departures by the evacuation interval', () => {
+      const now = Date.now();
+      service.mayEvacuateApp('someapp', locations, LOCAL, now);
+      const wait = service.QUEUE_BASE_MS + service.QUEUE_STEP_MS;
+      expect(service.mayEvacuateApp('someapp', locations, LOCAL, now + wait + 1).ok).to.equal(true);
 
-      // Geolocation resolves: that tick decides, so the next inconclusive run
-      // starts over at the short retry instead of the grown delay.
-      geolocationServiceStub.getNodeGeolocation.resolves({ ip: '1.2.3.4' });
-      await clock.tickAsync(service.RETRY_INTERVAL_MS * 4);
-      expect(geolocationServiceStub.getNodeGeolocation.callCount).to.equal(4);
+      service.noteEvacuated('someapp', now + wait + 1);
+      const next = service.mayEvacuateApp('other', locations, LOCAL, now + wait + 2);
 
-      geolocationServiceStub.getNodeGeolocation.resolves(null);
-      await clock.tickAsync(service.CHECK_INTERVAL_MS);
-      expect(geolocationServiceStub.getNodeGeolocation.callCount).to.equal(5);
-      await clock.tickAsync(service.RETRY_INTERVAL_MS);
-      expect(geolocationServiceStub.getNodeGeolocation.callCount).to.equal(6);
+      expect(next.ok).to.equal(false);
+      expect(next.reason).to.contain('next departure in');
     });
 
-    it('reschedules on the full interval after a decided tick', async () => {
-      await service.start();
-      expect(benchmarkServiceStub.getBenchmarks.callCount).to.equal(1);
+    it("restarts an app's observation when it stops being whole", () => {
+      const now = Date.now();
+      service.mayEvacuateApp('someapp', locations, LOCAL, now);
+      service.forgetAppObservation('someapp');
+      const wait = service.QUEUE_BASE_MS + service.QUEUE_STEP_MS;
 
-      await clock.tickAsync(service.RETRY_INTERVAL_MS);
-      expect(benchmarkServiceStub.getBenchmarks.callCount).to.equal(1);
+      const result = service.mayEvacuateApp('someapp', locations, LOCAL, now + wait + 1);
 
-      await clock.tickAsync(service.CHECK_INTERVAL_MS);
-      expect(benchmarkServiceStub.getBenchmarks.callCount).to.equal(2);
+      expect(result.ok).to.equal(false);
+    });
+  });
+
+  describe('queueDelayMs is a delay, never a veto', () => {
+    it('gives the senior instance the shortest wait, and still a non-zero one', () => {
+      const locations = [
+        { ip: LOCAL, runningSince: new Date(1000) },
+        { ip: '5.6.7.8:16127', runningSince: new Date(2000) },
+      ];
+
+      expect(service.queueDelayMs(locations, LOCAL)).to.equal(service.QUEUE_BASE_MS);
     });
 
-    it('a second start does not add a second tick chain', async () => {
-      await service.start();
-      await service.start();
+    it('spaces each subsequent position by one step', () => {
+      const locations = [
+        { ip: '5.6.7.8:16127', runningSince: new Date(1000) },
+        { ip: '9.9.9.9:16127', runningSince: new Date(2000) },
+        { ip: LOCAL, runningSince: new Date(3000) },
+      ];
 
-      await clock.tickAsync(service.CHECK_INTERVAL_MS);
-
-      expect(benchmarkServiceStub.getBenchmarks.callCount).to.equal(2);
+      expect(service.queueDelayMs(locations, LOCAL)).to.equal(
+        service.QUEUE_BASE_MS + (2 * service.QUEUE_STEP_MS),
+      );
     });
 
-    it('stop prevents any further tick', async () => {
-      await service.start();
+    it('gives an instance it cannot find in the list the longest wait', () => {
+      const locations = [{ ip: '5.6.7.8:16127', runningSince: new Date(1000) }];
+
+      expect(service.queueDelayMs(locations, LOCAL)).to.equal(
+        service.QUEUE_BASE_MS + service.QUEUE_STEP_MS,
+      );
+    });
+  });
+
+  describe('listInstalledApps', () => {
+    it('returns null rather than an empty list when the read fails', async () => {
+      const result = await service.listInstalledApps(async () => ({ status: 'error', data: 'nope' }));
+
+      expect(result).to.equal(null);
+    });
+
+    it('returns null when the lister throws', async () => {
+      const result = await service.listInstalledApps(async () => { throw new Error('boom'); });
+
+      expect(result).to.equal(null);
+    });
+
+    it('returns the app names on success', async () => {
+      const result = await service.listInstalledApps(async () => ({
+        status: 'success', data: [{ name: 'a' }, { name: 'b' }],
+      }));
+
+      expect(result).to.deep.equal(['a', 'b']);
+    });
+  });
+
+  describe('lifecycle', () => {
+    it('stop() drops our DOS claim so a later start() re-reads the slot', async () => {
+      installedApps = [];
+      await service.enforceResidentialPolicy(deps);
+      expect(service.isDosActive()).to.equal(true);
+
       service.stop();
 
-      await clock.tickAsync(service.CHECK_INTERVAL_MS * 3);
+      expect(service.isDosActive()).to.equal(false);
+    });
 
-      expect(benchmarkServiceStub.getBenchmarks.callCount).to.equal(1);
+    it('stop() stops evacuating', async () => {
+      installedApps = [{ name: 'someapp' }];
+      markerStore.set('residentialDos', {
+        _id: 'residentialDos', residentialSince: Date.now() - service.SETTLE_MS - 1000,
+      });
+      await service.enforceResidentialPolicy(deps);
+      expect(service.isEvacuating()).to.equal(true);
+
+      service.stop();
+
+      expect(service.isEvacuating()).to.equal(false);
+    });
+
+    it('a second start() does not run a second self-rescheduling chain', async () => {
+      installedApps = [];
+      await service.start(deps);
+      const callsAfterFirst = deps.installedAppsFn.callCount;
+
+      await service.start(deps);
+
+      expect(deps.installedAppsFn.callCount).to.equal(callsAfterFirst);
     });
   });
 });

--- a/tests/unit/residentialNodeDosService.test.js
+++ b/tests/unit/residentialNodeDosService.test.js
@@ -1,6 +1,9 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
+const { EventEmitter } = require('node:events');
 const proxyquire = require('proxyquire').noCallThru();
+
+const { EVENTS: SYNC_EVENTS } = require('../../ZelBack/src/services/utils/appSyncEvents');
 
 const { CLASSIFICATION } = require('../../ZelBack/src/services/utils/networkClassifier');
 
@@ -41,6 +44,17 @@ describe('residentialNodeDosService tests', () => {
       './geolocationService': geolocationServiceStub,
       './benchmarkService': benchmarkServiceStub,
       './utils/globalState': globalStateStub,
+      // A private emitter per load. The service registers its readiness
+      // listeners at module top level - deliberately, so the listener exists
+      // before SPAWNER_READY can fire, which appSpawner's registration inside
+      // initialize() cannot guarantee - and never removes them. That is right
+      // for a module required once, and wrong for a test that reloads it forty
+      // times onto the SHARED emitter: eighty listeners, a
+      // MaxListenersExceededWarning, and every one of them still live. It is
+      // not inert either, because appSpawner.test.js emits SPAWNER_READY on
+      // that same emitter and mocha runs both files in one process, so those
+      // dead instances take readiness from another file's test.
+      './utils/appSyncEvents': { appSyncEvents: new EventEmitter(), EVENTS: SYNC_EVENTS },
     });
   }
 

--- a/tests/unit/residentialNodeDosService.test.js
+++ b/tests/unit/residentialNodeDosService.test.js
@@ -667,6 +667,86 @@ describe('residentialNodeDosService tests', () => {
     });
   });
 
+  describe('what /flux/info reports: dosStaging', () => {
+    it('reports nothing on a node that is not being enforced', async () => {
+      geolocationServiceStub.getNetworkClassification.returns({ classification: CLASSIFICATION.DATACENTER });
+      installedApps = [{ name: 'someapp' }];
+
+      await service.enforceResidentialPolicy(deps);
+
+      expect(service.getDosStaging()).to.equal(null);
+    });
+
+    it('reports HOLD from the first enforced evaluation, before anything is deleted', async () => {
+      // The stage worth reporting. It lasts a whole settling window, nothing has
+      // been deleted in it, and the operator can still put the node right and
+      // lose nothing - and without it a held node looks exactly like one that
+      // has simply not been given any work.
+      installedApps = [{ name: 'someapp' }];
+
+      await service.enforceResidentialPolicy(deps);
+
+      expect(service.getDosStaging()).to.equal('HOLD');
+      expect(service.isEvacuating()).to.equal(false);
+    });
+
+    it('reports EVACUATE once the window is served', async () => {
+      installedApps = [{ name: 'someapp' }];
+      markerStore.set('residentialDos', windowServed());
+
+      await service.enforceResidentialPolicy(deps);
+
+      expect(service.getDosStaging()).to.equal('EVACUATE');
+    });
+
+    it('does not go backwards when a tick cannot decide', async () => {
+      // THE REASON THIS IS NOT DERIVED FROM `evacuating`. That flag is a per-tick
+      // permission for the give-up pass and any tick that cannot read something
+      // turns it off - correctly. Reporting it as a STAGE would show the node
+      // retreating through a staging it never retreated through, on a tick where
+      // nothing about the node changed at all.
+      installedApps = [{ name: 'someapp' }];
+      markerStore.set('residentialDos', windowServed());
+      await service.enforceResidentialPolicy(deps);
+      expect(service.getDosStaging()).to.equal('EVACUATE');
+
+      benchmarkServiceStub.getBenchmarks.resolves({ status: 'error' });
+      await service.enforceResidentialPolicy(deps);
+
+      expect(service.isEvacuating(), 'the drain stops, which is correct').to.equal(false);
+      expect(service.getDosStaging(), 'but the node has not moved back a stage').to.equal('EVACUATE');
+    });
+
+    it('does not go backwards when the settling marker cannot be written', async () => {
+      // The other way a tick gives up, and it reaches FURTHER than an unreadable
+      // benchmark does - past the point where the window figure is read. The
+      // stage still must not move: the node has not retreated anywhere, this
+      // node simply could not write its own note.
+      installedApps = [{ name: 'someapp' }];
+      markerStore.set('residentialDos', windowServed());
+      await service.enforceResidentialPolicy(deps);
+      expect(service.getDosStaging()).to.equal('EVACUATE');
+
+      dbHelperStub.findOneAndUpdateInDatabase.rejects(new Error('marker write failed'));
+      await service.enforceResidentialPolicy(deps);
+
+      expect(service.isEvacuating(), 'the drain stops, which is correct').to.equal(false);
+      expect(service.getDosStaging(), 'but the node has not moved back a stage').to.equal('EVACUATE');
+    });
+
+    it('reports nothing again once the node stops being enforced', async () => {
+      installedApps = [{ name: 'someapp' }];
+      markerStore.set('residentialDos', windowServed());
+      await service.enforceResidentialPolicy(deps);
+      expect(service.getDosStaging()).to.equal('EVACUATE');
+
+      geolocationServiceStub.getNetworkClassification.returns({ classification: CLASSIFICATION.DATACENTER });
+      await service.enforceResidentialPolicy(deps);
+
+      expect(service.getDosStaging()).to.equal(null);
+    });
+  });
+
   describe('pacing: mayEvacuateApp', () => {
     // Junior first, so the senior LOCAL sits at position 1 - the pacing tests
     // below are about the interval and the observation window, and they only

--- a/tests/unit/residentialNodeDosService.test.js
+++ b/tests/unit/residentialNodeDosService.test.js
@@ -11,6 +11,7 @@ describe('residentialNodeDosService tests', () => {
   let benchmarkServiceStub;
   let dbHelperStub;
   let markerStore;
+  let globalStateStub;
   let deps;
   let installedApps;
 
@@ -39,6 +40,7 @@ describe('residentialNodeDosService tests', () => {
       './fluxNetworkHelper': fluxNetworkHelperStub,
       './geolocationService': geolocationServiceStub,
       './benchmarkService': benchmarkServiceStub,
+      './utils/globalState': globalStateStub,
     });
   }
 
@@ -75,6 +77,10 @@ describe('residentialNodeDosService tests', () => {
     benchmarkServiceStub = {
       getBenchmarks: sinon.stub().resolves({ status: 'success', data: { systemsecure: false } }),
     };
+
+    // An install in flight is real before its database record exists, so the
+    // empty check reads this rather than trusting an ordering in another file.
+    globalStateStub = { installationInProgress: false, removalInProgress: false };
 
     // The settle marker lives in mongo, so the double has to remember it across
     // a reload - surviving a restart is the whole point of that field.
@@ -457,6 +463,129 @@ describe('residentialNodeDosService tests', () => {
 
       expect(markerStore.get('residentialDos').residentialSince).to.equal(firstSeen);
       expect(service.isEvacuating()).to.equal(false);
+    });
+  });
+
+  describe('the bounded correctness set', () => {
+    const HOUR = 60 * 60 * 1000;
+
+    beforeEach(() => {
+      installedApps = [{ name: 'someapp' }];
+    });
+
+    it('does not re-open the departure gate on a restart', async () => {
+      // lastEvacuationAt started at 0, so `now - 0` is about 1.7e12 and the
+      // gate was open on the first call after every process start. A node
+      // restarting on a cron shed an app every queue wait instead of every
+      // departure interval.
+      const now = Date.now();
+      markerStore.set('residentialDos', {
+        ...windowServed(now), lastEvacuationAt: now - HOUR,
+      });
+
+      await service.enforceResidentialPolicy(deps);
+      const verdict = service.mayEvacuateApp('someapp', [{ ip: LOCAL, runningSince: new Date(1) }], LOCAL, now);
+
+      expect(verdict.ok).to.equal(false);
+      expect(verdict.reason).to.contain('next departure in');
+    });
+
+    it('records the departure so the next process sees it', async () => {
+      markerStore.set('residentialDos', windowServed());
+
+      service.noteEvacuated('someapp');
+      await new Promise((resolve) => { setImmediate(resolve); });
+
+      expect(markerStore.get('residentialDos').lastEvacuationAt).to.be.a('number');
+    });
+
+    it('gives an empty location list the longest wait, not the shortest', async () => {
+      // `index < 0 ? ordered.length : index` made an EMPTY list position 0 -
+      // the most senior slot - inverting the rule the sibling test asserts. An
+      // empty list is the ordinary result of expired location records.
+      expect(service.queueDelayMs([], LOCAL)).to.be.above(service.QUEUE_BASE_MS);
+    });
+
+    it('refuses to drain on a settle comparison that is not a number', async () => {
+      // NaN is neither < nor >= the window, so a gate written as `<` fell
+      // through to draining. Reachable without malformed data: a clock behind
+      // when the marker is written and corrected FORWARD reads it all as served.
+      markerStore.set('residentialDos', {
+        _id: 'residentialDos',
+        residentialSince: Date.now(),
+        lastConfirmedAt: 'not-a-number',
+        observedMs: 'also-not-a-number',
+      });
+
+      await service.enforceResidentialPolicy(deps);
+
+      expect(service.isEvacuating()).to.equal(false);
+    });
+
+    it('refuses to drain on a stored observation that is not finite', async () => {
+      // Infinity is the case that separates the two guards. A string is
+      // stopped by the negated comparison on its own; Infinity passes that -
+      // it really is >= the window - and is stopped only by rejecting
+      // non-finite values where the marker is read.
+      markerStore.set('residentialDos', {
+        _id: 'residentialDos',
+        residentialSince: Date.now(),
+        lastConfirmedAt: Date.now(),
+        observedMs: Infinity,
+      });
+
+      await service.enforceResidentialPolicy(deps);
+
+      expect(service.isEvacuating()).to.equal(false);
+    });
+
+    it('stops draining when the benchmark stops answering', async () => {
+      // evacuating was latched, so a node already draining whose bench became
+      // unreadable kept handing an app back per interval with no verdict.
+      markerStore.set('residentialDos', windowServed());
+      await service.enforceResidentialPolicy(deps);
+      expect(service.isEvacuating()).to.equal(true);
+
+      benchmarkServiceStub.getBenchmarks.resolves({ status: 'error' });
+      const decided = await service.enforceResidentialPolicy(deps);
+
+      expect(decided).to.equal(false);
+      expect(service.isEvacuating()).to.equal(false);
+    });
+
+    it('stops draining when the classification stops answering', async () => {
+      markerStore.set('residentialDos', windowServed());
+      await service.enforceResidentialPolicy(deps);
+      expect(service.isEvacuating()).to.equal(true);
+
+      geolocationServiceStub.getNetworkClassification.returns(null);
+      const decided = await service.enforceResidentialPolicy(deps);
+
+      expect(decided).to.equal(false);
+      expect(service.isEvacuating()).to.equal(false);
+    });
+
+    it('does not DOS an apparently empty node while an install is in flight', async () => {
+      // The placement hold stops the spawner taking anything NEW, but not an
+      // install already running - and an install is real from
+      // installationProgress some way before its database record exists for the
+      // app list to see.
+      installedApps = [];
+      globalStateStub.installationInProgress = true;
+
+      const decided = await service.enforceResidentialPolicy(deps);
+
+      expect(decided).to.equal(false);
+      expect(service.isDosActive()).to.equal(false);
+    });
+
+    it('DOSes an empty node once no install is in flight', async () => {
+      installedApps = [];
+      globalStateStub.installationInProgress = false;
+
+      await service.enforceResidentialPolicy(deps);
+
+      expect(service.isDosActive()).to.equal(true);
     });
   });
 

--- a/tests/unit/residentialNodeDosService.test.js
+++ b/tests/unit/residentialNodeDosService.test.js
@@ -579,7 +579,7 @@ describe('residentialNodeDosService tests', () => {
 
     it('gives an empty location list the longest wait, not the shortest', async () => {
       // `index < 0 ? ordered.length : index` made an EMPTY list position 0 -
-      // the most senior slot - inverting the rule the sibling test asserts. An
+      // the front of the queue - inverting the rule the sibling test asserts. An
       // empty list is the ordinary result of expired location records.
       expect(service.queueDelayMs([], LOCAL)).to.be.above(service.QUEUE_BASE_MS);
     });
@@ -668,9 +668,12 @@ describe('residentialNodeDosService tests', () => {
   });
 
   describe('pacing: mayEvacuateApp', () => {
+    // Junior first, so the senior LOCAL sits at position 1 - the pacing tests
+    // below are about the interval and the observation window, and they only
+    // say what they mean from a position that is not the front of the queue.
     const locations = [
-      { ip: '5.6.7.8:16127', runningSince: new Date(1000) },
-      { ip: LOCAL, runningSince: new Date(2000) },
+      { ip: '5.6.7.8:16127', runningSince: new Date(2000) },
+      { ip: LOCAL, runningSince: new Date(1000) },
     ];
 
     beforeEach(async () => {
@@ -702,7 +705,7 @@ describe('residentialNodeDosService tests', () => {
     it('allows once the queue turn has been served', () => {
       const now = Date.now();
       service.mayEvacuateApp('someapp', locations, LOCAL, now);
-      // Position 1 in the seniority order: base plus one step.
+      // Position 1 in the queue order (junior first): base plus one step.
       const wait = service.QUEUE_BASE_MS + service.QUEUE_STEP_MS;
 
       const result = service.mayEvacuateApp('someapp', locations, LOCAL, now + wait + 1);
@@ -736,24 +739,43 @@ describe('residentialNodeDosService tests', () => {
   });
 
   describe('queueDelayMs is a delay, never a veto', () => {
-    it('gives the senior instance the shortest wait, and still a non-zero one', () => {
+    it('gives the junior instance the shortest wait, and still a non-zero one', () => {
       const locations = [
-        { ip: LOCAL, runningSince: new Date(1000) },
-        { ip: '5.6.7.8:16127', runningSince: new Date(2000) },
+        { ip: '5.6.7.8:16127', runningSince: new Date(1000) },
+        { ip: LOCAL, runningSince: new Date(2000) },
       ];
 
       expect(service.queueDelayMs(locations, LOCAL)).to.equal(service.QUEUE_BASE_MS);
     });
 
+    it('makes the senior instance wait longest, whatever order the list arrives in', () => {
+      // The senior instance is the one masterSlaveApps elects primary, and it
+      // is the only instance that cannot simply leave - it has to stand down
+      // and hand the app back first. Ranking the senior end first put exactly
+      // that node at the head of the queue, ahead of every node that could just
+      // go. Locations arrive in broadcast order, so the answer must not depend
+      // on it either.
+      const senior = { ip: LOCAL, runningSince: new Date(1000) };
+      const middle = { ip: '5.6.7.8:16127', runningSince: new Date(2000) };
+      const junior = { ip: '9.9.9.9:16127', runningSince: new Date(3000) };
+
+      [[senior, middle, junior], [junior, senior, middle]].forEach((locations) => {
+        expect(service.queueDelayMs(locations, LOCAL)).to.equal(
+          service.QUEUE_BASE_MS + (2 * service.QUEUE_STEP_MS),
+        );
+        expect(service.queueDelayMs(locations, junior.ip)).to.equal(service.QUEUE_BASE_MS);
+      });
+    });
+
     it('spaces each subsequent position by one step', () => {
       const locations = [
         { ip: '5.6.7.8:16127', runningSince: new Date(1000) },
-        { ip: '9.9.9.9:16127', runningSince: new Date(2000) },
-        { ip: LOCAL, runningSince: new Date(3000) },
+        { ip: '9.9.9.9:16127', runningSince: new Date(3000) },
+        { ip: LOCAL, runningSince: new Date(2000) },
       ];
 
       expect(service.queueDelayMs(locations, LOCAL)).to.equal(
-        service.QUEUE_BASE_MS + (2 * service.QUEUE_STEP_MS),
+        service.QUEUE_BASE_MS + service.QUEUE_STEP_MS,
       );
     });
 

--- a/tests/unit/residentialNodeDosService.test.js
+++ b/tests/unit/residentialNodeDosService.test.js
@@ -19,6 +19,7 @@ describe('residentialNodeDosService tests', () => {
   let installedApps;
 
   const LOCAL = '1.2.3.4:16127';
+  let fluxEventBusStub;
 
   // A node that has WATCHED the verdict hold for the whole window. The gate
   // counts observed time, not elapsed time, so seeding a start timestamp alone
@@ -32,6 +33,15 @@ describe('residentialNodeDosService tests', () => {
       lastConfirmedAt: now,
       observedMs: service.SETTLE_MS + 1000,
     };
+  }
+
+  // The harness's only way to see a tick that decided NOT to enforce: that
+  // outcome sets no hold, writes no marker and raises no DOS, so without this
+  // event a suite can only sleep and infer it from nothing having happened.
+  function decisions() {
+    return fluxEventBusStub.publish.getCalls()
+      .filter((c) => c.args[0] === 'residential:decided')
+      .map((c) => c.args[1]);
   }
 
   function loadService() {
@@ -55,6 +65,7 @@ describe('residentialNodeDosService tests', () => {
       // that same emitter and mocha runs both files in one process, so those
       // dead instances take readiness from another file's test.
       './utils/appSyncEvents': { appSyncEvents: new EventEmitter(), EVENTS: SYNC_EVENTS },
+      './utils/fluxEventBus': fluxEventBusStub,
     });
   }
 
@@ -94,6 +105,7 @@ describe('residentialNodeDosService tests', () => {
 
     // An install in flight is real before its database record exists, so the
     // empty check reads this rather than trusting an ordering in another file.
+    fluxEventBusStub = { publish: sinon.stub() };
     globalStateStub = { installationInProgress: false, removalInProgress: false };
 
     // The settle marker lives in mongo, so the double has to remember it across
@@ -235,6 +247,42 @@ describe('residentialNodeDosService tests', () => {
 
       expect(decided).to.equal(false);
       expect(fluxNetworkHelperStub.isPlacementHeld()).to.equal(false);
+    });
+  });
+
+  describe('every tick publishes what it concluded', () => {
+    it('says enforce=false when the node is fit to serve', async () => {
+      geolocationServiceStub.getNetworkClassification.returns({ classification: 'DATACENTER' });
+
+      await service.enforceResidentialPolicy(deps);
+
+      expect(decisions()).to.have.lengthOf(1);
+      expect(decisions()[0]).to.include({ enforce: false, residential: false, undecidedBecause: null });
+    });
+
+    it('says enforce=true when it is not', async () => {
+      await service.enforceResidentialPolicy(deps);
+
+      expect(decisions()[0]).to.include({ enforce: true, residential: true, undecidedBecause: null });
+    });
+
+    it('separates a tick that could not decide from one that decided no', async () => {
+      // null and false are opposite claims: one says nobody knows yet, the
+      // other says this node is fit to serve. A consumer that reads them the
+      // same way treats an unreadable benchmark as an all-clear.
+      benchmarkServiceStub.getBenchmarks.resolves({ status: 'error', data: 'down' });
+
+      await service.enforceResidentialPolicy(deps);
+
+      expect(decisions()[0]).to.include({ enforce: null, undecidedBecause: 'benchmark' });
+    });
+
+    it('names the classification when that is the missing input', async () => {
+      geolocationServiceStub.getNetworkClassification.returns(null);
+
+      await service.enforceResidentialPolicy(deps);
+
+      expect(decisions()[0]).to.include({ enforce: null, undecidedBecause: 'classification' });
     });
   });
 

--- a/tests/unit/residentialNodeDosService.test.js
+++ b/tests/unit/residentialNodeDosService.test.js
@@ -75,16 +75,20 @@ describe('residentialNodeDosService tests', () => {
     // read-back. A getter pinned to null would let a clear that must not happen
     // pass as if it had.
     let sticky = null;
-    let hold = null;
+    // Owner-keyed, like the real one. A double that kept a single slot would
+    // accept a clear from any owner and so could never fail the way the real
+    // module now refuses to.
+    const holds = new Map();
     fluxNetworkHelperStub = {
       setStickyDosMessage: sinon.stub().callsFake((msg) => { sticky = msg; }),
       setStickyDosStateValue: sinon.stub(),
       clearStickyDosMessage: sinon.stub().callsFake(() => { sticky = null; }),
       getStickyDosMessage: sinon.stub().callsFake(() => sticky),
-      setPlacementHold: sinon.stub().callsFake((reason) => { hold = reason; }),
-      clearPlacementHold: sinon.stub().callsFake(() => { hold = null; }),
-      getPlacementHold: sinon.stub().callsFake(() => hold),
-      isPlacementHeld: sinon.stub().callsFake(() => hold !== null),
+      PlacementHoldOwner: Object.freeze({ RESIDENTIAL_DOS: 'residentialDos' }),
+      setPlacementHold: sinon.stub().callsFake((owner, reason) => { holds.set(owner, reason); }),
+      clearPlacementHold: sinon.stub().callsFake((owner) => { holds.delete(owner); }),
+      getPlacementHold: sinon.stub().callsFake(() => (holds.size ? [...holds.values()].join('; ') : null)),
+      isPlacementHeld: sinon.stub().callsFake(() => holds.size > 0),
       getLocalSocketAddress: sinon.stub().resolves(LOCAL),
     };
 

--- a/tests/unit/residentialNodeDosService.test.js
+++ b/tests/unit/residentialNodeDosService.test.js
@@ -1,0 +1,367 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire').noCallThru();
+
+describe('residentialNodeDosService tests', () => {
+  let service;
+  let fluxNetworkHelperStub;
+  let geolocationServiceStub;
+  let benchmarkServiceStub;
+  let configStub;
+
+  function loadService() {
+    return proxyquire('../../ZelBack/src/services/residentialNodeDosService', {
+      config: configStub,
+      '../lib/log': {
+        info: sinon.stub(), warn: sinon.stub(), error: sinon.stub(),
+      },
+      './fluxNetworkHelper': fluxNetworkHelperStub,
+      './geolocationService': geolocationServiceStub,
+      './benchmarkService': benchmarkServiceStub,
+    });
+  }
+
+  beforeEach(() => {
+    configStub = { residentialDos: { enabled: true } };
+
+    // Stateful on purpose: the real fluxNetworkHelper reads back the message it
+    // was given, and the ownership rules here are all written against that
+    // read-back. A getter pinned to null would let a clear that must not happen
+    // pass as if it had.
+    let sticky = null;
+    fluxNetworkHelperStub = {
+      setStickyDosMessage: sinon.stub().callsFake((msg) => { sticky = msg; }),
+      setStickyDosStateValue: sinon.stub(),
+      clearStickyDosMessage: sinon.stub().callsFake(() => { sticky = null; }),
+      getStickyDosMessage: sinon.stub().callsFake(() => sticky),
+    };
+
+    // Default: geolocation resolved, IP is not a data center -> residential.
+    geolocationServiceStub = {
+      getNodeGeolocation: sinon.stub().resolves({ ip: '1.2.3.4', org: 'Some Telecom' }),
+      isDataCenter: sinon.stub().returns(false),
+    };
+
+    // Default: bench reachable, node is NOT ArcaneOS.
+    benchmarkServiceStub = {
+      getBenchmarks: sinon.stub().resolves({ status: 'success', data: { systemsecure: false } }),
+    };
+
+    service = loadService();
+  });
+
+  afterEach(() => {
+    service.stop();
+    sinon.restore();
+  });
+
+  describe('isArcaneOs', () => {
+    it('returns true when bench reports systemsecure true', async () => {
+      benchmarkServiceStub.getBenchmarks.resolves({ status: 'success', data: { systemsecure: true } });
+
+      expect(await service.isArcaneOs()).to.equal(true);
+    });
+
+    it('returns false when bench reports systemsecure false', async () => {
+      expect(await service.isArcaneOs()).to.equal(false);
+    });
+
+    it('returns null when bench call errors', async () => {
+      benchmarkServiceStub.getBenchmarks.resolves({ status: 'error', data: 'benchd down' });
+
+      expect(await service.isArcaneOs()).to.equal(null);
+    });
+
+    it('returns null when systemsecure is not a boolean', async () => {
+      benchmarkServiceStub.getBenchmarks.resolves({ status: 'success', data: { systemsecure: null } });
+
+      expect(await service.isArcaneOs()).to.equal(null);
+    });
+
+    it('returns null when bench throws', async () => {
+      benchmarkServiceStub.getBenchmarks.rejects(new Error('socket hang up'));
+
+      expect(await service.isArcaneOs()).to.equal(null);
+    });
+  });
+
+  describe('isResidential', () => {
+    it('returns true when geolocation resolved and the IP is not a data center', async () => {
+      expect(await service.isResidential()).to.equal(true);
+    });
+
+    it('returns false when geolocation says the IP is a data center', async () => {
+      geolocationServiceStub.isDataCenter.returns(true);
+
+      expect(await service.isResidential()).to.equal(false);
+    });
+
+    it('returns null when no geolocation has resolved yet - the flag alone would read as residential', async () => {
+      geolocationServiceStub.getNodeGeolocation.resolves(null);
+      geolocationServiceStub.isDataCenter.returns(false);
+
+      expect(await service.isResidential()).to.equal(null);
+    });
+
+    it('returns null when the geolocation lookup throws', async () => {
+      geolocationServiceStub.getNodeGeolocation.rejects(new Error('db down'));
+
+      expect(await service.isResidential()).to.equal(null);
+    });
+  });
+
+  describe('enforceResidentialPolicy', () => {
+    it('DOSes a residential node that is not running ArcaneOS', async () => {
+      const decided = await service.enforceResidentialPolicy();
+
+      expect(decided).to.equal(true);
+      sinon.assert.calledOnce(fluxNetworkHelperStub.setStickyDosMessage);
+      expect(fluxNetworkHelperStub.setStickyDosMessage.firstCall.args[0])
+        .to.include(service.DOS_MESSAGE_PREFIX);
+      sinon.assert.calledWith(fluxNetworkHelperStub.setStickyDosStateValue, 100);
+      expect(service.isDosActive()).to.equal(true);
+    });
+
+    it('does not DOS a residential node running ArcaneOS', async () => {
+      benchmarkServiceStub.getBenchmarks.resolves({ status: 'success', data: { systemsecure: true } });
+
+      await service.enforceResidentialPolicy();
+
+      sinon.assert.notCalled(fluxNetworkHelperStub.setStickyDosMessage);
+      expect(service.isDosActive()).to.equal(false);
+    });
+
+    it('does not DOS a data center node that is not running ArcaneOS', async () => {
+      geolocationServiceStub.isDataCenter.returns(true);
+
+      await service.enforceResidentialPolicy();
+
+      sinon.assert.notCalled(fluxNetworkHelperStub.setStickyDosMessage);
+      expect(service.isDosActive()).to.equal(false);
+    });
+
+    it('decides nothing when bench is unreachable, even on a residential IP', async () => {
+      benchmarkServiceStub.getBenchmarks.rejects(new Error('benchd down'));
+
+      const decided = await service.enforceResidentialPolicy();
+
+      expect(decided).to.equal(false);
+      sinon.assert.notCalled(fluxNetworkHelperStub.setStickyDosMessage);
+      sinon.assert.notCalled(fluxNetworkHelperStub.clearStickyDosMessage);
+    });
+
+    it('decides nothing when geolocation has not resolved yet', async () => {
+      geolocationServiceStub.getNodeGeolocation.resolves(null);
+
+      const decided = await service.enforceResidentialPolicy();
+
+      expect(decided).to.equal(false);
+      sinon.assert.notCalled(fluxNetworkHelperStub.setStickyDosMessage);
+      sinon.assert.notCalled(fluxNetworkHelperStub.clearStickyDosMessage);
+    });
+
+    it('an unavailable input does not clear a DOS this service already set', async () => {
+      await service.enforceResidentialPolicy();
+      expect(service.isDosActive()).to.equal(true);
+
+      benchmarkServiceStub.getBenchmarks.rejects(new Error('benchd down'));
+      await service.enforceResidentialPolicy();
+
+      sinon.assert.notCalled(fluxNetworkHelperStub.clearStickyDosMessage);
+      expect(service.isDosActive()).to.equal(true);
+    });
+
+    it('clears its own DOS once the node moves to ArcaneOS', async () => {
+      await service.enforceResidentialPolicy();
+      expect(service.isDosActive()).to.equal(true);
+
+      benchmarkServiceStub.getBenchmarks.resolves({ status: 'success', data: { systemsecure: true } });
+      await service.enforceResidentialPolicy();
+
+      sinon.assert.calledOnce(fluxNetworkHelperStub.clearStickyDosMessage);
+      expect(service.isDosActive()).to.equal(false);
+    });
+
+    it('clears a DOS left by a previous process when the condition no longer holds', async () => {
+      fluxNetworkHelperStub.getStickyDosMessage.returns(`${service.DOS_MESSAGE_PREFIX}. Migrate this node`);
+      geolocationServiceStub.isDataCenter.returns(true);
+
+      await service.enforceResidentialPolicy();
+
+      sinon.assert.calledOnce(fluxNetworkHelperStub.clearStickyDosMessage);
+    });
+
+    it('does not clear a sticky slot another owner took over after we set ours', async () => {
+      await service.enforceResidentialPolicy();
+      expect(service.isDosActive()).to.equal(true);
+
+      // Another enforcer overwrote the single sticky slot with its own message.
+      fluxNetworkHelperStub.getStickyDosMessage.returns('Node flagged via tampering blocklist: score 12');
+      // ...and our own condition stops holding.
+      geolocationServiceStub.isDataCenter.returns(true);
+      await service.enforceResidentialPolicy();
+
+      sinon.assert.notCalled(fluxNetworkHelperStub.clearStickyDosMessage);
+      expect(service.isDosActive()).to.equal(false);
+    });
+
+    it('does not clear another owner\'s sticky slot when disabled by config', async () => {
+      await service.enforceResidentialPolicy();
+      fluxNetworkHelperStub.getStickyDosMessage.returns('Node flagged via tampering blocklist: score 12');
+
+      configStub.residentialDos.enabled = false;
+      await service.enforceResidentialPolicy();
+
+      sinon.assert.notCalled(fluxNetworkHelperStub.clearStickyDosMessage);
+      expect(service.isDosActive()).to.equal(false);
+    });
+
+    it('does not overwrite another owner\'s sticky DOS', async () => {
+      fluxNetworkHelperStub.getStickyDosMessage.returns('Node flagged via tampering blocklist: score 12');
+
+      const decided = await service.enforceResidentialPolicy();
+
+      expect(decided).to.equal(true);
+      sinon.assert.notCalled(fluxNetworkHelperStub.setStickyDosMessage);
+      sinon.assert.notCalled(fluxNetworkHelperStub.clearStickyDosMessage);
+      expect(service.isDosActive()).to.equal(false);
+    });
+
+    it('refreshes its own sticky DOS rather than treating it as foreign', async () => {
+      fluxNetworkHelperStub.getStickyDosMessage.returns(`${service.DOS_MESSAGE_PREFIX}. Migrate this node`);
+
+      await service.enforceResidentialPolicy();
+
+      sinon.assert.calledOnce(fluxNetworkHelperStub.setStickyDosMessage);
+      sinon.assert.calledWith(fluxNetworkHelperStub.setStickyDosStateValue, 100);
+    });
+
+    it('enforces nothing and releases its own DOS when disabled by config', async () => {
+      await service.enforceResidentialPolicy();
+      expect(service.isDosActive()).to.equal(true);
+
+      configStub.residentialDos.enabled = false;
+      const decided = await service.enforceResidentialPolicy();
+
+      expect(decided).to.equal(true);
+      sinon.assert.calledOnce(fluxNetworkHelperStub.clearStickyDosMessage);
+      expect(service.isDosActive()).to.equal(false);
+      sinon.assert.calledOnce(fluxNetworkHelperStub.setStickyDosMessage);
+    });
+
+    it('enforces when the config section is absent altogether', async () => {
+      configStub = {};
+      service = loadService();
+
+      await service.enforceResidentialPolicy();
+
+      sinon.assert.calledWith(fluxNetworkHelperStub.setStickyDosStateValue, 100);
+    });
+  });
+
+  describe('start / stop scheduling', () => {
+    let clock;
+
+    beforeEach(() => {
+      clock = sinon.useFakeTimers();
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    it('reschedules on the short retry delay after an inconclusive tick', async () => {
+      geolocationServiceStub.getNodeGeolocation.resolves(null);
+
+      await service.start();
+      expect(geolocationServiceStub.getNodeGeolocation.callCount).to.equal(1);
+
+      await clock.tickAsync(service.RETRY_INTERVAL_MS);
+      expect(geolocationServiceStub.getNodeGeolocation.callCount).to.equal(2);
+    });
+
+    it('doubles the retry delay while ticks stay inconclusive, capped at the full interval', async () => {
+      geolocationServiceStub.getNodeGeolocation.resolves(null);
+      const calls = () => geolocationServiceStub.getNodeGeolocation.callCount;
+
+      await service.start();
+      expect(calls()).to.equal(1);
+
+      await clock.tickAsync(service.RETRY_INTERVAL_MS);
+      expect(calls()).to.equal(2);
+
+      // Second retry is 2x, so the first delay alone is not enough.
+      await clock.tickAsync(service.RETRY_INTERVAL_MS);
+      expect(calls()).to.equal(2);
+      await clock.tickAsync(service.RETRY_INTERVAL_MS);
+      expect(calls()).to.equal(3);
+
+      // Walk the doubling out to where it would exceed the interval.
+      let expected = 3;
+      for (let delay = service.RETRY_INTERVAL_MS * 4;
+        delay < service.CHECK_INTERVAL_MS;
+        delay *= 2) {
+        // eslint-disable-next-line no-await-in-loop
+        await clock.tickAsync(delay);
+        expected += 1;
+        expect(calls()).to.equal(expected);
+      }
+
+      // The next delay doubles past the interval and is capped to it exactly:
+      // one tick short of the interval fires nothing, the interval fires once.
+      await clock.tickAsync(service.CHECK_INTERVAL_MS - 1);
+      expect(calls()).to.equal(expected);
+      await clock.tickAsync(1);
+      expect(calls()).to.equal(expected + 1);
+    });
+
+    it('resets the backoff once a tick decides again', async () => {
+      geolocationServiceStub.getNodeGeolocation.resolves(null);
+      await service.start();
+      await clock.tickAsync(service.RETRY_INTERVAL_MS);
+      await clock.tickAsync(service.RETRY_INTERVAL_MS * 2);
+      expect(geolocationServiceStub.getNodeGeolocation.callCount).to.equal(3);
+
+      // Geolocation resolves: that tick decides, so the next inconclusive run
+      // starts over at the short retry instead of the grown delay.
+      geolocationServiceStub.getNodeGeolocation.resolves({ ip: '1.2.3.4' });
+      await clock.tickAsync(service.RETRY_INTERVAL_MS * 4);
+      expect(geolocationServiceStub.getNodeGeolocation.callCount).to.equal(4);
+
+      geolocationServiceStub.getNodeGeolocation.resolves(null);
+      await clock.tickAsync(service.CHECK_INTERVAL_MS);
+      expect(geolocationServiceStub.getNodeGeolocation.callCount).to.equal(5);
+      await clock.tickAsync(service.RETRY_INTERVAL_MS);
+      expect(geolocationServiceStub.getNodeGeolocation.callCount).to.equal(6);
+    });
+
+    it('reschedules on the full interval after a decided tick', async () => {
+      await service.start();
+      expect(benchmarkServiceStub.getBenchmarks.callCount).to.equal(1);
+
+      await clock.tickAsync(service.RETRY_INTERVAL_MS);
+      expect(benchmarkServiceStub.getBenchmarks.callCount).to.equal(1);
+
+      await clock.tickAsync(service.CHECK_INTERVAL_MS);
+      expect(benchmarkServiceStub.getBenchmarks.callCount).to.equal(2);
+    });
+
+    it('a second start does not add a second tick chain', async () => {
+      await service.start();
+      await service.start();
+
+      await clock.tickAsync(service.CHECK_INTERVAL_MS);
+
+      expect(benchmarkServiceStub.getBenchmarks.callCount).to.equal(2);
+    });
+
+    it('stop prevents any further tick', async () => {
+      await service.start();
+      service.stop();
+
+      await clock.tickAsync(service.CHECK_INTERVAL_MS * 3);
+
+      expect(benchmarkServiceStub.getBenchmarks.callCount).to.equal(1);
+    });
+  });
+});

--- a/tests/unit/residentialNodeDosService.test.js
+++ b/tests/unit/residentialNodeDosService.test.js
@@ -692,11 +692,27 @@ describe('residentialNodeDosService tests', () => {
       expect(result.reason).to.contain('not evacuating');
     });
 
+    // Two locations, so two is full strength for this app.
+    const WHOLE = 2;
+    // Position 1 in the queue order (junior first): base plus one step.
+    const WAIT = () => service.QUEUE_BASE_MS + service.QUEUE_STEP_MS;
+
+    // Walk the ticket forward the way the give-up pass does - an evaluation
+    // every half step, which is well inside the gap an observation tolerates.
+    // Written out rather than jumped, because what the ticket measures is an
+    // uninterrupted observation and a single jump is not one.
+    const walk = (name, locs, from, to, min = WHOLE) => {
+      for (let t = from; t < to; t += service.MAX_TICKET_GAP_MS / 2) {
+        service.mayEvacuateApp(name, locs, LOCAL, min, t);
+      }
+      return service.mayEvacuateApp(name, locs, LOCAL, min, to);
+    };
+
     it('refuses until the app has been seen whole for its queue turn', () => {
       const now = Date.now();
-      service.mayEvacuateApp('someapp', locations, LOCAL, now);
+      service.mayEvacuateApp('someapp', locations, LOCAL, WHOLE, now);
 
-      const result = service.mayEvacuateApp('someapp', locations, LOCAL, now + 1000);
+      const result = service.mayEvacuateApp('someapp', locations, LOCAL, WHOLE, now + 1000);
 
       expect(result.ok).to.equal(false);
       expect(result.reason).to.contain('its turn is in');
@@ -704,23 +720,19 @@ describe('residentialNodeDosService tests', () => {
 
     it('allows once the queue turn has been served', () => {
       const now = Date.now();
-      service.mayEvacuateApp('someapp', locations, LOCAL, now);
-      // Position 1 in the queue order (junior first): base plus one step.
-      const wait = service.QUEUE_BASE_MS + service.QUEUE_STEP_MS;
 
-      const result = service.mayEvacuateApp('someapp', locations, LOCAL, now + wait + 1);
+      const result = walk('someapp', locations, now, now + WAIT() + 1);
 
       expect(result.ok).to.equal(true);
     });
 
     it('paces departures by the evacuation interval', () => {
       const now = Date.now();
-      service.mayEvacuateApp('someapp', locations, LOCAL, now);
-      const wait = service.QUEUE_BASE_MS + service.QUEUE_STEP_MS;
-      expect(service.mayEvacuateApp('someapp', locations, LOCAL, now + wait + 1).ok).to.equal(true);
+      const wait = WAIT();
+      expect(walk('someapp', locations, now, now + wait + 1).ok).to.equal(true);
 
       service.noteEvacuated('someapp', now + wait + 1);
-      const next = service.mayEvacuateApp('other', locations, LOCAL, now + wait + 2);
+      const next = service.mayEvacuateApp('other', locations, LOCAL, WHOLE, now + wait + 2);
 
       expect(next.ok).to.equal(false);
       expect(next.reason).to.contain('next departure in');
@@ -728,13 +740,75 @@ describe('residentialNodeDosService tests', () => {
 
     it("restarts an app's observation when it stops being whole", () => {
       const now = Date.now();
-      service.mayEvacuateApp('someapp', locations, LOCAL, now);
+      service.mayEvacuateApp('someapp', locations, LOCAL, WHOLE, now);
       service.forgetAppObservation('someapp');
-      const wait = service.QUEUE_BASE_MS + service.QUEUE_STEP_MS;
+      const wait = WAIT();
 
-      const result = service.mayEvacuateApp('someapp', locations, LOCAL, now + wait + 1);
+      const result = service.mayEvacuateApp('someapp', locations, LOCAL, WHOLE, now + wait + 1);
 
       expect(result.ok).to.equal(false);
+    });
+
+    it('does not arrive ready the instant its departure interval clears', () => {
+      // The serialisation between two evacuating holders is the ticket, and the
+      // ticket only separates them if it is still binding after a departure.
+      // Both nodes stamp their tickets in the same pass; one leaves; and if the
+      // other's ticket keeps maturing through the six hours it is blocked, then
+      // when the blocks expire together - they are fired from the same block
+      // height - both are ready for the same app in the same pass.
+      const now = Date.now();
+      const wait = WAIT();
+      walk('other', locations, now, now + wait + 1);
+      expect(walk('someapp', locations, now, now + wait + 1).ok).to.equal(true);
+      service.noteEvacuated('someapp', now + wait + 1);
+
+      // The pass goes on running through the block and goes on asking. It is
+      // refused at the interval gate, and being refused there is NOT having
+      // watched the app: the accounting sits below that gate for this reason.
+      const cleared = now + wait + 1 + service.EVACUATION_INTERVAL_MS + 1;
+      for (let t = now + wait + 2; t < cleared; t += service.MAX_TICKET_GAP_MS / 2) {
+        service.mayEvacuateApp('other', locations, LOCAL, WHOLE, t);
+      }
+
+      const result = service.mayEvacuateApp('other', locations, LOCAL, WHOLE, cleared);
+
+      expect(result.ok).to.equal(false);
+      expect(result.reason).to.contain('its turn is in');
+    });
+
+    it('counts nothing towards the turn while the app is short', () => {
+      // The clock is named for seeing the app at full strength and used to
+      // start on the first ASK, so an app short for its entire wait served the
+      // full wait anyway and was only caught later, by the safety gate.
+      const now = Date.now();
+      const wait = WAIT();
+      const short = [{ ip: LOCAL, runningSince: new Date(1000) }];
+
+      const during = walk('someapp', short, now, now + wait + 1);
+
+      expect(during.ok).to.equal(false);
+      expect(during.reason).to.contain('short');
+
+      // And the turn runs from the moment it is whole, not from the first ask.
+      const result = service.mayEvacuateApp('someapp', locations, LOCAL, WHOLE, now + wait + 2);
+
+      expect(result.ok).to.equal(false);
+    });
+
+    it('restarts the turn when a gap says the node stopped watching', () => {
+      const now = Date.now();
+      const wait = WAIT();
+
+      // Watched without interruption, the turn is served on time.
+      expect(walk('someapp', locations, now, now + wait + 1).ok).to.equal(true);
+
+      service.forgetAppObservation('someapp');
+      // The same elapsed time with one missed pass inside it is not the same
+      // observation, and does not buy the turn.
+      service.mayEvacuateApp('someapp', locations, LOCAL, WHOLE, now);
+      const resumed = now + service.MAX_TICKET_GAP_MS + 1;
+
+      expect(walk('someapp', locations, resumed, now + wait + 1).ok).to.equal(false);
     });
   });
 

--- a/tests/unit/residentialNodeDosService.test.js
+++ b/tests/unit/residentialNodeDosService.test.js
@@ -19,7 +19,6 @@ describe('residentialNodeDosService tests', () => {
   let installedApps;
 
   const LOCAL = '1.2.3.4:16127';
-  let fluxEventBusStub;
 
   // A node that has WATCHED the verdict hold for the whole window. The gate
   // counts observed time, not elapsed time, so seeding a start timestamp alone
@@ -33,15 +32,6 @@ describe('residentialNodeDosService tests', () => {
       lastConfirmedAt: now,
       observedMs: service.SETTLE_MS + 1000,
     };
-  }
-
-  // The harness's only way to see a tick that decided NOT to enforce: that
-  // outcome sets no hold, writes no marker and raises no DOS, so without this
-  // event a suite can only sleep and infer it from nothing having happened.
-  function decisions() {
-    return fluxEventBusStub.publish.getCalls()
-      .filter((c) => c.args[0] === 'residential:decided')
-      .map((c) => c.args[1]);
   }
 
   function loadService() {
@@ -65,7 +55,6 @@ describe('residentialNodeDosService tests', () => {
       // that same emitter and mocha runs both files in one process, so those
       // dead instances take readiness from another file's test.
       './utils/appSyncEvents': { appSyncEvents: new EventEmitter(), EVENTS: SYNC_EVENTS },
-      './utils/fluxEventBus': fluxEventBusStub,
     });
   }
 
@@ -109,7 +98,6 @@ describe('residentialNodeDosService tests', () => {
 
     // An install in flight is real before its database record exists, so the
     // empty check reads this rather than trusting an ordering in another file.
-    fluxEventBusStub = { publish: sinon.stub() };
     globalStateStub = { installationInProgress: false, removalInProgress: false };
 
     // The settle marker lives in mongo, so the double has to remember it across
@@ -237,7 +225,7 @@ describe('residentialNodeDosService tests', () => {
     it('does not hold or DOS when bench cannot be read', async () => {
       benchmarkServiceStub.getBenchmarks.resolves({ status: 'error', data: 'down' });
 
-      const decided = await service.enforceResidentialPolicy(deps);
+      const { decided } = await service.enforceResidentialPolicy(deps);
 
       expect(decided).to.equal(false);
       expect(fluxNetworkHelperStub.isPlacementHeld()).to.equal(false);
@@ -247,7 +235,7 @@ describe('residentialNodeDosService tests', () => {
     it('does not hold or DOS when there is no settled classification', async () => {
       geolocationServiceStub.getNetworkClassification.returns(null);
 
-      const decided = await service.enforceResidentialPolicy(deps);
+      const { decided } = await service.enforceResidentialPolicy(deps);
 
       expect(decided).to.equal(false);
       expect(fluxNetworkHelperStub.isPlacementHeld()).to.equal(false);
@@ -258,16 +246,16 @@ describe('residentialNodeDosService tests', () => {
     it('says enforce=false when the node is fit to serve', async () => {
       geolocationServiceStub.getNetworkClassification.returns({ classification: 'DATACENTER' });
 
-      await service.enforceResidentialPolicy(deps);
+      const { decision } = await service.enforceResidentialPolicy(deps);
 
-      expect(decisions()).to.have.lengthOf(1);
-      expect(decisions()[0]).to.include({ enforce: false, residential: false, undecidedBecause: null });
+      expect(decision).to.not.equal(null);
+      expect(decision).to.include({ enforce: false, residential: false, undecidedBecause: null });
     });
 
     it('says enforce=true when it is not', async () => {
-      await service.enforceResidentialPolicy(deps);
+      const { decision } = await service.enforceResidentialPolicy(deps);
 
-      expect(decisions()[0]).to.include({ enforce: true, residential: true, undecidedBecause: null });
+      expect(decision).to.include({ enforce: true, residential: true, undecidedBecause: null });
     });
 
     it('separates a tick that could not decide from one that decided no', async () => {
@@ -276,9 +264,9 @@ describe('residentialNodeDosService tests', () => {
       // same way treats an unreadable benchmark as an all-clear.
       benchmarkServiceStub.getBenchmarks.resolves({ status: 'error', data: 'down' });
 
-      await service.enforceResidentialPolicy(deps);
+      const { decision } = await service.enforceResidentialPolicy(deps);
 
-      expect(decisions()[0]).to.include({ enforce: null, undecidedBecause: 'benchmark' });
+      expect(decision).to.include({ enforce: null, undecidedBecause: 'benchmark' });
     });
 
     it('carries the verdict, so a veto is not read as an unread table', async () => {
@@ -290,9 +278,9 @@ describe('residentialNodeDosService tests', () => {
         classification: 'CONFLICTED', source: 'node-veto',
       });
 
-      await service.enforceResidentialPolicy(deps);
+      const { decision } = await service.enforceResidentialPolicy(deps);
 
-      expect(decisions()[0]).to.include({
+      expect(decision).to.include({
         enforce: null, classification: 'CONFLICTED', source: 'node-veto',
       });
     });
@@ -300,9 +288,9 @@ describe('residentialNodeDosService tests', () => {
     it('names the classification when that is the missing input', async () => {
       geolocationServiceStub.getNetworkClassification.returns(null);
 
-      await service.enforceResidentialPolicy(deps);
+      const { decision } = await service.enforceResidentialPolicy(deps);
 
-      expect(decisions()[0]).to.include({ enforce: null, undecidedBecause: 'classification' });
+      expect(decision).to.include({ enforce: null, undecidedBecause: 'classification' });
     });
   });
 
@@ -330,7 +318,7 @@ describe('residentialNodeDosService tests', () => {
       // node that has apps, and nodeStatusMonitor would then delete every one.
       deps.installedAppsFn.resolves({ status: 'error', data: 'db down' });
 
-      const decided = await service.enforceResidentialPolicy(deps);
+      const { decided } = await service.enforceResidentialPolicy(deps);
 
       expect(decided).to.equal(false);
       sinon.assert.notCalled(fluxNetworkHelperStub.setStickyDosStateValue);
@@ -341,7 +329,7 @@ describe('residentialNodeDosService tests', () => {
       service.setNodeReadyForTests(false);
       installedApps = [];
 
-      const decided = await service.enforceResidentialPolicy(deps);
+      const { decided } = await service.enforceResidentialPolicy(deps);
 
       expect(decided).to.equal(false);
       sinon.assert.notCalled(fluxNetworkHelperStub.setStickyDosStateValue);
@@ -451,7 +439,7 @@ describe('residentialNodeDosService tests', () => {
       expect(service.isEvacuating()).to.equal(true);
 
       dbHelperStub.databaseConnection.returns(null);
-      const decided = await service.enforceResidentialPolicy(deps);
+      const { decided } = await service.enforceResidentialPolicy(deps);
 
       expect(decided).to.equal(false);
       expect(service.isEvacuating()).to.equal(false);
@@ -629,7 +617,7 @@ describe('residentialNodeDosService tests', () => {
       expect(service.isEvacuating()).to.equal(true);
 
       benchmarkServiceStub.getBenchmarks.resolves({ status: 'error' });
-      const decided = await service.enforceResidentialPolicy(deps);
+      const { decided } = await service.enforceResidentialPolicy(deps);
 
       expect(decided).to.equal(false);
       expect(service.isEvacuating()).to.equal(false);
@@ -641,7 +629,7 @@ describe('residentialNodeDosService tests', () => {
       expect(service.isEvacuating()).to.equal(true);
 
       geolocationServiceStub.getNetworkClassification.returns(null);
-      const decided = await service.enforceResidentialPolicy(deps);
+      const { decided } = await service.enforceResidentialPolicy(deps);
 
       expect(decided).to.equal(false);
       expect(service.isEvacuating()).to.equal(false);
@@ -655,7 +643,7 @@ describe('residentialNodeDosService tests', () => {
       installedApps = [];
       globalStateStub.installationInProgress = true;
 
-      const decided = await service.enforceResidentialPolicy(deps);
+      const { decided } = await service.enforceResidentialPolicy(deps);
 
       expect(decided).to.equal(false);
       expect(service.isDosActive()).to.equal(false);

--- a/tests/unit/residentialNodeDosService.test.js
+++ b/tests/unit/residentialNodeDosService.test.js
@@ -16,6 +16,20 @@ describe('residentialNodeDosService tests', () => {
 
   const LOCAL = '1.2.3.4:16127';
 
+  // A node that has WATCHED the verdict hold for the whole window. The gate
+  // counts observed time, not elapsed time, so seeding a start timestamp alone
+  // no longer serves the window - which is the defect these tests used to
+  // encode: two evaluations 24h apart, with a day of silence between them,
+  // satisfied a check meant to prove the verdict held throughout.
+  function windowServed(now = Date.now()) {
+    return {
+      _id: 'residentialDos',
+      residentialSince: now - service.SETTLE_MS - 1000,
+      lastConfirmedAt: now,
+      observedMs: service.SETTLE_MS + 1000,
+    };
+  }
+
   function loadService() {
     return proxyquire('../../ZelBack/src/services/residentialNodeDosService', {
       '../lib/log': {
@@ -303,10 +317,7 @@ describe('residentialNodeDosService tests', () => {
 
     it('begins evacuating once the window has elapsed', async () => {
       installedApps = [{ name: 'someapp' }];
-      markerStore.set('residentialDos', {
-        _id: 'residentialDos',
-        residentialSince: Date.now() - service.SETTLE_MS - 1000,
-      });
+      markerStore.set('residentialDos', windowServed());
 
       await service.enforceResidentialPolicy(deps);
 
@@ -318,15 +329,18 @@ describe('residentialNodeDosService tests', () => {
       // restarting FluxOS, which would make restarting on a cron a way to
       // postpone evacuation indefinitely.
       installedApps = [{ name: 'someapp' }];
-      const startedAt = Date.now() - service.SETTLE_MS - 1000;
-      markerStore.set('residentialDos', { _id: 'residentialDos', residentialSince: startedAt });
+      const seeded = windowServed();
+      markerStore.set('residentialDos', seeded);
 
       service.stop();
       service = loadService();
       service.setNodeReadyForTests(true);
       await service.enforceResidentialPolicy(deps);
 
-      expect(markerStore.get('residentialDos').residentialSince).to.equal(startedAt);
+      expect(markerStore.get('residentialDos').residentialSince).to.equal(seeded.residentialSince);
+      // The observed total survived the restart too, which is the half that
+      // actually decides now.
+      expect(markerStore.get('residentialDos').observedMs).to.be.at.least(service.SETTLE_MS);
       expect(service.isEvacuating()).to.equal(true);
     });
 
@@ -344,9 +358,7 @@ describe('residentialNodeDosService tests', () => {
 
     it('stops evacuating when the marker cannot be read', async () => {
       installedApps = [{ name: 'someapp' }];
-      markerStore.set('residentialDos', {
-        _id: 'residentialDos', residentialSince: Date.now() - service.SETTLE_MS - 1000,
-      });
+      markerStore.set('residentialDos', windowServed());
       await service.enforceResidentialPolicy(deps);
       expect(service.isEvacuating()).to.equal(true);
 
@@ -354,6 +366,96 @@ describe('residentialNodeDosService tests', () => {
       const decided = await service.enforceResidentialPolicy(deps);
 
       expect(decided).to.equal(false);
+      expect(service.isEvacuating()).to.equal(false);
+    });
+  });
+
+  describe('the window counts time the verdict was WATCHED, not time that passed', () => {
+    const HOUR = 60 * 60 * 1000;
+
+    beforeEach(() => {
+      installedApps = [{ name: 'someapp' }];
+    });
+
+    it('does not drain on two evaluations a day apart with silence between them', async () => {
+      // The defect. A tick that cannot decide - unreadable bench, table that
+      // will not load - returns without touching state, so a node could answer
+      // once, say nothing for 24h, answer once more, and start deleting apps.
+      // 293 of 6,115 fleet slots cannot read their bench today, and that is the
+      // population being judged.
+      const now = Date.now();
+      markerStore.set('residentialDos', {
+        _id: 'residentialDos',
+        residentialSince: now - service.SETTLE_MS - HOUR,
+        lastConfirmedAt: now - (24 * HOUR),
+        observedMs: 0,
+      });
+
+      await service.enforceResidentialPolicy(deps);
+
+      expect(service.isEvacuating()).to.equal(false);
+      // And the silence bought nothing, so it cannot drain on the next tick either.
+      expect(markerStore.get('residentialDos').observedMs).to.equal(0);
+    });
+
+    it('credits a gap at the normal check cadence', async () => {
+      const now = Date.now();
+      markerStore.set('residentialDos', {
+        _id: 'residentialDos',
+        residentialSince: now - service.SETTLE_MS,
+        lastConfirmedAt: now - service.CHECK_INTERVAL_MS,
+        observedMs: service.SETTLE_MS - service.CHECK_INTERVAL_MS,
+      });
+
+      await service.enforceResidentialPolicy(deps);
+
+      expect(markerStore.get('residentialDos').observedMs).to.be.at.least(service.SETTLE_MS);
+      expect(service.isEvacuating()).to.equal(true);
+    });
+
+    it('credits at most one check interval, however long the gap', async () => {
+      // A gap short enough to count still buys only a tick's worth. Otherwise a
+      // node that checks in rarely accrues the window faster than one checking
+      // in as designed.
+      const now = Date.now();
+      markerStore.set('residentialDos', {
+        _id: 'residentialDos',
+        residentialSince: now - (11 * HOUR),
+        lastConfirmedAt: now - (11 * HOUR),
+        observedMs: 0,
+      });
+
+      await service.enforceResidentialPolicy(deps);
+
+      expect(markerStore.get('residentialDos').observedMs).to.equal(service.CHECK_INTERVAL_MS);
+    });
+
+    it('starts a marker written before observed time was kept at zero, not credited', async () => {
+      // An in-place upgrade. The old marker records when the clock started,
+      // which is precisely the measure being replaced, so it earns nothing -
+      // the node waits out a real window instead of inheriting a notional one.
+      const now = Date.now();
+      markerStore.set('residentialDos', {
+        _id: 'residentialDos',
+        residentialSince: now - (10 * 24 * HOUR),
+      });
+
+      await service.enforceResidentialPolicy(deps);
+
+      expect(markerStore.get('residentialDos').observedMs).to.equal(0);
+      expect(service.isEvacuating()).to.equal(false);
+    });
+
+    it('keeps the first-seen timestamp for the record while the gate reads observed time', async () => {
+      const now = Date.now();
+      const firstSeen = now - (5 * 24 * HOUR);
+      markerStore.set('residentialDos', {
+        _id: 'residentialDos', residentialSince: firstSeen, lastConfirmedAt: now - HOUR, observedMs: HOUR,
+      });
+
+      await service.enforceResidentialPolicy(deps);
+
+      expect(markerStore.get('residentialDos').residentialSince).to.equal(firstSeen);
       expect(service.isEvacuating()).to.equal(false);
     });
   });
@@ -366,9 +468,7 @@ describe('residentialNodeDosService tests', () => {
 
     beforeEach(async () => {
       installedApps = [{ name: 'someapp' }];
-      markerStore.set('residentialDos', {
-        _id: 'residentialDos', residentialSince: Date.now() - service.SETTLE_MS - 1000,
-      });
+      markerStore.set('residentialDos', windowServed());
       await service.enforceResidentialPolicy(deps);
     });
 
@@ -459,6 +559,70 @@ describe('residentialNodeDosService tests', () => {
     });
   });
 
+  describe('the queue step outlasts the pass that reads it', () => {
+    // mayEvacuateApp is reachable only from the give-up pass
+    // (explorerService.js:651 -> checkAndRemoveApplicationInstance) and
+    // wholeSince is stamped inside that pass, so ticket maturity is quantised
+    // to the pass interval. A step shorter than the pass cannot separate two
+    // points on that grid: adjacent positions mature on the same pass, and the
+    // pass is keyed on block height so every node in the fleet evaluates in the
+    // same instant. Both holders then read the app at full strength, because
+    // fluxappremoved is broadcast only after the volume is already deleted, and
+    // an app at N drops to 1 in a single pass.
+    //
+    // Asserted against PRODUCTION's config, not the copy under
+    // tests/unit/globalconfig and not the harness overlay. The harness
+    // compresses both sides of this inequality, and compressing them by
+    // different factors is what hid the defect - suite 55 separates every
+    // position by about four passes and is structurally incapable of producing
+    // the collision. An environment tuned until it is green cannot test what
+    // was tuned, so the inequality is checked where the fleet reads it.
+    const BLOCK_SECONDS = 30; // post-PON; stated in-repo at fluxService.js:1774
+    const PON_SPEED_MULTIPLIER = 4; // explorerService.js:610
+
+    // ZelBack/config/default.js requires config/userconfig, which is gitignored
+    // and absent from a fresh checkout, so it is stubbed rather than resolved.
+    function productionConfig() {
+      return proxyquire('../../ZelBack/config/default', {
+        '../../config/userconfig': { initial: { development: false } },
+      });
+    }
+
+    function passIntervalMs(fluxapps) {
+      return fluxapps.removeFluxAppsPeriod * PON_SPEED_MULTIPLIER * BLOCK_SECONDS * 1000;
+    }
+
+    it('spaces adjacent queue positions by more than one give-up pass', () => {
+      const { fluxapps } = productionConfig();
+
+      expect(fluxapps.residentialQueueStepMs).to.be.above(passIntervalMs(fluxapps));
+    });
+
+    it('gives every position in an instance list a pass of its own', () => {
+      const { fluxapps } = productionConfig();
+      const pass = passIntervalMs(fluxapps);
+      const passIndex = (position) => Math.ceil(
+        (fluxapps.residentialQueueBaseMs + (position * fluxapps.residentialQueueStepMs)) / pass,
+      );
+
+      // Nine positions covers the largest instance count the fleet runs.
+      const indices = [0, 1, 2, 3, 4, 5, 6, 7, 8].map(passIndex);
+
+      expect(new Set(indices).size).to.equal(indices.length);
+    });
+
+    it('is the same relationship the unit config copy models', () => {
+      // Every other test in this file reads the copy, so a copy that has
+      // drifted would silently measure a different model from the fleet's.
+      const production = productionConfig().fluxapps;
+      const unitCopy = require('config').fluxapps;
+
+      expect(unitCopy.removeFluxAppsPeriod).to.equal(production.removeFluxAppsPeriod);
+      expect(unitCopy.residentialQueueBaseMs).to.equal(production.residentialQueueBaseMs);
+      expect(unitCopy.residentialQueueStepMs).to.equal(production.residentialQueueStepMs);
+    });
+  });
+
   describe('listInstalledApps', () => {
     it('returns null rather than an empty list when the read fails', async () => {
       const result = await service.listInstalledApps(async () => ({ status: 'error', data: 'nope' }));
@@ -494,9 +658,7 @@ describe('residentialNodeDosService tests', () => {
 
     it('stop() stops evacuating', async () => {
       installedApps = [{ name: 'someapp' }];
-      markerStore.set('residentialDos', {
-        _id: 'residentialDos', residentialSince: Date.now() - service.SETTLE_MS - 1000,
-      });
+      markerStore.set('residentialDos', windowServed());
       await service.enforceResidentialPolicy(deps);
       expect(service.isEvacuating()).to.equal(true);
 

--- a/tests/unit/residentialNodeDosService.test.js
+++ b/tests/unit/residentialNodeDosService.test.js
@@ -277,6 +277,22 @@ describe('residentialNodeDosService tests', () => {
       expect(decisions()[0]).to.include({ enforce: null, undecidedBecause: 'benchmark' });
     });
 
+    it('carries the verdict, so a veto is not read as an unread table', async () => {
+      // Both come back enforce: null. CONFLICTED from a node declining a
+      // published verdict about its own address is a decision; a null
+      // classification is the absence of one, and a consumer that cannot
+      // separate them learns nothing from either.
+      geolocationServiceStub.getNetworkClassification.returns({
+        classification: 'CONFLICTED', source: 'node-veto',
+      });
+
+      await service.enforceResidentialPolicy(deps);
+
+      expect(decisions()[0]).to.include({
+        enforce: null, classification: 'CONFLICTED', source: 'node-veto',
+      });
+    });
+
     it('names the classification when that is the missing input', async () => {
       geolocationServiceStub.getNetworkClassification.returns(null);
 

--- a/tests/unit/syncthingFolderStateMachine.test.js
+++ b/tests/unit/syncthingFolderStateMachine.test.js
@@ -1906,20 +1906,21 @@ describe('syncthingFolderStateMachine tests', () => {
     // What separated "a peer holds it" from "I hold it" was only that syncthing
     // does not report remoteState 'valid' for the local device: an incidental
     // property of a field read with a default, not an intention.
+    // getConfig and getDbCompletion answer with the value, not a {status, data}
+    // envelope. Stubbed the old way, findSyncedPeer bailed at the folder lookup
+    // and returned null without asking a device - which is what the first test
+    // below asserts, so it passed with the self-exclusion it exists to prove
+    // deleted.
     beforeEach(() => {
       syncthingServiceMock.getConfig.resolves({
-        status: 'success',
-        data: { folders: [{ id: 'fluxappone', devices: [{ deviceID: 'LOCAL-DEVICE' }] }] },
+        folders: [{ id: 'fluxappone', devices: [{ deviceID: 'LOCAL-DEVICE' }] }],
       });
     });
 
     it('does not accept this node\'s own copy as a peer holding the data', async () => {
       // If it were asked, the local device would answer exactly like a healthy
       // peer - so the test makes it answer that way.
-      syncthingServiceMock.getDbCompletion.resolves({
-        status: 'success',
-        data: { completion: 100, globalBytes: 4096, remoteState: 'valid' },
-      });
+      syncthingServiceMock.getDbCompletion.resolves({ completion: 100, globalBytes: 4096, remoteState: 'valid' });
 
       const peer = await stateMachine.findSyncedPeer('fluxappone');
 
@@ -1929,18 +1930,12 @@ describe('syncthingFolderStateMachine tests', () => {
 
     it('still accepts a genuine peer alongside the local device', async () => {
       syncthingServiceMock.getConfig.resolves({
-        status: 'success',
-        data: {
-          folders: [{
-            id: 'fluxappone',
-            devices: [{ deviceID: 'LOCAL-DEVICE' }, { deviceID: 'PEER-DEVICE' }],
-          }],
-        },
+        folders: [{
+          id: 'fluxappone',
+          devices: [{ deviceID: 'LOCAL-DEVICE' }, { deviceID: 'PEER-DEVICE' }],
+        }],
       });
-      syncthingServiceMock.getDbCompletion.resolves({
-        status: 'success',
-        data: { completion: 100, globalBytes: 4096, remoteState: 'valid' },
-      });
+      syncthingServiceMock.getDbCompletion.resolves({ completion: 100, globalBytes: 4096, remoteState: 'valid' });
 
       const peer = await stateMachine.findSyncedPeer('fluxappone');
 
@@ -1951,10 +1946,7 @@ describe('syncthingFolderStateMachine tests', () => {
     it('excludes nothing when this node cannot establish its own device id', async () => {
       // The safe direction: the completion checks still have to pass.
       syncthingServiceMock.getDeviceId.rejects(new Error('syncthing unreachable'));
-      syncthingServiceMock.getDbCompletion.resolves({
-        status: 'success',
-        data: { completion: 100, globalBytes: 4096, remoteState: 'valid' },
-      });
+      syncthingServiceMock.getDbCompletion.resolves({ completion: 100, globalBytes: 4096, remoteState: 'valid' });
 
       const peer = await stateMachine.findSyncedPeer('fluxappone');
 

--- a/tests/unit/syncthingFolderStateMachine.test.js
+++ b/tests/unit/syncthingFolderStateMachine.test.js
@@ -11,6 +11,10 @@ const syncthingServiceMock = {
   systemRestart: sinon.stub(),
   getConfig: sinon.stub(),
   getDbCompletion: sinon.stub(),
+  // findSyncedPeer asks for this node's own device so it can skip it: every
+  // folder's device list begins with the local device, and its copy trivially
+  // reports 100% complete.
+  getDeviceId: sinon.stub().resolves('LOCAL-DEVICE'),
   getConfigDevices: sinon.stub(),
   dbRevert: sinon.stub(),
   systemPause: sinon.stub(),
@@ -1892,6 +1896,69 @@ describe('syncthingFolderStateMachine tests', () => {
       const result = await stateMachine.verifySendReceiveFolderSafety('test-app', '/apps/test-app');
 
       expect(result.isSafe).to.be.true;
+    });
+  });
+
+  describe('findSyncedPeer excludes this node', () => {
+    // Every folder's device list BEGINS with the local device - see
+    // syncthingMonitorHelpers, `const devices = [{ deviceID: myDeviceId }]` -
+    // and this node's own copy trivially reports 100% with globalBytes > 0.
+    // What separated "a peer holds it" from "I hold it" was only that syncthing
+    // does not report remoteState 'valid' for the local device: an incidental
+    // property of a field read with a default, not an intention.
+    beforeEach(() => {
+      syncthingServiceMock.getConfig.resolves({
+        status: 'success',
+        data: { folders: [{ id: 'fluxappone', devices: [{ deviceID: 'LOCAL-DEVICE' }] }] },
+      });
+    });
+
+    it('does not accept this node\'s own copy as a peer holding the data', async () => {
+      // If it were asked, the local device would answer exactly like a healthy
+      // peer - so the test makes it answer that way.
+      syncthingServiceMock.getDbCompletion.resolves({
+        status: 'success',
+        data: { completion: 100, globalBytes: 4096, remoteState: 'valid' },
+      });
+
+      const peer = await stateMachine.findSyncedPeer('fluxappone');
+
+      expect(peer).to.equal(null);
+      sinon.assert.notCalled(syncthingServiceMock.getDbCompletion);
+    });
+
+    it('still accepts a genuine peer alongside the local device', async () => {
+      syncthingServiceMock.getConfig.resolves({
+        status: 'success',
+        data: {
+          folders: [{
+            id: 'fluxappone',
+            devices: [{ deviceID: 'LOCAL-DEVICE' }, { deviceID: 'PEER-DEVICE' }],
+          }],
+        },
+      });
+      syncthingServiceMock.getDbCompletion.resolves({
+        status: 'success',
+        data: { completion: 100, globalBytes: 4096, remoteState: 'valid' },
+      });
+
+      const peer = await stateMachine.findSyncedPeer('fluxappone');
+
+      expect(peer).to.not.equal(null);
+      expect(peer.deviceID).to.equal('PEER-DEVICE');
+    });
+
+    it('excludes nothing when this node cannot establish its own device id', async () => {
+      // The safe direction: the completion checks still have to pass.
+      syncthingServiceMock.getDeviceId.rejects(new Error('syncthing unreachable'));
+      syncthingServiceMock.getDbCompletion.resolves({
+        status: 'success',
+        data: { completion: 100, globalBytes: 4096, remoteState: 'valid' },
+      });
+
+      const peer = await stateMachine.findSyncedPeer('fluxappone');
+
+      expect(peer).to.not.equal(null);
     });
   });
 });


### PR DESCRIPTION
A node on a residential connection is only fit to serve the network when it runs ArcaneOS. This puts such a node out of service in three stages, so that the destructive step is only ever reached on a node holding nothing.

```
HOLD      stops accepting NEW apps. Immediate, and it deletes nothing.
EVACUATE  gives up one app at a time, and only ones another host demonstrably holds.
DOS       once it runs nothing, and removeAllAppsLocally finds nothing to delete.
```

DOS >= 100 is not a mark: `nodeStatusMonitor` calls `removeAllAppsLocally` on it and `appStartupManager` does the same on every boot, so a node in that state has every app directory and volume on it deleted. Reaching it only on an empty node is the whole point of the staging.

**There is no in-FluxOS off switch, and the one that exists is better.** Enforcement acts only on a `RESIDENTIAL` verdict from the published table, so blanking `orgClasses` in `fluxos-network-policy` ends it fleet-wide within a day — no release, no node upgrades, nothing to roll back. A config flag would have needed all three.

**The trust boundary this inherits, stated rather than inherited silently.** The table is fetched unsigned from `fluxos-network-policy`; trust is TLS, GitHub, and write access to that repo, and this PR moves what those bytes can do from "placement quality" to "stage a non-ArcaneOS residential node out of service". That is a conscious trade. It is bounded — at most the 541 non-Arcane slots with readable bench, one app per 6 hours behind the full safety gate, DOS only on an empty node, self-healing on the corrected row — and it replaces a weaker root, not a stronger one: today's classification rests on plaintext `http://ip-api.com`, forgeable per node by any on-path party with no history to audit, while every byte the policy repo has ever served is in its git history behind branch protection (no force-push, admins bound, validated on publish — though merges do not yet require a second reviewer). Signed manifests (the fluxhashes scheme, in progress) are the successor; this artifact adopts that signing when it lands.

## What it acts on

Measured against `stats.runonflux.io/fluxinfo` (6,115 slots on 2,513 machines, 5,822 slots with readable bench) and `api.runonflux.io/apps/locations` (6,340 placements, 1,085 apps), classified by reading the published artifact through this branch's own `ipLocationStore` and `networkClassifier`.

Enforcement acts only on a `RESIDENTIAL` verdict from the published table. Of the 541 slots on 316 hosts whose bench confirms they are not ArcaneOS:

| verdict | hosts | slots | share | app placements |
|---|---:|---:|---:|---:|
| **Residential — enforced** | **83** | **218** | **40%** | **494** |
| Datacenter | 195 | 253 | 47% | 52 |
| No published verdict — never enforced | 38 | 70 | 13% | 98 |
| **Apps losing every copy** | | **0** | | |
| Volumes deleted | | **none** | | |

**A legacy node is very nearly as likely to be in a data centre as on a home line**, so "not ArcaneOS" is not a usable proxy for "residential" and is not used as one. A further 293 slots, on 83 hosts, have no readable bench at all; `isArcaneOs()` returns `null` for those and a `null` tick decides nothing.

No node in this population vetoes its published verdict: the node veto declines a published `RESIDENTIAL` on local hosting evidence, and the one fleet host it currently covers — `213.44.137.57` — runs ArcaneOS, so it is outside the enforceable set to begin with.

## Why it is staged rather than immediate

63 apps have every copy on a node that qualifies for enforcement:

| | apps | stateful |
|---|---:|---:|
| Single instance | 49 | **0** |
| 2+ instances | 14 | **9** |

None of the 49 single-instance apps hold synced data. An owner who deploys `instances: 1` chose a service with no continuity guarantee, and the platform's standing semantics for any departing node — expiry, powercut, surplus trim, geolocation redeploy — already remove the instance and its volume; nothing anywhere preserves an unsynced volume, so the rebuild starting empty is not a property of this path. Evacuation is in fact the gentlest departure the platform has: the removal is broadcast immediately and the spawner rebuilds elsewhere at once, where a node that simply dies leaves its stale location record holding the app at apparent full strength for up to 125 minutes (the running-location TTL) before anyone acts. It is still an outage window, and a longer one where placement is constrained by a geo pin, hardware, or enterprise ownership.

All 9 stateful ones are `g:` apps at **exactly 2 instances**: seven Palworld and two Minecraft world saves. The ordering is what makes them safe — the junior leaves, the senior copy still holds the world, the replacement syncs from it, and only then does the senior go.

**218 slots sit on 83 machines.** Several FluxNode registrations routinely share one physical connection — a residential line hosting 8 nodes loses all 8 at once. The spawner already refuses to place a second instance of an app on an occupied IP, so one app's instances land one per host by construction; the safety gate's other-host count dedupes to machines as well, covering the pair that converges after placement through an IP change.

## Why the evacuation terminates

The departure creates the deficit that drives it. Only 4 apps in the entire fleet carry any surplus — the trim path removes above N and the spawner fills below N, so the network sits at exactly-N and a drain conditioned on staying above the requirement never starts.

So the node leaves first: the app is one short, the spawner is already asking every 120s who is short, a node that is not held volunteers, and the count returning to N is what releases the next holder. Serialisation needs no coordination and no wire change — a departure leaves the app short, every other holder's gate refuses to act on a short app and resets that app's queue clock, so each further departure waits for the spawner to restore full strength and then serves its full wait again.

**The queue ticket is an uninterrupted observation, not elapsed time**, and that is what keeps position binding on every departure rather than only the first. A node inside its own departure interval cannot act on anything, so it records nothing against its tickets; the block then reads afterwards as one long gap and every ticket starts again. Without that the tickets matured untouched through the six hours, the node came out of the block instantly ready for everything it held, and two holders whose blocks expired on the same pass — the pass is keyed on block height, so the fleet evaluates together — could hand back the same app in the same pass, each reading it at full strength because the removal is broadcast after the volume is already gone. The strength test sits at the same point: an app short of its instance count accrues nothing towards its turn, so the wait means what it says. Both clocks are monotonic, so a step of the system clock cannot mature a ticket against time the node never spent watching.

Position in the shared instance order sets a delay, never a veto. "Only the most junior may leave" deadlocks, because the replacement is itself the most junior and does not want to leave.

**The junior copy leaves first**, which is the same order `reasonToGiveUpApp` already ranks SURPLUS by and for the same reason: the newest copy stands aside and the senior one goes on holding the data. It also puts the one case that cannot simply leave at the back of the queue rather than the front — the elected primary is the senior instance, and it has to stand down and hand the app back before it can go.

The pacing is config-tunable: 6h between evaluations, a 24h settling window before anything moves customer data, 6h between departures, and a queue ticket of 30min + position × 40min. The step has to outlast the pass that reads it — `mayEvacuateApp` is reachable only from the give-up pass, which runs every `removeFluxAppsPeriod` (11) × `speedMultiplier` (4 post-PON) = 44 blocks = 22 minutes, so maturity is quantised to a 22-minute grid and a shorter step cannot separate adjacent positions on it. That inequality is asserted against production's own config in the unit tests. Two intervals are hardcoded rather than tunable: `RETRY_INTERVAL_MS` (5min, the retry after a tick that could not decide — it doubles up to and is capped by the check interval) and `staticIpStabilityDays` (10).

**What the grid does not separate.** The step separates *positions* on the 22-minute grid; it does not separate *maturities that began at different moments*. A ticket is measured from each node's own observation start, so two holders whose starts differ by about a step mature inside the same pass whatever the step is — and the pass is block-keyed, so the fleet evaluates together. What keeps that empty is not the pacing: every stateful 2-instance app on the network is `g:`, and the election refuses to let the writer leave, so one of any two colliding holders declines regardless of its turn. That is a property of today's app population, not a guarantee this code makes. Closing it structurally means taking the turn from the shared clock the pass already runs on — a node acts only in the pass its rank selects — rather than from elapsed observation, which is a private measurement answering a fleet-wide question. Per-node jitter does not close it: it separates a colliding pair by the difference of two fixed offsets, which can be zero, and moves an already-separated pair together as readily as apart.

The settling window counts time the node **observed** the verdict, not time that elapsed. Each confirming tick credits the gap since the last, capped at one check interval, and credits nothing once the gap is long enough that the node plainly stopped watching. It is persisted in the `nodeStartupTracker` collection, so restarting FluxOS costs nothing and cannot postpone the drain — and a node that answers once, says nothing for a day, then answers once more has accrued two ticks, not a day.

An **empty** residential node is DOSed on the first decisive tick, with no settling window at all. The window exists to protect customer data and an empty node has none; the DOS deletes nothing and is released the moment the node is attested again. It does mean a mistaken policy row reaches empty nodes in minutes rather than a day.

## The classification

A node is `RESIDENTIAL` only when something positively says so and nothing contradicts it:

| | |
|---|---|
| RESIDENTIAL | a positive signal, no contradiction |
| DATACENTER | positive hosting evidence, no positive residential signal |
| CONFLICTED | both — never enforced |
| UNKNOWN | neither — never enforced |

**The published location table is the authority, and where it holds no verdict nobody does.** It is built in `fluxos-network-policy` from registry evidence a node cannot gather for itself: six thousand nodes cannot each query the RIRs. There is no fallback to the node's own reading — that rule is the published rule with its strongest signal removed, its error rate has never been measured, and it would have decided for the 13% of the enforceable population — 70 of the 541 non-ArcaneOS slots — whose organisation carries no published verdict, on the one path that deletes customer data. Tuning belongs in the policy repo, where a verdict is evidence-backed, auditable, and correctable by hand through `data/orgclass-overrides.json` without a FluxOS release.

What the node's own evidence still does is **decline** a published `RESIDENTIAL` about its own address. An organisation is decided by 80% of its hosts agreeing, so a minority tail of the other kind is guaranteed by construction, and the veto is how one of them steps out until someone adjudicates the range. It can only ever remove a node from enforcement.

**The evidence a verdict is read against can lag an address change by up to three days.** `getNetworkClassification()` looks the published table up on `networkEvidence.ip`, which is refreshed on `setNodeGeolocation`'s three-day cadence, while the enforcement tick runs every six hours — so a node whose address moved between geolocation passes is classified against its previous address's row until the next one. It cannot begin a drain inside that window: both the 24h observed window and the queue ticket restart on the change. The HOLD is immediate, which is the conservative direction. `isDataCenter()` and `isStaticIP()` carried the same latency before this PR.

Measured at the point of enforcement: of the **1,569** fleet hosts ip-api positively calls hosting, across all 29 hosting ASNs the fleet uses, exactly **one** carries a published residential verdict — `213.44.137.57`, in Bouygues' consumer space — and the node veto covers it. **One ledger-level error in 1,569, zero enforced.**

That is the only accuracy figure worth quoting for this design. A rate measured on the classifier alone cannot be one: `hosting` is itself a contradiction, so `RESIDENTIAL` is unreachable on that population whatever the other signals say.

Signals are read from the operator (`isp`/`as`), never from `org`, which is the block registrant and frequently a reseller: `46.250.240.89` carries isp "Contabo Asia Private Limited" and org "Yorkshire Tech Limited". Link asymmetry corroborates and never decides — a bench figure is a speed test's result, not a property of the link, so it can support a verdict the real signals already reached and can never reach one.

A verdict also requires that the contradicting signals were **consulted at all**. When ip-api answers 200 with an unusable body, `geolocationService` falls back to `stats.runonflux.io`, which carries none of `hosting`/`proxy`/`mobile`/`isp`/`as` — `fluxstats` never requests them and its `/fluxlocation` handler projects them away. On that path an empty `evidenceAgainst` means nobody looked rather than nothing found, and the node is left unclassified rather than residential.

**No table means no verdict** — not a fallback. A booting node fetches a 4.6 MB artifact and ingests two million rows while a single ip-api call answers in milliseconds, so the table is reliably absent at the moment a booting node would otherwise decide, and nothing enforces on `null`.

The verdict is not stored. `setNodeGeolocation` gathers evidence on its three-day cadence; `getNetworkClassification()` reaches the verdict when asked, from that evidence and whatever table the node currently holds — which is what `placementFeasibility`, `hwRequirements` and `appSpawner` already do with the same table.

## What `staticip` is for, and why the rule changed

`staticip` is **two promises**, and the apps that ask for it need both. The live consumers are VPN endpoints (`cumulusvpn*`), Kaspa nodes, and `quipbootnode` — peers and clients hold an `ip:port` pair written down, so what they need is an endpoint that **stays reachable at a fixed address**:

1. **Directly connected** — the node holds the address itself, so reaching it does not depend on a port mapping.
2. **Not seen to move** — this node has not watched that address change.

Both are properties of the host, so only the host can attest to them. The whole rule is now four rows of observation, and no table, vendor flag or operator name appears in it:

| this node watched it change <10d ago | public address on the interface | verdict |
|---|---|---|
| yes | — | UNKNOWN |
| no | yes | **STATIC** |
| no | no (NAT) | DYNAMIC |
| no | unreadable | UNKNOWN |

Only `STATIC` satisfies the requirement. `UNKNOWN` and `DYNAMIC` both fail it and are kept apart, so a node that could not answer does not read as one that answered "behind NAT".

### What the fleet actually looks like

Random sample of 500 ArcaneOS slots, 442 reachable, reproducing `hasPublicIpOnInterface()` on each node by SSH. Scaled ×12.3 to the 5,438 reachable Arcane slots.

| how the node reaches the world | slots | share | claim `staticIp` today | fleet est |
|---|---:|---:|---:|---:|
| **Public address on its own interface** | 102 | 23.1% | 102 (**100%**) | ~1,255 |
| **Behind a UPnP router** | 336 | 76.0% | 126 (**38%**) | ~4,134 |
| NAT, no UPnP (1:1 or manual forward) | 4 | 0.9% | 0 (0%) | ~49 |

95% CI on the public-address share: **19.1–27.0%**.

**Of the 228 slots advertising `staticIp: true`, 126 — 55% — are behind a UPnP router on an RFC1918 address.** Every one of them qualifies through a third-party flag about the address RANGE, never through anything the node observed about itself:

| route to `static` | slots |
|---|---:|
| ip-api `hosting: true` | 112 |
| ip-api `proxy: true` | 12 |
| no ip-api record at all | 2 |

That is `storedGeolocation.static = proxy || hosting` on `development`. So "static IP" has meant *"ip-api says this address sits in a hosting or proxy range"* — a statement about the block, not about the node.

### Why a range flag answers neither promise

- **It cannot see whether the host is directly connected.** Those 126 slots reach the world through a **UPnP port mapping**, which no vendor flag knows anything about. The address can be rock solid while the mapping lapses on a router reboot, a lease expiry, or a firmware quirk — the fleet UPnP survey found 135 router models and defects in several. The node cannot see its own public address, cannot verify it, and the claim is unfalsifiable locally.
- **It does not imply a fixed address either.** "This block is assigned to a hosting company" states what the block is *for*. An operator reassigns on rebuild, migration, or a released elastic address, and the node comes back on a different address — same hosting range, same `DATACENTER` verdict, different endpoint.

The 12 qualifying on `proxy` are the clearest failure: that flag is a VPN artefact, and `geolocationService`'s own comment said so while the code it commented on granted static on exactly that basis.

### What it costs

| | |
|---|---:|
| Arcane slots that stop claiming static | **~1,550** (95% CI 1,321–1,779) |
| Static pool | 2,800 → **~1,255** |
| Slots that **gain** static | **0** — all 102 public-address slots already claim it |
| Apps requiring `staticip` | 44 |
| Placements currently on slots that would lose it | 74 |

**Nothing evicts those 74.** `checkAppStaticIpRequirements` is reachable only from `checkAppRequirements`, which runs on install and redeploy; there is no periodic compliance sweep in ZelBack. They drain by attrition as owners push spec updates, because `reinstallOldApplications` removes before it checks.

**How much of that attrition touches data, measured:** of the apps requiring `staticip`, **3 carry synced components** — all of them `r:`, all at `instances: 3`, 9 placements between them. Two of those 9 sit on slots that lose static. Every other app requiring `staticip` keeps no synced state at all, so an attrition removal costs them a container the spawner rebuilds from the specification.

So the bound is **one of three copies**, on two apps, re-synced from the two survivors; losing an app outright would need all three of its copies on losing slots and an owner update, which no app in the population is in a position for. The removal is still a removal that the evacuation safety gate never sees, and that is the honest residual here.

**The ordering behind it is not this branch's to fix, and is being fixed.** `reinstallOldApplications` deletes the app and its volume and only then asks whether the node may still run it, so any requirement that fails — disk, geolocation, static IP — fails after the data is gone. It fires today, on `development`, for every one of those reasons; this branch widens the set of nodes one of them says no to. The fix is a make-before-break drain: a node that can no longer satisfy a spec keeps serving the old one and keeps its data while being excluded from the counts that decide whether the network needs another instance, and only tears down once a replacement is ready. That is designed and lands in a subsequent PR. Reordering the check alone is not the fix — it converts the deletion into a node stuck on a stale spec forever, which is why it is not done here.

The operator's remedy is to put a routed public address on the interface rather than NAT, which is the behaviour worth steering toward.

### What else moves with it

`isStaticIP()` is not read only by the `staticip` gate. It also drives a spawner deferral: a node claiming static defers apps that do **not** require static, so as to stay available for apps that do. So on upgrade day roughly **1,550 slots stop deferring** and become immediately available for ordinary placements. That is a fleet-wide placement shift and it is not priced in the table above. It is a correction rather than a regression — those slots were deferring on a claim they could not support — and the static pool that remains, ~1,255 slots, still exceeds the 74 placements that ask for it by more than an order of magnitude.

Second-order, and ongoing rather than one-off: a genuinely static node that **changes its address** now reads `UNKNOWN` for the full ten-day stability window, where on `development` a hosting-range node recovered `static` on its very next pass through `proxy || hosting`. `checkAppStaticIpRequirements` is a hard gate throughout that window. This is the same pre-existing ordering described above, reached by a different route, and it closes with the same change.

### The case this knowingly refuses

Genuine 1:1 NAT, where a fixed address is mapped to a host that never sees it locally. The sample holds 4 such slots (~49 fleet-wide) and **none claims a static address today**; the fleet's entire hyperscaler population is one Oracle slot. Real, and priced at nil.

The sample was drawn at random and each slot was read directly, so the shares above carry the stated confidence interval rather than being a count of whoever answered.

## Behaviour this changes for every node

- **Surplus removal refuses when no connected peer demonstrably holds a stateful app's data.** SURPLUS and EVACUATION share one safety gate, so this applies fleet-wide, not only to residential nodes. A surplus copy may now persist while syncthing cannot prove a peer holds the folder — the trade against deleting a last remaining copy, and the only signal is a warning every 12 refusals. The gate also refuses to hand back a `g:` component this node is the elected primary for, and refuses when no FDM can name the primary at all: an election that has not run is not an election that said no.
- **A surplus copy that is running the `g:` writer is left alone, and the next copy trims instead.** "The newest copy stands aside" is a stand-in for "the least valuable copy stands aside", and when the newest copy is the one writing it is backwards — that is the most valuable copy on the network. The election is allowed to seat the writer anywhere in the instance order: it will not start a node whose data has not finished syncing, so it works down the list until it finds one that is ready, and the designated-leader branch leaves the order outright. The second-newest steps in only on a **positive confirmation** that the newest is running the writer, asked through the same peer probe the election uses. Silence, a timeout, a refusal and "not running" all mean it does nothing — every node ranks the same shared order, but "who is writing" is each node's own reading and FDM's registration lags it by ~110s, so the rule can only ever fail towards no trim, never towards two. What it does not do is stop the writer to make the ordering come true: an app that is over-served is not down, and an app whose writer was stopped to tidy up a count is.
- **`/flux/info` reports which stage of being staged out a node is in** — `dosStaging`, one of `null`, `HOLD` or `EVACUATE`, beside the `dos` it leads to. Always present, so it can be counted across the fleet. The first stage was otherwise invisible: a held node takes no new apps and is in every other respect indistinguishable from one that has simply not been given work, and that stage lasts a whole settling window — the only part of this where an operator can still put the node right and lose nothing. It is derived from the settling window rather than from the evacuation flag, because that flag is a per-tick permission for the give-up pass that any undecidable tick turns off, and reporting it as a stage would show a node moving backwards through a staging it never moved backwards through.
- **During a total FDM outage, no node elects a g: primary.** `getMasterIpFromFdm` now reports whether any region actually answered, which makes the `if (!fdmOk)` guard in `masterSlaveApps` live: a node that gets no answer from all three regions skips primary selection for that cycle instead of reading silence as "no primary set" and promoting itself. A g: app whose primary dies while every FDM is unreachable stays down until one answers. That is the trade, and it is the right one: the node the old behaviour promoted was one that could not reach three services on three continents — at least as likely to be network-isolated itself as witnessing a global outage, which is exactly the split-brain writer the election exists to prevent.
- **One instance of an app per host, and the safety gate counts hosts.** The spawner refuses to place an instance on an IP that already holds one, and an app's fixed ports make a second copy on one machine moot regardless — so a given app's instances land one per host by construction. The safety gate's "does anyone else hold this?" dedupes locations to distinct machines anyway, covering the one way a pair can converge after placement: an IP change. The strength count and the SURPLUS test count registrations, which under the placement rule is the same number.
- **An app is no longer written off for twelve hours on a count that included a claim.** `trySpawningGlobalApplication` counts instances twice — once while choosing an app, and again after it has selected and cached it — and the second count returned without clearing the entry the selection had just set. That entry is the candidate filter rather than a re-decision skip, so it removes the app from consideration entirely, and it lives twelve hours. A claim is provisional by design: the fault-domain share is checked *after* the claim goes out, so a claim is withdrawn seconds later once its node finds the share filled. A node that re-counted inside that window recorded "the network has this covered" for half a day. The entry is now **kept** when running copies alone meet the count and **cleared** only when the claims were needed to reach it. Clearing it unconditionally is the other way to be wrong: an app genuinely covered by running copies would re-enter the candidate pool every pass, be declined again, and never be cached — because this node never installs it, and installing is the only other thing that sets the entry. No deferral is added; `appsToBeCheckedLater` carries conditions lasting 30–57 minutes and this one lasts seconds.
- **A placement hold is released by its owner, and only by its owner.** The hold was a single slot, so a second `set` overwrote the first reason outright and either caller's release cleared the other's. It is now a map of owner to reason, the owner drawn from a frozen enum, an unknown owner refused at the `set`, and `getPlacementHold()` reporting every reason held. An ownership check on the single slot would have deadlocked rather than fixed it: two owners cannot coexist in one, so the first would have been left unable to release and the node held indefinitely.
- **One removal per pass**, rather than several spaced 300s apart inside one pass. The sleep held the whole pass open — every app behind the removed one waited on it, and every decision after it was made against an installed-app list read minutes earlier — and the pass is fired unawaited from the block handler, so one long enough to outlive its own interval could overlap the next. Surplus removal is correspondingly slower: one app per pass rather than several, on work that is not urgent because a surplus app is over-served rather than down.
- **`isStaticIP()` is observed, not inferred, and is three-state.** The table above is the whole rule. `publishedHosting` and the `staticIpOrgs` list of nine hoster names are deleted; the decision collapses from six rows to four, and nothing outside the node's own interface can confer a static address. `isStaticIP()` is a hard gate in `hwRequirements`, so apps requiring a stable endpoint are no longer placed on nodes that only look stable from the outside.
- **`isDataCenter()` rests on positive hosting evidence.** It used to be ip-api's `hosting` flag OR the block registrant's name matching one of nine hosters. It is now a `DATACENTER` verdict from the classifier: a hosting PTR, the hosting flag, or an operator that sells hosting. `proxy` deliberately does **not** qualify — it is a VPN artefact, and a home machine behind a VPN exit carries that signature and nothing else, which is exactly what an owner buying `datacenter: true` is paying to avoid. Measured over 2,432 fleet hosts with an ip-api record:

  | | hosts qualifying |
  |---|---:|
  | `development` | 1,570 |
  | this branch | **1,673** (+105, −2) |

  The two that lose it are `212.83.170.245` (Scaleway) and `213.44.137.57` (Bouygues), both hosting addresses whose reverse DNS carries access-network vocabulary, so the classifier reads them as CONFLICTED rather than guessing.

## Also in this branch

`config.fluxapps.explorerPollIntervalMs` is configurable, defaulting to the current 5000. It is **not** how often the chain is asked: `pollForNewBlocks` reads a height cached by `daemonServiceMiscRpcs` and refreshed on its own `daemonInfoIntervalMs` timer, so the poll is the rate at which a node works *through* blocks once it knows it is behind. Its share of that refresh window — 5000/30000, 16.7% — is what decides whether a block is still the tip when processed, and everything downstream of block processing inherits it. Production is unchanged; the harness runs 833ms against a 5s refresh, which is the same 16.7%.

`isSynced` is documented as what it is: true when the block was still the chain tip when fetched, which is not the same as "the node is caught up". The tip comes from a cache refreshed every `daemonInfoIntervalMs`, and `processBlock` chains straight into the next block when behind, so a burst arriving between two refreshes is processed back to back and only the last block qualifies — silently skipping expiring app records, trimming surplus instances and reinstalling outdated apps for the rest. Post-PON that is a 30s block against a 30s refresh. It is named rather than worked around: v9 removes the race by pushing `hashblockheight` to `chainTipSource`.

`ipLocationSync.startSync()` is split. The restore half — one marker read against rows already in mongo — runs with the database schema prep in `serviceManager`; the fetch half, a 4.2 MB download and a two-million-row ingest, stays behind `waitForDbReady`. The residential verdict was otherwise waiting minutes for data it could have in milliseconds. Splitting rather than moving wholesale is deliberate: on a node with no cache, moving the fetch early would run that ingest concurrently with the app-database rebuild, which is the busiest the database ever is.

`config.fluxapps.sigtermExpiryS` replaces a hardcoded 420s constant, defaulting to 420 so production is unchanged. It must stay below `locationTtlS`: `appStartupManager` expires locations on `(cleanShutdown && downtime > sigterm) || downtime > running`, so a sigterm window above the running expiry is unreachable and a clean shutdown gets no grace at all.

`fluxNetworkHelper` publishes `dos:changed` from the sticky DOS setters, carrying the value `isNodeDos()` reads. `residentialNodeDosService` publishes `residential:decided` on every terminal path of a tick, with `enforce` three-state so a tick that could not decide is distinguishable from one that decided this node is fit to serve. Both are inert on a real node — `fluxEventBus.publish` returns immediately unless `config.testEventStream` is set.

### Harness

Three `shared.js` keys — `locationTtlS`, `installingTtlS`, `installErrorTtlS` — were wired to collection-level TTL indexes dropped when expiry moved per-document, so the harness ran on production durations while the file claimed 25×, 15× and 12× compression. They are live, and `HARNESS_TUNABLES.md` records which are compressible and why the other two are not.

`explorerPollIntervalMs` is 833ms, holding production's 16.7% share of the tip-refresh window rather than the 250ms that was three times more forgiving than production.

`test-infra/runner/framework/coupled-knobs.js` derives the knobs that only mean something relative to another knob, and `test-env.js` asserts them on the effective config of every node of every fleet before boot. A ratio at or above production's passes; below throws, because that is where the property inverts rather than merely slows. Two pairs are checked: `residentialQueueStepMs` against the give-up pass, and `sigtermExpiryS` against both `locationTtlS` and the measured cost of one node boot.

The `external-http-stub` no longer synthesises `static` and `dataCenter` for `/fluxlocation`. The real service has never carried either — it batch-queries ip-api for location and `org` only — so the stub made the degraded fallback look richer in the harness than it is on any real node, and put the one path where the classifier loses its contradiction signals beyond anything a suite could observe.

## Operator evasion

`ZelBack/config/default.js` cannot be edited to disable this: fluxbench's `GetFluxCheckSum()` hashes every file under the backend folder against `hashes.runonflux.io`, so a changed config fails the checksum, `signfluxnodetransaction` refuses, and the node expires at 640 blocks.

**The node veto is the cheapest evasion available, and it fails open by design.** `getNetworkClassification` declines a published `RESIDENTIAL` on any evidence against it, and `proxy` is such evidence — so an operator who routes a residential node through a commercial VPN reads as `CONFLICTED`, or more often as `DATACENTER` outright once the exit address is in a hosting range, and is never enforced against. It is not a safety bug: everything here is built to enforce only on a node that is provably residential, and every unavailable or contradictory input already means "do nothing". It is stated rather than closed because closing it would mean enforcing on contested evidence, which is the trade this design refuses everywhere else. It is not free to the operator either — a commercial VPN exit generally cannot offer the inbound reachability a FluxNode needs, and the added path shows up in the benchmark figures that set the node's tier.

Mongo is not hashed, and `geolocationService` restores `dataCenter` from the local collection when memory is empty — which is the state at boot. That is pre-existing and is not closable while an unverified machine judges itself. The settling clock is persisted precisely because restarting a service on a cron is near-accidental and worth closing; forging a classification in the database is deliberate tampering and is not.

## Depends on

**This PR is the top of a stack and targets #1795, not `development`.** Its diff shows everything below it until those land:

```
development <- #1781 <- #1782 <- #1791 <- #1795 <- #1784
```

It sits on #1795 because it needs the harness port allocator that lives in `buildSeedableApp` — a specification is signed and hashed the moment it is built, so a port added afterwards leaves the app carrying the hash of a specification that no longer exists — and because suite 98 covers a `appSpawner` refusal that lives on that branch. This branch previously carried six of those commits as cherry-picks; they are gone, and the originals are underneath.


`fluxos-network-policy` **#17, #18 and #19, all merged** — the artifact carrying the organisation classes, the hand-adjudication file `data/orgclass-overrides.json` for the populations a supermajority vote cannot reach, and the rename of class code 2 from `hosting` to `datacenter` (a ledger-text change; the artifact carries codes, so there is no wire change). It is inert until this ships: the ipLocation stack is not on `master`, so no released node reads `orgClasses`.

Verified end to end: the artifact fetched from the live `raw.githubusercontent.com/.../main` URL nodes read, parsed with this branch's `ipLocationStore` — 2,009,526 rows, and all 1,599 ledger ranges resolve to exactly the class the ledger claims. Every fleet figure above was produced through that same reader.

Per-host lists — every host counted residential, and every host with no evidence either way — can be reproduced from the published artifact with the reader in this branch, and are available to reviewers on request.

## The spawner reports its verdict when the verdict changes

`spawner:noCandidates` was published on every pass that placed nothing — roughly every
240ms per node, and continuously true for any fleet whose apps all sit at their instance
count. `fluxEventBus` states the rule at the top of its own file: facts as events, cadence
as a counter. Publishing the cadence pushed the `Last-Event-ID` replay window down from
most of a run to about four minutes, so nothing could afford to subscribe — leaving product
code publishing an event no listener could receive.

The cadence is a counter now, and the fact it was standing in for is an event:
`spawner:candidacy`, published only when this node's verdict on an app **changes**, and
carrying the app and the filter that removed it, or `candidate`. The survivor breakdown
stays in the log line, which is where it was already the useful thing.

## Two unowned-lifetime fixes that came along

Neither is residential DOS. Both were found while gating this branch and both are small, so they
are here rather than trailing behind it.

**`checkLoggedUser` answered a failure where a privilege belongs.** `PRIVILEGE_RESPONSE` is a
published contract — the frontend branches on those four strings and reads them out of the body
whether the status says success or error. The not-authorised path put `'none'` in `data.message`;
the catch put the thrown error's text there. fluxos-frontend's router guard clears
`localStorage.zelidauth` on exactly `'none'`, so a genuine backend failure set the privilege to a
string like `'No user Flux ID specificed'` and left the stale session in place, repeating on every
navigation. Access still failed closed — no route's privilege list contains an error string — but
the user was never logged out. `message` now carries the contract on both paths, with the error
kept in `name`/`code` and in the log. Every other consumer of `/id/checkprivilege` was checked and
none reads `message` on the error path.

**The geolocation refresh loop was one chain per caller.** `setNodeGeolocation` reschedules itself
three ways and kept no handle, and it has two callers: `serviceManager` at boot and
`fluxNetworkHelper` on every IP change. So each IP change started another self-perpetuating loop
and none could be stopped — a node that changed IP three times ran four of them for the life of
the process, each hitting the geolocation API and writing the same record, and on a node that never
detects its IP each one logged an error every ten seconds. It is now a singleton the module owns:
one handle cancelled before it is re-armed, one pass at a time so an IP change arriving mid-pass
cannot interleave its writes, and an exported `stopNodeGeolocation`. This branch reads
`isStaticIP`, `isDataCenter` and `getNetworkClassification` from that service, which is how it
surfaced.

## Testing

- Unit: **6,057 passing**, 18 pending, 0 failing, at this head.
- Harness suite 55 (`55-residential-node-evacuation`), 18 tests across three live 5-node fleets:

```
classifies the node RESIDENTIAL from the operator, not the registrant org; leaves an
attested data-centre node alone; takes the published verdict where the node has nothing
of its own to go on; declines a published verdict its own address contradicts; leaves a
residential node alone while it is still attested; stops taking new apps the moment
attestation is withdrawn, deleting nothing; hands the app back once the settling window
has passed; the app survives the departure on every other host; goes into DOS only once
it holds nothing; releases the node the moment it becomes attested; will not hand back a
stateful app while no peer demonstrably holds its data; hands the stateful app back once
a peer holds it in full; keeps the settling clock across a restart, so restarting cannot
postpone the drain; only one residential node gives up an app at a time; stands down as
the elected primary rather than handing the app back from under itself; hands the app
back on the pass after standing down, and the app survives elsewhere; will not hand back
a g: app it is running while no FDM can name the primary; serves a fresh queue turn
after a departure, not one that matured during it
```

  The suite runs on three fleets rather than one because every test it contains seeds an
  app asking for five instances on a five-node fleet, and nothing is cleaned up between
  tests. Holdings accumulate, and evacuation sheds one app per departure interval, so a
  test late in the file starts against a node holding seven apps and runs out of budget
  before it reaches the assertion — with the node enforcing correctly the whole time. The
  stand-down tests and the one-holder-at-a-time tests each get a fleet of their own, so
  what they assert is decided by the rule rather than by how many apps the node happened
  to have collected. Sizing a timeout to the accumulation instead would have left the
  accumulation in place for the next test written.

- Harness suite 96 (`96-surplus-trim-and-the-writer`), on its own fleet with a stub peer
  holding a fourth copy of a three-instance `g:` app, so the surplus is built rather than
  waited for:

```
trims nothing while it cannot confirm the newest copy is the writer; leaves the writer in
place and trims the next copy instead
```

  The first holds the second-newest copy where it cannot reach the newest, while the writer
  goes on running: a rule that trimmed on silence would remove a copy with the writer up and
  healthy. It waits for the pass to **report** the surplus it declined, so a pass that never
  ran cannot read as a pass that declined.

- Harness suite 89 waits for the app to be stoppable before replacing its data, and suite
  78 covers a spawner claim being withdrawn and the node's candidacy for that app coming
  back.

- A node's static IP is now **declared by the fleet rather than inherited from the
  wiring**. `hasPublicIpOnInterface()` reads `/proc/net/route` for a default route, and the
  harness network is `Internal`, so docker gives node containers no route out and every
  node read DYNAMIC — making `static_ip` deferral unreachable and silently swapping which
  reason a test was waiting for. A suite that wants a static node now gets a real default
  route installed via the network's own gateway before FluxOS starts, and its absence is
  how a suite asks for a NAT'd node. The route failure is loud, because a swallowed one
  reads exactly like a node that was never asked for a route.

- Full harness gate, 94 suites, `MAXN=6`, at `7523568a3`: **94 passed, 0 failed.**

  Run after #1791 merged into `development` and this branch was rippled onto #1795 at `18a705431`.
  157 commits above `development` (37 + 120); the ripple verified by `--numstat` and per-commit
  patch-id rather than by the rebase's own report.

  The two suites that were red on an earlier gate are green. Suite 02 lost its `after all` hook to a
  harness teardown defect — the mongo client was closed after the mongo container had stopped, and
  mongodb 7.5.0 then waits out a full 30s server-selection timeout that `squashError` swallows,
  against a hook budget that is a flat 30s. Closing the client while the server is still up removes
  the precondition: 27 of 30 runs slow before, 0 of 30 after, and the `db` teardown step has not
  exceeded 11ms on any gate since, against one outlier of 32,831ms.

  Suite 96 asserts that a surplus copy which is also the writer is left alone and the next copy
  trimmed instead. The trim is permitted only when a 10s peer probe confirms the newest copy holds
  the writer, and the give-up pass runs every 44 blocks — so the drive gets one attempt, and an
  earlier gate lost it with the product declining for entirely the right reason. `driveUntil` now
  waits for that peer to be answering before it drives another block, so the chain cannot advance
  into a pass through a window in which the pass would have to refuse. The budget is unchanged:
  driving longer would have bought a second coin toss rather than removing the coin.

  The gate is re-run per revision and this section carries the latest result at the head it names.







