### PR TITLE
Publish the tree hash into fluxhashes without wiping the directory

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -38,7 +38,13 @@ jobs:
       #
       # Each attempt re-syncs to origin/master before deciding, so it is idempotent and safe when
       # two builds publish at once: the loser of a push race re-reads, finds the list already moved
-      # on, and either adds its hash to the new tip or exits because someone else added it.
+      # on, and either adds its hash to the new tip or exits because nothing is left to change.
+      #
+      # Alongside the hash it records a provenance row -- date, commit, branch, tag -- in the same
+      # commit. The list itself is opaque md5s, and the commit that produced an entry can stop
+      # existing (a force-push, a branch deleted after merge), so the row is what makes an entry
+      # attributable later. A tag push finds its hash already listed and fills in the tag on the
+      # existing row.
       - name: Publish the tree hash to fluxhashes
         env:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
@@ -52,19 +58,41 @@ jobs:
             git fetch --quiet origin master
             git reset --quiet --hard origin/master
 
-            if grep -q "'${NEW_HASH}'" src/hashes/hashes.js; then
-              echo "already published: ${NEW_HASH}"
-              exit 0
+            if ! grep -q "'${NEW_HASH}'" src/hashes/hashes.js; then
+              sed -i "s/  ];/    '${NEW_HASH}',\n  ];/" src/hashes/hashes.js
             fi
 
-            sed -i "s/  ];/    '${NEW_HASH}',\n  ];/" src/hashes/hashes.js
-
-            # Refuse to publish a file that will not load. The list is served by requiring it, so a
-            # malformed edit would take the endpoint down rather than merely publishing something odd.
+            # Everything read from the environment inside a single-quoted script: in a double-quoted
+            # shell string the backticks and ${...} below would be the shell's, not node's.
             #
-            # Single-quoted, with the hash read from the environment: inside a double-quoted shell
-            # string the backticks below are command substitution and ${...} is the shell's, not
-            # node's.
+            # A row is only created, never rewritten -- a hash republished from another branch keeps
+            # its original attribution. The one later edit is a tag push filling in an empty tag.
+            node -e '
+              const fs = require("fs");
+              const FILE = "src/hashes/provenance.json";
+              const hash = process.env.NEW_HASH;
+              const isTag = process.env.GITHUB_REF_TYPE === "tag";
+              const record = fs.existsSync(FILE)
+                ? JSON.parse(fs.readFileSync(FILE, "utf8"))
+                : { hashes: {} };
+              if (!record.hashes) record.hashes = {};
+              const row = record.hashes[hash];
+              if (!row) {
+                record.hashes[hash] = {
+                  published: new Date().toISOString().slice(0, 10),
+                  commit: process.env.GITHUB_SHA,
+                  branch: isTag ? null : process.env.GITHUB_REF_NAME,
+                  tag: isTag ? process.env.GITHUB_REF_NAME : null,
+                };
+              } else if (isTag && !row.tag) {
+                row.tag = process.env.GITHUB_REF_NAME;
+              }
+              fs.writeFileSync(FILE, `${JSON.stringify(record, null, 2)}\n`);
+            '
+
+            # Refuse to publish files that will not load. The list is served by requiring it, so a
+            # malformed edit would take the endpoint down rather than merely publishing something
+            # odd; a malformed provenance record would take the signing run down.
             node -e '
               const expected = process.env.NEW_HASH;
               const hashes = require("./src/hashes/hashes").getHashes();
@@ -74,11 +102,20 @@ jobs:
               if (!hashes.includes(expected)) {
                 throw new Error("the new hash is not in the patched file");
               }
+              const record = JSON.parse(require("fs").readFileSync("src/hashes/provenance.json", "utf8"));
+              if (!record.hashes[expected]) {
+                throw new Error("the new hash has no provenance row");
+              }
               console.log(`hashes.js holds ${hashes.length} entries`);
             '
 
-            git add src/hashes/hashes.js
-            git commit --quiet -m "Update from https://github.com/RunOnFlux/flux/commit/${GITHUB_SHA}"
+            git add src/hashes/hashes.js src/hashes/provenance.json
+            if git diff --cached --quiet -- src/hashes/hashes.js src/hashes/provenance.json; then
+              echo "already published: ${NEW_HASH}"
+              exit 0
+            fi
+
+            git commit --quiet -m "Update from https://github.com/RunOnFlux/flux/commit/${GITHUB_SHA}" -- src/hashes/hashes.js src/hashes/provenance.json
 
             if git push --quiet; then
               echo "published ${NEW_HASH}"

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -61,16 +61,21 @@ jobs:
 
             # Refuse to publish a file that will not load. The list is served by requiring it, so a
             # malformed edit would take the endpoint down rather than merely publishing something odd.
-            node -e "
-              const hashes = require('./src/hashes/hashes').getHashes();
+            #
+            # Single-quoted, with the hash read from the environment: inside a double-quoted shell
+            # string the backticks below are command substitution and ${...} is the shell's, not
+            # node's.
+            node -e '
+              const expected = process.env.NEW_HASH;
+              const hashes = require("./src/hashes/hashes").getHashes();
               if (!Array.isArray(hashes) || !hashes.every((h) => /^[0-9a-f]{32}$/.test(h))) {
-                throw new Error('hashes.js did not parse as a list of md5s');
+                throw new Error("hashes.js did not parse as a list of md5s");
               }
-              if (!hashes.includes('${NEW_HASH}')) {
-                throw new Error('the new hash is not in the patched file');
+              if (!hashes.includes(expected)) {
+                throw new Error("the new hash is not in the patched file");
               }
               console.log(`hashes.js holds ${hashes.length} entries`);
-            "
+            '
 
             git add src/hashes/hashes.js
             git commit --quiet -m "Update from https://github.com/RunOnFlux/flux/commit/${GITHUB_SHA}"

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -29,34 +29,62 @@ jobs:
           newhash=$(find ./ZelBack -type f -exec md5sum {} + | awk '{print $1}' | LC_ALL=C sort | md5sum | awk '{printf $1}')
           echo $newhash
           echo NEW_HASH=$newhash >> $GITHUB_ENV
-      - name: Get current hashes
-        run: |
-          mkdir hashes
-          wget 'https://raw.githubusercontent.com/RunOnFlux/fluxhashes/master/src/hashes/hashes.js' -P hashes
-          hashfile=`cat hashes/hashes.js | sed "s/return/_/gi" | sed "s/\n/_/gi"`
-          echo HASH_FILE=$hashfile >> $GITHUB_ENV
-      - name: Show hashes
-        run: |
-          echo $HASH_FILE
-          echo $NEW_HASH
-      - name: Patch hashes
-        if: ${{ !contains(env.HASH_FILE, env.NEW_HASH) }}
-        run: |
-          newhash=$(find ./ZelBack -type f -exec md5sum {} + | awk '{print $1}' | LC_ALL=C sort | md5sum | awk '{printf $1}')
-          sed -i "s/  ];/    '$newhash',\n  ];/gi" hashes/hashes.js
-          tail -n 200 hashes/hashes.js
-      - name: Push hashes to fluxhashes
-        if: ${{ !contains(env.HASH_FILE, env.NEW_HASH) }}
-        uses: cpina/github-action-push-to-another-repository@main
+      # Publishes into fluxhashes in place.
+      #
+      # This previously pushed a directory containing only hashes.js into src/hashes/ using an
+      # action that deletes the destination directory before copying, so anything else kept there
+      # was removed on every build. Cloning and editing the file leaves the rest of the directory
+      # alone.
+      #
+      # Each attempt re-syncs to origin/master before deciding, so it is idempotent and safe when
+      # two builds publish at once: the loser of a push race re-reads, finds the list already moved
+      # on, and either adds its hash to the new tip or exits because someone else added it.
+      - name: Publish the tree hash to fluxhashes
         env:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
-        with:
-          source-directory: "hashes"
-          destination-github-username: "RunOnFlux"
-          destination-repository-name: "fluxhashes"
-          user-email: runonfluxbot@gmail.com
-          target-branch: master
-          target-directory: src/hashes/
+        run: |
+          git clone --quiet "https://x-access-token:${API_TOKEN_GITHUB}@github.com/RunOnFlux/fluxhashes.git" fluxhashes
+          cd fluxhashes
+          git config user.email runonfluxbot@gmail.com
+          git config user.name runonfluxbot
+
+          for attempt in 1 2 3; do
+            git fetch --quiet origin master
+            git reset --quiet --hard origin/master
+
+            if grep -q "'${NEW_HASH}'" src/hashes/hashes.js; then
+              echo "already published: ${NEW_HASH}"
+              exit 0
+            fi
+
+            sed -i "s/  ];/    '${NEW_HASH}',\n  ];/" src/hashes/hashes.js
+
+            # Refuse to publish a file that will not load. The list is served by requiring it, so a
+            # malformed edit would take the endpoint down rather than merely publishing something odd.
+            node -e "
+              const hashes = require('./src/hashes/hashes').getHashes();
+              if (!Array.isArray(hashes) || !hashes.every((h) => /^[0-9a-f]{32}$/.test(h))) {
+                throw new Error('hashes.js did not parse as a list of md5s');
+              }
+              if (!hashes.includes('${NEW_HASH}')) {
+                throw new Error('the new hash is not in the patched file');
+              }
+              console.log(`hashes.js holds ${hashes.length} entries`);
+            "
+
+            git add src/hashes/hashes.js
+            git commit --quiet -m "Update from https://github.com/RunOnFlux/flux/commit/${GITHUB_SHA}"
+
+            if git push --quiet; then
+              echo "published ${NEW_HASH}"
+              exit 0
+            fi
+            echo "push raced with another build, retrying"
+          done
+
+          echo "could not publish ${NEW_HASH} after 3 attempts"
+          exit 1
+
       - name: install flux and flux benchmark daemons
         run: |
           echo 'deb https://apt.runonflux.io/ '$(lsb_release -cs)' main' | sudo tee /etc/apt/sources.list.d/flux.list


### PR DESCRIPTION
## Background

fluxbench validates a FluxOS installation by checking its `ZelBack` tree hash against a list of known-good hashes, which this repository's CI publishes into [RunOnFlux/fluxhashes](https://github.com/RunOnFlux/fluxhashes) on every push. That list is becoming verifiable: [fluxhashes#2](https://github.com/RunOnFlux/fluxhashes/pull/2) signs it with Ed25519, and [#1788](https://github.com/RunOnFlux/flux/pull/1788) gates releases on the signed copy. **This PR is the publish side both of those depend on, and it merges first** — the current publish mechanism would delete the files they introduce.

The hash push uses `cpina/github-action-push-to-another-repository`, which deletes the destination directory before copying:

```sh
ABSOLUTE_TARGET_DIRECTORY="$CLONE_DIR/$TARGET_DIRECTORY/"   # = src/hashes/
rm -rf "$ABSOLUTE_TARGET_DIRECTORY"
mkdir -p "$ABSOLUTE_TARGET_DIRECTORY"
cp -ra "$SOURCE_DIRECTORY"/. "$CLONE_DIR/$TARGET_DIRECTORY"
```

The source directory we push holds only `hashes.js`, so **every build removes anything else kept in fluxhashes' `src/hashes/`**. Nothing else has lived there so far, but [RunOnFlux/fluxhashes#2](https://github.com/RunOnFlux/fluxhashes/pull/2) adds two files there — the signed copy of the list and the provenance record that anchors its sequence — and it also silently drops a hash whenever two builds publish at once, leaving a red X on a branch build as the only trace.

## What changes

Clones fluxhashes and edits `hashes.js` in place, leaving the rest of the directory alone.

- **Push races cannot lose a hash.** Three attempts, each re-syncing to `origin/master` before deciding, so the step is idempotent: the loser of a race re-reads and either adds its hash to the new tip or exits because nothing is left to change.
- **A malformed edit cannot be published.** The published list is served by `require`ing it, so a bad edit would take the endpoint down. The step refuses to push a `hashes.js` that does not load, is not a list of md5s, or does not contain the hash just added — and a provenance record that does not parse or is missing the new row.
- **The "already published" check reads the repository** rather than a `wget` of the raw file, so it cannot act on a stale CDN copy.

## The provenance record

Alongside the hash, each publish writes a row into `src/hashes/provenance.json` in the same commit: date, commit, branch, tag. The list itself is opaque md5s — nothing ties an entry to what produced it, and a commit referenced only by a commit message stops being resolvable when a branch is force-pushed or deleted after merge. The row is what keeps every entry attributable.

Rows are created, never rewritten: a hash republished from another branch keeps its original attribution. The one later edit is a tag push — it finds its hash already listed and fills in the tag on the existing row. The record sits outside the signed payload, so nothing that consumes the list changes.

## Tested

Against a local origin under Linux (GNU sed, `bash -e`, node 20 — the shape `ubuntu-latest` gives) and end to end on real GitHub in throwaway private copies of both repositories, driving the fluxhashes#2 signing workflow behind it.

| | |
|---|---|
| new hash | published with its provenance row, the rest of `src/hashes/` left intact |
| same hash again | no-op |
| malformed hash | exit 1, nothing published |
| corrupt provenance record | exit 1, nothing published |
| two builds racing | both hashes land, including a rejected push recovering on the retry |
| tag push | annotates the existing row exactly once; original date, commit and branch preserved |

Every hash CI computed in the live runs matched the locally computed value, and the resulting files load via `require`/`JSON.parse`.

Pairs with [RunOnFlux/fluxhashes#2](https://github.com/RunOnFlux/fluxhashes/pull/2), which adds the files this protects. Merging this one first avoids the first signed document being wiped by the next build.

## Not changed

The other use of that action — mirroring `ZelBack/src/services` into `fluxjsdocs` — is left alone. There the destination holds only what is pushed, so replacing the directory is exactly what it should do. The action is not the problem; using it for a destination that holds more than the source is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
