### PR TITLE
fix(networkstate): a node it has not heard of yet is not a node that is absent

### DIFF
--- a/ZelBack/src/services/fluxCommunication.js
+++ b/ZelBack/src/services/fluxCommunication.js
@@ -1502,12 +1502,29 @@ async function fluxDiscovery() {
 
 function initializeDiscovery() {
   nodeConfirmationService.onConfirmationChange((confirmed) => {
-    if (confirmed) {
-      peerManager.allowConnections();
-    } else {
+    if (!confirmed) {
       log.info('fluxDiscovery - Confirmation lost, disconnecting all peers');
       peerManager.disconnectAll();
+      return;
     }
+
+    // Confirmed is not the same as ready to peer. Every message an inbound peer
+    // sends is checked against the node list, so a peer that arrives before the
+    // list does is refused however legitimate it is - there is nothing to
+    // validate it against. The two facts come from different calls to the same
+    // daemon, one carrying a single record and one carrying every node, so the
+    // list lands well after the confirmation and that gap is the whole of the
+    // window peers were being turned away in.
+    //
+    // Only the first open waits: once the list is here isReady() is true and
+    // this runs inline, so regaining confirmation reconnects immediately.
+    networkStateService.onReady(() => {
+      // The wait is not instant, and confirmation can be lost inside it. Without
+      // this the callback would re-open the door straight after disconnectAll().
+      if (!nodeConfirmationService.isConfirmed()) return;
+
+      peerManager.allowConnections();
+    });
   });
 }
 

--- a/ZelBack/src/services/networkStateService.js
+++ b/ZelBack/src/services/networkStateService.js
@@ -116,9 +116,11 @@ function networkState(options = {}) {
 /**
  * Whether the node list has been fetched and indexed.
  *
- * Every accessor on this service answers an unknown state and a genuinely empty
- * one with the same value - an empty list, a zero, a null. Callers that would
- * read those differently ask this first rather than guessing.
+ * The bulk accessors - networkState(), nodeCount() - answer an unknown state
+ * and a genuinely empty one with the same value, so a caller that would read
+ * those differently asks this first rather than guessing. The lookups that
+ * answer a question about one node do not: they wait for the list rather than
+ * report it absent from a state that has never held it.
  * @returns {boolean}
  */
 function isReady() {

--- a/ZelBack/src/services/utils/networkStateManager.js
+++ b/ZelBack/src/services/utils/networkStateManager.js
@@ -395,6 +395,19 @@ class NetworkStateManager extends EventEmitter {
     this.#pubkeyIndex = new Map();
     this.#socketAddressIndex = new Map();
     this.#state = [];
+    // Back to un-started, which is the whole point of this method: the indexes
+    // above are empty again, so the manager must not go on saying it can answer
+    // from them. stop() releases anyone already waiting before it gets here, so
+    // rewinding cannot strand them - it only means the next start() has to
+    // fetch before anyone is answered, exactly as a freshly built one does.
+    this.#answerable = false;
+    this.#answerableWait = new Promise((resolve) => {
+      this.#onAnswerable = () => {
+        resolve();
+        this.#onAnswerable = () => {};
+      };
+    });
+    this.#started = false;
   }
 
   /**
@@ -542,6 +555,14 @@ class NetworkStateManager extends EventEmitter {
   async start() {
     await this.fetchNetworkState();
     await this.waitStarted;
+
+    // Only a manager that got its list runs a loop to keep it fresh. A stop
+    // landing during that first fetch breaks the loop without populating and
+    // then releases everything waiting - this included - so without this the
+    // updater is armed on a manager that has just been torn down. The abort
+    // flag cannot be read for it: abort() installs a fresh AbortController on
+    // its way out, so by here it may already say it was never aborted.
+    if (!this.#started) return;
 
     const updater = this.#stateEmitter && this.stateEvent
       ? this.#startEventEmitter

--- a/ZelBack/src/services/utils/networkStateManager.js
+++ b/ZelBack/src/services/utils/networkStateManager.js
@@ -67,6 +67,28 @@ class NetworkStateManager extends EventEmitter {
   });
 
   /**
+   * Whether a fetch has completed, so that what the indexes hold is what this
+   * node knows about the fleet - as distinct from having populated them, which
+   * an empty fleet never does.
+   */
+  #answerable = false;
+
+  /**
+   * @type {() => void | null}
+   */
+  #onAnswerable = null;
+
+  /**
+   * @type {Promise<void>}
+   */
+  #answerableWait = new Promise((resolve) => {
+    this.#onAnswerable = () => {
+      resolve();
+      this.#onAnswerable = () => {};
+    };
+  });
+
+  /**
    * @type { "polling" | "subscription" }
    */
   #updateTrigger = 'subscription';
@@ -175,6 +197,48 @@ class NetworkStateManager extends EventEmitter {
     return this.#controller.lock.waitReady();
   }
 
+  /**
+   * Resolves once a lookup can be answered truthfully.
+   *
+   * A node list has three conditions, not two. Never fetched: the node cannot
+   * answer, and the indexing lock is free at that point, so waiting on that
+   * alone reads an empty index and reports every node absent - the answer a
+   * node gives about a peer it has simply not heard of yet. Fetched and empty:
+   * it can answer, and "absent" is the truth. Fetched and populated: it answers
+   * from the index. Only the first of those waits.
+   *
+   * The indexing wait then still earns its place: mid-rebuild it costs ~10ms
+   * and returns the newer state.
+   * @returns {Promise<void>}
+   */
+  async #waitAnswerable() {
+    if (!this.#answerable) await this.#answerableWait;
+
+    await this.waitIndexesReady;
+  }
+
+  /**
+   * Marks the node able to answer questions about the fleet: a fetch has come
+   * back and the indexes hold what it returned.
+   * @returns {void}
+   */
+  #markAnswerable() {
+    this.#answerable = true;
+
+    if (this.#onAnswerable) this.#onAnswerable();
+  }
+
+  /**
+   * Releases anything waiting to be able to answer. Called when the manager
+   * stops, where no fetch is coming and a waiter would never return.
+   * @returns {void}
+   */
+  #releaseWaiters() {
+    if (this.#onStartComplete) this.#onStartComplete();
+
+    this.#markAnswerable();
+  }
+
   get nodeCount() {
     return this.#state.length;
   }
@@ -273,7 +337,7 @@ class NetworkStateManager extends EventEmitter {
    * @returns {Promise<string | null>} A random socketAddress from the map
    */
   async getRandomSocketAddress(localSocketAddress) {
-    await this.waitIndexesReady;
+    await this.#waitAnswerable();
 
     const indexSize = this.#socketAddressIndex.size;
 
@@ -376,8 +440,14 @@ class NetworkStateManager extends EventEmitter {
       const blockMsg = blockHeight ? `. Block height: ${blockHeight}` : '';
       log.info(elapsedMsg + blockMsg);
 
-      // eslint-disable-next-line no-await-in-loop
-      if (!state.length) await this.#controller.sleep(15_000);
+      if (!state.length) {
+        // An empty list is an answer, so lookups stop waiting here even though
+        // the loop keeps asking - it retries for a fleet, not for the ability
+        // to say there isn't one.
+        this.#markAnswerable();
+        // eslint-disable-next-line no-await-in-loop
+        await this.#controller.sleep(15_000);
+      }
     } while (!populated && !state.length);
 
     if (state.length) {
@@ -402,6 +472,10 @@ class NetworkStateManager extends EventEmitter {
       log.info(
         `pubkeyIndexSize: ${pubkeySize}, socketAddressSize: ${socketAddressSize}`,
       );
+
+      // after the build, never before it: between the fetch returning and the
+      // indexes being swapped in, the index a waiter would read is still empty
+      this.#markAnswerable();
 
       if (!populated) {
         this.emit('populated');
@@ -479,6 +553,8 @@ class NetworkStateManager extends EventEmitter {
   async stop() {
     await this.#controller.abort();
 
+    this.#releaseWaiters();
+
     if (this.#stateEmitter && this.#boundEventHandler) {
       this.#stateEmitter.removeListener(this.stateEvent, this.#boundEventHandler);
       if (this.progressEvent) {
@@ -504,9 +580,7 @@ class NetworkStateManager extends EventEmitter {
 
     if (!Object.keys(this.#indexes).includes(type)) return null;
 
-    // if we are mid stroke indexing, may as well wait the ~10ms and get the
-    // latest block
-    await this.waitIndexesReady;
+    await this.#waitAnswerable();
 
     const key = type === 'socketAddress' ? normalizeSocketAddress(filter) : filter;
     const cached = this.#indexes[type].get(key);
@@ -526,9 +600,7 @@ class NetworkStateManager extends EventEmitter {
     if (!filter) return false;
     if (!Object.keys(this.#indexes).includes(type)) return false;
 
-    // if we are mid stroke indexing, may as well wait the 10ms (max) and get the
-    // latest block
-    await this.waitIndexesReady;
+    await this.#waitAnswerable();
 
     const key = type === 'socketAddress' ? normalizeSocketAddress(filter) : filter;
     const found = this.#indexes[type].has(key);

--- a/ZelBack/src/services/utils/networkStateManager.js
+++ b/ZelBack/src/services/utils/networkStateManager.js
@@ -47,7 +47,7 @@ class NetworkStateManager extends EventEmitter {
   #lastFetchTime = BigInt(0);
 
   /**
-   * @type {() => Promise | null}
+   * @type {(() => Promise) | null}
    */
   #onStartComplete = null;
 
@@ -74,7 +74,7 @@ class NetworkStateManager extends EventEmitter {
   #answerable = false;
 
   /**
-   * @type {() => void | null}
+   * @type {(() => void) | null}
    */
   #onAnswerable = null;
 

--- a/tests/unit/fluxCommunication.test.js
+++ b/tests/unit/fluxCommunication.test.js
@@ -69,6 +69,87 @@ describe('fluxCommunication tests', () => {
     localWsServer.close(done);
   });
 
+  describe('initializeDiscovery tests', () => {
+    // Being confirmed is not the same as being ready to peer. Every message an
+    // inbound peer sends is checked against the node list, so a peer admitted
+    // before the list arrives is refused however legitimate it is. Measured at
+    // 1391ms on a live node holding 6091 nodes - short, but it is the whole of
+    // the window the node was turning real peers away in.
+    let onConfirmationChange;
+    let onReady;
+    let allowConnections;
+    let disconnectAll;
+
+    beforeEach(() => {
+      onConfirmationChange = sinon.stub(nodeConfirmationService, 'onConfirmationChange');
+      onReady = sinon.stub(networkStateService, 'onReady');
+      allowConnections = sinon.stub(peerManager, 'allowConnections');
+      disconnectAll = sinon.stub(peerManager, 'disconnectAll');
+      sinon.stub(log, 'info');
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    // Runs initializeDiscovery and hands back the confirmation callback it
+    // registered, which is the only way into this code.
+    function confirmationHandler() {
+      fluxCommunication.initializeDiscovery();
+
+      expect(onConfirmationChange.calledOnce).to.equal(true);
+
+      return onConfirmationChange.firstCall.args[0];
+    }
+
+    it('does not accept peers on confirmation alone', () => {
+      const confirmed = confirmationHandler();
+
+      confirmed(true);
+
+      expect(onReady.calledOnce).to.equal(true);
+      expect(allowConnections.called).to.equal(false);
+    });
+
+    it('accepts peers once the node list has arrived', () => {
+      sinon.stub(nodeConfirmationService, 'isConfirmed').returns(true);
+
+      const confirmed = confirmationHandler();
+
+      confirmed(true);
+      onReady.firstCall.args[0]();
+
+      expect(allowConnections.calledOnce).to.equal(true);
+    });
+
+    it('does not re-open after confirmation is lost while waiting for the list', () => {
+      // onReady fires whenever the list lands, which can be after a
+      // disconnectAll. Without the re-check this hands the door straight back.
+      const isConfirmed = sinon.stub(nodeConfirmationService, 'isConfirmed');
+      const confirmed = confirmationHandler();
+
+      confirmed(true);
+
+      isConfirmed.returns(false);
+      confirmed(false);
+
+      onReady.firstCall.args[0]();
+
+      expect(disconnectAll.calledOnce).to.equal(true);
+      expect(allowConnections.called).to.equal(false);
+    });
+
+    it('disconnects every peer when confirmation is lost, without consulting the list', () => {
+      const confirmed = confirmationHandler();
+
+      confirmed(false);
+
+      expect(disconnectAll.calledOnce).to.equal(true);
+      expect(onReady.called).to.equal(false);
+      expect(allowConnections.called).to.equal(false);
+    });
+  });
+
   describe('handleAppMessages tests', () => {
     const privateKey = 'KxA2iy4aVuVKXsK8pBnJGM9vNm4z6PLNRTzsPuSFBw6vWL5StbqD';
     const ownerAddress = '13ienDRfUwFEgfZxm5dk4drTQsmj5hDGwL';

--- a/tests/unit/networkStateManager.test.js
+++ b/tests/unit/networkStateManager.test.js
@@ -434,6 +434,128 @@ describe('networkStateManager tests', () => {
     expect(response).to.equal(null);
   });
 
+  describe('lookups before the first population', () => {
+    const knownPubkey = '04d50620a31f045c61be42bad44b7a9424ffb6de37bf256b88f00e118e59736165255f2f4585b36c7e1f8f3e20db4fa4e55e61cc01dc7a5cd2b2ed0153627588dc';
+
+    let nsm;
+    let releaseFetch;
+
+    async function flush() {
+      await new Promise((r) => { setImmediate(r); });
+    }
+
+    beforeEach(() => {
+      const blockEmitter = new EventEmitter();
+
+      const options = {
+        stateEvent: 'blocksProcessed',
+        stateEmitter: blockEmitter,
+      };
+
+      const firstFetch = new Promise((resolve) => { releaseFetch = resolve; });
+
+      fetcher.callsFake(async () => {
+        await firstFetch;
+        return defaultNetworkState;
+      });
+
+      nsm = new NetworkStateManager(fetcher, options);
+    });
+
+    it('does not report a node absent while the fleet is still unknown', async () => {
+      const startPromise = nsm.start();
+
+      let answered = false;
+      let found = null;
+
+      async function askEarly() {
+        found = await nsm.includes(knownPubkey, 'pubkey');
+        answered = true;
+      }
+
+      const lookup = askEarly();
+
+      await flush();
+
+      expect(answered).to.equal(false);
+
+      releaseFetch();
+      await startPromise;
+      await lookup;
+
+      expect(found).to.equal(true);
+
+      await nsm.stop();
+    });
+
+    it('does not draw a null peer while the fleet is still unknown', async () => {
+      const startPromise = nsm.start();
+
+      let answered = false;
+      let address = null;
+
+      async function askEarly() {
+        address = await nsm.getRandomSocketAddress('203.0.113.1:16127');
+        answered = true;
+      }
+
+      const lookup = askEarly();
+
+      await flush();
+
+      expect(answered).to.equal(false);
+
+      releaseFetch();
+      await startPromise;
+      await lookup;
+
+      expect(address).to.be.a('string');
+
+      await nsm.stop();
+    });
+
+    it('answers absent once a fetch has come back empty', async () => {
+      fetcher.callsFake(async () => []);
+
+      // start() does not resolve here: the loop keeps asking until it gets a
+      // fleet. The lookup is what has to come back - an empty list is a
+      // truthful "absent", not a state that cannot answer.
+      const startPromise = nsm.start();
+
+      const response = await nsm.search(knownPubkey, 'pubkey');
+
+      expect(response).to.equal(null);
+
+      await nsm.stop();
+
+      try {
+        await startPromise;
+      } catch (error) {
+        // stopping interrupts the retry sleep, which is how the loop ends here
+      }
+    });
+
+    it('releases a waiting lookup when the manager is stopped', async () => {
+      const startPromise = nsm.start();
+
+      const lookup = nsm.search(knownPubkey, 'pubkey');
+
+      await flush();
+
+      // The fleet never arrives here. A stop is the other way a lookup becomes
+      // answerable: no population is coming, so a waiter still holding out for
+      // one would never return.
+      await nsm.stop();
+
+      const response = await lookup;
+
+      expect(response).to.equal(null);
+
+      releaseFetch();
+      await startPromise;
+    });
+  });
+
   it('should set the indexesReady property to false if indexes are being built', async () => {
     const dummyElement = {
       collateral: 'COutPoint(43c9ae0313fc128d0fb4327f5babc7868fe557135b58e0a7cb475cdd8819f8c8, 0)',

--- a/tests/unit/networkStateManager.test.js
+++ b/tests/unit/networkStateManager.test.js
@@ -535,6 +535,212 @@ describe('networkStateManager tests', () => {
       }
     });
 
+    it('arms no refresh loop when the stop lands after a retry sleep', async () => {
+      // The one way into it. A fetch that comes back empty sleeps before asking
+      // again; aborting DURING that sleep rejects it and start() throws, so it
+      // never reaches the updater. Aborting once the sleep has fired is the
+      // narrow case that gets through: the loop wakes, sees the abort at the
+      // top, breaks without populating, and start() carries on to arm a loop on
+      // a manager that has just been torn down.
+      const clock = sinon.useFakeTimers({ toFake: ['setTimeout'] });
+
+      try {
+        fetcher.callsFake(async () => []);
+
+        const startPromise = nsm.start();
+
+        // First fetch comes back empty and the retry sleep is armed.
+        await clock.tickAsync(0);
+        const askedBeforeSleep = fetcher.callCount;
+        expect(askedBeforeSleep).to.be.greaterThan(0);
+
+        // Fire the sleep rather than abort it: the timer is consumed here, so
+        // the abort below has no timeout left to reject. tick() rather than
+        // tickAsync() so the loop has not resumed and armed the NEXT sleep -
+        // aborting that one rejects it and start() throws instead, which is the
+        // path that already cannot arm anything.
+        clock.tick(15_000);
+
+        const stopPromise = nsm.stop();
+        await startPromise;
+        await stopPromise;
+
+        // A refresh loop would keep asking. Nothing should be asking now.
+        const askedAfterStop = fetcher.callCount;
+        await clock.tickAsync(120_000);
+
+        expect(fetcher.callCount).to.equal(askedAfterStop);
+      } finally {
+        clock.restore();
+      }
+    });
+
+    describe('after a stop, on the same instance', () => {
+      // stop() empties the indexes, so the instance must stop saying it can
+      // answer from them - otherwise a restarted manager reports every node
+      // absent until its own first fetch lands, which is the defect this whole
+      // class of wait exists to close.
+      //
+      // Nothing restarts one in production: networkStateService drops the
+      // instance and builds a fresh one. That is the service's arrangement
+      // though, not a promise this class makes about itself.
+
+      // A fetcher held shut until the test says otherwise, so a restart can be
+      // examined in the window between start() and the fetch coming back.
+      // Held by whichever promise is current when a run begins: the loop is
+      // free to ask more than once, and every one of those waits.
+      function gatedFetcher() {
+        let open;
+        let shut;
+
+        function close() {
+          shut = new Promise((resolve) => { open = resolve; });
+        }
+
+        close();
+
+        fetcher.callsFake(async () => {
+          await shut;
+          return defaultNetworkState;
+        });
+
+        return {
+          close,
+          async release() {
+            open();
+            await flush();
+          },
+        };
+      }
+
+      async function startAndPopulate(gate) {
+        const started = nsm.start();
+        await gate.release();
+        await started;
+        gate.close();
+      }
+
+      it('reports itself un-started, so nothing arms a loop on it', async () => {
+        // start() only switches on the refresh loop for a manager that got its
+        // list. Leaving `started` true after a stop tells it - and isReady() -
+        // that a torn-down manager is running.
+        const gate = gatedFetcher();
+
+        await startAndPopulate(gate);
+        expect(nsm.started).to.equal(true);
+
+        await nsm.stop();
+
+        expect(nsm.started).to.equal(false);
+      });
+
+      it('does not answer from the empty index until its own fetch returns', async () => {
+        const gate = gatedFetcher();
+
+        await startAndPopulate(gate);
+        expect(await nsm.includes(knownPubkey, 'pubkey')).to.equal(true);
+
+        await nsm.stop();
+
+        const restarted = nsm.start();
+
+        let answered = false;
+        const lookup = nsm.includes(knownPubkey, 'pubkey').then((found) => {
+          answered = true;
+          return found;
+        });
+
+        await flush();
+
+        // The index is empty here. Answering at all would answer `false`.
+        expect(answered).to.equal(false);
+
+        await gate.release();
+        await restarted;
+
+        expect(await lookup).to.equal(true);
+
+        await nsm.stop();
+      });
+
+      it('holds every lookup that can report a node absent, not just one', async () => {
+        const gate = gatedFetcher();
+
+        await startAndPopulate(gate);
+        await nsm.stop();
+
+        const restarted = nsm.start();
+
+        const answered = { search: false, includes: false, random: false };
+        const lookups = [
+          nsm.search(knownPubkey, 'pubkey').then(() => { answered.search = true; }),
+          nsm.includes(knownPubkey, 'pubkey').then(() => { answered.includes = true; }),
+          nsm.getRandomSocketAddress('203.0.113.1:16127').then(() => { answered.random = true; }),
+        ];
+
+        await flush();
+
+        expect(answered).to.deep.equal({ search: false, includes: false, random: false });
+
+        await gate.release();
+        await restarted;
+        await Promise.all(lookups);
+
+        expect(answered).to.deep.equal({ search: true, includes: true, random: true });
+
+        await nsm.stop();
+      });
+
+      it('answers absent promptly when the restarted fleet comes back empty', async () => {
+        // The rewind must not turn the legitimately empty fleet into a hang:
+        // a fetch that comes back with nothing is a truthful "absent".
+        const gate = gatedFetcher();
+
+        await startAndPopulate(gate);
+        await nsm.stop();
+
+        fetcher.callsFake(async () => []);
+
+        const restarted = nsm.start();
+
+        expect(await nsm.includes(knownPubkey, 'pubkey')).to.equal(false);
+
+        await nsm.stop();
+
+        try {
+          await restarted;
+        } catch (error) {
+          // the retry loop ends by being stopped, as it does elsewhere here
+        }
+      });
+
+      it('rewinds on every stop, not only the first', async () => {
+        const gate = gatedFetcher();
+
+        await startAndPopulate(gate);
+        await nsm.stop();
+        await startAndPopulate(gate);
+        await nsm.stop();
+
+        const restarted = nsm.start();
+
+        let answered = false;
+        const lookup = nsm.includes(knownPubkey, 'pubkey').then(() => { answered = true; });
+
+        await flush();
+
+        expect(answered).to.equal(false);
+
+        await gate.release();
+        await restarted;
+        await lookup;
+
+        expect(answered).to.equal(true);
+
+        await nsm.stop();
+      });
+    });
+
     it('releases a waiting lookup when the manager is stopped', async () => {
       const startPromise = nsm.start();
 


### PR DESCRIPTION
Three lookups on `networkStateManager` answered questions about the fleet before the node had ever asked what the fleet was, and the answer they gave was "absent".

## The defect

`search()`, `includes()` and `getRandomSocketAddress()` each awaited `waitIndexesReady`. That getter is `this.#controller.lock.waitReady()` — the *indexing* lock. Before the first fetch has ever run the lock is free, so the await returns immediately and the lookup reads an empty index. Every node in the fleet comes back absent, and nothing distinguishes that from a node genuinely not being one.

The wait that means "I know the fleet" is a different one. `waitIndexesReady` is about not reading mid-rebuild; it says nothing about whether there has ever been anything to read.

## How it was found

An integration suite caught a node reporting a legitimate peer as not being in the node list, 58 ms before it logged creating its first index:

```
Network State Indexes created, nodes found: 3
pubkeyIndexSize: 3, socketAddressSize: 3
```

The membership question had been answered from an index that did not yet exist. Callers that treat a falsy answer as "not a node" then act on it, and a node that has simply not read the fleet yet is indistinguishable from one that is not in it.

What that cost downstream: the peer refused the sync request, so the requesting node collected no completions and took the block-timer route to readiness instead — which is what that fallback is for. Nothing downstream needed changing. The only thing that was wrong was the answer that sent it down that path.

## The fix

A node list has three conditions, not two, and the code modelled two:

- **never fetched** — cannot answer, must wait
- **fetched and empty** — can answer, and "absent" is the truth
- **fetched and populated** — answers from the index

What is tracked is the first fetch *coming back*, not the first *population*. Those differ exactly when the fleet is legitimately empty: a list that never populates would leave a lookup waiting for the life of the process, which trades a false answer for a hang. Suites that run with `nodes: 0` reach that case.

`#waitAnswerable()` keeps the indexing wait on top of the new one. Mid-rebuild it costs ~10 ms and returns the newer state, which is why it was there; it simply was never the whole condition. Waiters are also released when the manager stops, where no fetch is coming and a waiter would otherwise never return.

A timeout was considered and rejected: bounding the wait reintroduces the false answer on a slow node and only changes when it happens.

## Blast radius

These three lookups back `getFluxnodesByPubkey`, `socketAddressInNetworkState`, `pubkeyInNetworkState`, `getRandomSocketAddress` and `getFluxnodeBySocketAddress` on `networkStateService`, which are used across peering, messaging, app sync, port testing and availability checking. The `isReady()` docblock claimed every accessor on that service conflates unknown with empty; that is now true only of the bulk accessors, and it says so.

## Testing

Each test was proven to fail without the fix. The two false-answer tests assert immediately against the old code; the empty-fleet test times out.

**Unit:** 4,873 passing / 18 pending / 0 failing on this branch, four of them new. `eslint` clean on all three changed files.

**Integration, targeted:** the nine suites this change most directly touches — `06-daemon-interaction` and `12-ticker-control` because they run with empty and shrinking node lists, `19-boundary-conditions` because it is the suite that surfaced the defect, and `72`, `73`, `74`, `75`, `81`, `82` because `getRandomSocketAddress` is how a node draws a peer for an image. All nine green, 92 tests, zero failures.

**Integration, full gate:** `suites_pass=72 suites_fail=1` at `40a10a4ba`. `19-boundary-conditions` — the suite that surfaced this defect, and the one that failed the same gate on the same tree without this fix — **passes**. The single red is `60-volume-mount-ownership`, which neither this branch nor #1778 touches and which is already fixed in [#1781](https://github.com/RunOnFlux/flux/pull/1781) higher up the stack: its probe stopped the app container before unmounting, and the stop's own die event drives a reconcile that remounts the volume, so the write it expects to be refused lands on a remounted one. It passes 8/8 run alone.

**Worth stating plainly about that gate:** it runs on #1778's tree with this fix applied, not on this branch. #1778's suite set is a strict superset of `development`'s — the same 69 suites plus six volume ones, with nothing present only on `development` — and of the three files changed here, the manager and its unit test are byte-identical on both branches, while the service file differs only by a test-only addition #1778 makes in a different part of it. So the gate exercises every suite this branch would run and six more. It is not, however, literally a gate of this branch.
