### PR TITLE
Validate an app owner as an identity a signature can verify against

### DIFF
--- a/ZelBack/src/services/appRequirements/appValidator.js
+++ b/ZelBack/src/services/appRequirements/appValidator.js
@@ -8,6 +8,7 @@ const daemonServiceMiscRpcs = require('../daemonService/daemonServiceMiscRpcs');
 const fluxCommunicationMessagesSender = require('../fluxCommunicationMessagesSender');
 const registryManager = require('../appDatabase/registryManager');
 const messageVerifier = require('../appMessaging/messageVerifier');
+const signatureVerifier = require('../signatureVerifier');
 const imageManager = require('../appSecurity/imageManager');
 // const advancedWorkflows = require('../appLifecycle/advancedWorkflows'); // Moved to dynamic require to avoid circular dependency
 // eslint-disable-next-line no-unused-vars
@@ -1217,11 +1218,12 @@ function checkComposeHWParameters(appSpecsComposed) {
  * Validates specs including hardware requirements, architecture compatibility, and Docker compliance
  * @param {object} appSpecifications - Application specifications to validate
  * @param {number} height - Block height for validation context
- * @param {boolean} checkDockerAndWhitelist - Whether to check Docker, whitelist, and architecture requirements
+ * @param {boolean} liveSubmission - Whether the spec is being submitted now through the API, rather than
+ * replayed from a message already on chain. Gates the checks that only hold for a spec being accepted today.
  * @returns {Promise<boolean>} True if validation passes
  * @throws {Error} If validation fails (e.g., incompatible architectures, missing requirements)
  */
-async function verifyAppSpecifications(appSpecifications, height, checkDockerAndWhitelist = false) {
+async function verifyAppSpecifications(appSpecifications, height, liveSubmission = false) {
   if (!appSpecifications) {
     throw new Error('Invalid Flux App Specifications');
   }
@@ -1234,6 +1236,14 @@ async function verifyAppSpecifications(appSpecifications, height, checkDockerAnd
 
   // TYPE CHECKS
   verifyTypeCorrectnessOfApp(appSpecifications);
+
+  // OWNER IDENTITY
+  // Updates verify against the owner already on record, so the incoming owner is
+  // never used as a key and an owner that cannot be signed for is accepted. Held
+  // to live submissions only - messages already on chain replay unchanged.
+  if (liveSubmission && !signatureVerifier.isValidSigningIdentity(appSpecifications.owner)) {
+    throw new Error('Invalid Flux App owner. Must be a Flux ID or an Ethereum address');
+  }
 
   // RESTRICTION CHECKS
   verifyRestrictionCorrectnessOfApp(appSpecifications, height);
@@ -1258,7 +1268,7 @@ async function verifyAppSpecifications(appSpecifications, height, checkDockerAnd
   }
 
   // Whitelist, repository checks
-  if (checkDockerAndWhitelist) {
+  if (liveSubmission) {
     // check blacklist
     await imageManager.checkApplicationImagesCompliance(appSpecifications);
 

--- a/ZelBack/src/services/idService.js
+++ b/ZelBack/src/services/idService.js
@@ -14,8 +14,6 @@ const fluxNetworkHelper = require('./fluxNetworkHelper');
 const appInspector = require('./appManagement/appInspector');
 const signatureVerifier = require('./signatureVerifier');
 
-const goodchars = /^[1-9a-km-zA-HJ-NP-Z]+$/;
-
 async function deleteLoginPhrase(phrase) {
   try {
     const db = dbHelper.databaseConnection();
@@ -28,7 +26,6 @@ async function deleteLoginPhrase(phrase) {
     log.error(error);
   }
 }
-const ethRegex = /^0x[a-fA-F0-9]{40}$/;
 
 let syncthingWorking = false;
 
@@ -256,18 +253,7 @@ async function verifyLogin(req, res) {
         throw new Error('No Flux ID is specified');
       }
 
-      if (address[0] !== '1' && address[0] !== '0') {
-        throw new Error('Flux ID is not valid');
-      }
-
-      if (address[0] === '1') {
-        if (!goodchars.test(address)) {
-          throw new Error('Flux ID is not valid');
-        }
-        if (address.length > 34 || address.length < 25) {
-          throw new Error('Flux ID is not valid');
-        }
-      } else if (!ethRegex.test(address)) {
+      if (!signatureVerifier.isValidSigningIdentity(address)) {
         throw new Error('Flux ID is not valid');
       }
 
@@ -395,18 +381,7 @@ async function provideSign(req, res) {
         throw new Error('No Flux ID is specified');
       }
 
-      if (address[0] !== '1' && address[0] !== '0') {
-        throw new Error('Flux ID is not valid');
-      }
-
-      if (address[0] === '1') {
-        if (!goodchars.test(address)) {
-          throw new Error('Flux ID is not valid');
-        }
-        if (address.length > 34 || address.length < 25) {
-          throw new Error('Flux ID is not valid');
-        }
-      } else if (!ethRegex.test(address)) {
+      if (!signatureVerifier.isValidSigningIdentity(address)) {
         throw new Error('Flux ID is not valid');
       }
 

--- a/ZelBack/src/services/signatureVerifier.js
+++ b/ZelBack/src/services/signatureVerifier.js
@@ -1,7 +1,48 @@
+const bs58check = require('bs58check');
 const { pubKeyToAddr } = require('./utils/fluxCryptoUtils');
 const bitcoinMessage = require('bitcoinjs-message');
 const ethereumHelper = require('./ethereumHelper');
 const log = require('../lib/log');
+
+const base58Chars = /^[1-9a-km-zA-HJ-NP-Z]+$/;
+const ethAddress = /^0x[a-fA-F0-9]{40}$/;
+
+/**
+ * Whether an identity is one a signature can be verified against - a Flux ID
+ * (base58check P2PKH) or an Ethereum address.
+ *
+ * Login identities and app owners are both held to this. An app owner that is
+ * neither can never be signed for, which leaves the app unmanageable by anyone.
+ *
+ * @param {string} identity
+ *
+ * @returns {bool} isValid
+ */
+function isValidSigningIdentity(identity) {
+  if (!identity || typeof identity !== 'string') {
+    return false;
+  }
+
+  if (identity.startsWith('0x')) {
+    return ethAddress.test(identity);
+  }
+
+  if (identity[0] !== '1' || identity.length < 25 || identity.length > 34) {
+    return false;
+  }
+
+  if (!base58Chars.test(identity)) {
+    return false;
+  }
+
+  try {
+    // version byte + hash160. A bad checksum throws, and would fail signature
+    // verification just as surely as the wrong shape.
+    return bs58check.decode(identity).length === 21;
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Verifies signature of application owner on bitcoin or ethereum networks
@@ -41,5 +82,6 @@ function verifySignature(message, address, signature) {
 }
 
 module.exports = {
+  isValidSigningIdentity,
   verifySignature,
 };

--- a/tests/unit/appValidator.test.js
+++ b/tests/unit/appValidator.test.js
@@ -159,7 +159,7 @@ describe('appValidator tests', () => {
         name: 'testapp',
         version: 999,
         description: 'Test app',
-        owner: '1owner',
+        owner: '1Jwh4djGdRPvgLwXNGsGCoPE7uu4vihbEg',
         enterprise: false,
       };
 
@@ -177,7 +177,7 @@ describe('appValidator tests', () => {
         name: 'testapp',
         version: 4,
         description: 'Test app',
-        owner: '1owner',
+        owner: '1Jwh4djGdRPvgLwXNGsGCoPE7uu4vihbEg',
         compose: [{
           name: 'component1',
           description: 'Component 1',
@@ -201,6 +201,63 @@ describe('appValidator tests', () => {
     });
   });
 
+  describe('owner identity validation', () => {
+    function specsOwnedBy(owner) {
+      return {
+        name: 'testapp',
+        version: 4,
+        description: 'Test app',
+        owner,
+        compose: [{
+          name: 'component1',
+          description: 'Component 1',
+          repotag: 'nginx:latest',
+          ports: [],
+          domains: [],
+          environmentParameters: [],
+          commands: [],
+          containerPorts: [],
+          containerData: '/data',
+          cpu: 0.5,
+          ram: 500,
+          hdd: 5,
+          tiered: false,
+        }],
+        instances: 3,
+      };
+    }
+
+    it('should reject an owner that is not a signing identity on a live submission', async () => {
+      try {
+        await appValidator.verifyAppSpecifications(specsOwnedBy('TrippleCore'), 1000, true);
+        expect.fail('Should have thrown error');
+      } catch (error) {
+        expect(error.message).to.include('Invalid Flux App owner');
+      }
+    });
+
+    it('should reject a base58 owner whose checksum does not hold on a live submission', async () => {
+      try {
+        await appValidator.verifyAppSpecifications(specsOwnedBy('1Jwh4djGdRPvgLwXNGsGCoPE7uu4vihbEh'), 1000, true);
+        expect.fail('Should have thrown error');
+      } catch (error) {
+        expect(error.message).to.include('Invalid Flux App owner');
+      }
+    });
+
+    it('should accept a Flux ID owner on a live submission', async () => {
+      await appValidator.verifyAppSpecifications(specsOwnedBy('1Jwh4djGdRPvgLwXNGsGCoPE7uu4vihbEg'), 1000, true);
+    });
+
+    it('should accept an ethereum owner on a live submission', async () => {
+      await appValidator.verifyAppSpecifications(specsOwnedBy('0x2b8e7f6e8f0b6f4c6f8e2b8e7f6e8f0b6f4c6f8e'), 1000, true);
+    });
+
+    it('should accept an owner that is not a signing identity when replaying a message already on chain', async () => {
+      await appValidator.verifyAppSpecifications(specsOwnedBy('TrippleCore'), 1000);
+    });
+  });
+
   describe('exported functions', () => {
     it('should export validation functions', () => {
       expect(appValidator.verifyAppSpecifications).to.be.a('function');
@@ -219,7 +276,7 @@ describe('appValidator tests', () => {
           name: 'testarcane',
           version: 8,
           description: 'Test Arcane app',
-          owner: '1owner',
+          owner: '1Jwh4djGdRPvgLwXNGsGCoPE7uu4vihbEg',
           enterprise: true,
           contacts: ['contact@example.com'],
           geolocation: [],
@@ -259,7 +316,7 @@ describe('appValidator tests', () => {
           name: 'testarcane',
           version: 8,
           description: 'Test Arcane app',
-          owner: '1owner',
+          owner: '1Jwh4djGdRPvgLwXNGsGCoPE7uu4vihbEg',
           enterprise: true,
           contacts: ['contact@example.com'],
           geolocation: [],
@@ -306,7 +363,7 @@ describe('appValidator tests', () => {
           name: 'testv7enterprise',
           version: 7,
           description: 'Test v7 enterprise app',
-          owner: '1owner',
+          owner: '1Jwh4djGdRPvgLwXNGsGCoPE7uu4vihbEg',
           contacts: ['contact@example.com'],
           geolocation: [],
           expire: 88000,
@@ -351,7 +408,7 @@ describe('appValidator tests', () => {
           name: 'testv7enterprise',
           version: 7,
           description: 'Test v7 enterprise app',
-          owner: '1owner',
+          owner: '1Jwh4djGdRPvgLwXNGsGCoPE7uu4vihbEg',
           contacts: ['contact@example.com'],
           geolocation: [],
           expire: 88000,
@@ -416,7 +473,7 @@ describe('appValidator tests', () => {
           name: 'testapp',
           version: 4,
           description: 'Test app',
-          owner: '1owner',
+          owner: '1Jwh4djGdRPvgLwXNGsGCoPE7uu4vihbEg',
           compose: [
             {
               name: 'component1',
@@ -471,7 +528,7 @@ describe('appValidator tests', () => {
           name: 'testapp',
           version: 4,
           description: 'Test app',
-          owner: '1owner',
+          owner: '1Jwh4djGdRPvgLwXNGsGCoPE7uu4vihbEg',
           compose: [
             {
               name: 'component1',

--- a/tests/unit/idService.test.js
+++ b/tests/unit/idService.test.js
@@ -635,7 +635,7 @@ describe('idService tests', () => {
 
     it('should return error if the message is empty', async () => {
       const req = {
-        zelid: '1Z1234341Z1234341Z1234341Z1234341',
+        zelid: '1Jwh4djGdRPvgLwXNGsGCoPE7uu4vihbEg',
         signature: '1234356asdf',
         message: '',
       };
@@ -659,7 +659,7 @@ describe('idService tests', () => {
 
     it('should return error if message is undefined', async () => {
       const req = {
-        zelid: '1Z1234341Z1234341Z1234341Z1234341',
+        zelid: '1Jwh4djGdRPvgLwXNGsGCoPE7uu4vihbEg',
         signature: '1234356asdf',
       };
       const mockStream = new PassThrough();
@@ -682,7 +682,7 @@ describe('idService tests', () => {
 
     it('should return error if message is less than 40 chars', async () => {
       const req = {
-        zelid: '1Z1234341Z1234341Z1234341Z1234341',
+        zelid: '1Jwh4djGdRPvgLwXNGsGCoPE7uu4vihbEg',
         signature: '1234356asdf',
         message: '1234',
       };
@@ -706,7 +706,7 @@ describe('idService tests', () => {
 
     it('should return error if message first 13 chars timestamp is too low', async () => {
       const req = {
-        zelid: '1Z1234341Z1234341Z1234341Z1234341',
+        zelid: '1Jwh4djGdRPvgLwXNGsGCoPE7uu4vihbEg',
         signature: '1234356asdf',
         message: '111111111111111111111111111111111111111111111',
       };
@@ -730,7 +730,7 @@ describe('idService tests', () => {
 
     it('should return error if message first 13 chars timestamp is too high', async () => {
       const req = {
-        zelid: '1Z1234341Z1234341Z1234341Z1234341',
+        zelid: '1Jwh4djGdRPvgLwXNGsGCoPE7uu4vihbEg',
         signature: '1234356asdf',
         message: '999999999999911111111111111111111111111111111',
       };
@@ -758,7 +758,7 @@ describe('idService tests', () => {
       await dbHelper.initiateDB();
       dbHelper.databaseConnection();
       const req = {
-        zelid: '1Z1234341Z1234341Z1234341Z1234341',
+        zelid: '1Jwh4djGdRPvgLwXNGsGCoPE7uu4vihbEg',
         signature: '1234356asdf',
         message: `${timestamp - 300000}11111111111111111111111111111`,
       };
@@ -789,7 +789,7 @@ describe('idService tests', () => {
       await dbHelper.initiateDB();
       dbHelper.databaseConnection();
       const req = {
-        zelid: '1Z1234341Z1234341Z1234341Z1234341',
+        zelid: '1Jwh4djGdRPvgLwXNGsGCoPE7uu4vihbEg',
         signature: '1234356asdf',
         message: `${timestamp - 300000}11111111111111111111111111111`,
       };
@@ -821,7 +821,7 @@ describe('idService tests', () => {
       await dbHelper.initiateDB();
       dbHelper.databaseConnection();
       const req = {
-        zelid: '1Z1234341Z1234341Z1234341Z1234341',
+        zelid: '1Jwh4djGdRPvgLwXNGsGCoPE7uu4vihbEg',
         signature: '1234356asdf',
         message: `${timestamp - 300000}11111111111111111111111111111`,
       };
@@ -854,7 +854,7 @@ describe('idService tests', () => {
       await dbHelper.initiateDB();
       dbHelper.databaseConnection();
       const req = {
-        zelid: '1Z1234341Z1234341Z1234341Z1234341',
+        zelid: '1Jwh4djGdRPvgLwXNGsGCoPE7uu4vihbEg',
         signature: '1234356asdf',
         message: `${timestamp - 300000}11111111111111111111111111111`,
       };
@@ -866,7 +866,7 @@ describe('idService tests', () => {
         status: 'success',
         data: {
           message: 'Successfully logged in',
-          zelid: '1Z1234341Z1234341Z1234341Z1234341',
+          zelid: '1Jwh4djGdRPvgLwXNGsGCoPE7uu4vihbEg',
           loginPhrase: sinon.match.string,
           signature: '1234356asdf',
           privilage: 'user',
@@ -992,7 +992,7 @@ describe('idService tests', () => {
 
     it('should return error if the message is empty', async () => {
       const req = {
-        zelid: '1Z1234341Z1234341Z1234341Z1234341',
+        zelid: '1Jwh4djGdRPvgLwXNGsGCoPE7uu4vihbEg',
         signature: '1234356asdf',
         message: '',
       };
@@ -1016,7 +1016,7 @@ describe('idService tests', () => {
 
     it('should return error if message is undefined', async () => {
       const req = {
-        zelid: '1Z1234341Z1234341Z1234341Z1234341',
+        zelid: '1Jwh4djGdRPvgLwXNGsGCoPE7uu4vihbEg',
         signature: '1234356asdf',
       };
       const mockStream = new PassThrough();
@@ -1039,7 +1039,7 @@ describe('idService tests', () => {
 
     it('should return error if message is less than 40 chars', async () => {
       const req = {
-        zelid: '1Z1234341Z1234341Z1234341Z1234341',
+        zelid: '1Jwh4djGdRPvgLwXNGsGCoPE7uu4vihbEg',
         signature: '1234356asdf',
         message: '1234',
       };
@@ -1071,7 +1071,7 @@ describe('idService tests', () => {
       await dbHelper.initiateDB();
       dbHelper.databaseConnection();
       const req = {
-        zelid: '1Z1234341Z1234341Z1234341Z1234341',
+        zelid: '1Jwh4djGdRPvgLwXNGsGCoPE7uu4vihbEg',
         signature: '1234356asdf',
         message: `${timestamp - 300000}11111111111111111111111111111`,
       };
@@ -1082,7 +1082,7 @@ describe('idService tests', () => {
       const expectedError = {
         status: 'success',
         data: {
-          identifier: '1Z1234341Z1234341Z1234341Z12343411111111111111',
+          identifier: '1Jwh4djGdRPvgLwXNGsGCoPE7uu4vihbEg1111111111111',
           signature: '1234356asdf',
         },
       };

--- a/tests/unit/signatureVerifier.test.js
+++ b/tests/unit/signatureVerifier.test.js
@@ -1,0 +1,47 @@
+const { expect } = require('chai');
+
+const signatureVerifier = require('../../ZelBack/src/services/signatureVerifier');
+
+describe('signatureVerifier tests', () => {
+  describe('isValidSigningIdentity tests', () => {
+    it('should accept a Flux ID', () => {
+      expect(signatureVerifier.isValidSigningIdentity('1Jwh4djGdRPvgLwXNGsGCoPE7uu4vihbEg')).to.equal(true);
+    });
+
+    it('should accept an ethereum address', () => {
+      expect(signatureVerifier.isValidSigningIdentity('0x2b8e7f6e8f0b6f4c6f8e2b8e7f6e8f0b6f4c6f8e')).to.equal(true);
+    });
+
+    it('should reject an arbitrary string', () => {
+      expect(signatureVerifier.isValidSigningIdentity('TrippleCore')).to.equal(false);
+    });
+
+    it('should reject a Flux ID whose checksum does not hold', () => {
+      expect(signatureVerifier.isValidSigningIdentity('1Jwh4djGdRPvgLwXNGsGCoPE7uu4vihbEh')).to.equal(false);
+    });
+
+    it('should reject a Flux ID carrying characters outside the base58 alphabet', () => {
+      expect(signatureVerifier.isValidSigningIdentity('1Jwh4djGdRPvgLwXNGsGC0PE7uu4vihbEg')).to.equal(false);
+    });
+
+    it('should reject an address that is too short or too long', () => {
+      expect(signatureVerifier.isValidSigningIdentity('1Jwh4djGdRPvg')).to.equal(false);
+      expect(signatureVerifier.isValidSigningIdentity('1Jwh4djGdRPvgLwXNGsGCoPE7uu4vihbEgZ12')).to.equal(false);
+    });
+
+    it('should reject an ethereum address of the wrong width', () => {
+      expect(signatureVerifier.isValidSigningIdentity('0x2b8e7f6e8f0b6f4c6f8e2b8e7f6e8f0b6f4c6f')).to.equal(false);
+    });
+
+    it('should reject a public key, which verifySignature accepts but no login can hold', () => {
+      expect(signatureVerifier.isValidSigningIdentity('04a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd5b8dec5235a0fa8722476c7709c02559e3aa73aa03918ba2d492eea75abea235')).to.equal(false);
+    });
+
+    it('should reject empty and non string input', () => {
+      expect(signatureVerifier.isValidSigningIdentity('')).to.equal(false);
+      expect(signatureVerifier.isValidSigningIdentity(undefined)).to.equal(false);
+      expect(signatureVerifier.isValidSigningIdentity(null)).to.equal(false);
+      expect(signatureVerifier.isValidSigningIdentity(12345)).to.equal(false);
+    });
+  });
+});


### PR DESCRIPTION
## The problem

**One signed update can burn an app permanently, and FluxOS accepts it.**

`owner` is the field that says who controls an app, and FluxOS only ever checked that it was a string — there is no address validation on it anywhere in the service tree.

Set it to a username, or to an address with one character mistyped, and the app is not transferred to anyone. It is destroyed. No private key in existence produces a signature that verifies against `"TrippleCore"`, so the app has no controller at all — not its former owner, not FluxOS, not us. It cannot be updated, renewed, restarted or reassigned by anybody. It keeps running until its paid time runs out, and then it is gone, along with its name and its data.

This is not theoretical. On 2026-08-14 a customer's app `satisfactory1785685226558` had its `owner` changed to the literal string `TrippleCore` by a signed update 27 minutes after registration. The app was healthy with 18 days of paid life left and nobody on earth could touch it.

**It was only recoverable by accident.** The marketplace branch of the update verifier lets the FluxSupportTeam key sign for any app whose name merely *contains* a number greater than `Date.parse('2020-01-01')`. `satisfactory1785685226558` qualifies because of its timestamp suffix, so we could re-sign the owner back. **An app without a big number in its name would have been unrecoverable** — there would have been no path at all.

A sweep of all 1060 live global specs found exactly one bad owner: this app. The nine `0x…` owners are legitimate EVM logins. So one casualty so far, one that happened to be saveable, and nothing stopping the next.

## Why registration is safe and update is not

| message | signature verified against | result for a garbage `owner` |
|---|---|---|
| `fluxappregister` | `appSpec.owner` — the owner **in the message** | impossible: no signature verifies against `"TrippleCore"` |
| `fluxappupdate` | `previousAppSpecs.owner` — the **old** owner | accepted: the new value is never used as a key |

Registration is protected only as a side effect of the owner doubling as the verification key. On update the incoming owner is pure payload — it is inside the signed bytes, so the customer genuinely authorised it, but nothing asks whether the value is an address.

## What this changes

`signatureVerifier.isValidSigningIdentity()` accepts what `verifySignature` can actually verify against: a Flux ID (`1…`, base58, **checksum decoded**) or a `0x` Ethereum address.

That rule is not new — it already existed inline in `idService`'s login path (`:259-272` on `development`) and nowhere else. It now lives once, beside the verifier it describes, and both login sites call it too.

The checksum is deliberate. An address one character off its own is exactly as unsignable as a username and produces the identical unrecoverable state, so shape alone is not enough.

## Why there is no fork height

The check applies to **live submissions only** — the five call sites passing `verifyAppSpecifications(spec, height, true)`, all API paths sitting below a "timestamp over 1 hour old" guard:

- `registryManager.js:1821` (`/apps/appregister`)
- `advancedWorkflows.js:2751` (`/apps/appupdate`)
- `appValidator.js:1388`, `:1456`, `:1611` (the verify-spec endpoints)

The four sites that pass nothing are gossip and chain replay — `messageStore.js:167,175` and `appHashSyncService.js:317,322` — and they are untouched.

A message being submitted right now is not history, so there is nothing to grandfather and no constant to carry forever. Applying the rule to the replay path instead would make a node syncing from scratch reject the height-2826803 message: `appHashSyncService.js` catches per-message, so it counts `failed += 1`, never inserts it, and never marks the hash — leaving that node permanently divergent from every peer that stored the message before this shipped.

Because the verify-spec endpoints are included, the frontend gets the error *before* it prompts for a signature. A user can no longer sign a message that orphans their app.

The residual is that a modified node could still gossip a bad owner in. That only lets someone brick their own app.

The third parameter of `verifyAppSpecifications` is renamed `checkDockerAndWhitelist` → `liveSubmission`, since it now gates two things and the old name would be wrong about one of them.

## Testing

Full ZelBack unit suite: **4883 passing, 0 failing, 18 pending**.

New `tests/unit/signatureVerifier.test.js` covers the predicate, including that a hex public key is rejected. `verifySignature` does accept one — but that branch exists for node-to-node messaging, where a FluxNode's identity is its collateral pubkey, and no login or app owner can ever be one.

Five new `appValidator` cases. The one that matters is the last: an owner of `"TrippleCore"` **still validates** when replayed without the live flag. That is the regression guard for chain history — if someone later moves this check, that test goes red.

Fixtures in `appValidator.test.js` and `idService.test.js` moved off placeholder strings (`1owner`, `1Z1234341Z…`) onto a synthetic but checksum-valid address. They were fake data that never represented an identity.

## Not in this PR

The marketplace fallback at `messageVerifier.js:269-278` is untouched. Its test for "is this a marketplace app" is only *does the app name contain a number greater than `Date.parse('2020-01-01')`*, which is most timestamp-suffixed deploys — genuinely too broad. But it is currently the only recovery path for an already-orphaned app, and it is what recovered this customer. It should not be narrowed without a replacement.

The equivalent fix for v1–v9 specs in `flux-spec` is written separately, on the same reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
