### PR TITLE
Refuse app installs onto ports another Flux node on the same IP already holds

### DIFF
--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -441,6 +441,9 @@ module.exports = {
     portTestPropagationDelayMs: 10000,
     portTestPeerTimeoutMs: 30000,
     portTestMaxAttempts: 5,
+    // Scan of other Flux nodes sharing our public IP. Short on purpose: these are LAN-adjacent
+    // hops, and a sibling that does not answer promptly is skipped rather than delaying an install.
+    sameIpScanTimeoutMs: 5000,
     spawnReconfirmDelayMs: 7500000,
     nonEnterpriseSpawnDelayMs: 120000,
     globalCmdDelayMs: 500,

--- a/ZelBack/src/services/appLifecycle/appSpawner.js
+++ b/ZelBack/src/services/appLifecycle/appSpawner.js
@@ -485,6 +485,10 @@ async function trySpawningGlobalApplication() {
 
     await portManager.ensureApplicationPortsNotUsed(appSpecifications, runningAppsNames);
 
+    // The check above derives a sibling's ports from its broadcast specification, which is blank
+    // for enterprise apps — so ask the other Flux nodes on this IP what they have actually bound.
+    await portManager.ensureSameIpPortsFree(appSpecifications, localSocketAddr, runningAppsOnThisIP);
+
     // Note: User-blocked port check happens earlier (line ~353) before Docker Hub calls
     // Check if ports are publicly available - critical for proper Flux network operation
     const portsPubliclyAvailable = await portManager.checkInstallingAppPortAvailable(appPorts);

--- a/ZelBack/src/services/appNetwork/portManager.js
+++ b/ZelBack/src/services/appNetwork/portManager.js
@@ -1,4 +1,5 @@
 const config = require('config');
+const crypto = require('node:crypto');
 const axios = require('axios');
 const dbHelper = require('../dbHelper');
 const fluxNetworkHelper = require('../fluxNetworkHelper');
@@ -188,6 +189,110 @@ async function assignedPortsGlobalApps(appNames) {
   });
 
   return appsWithPorts;
+}
+
+/**
+ * Ports actually published by Flux apps on OTHER Flux nodes sharing our public IP.
+ *
+ * `assignedPortsGlobalApps` derives a sibling's ports from its globally broadcast specification.
+ * For a v8 enterprise app that specification is blanked — `compose` is empty by design, so the app
+ * contributes no ports and is skipped entirely. Every enterprise app is therefore invisible to the
+ * same-IP collision check, which is how several apps holding the same ports end up on one address.
+ *
+ * A node's published host ports are not secret — they are already served by /apps/listrunningapps,
+ * which the redaction leaves intact precisely because ports are needed for routing. So ask the
+ * sibling what it has bound rather than trying to infer it from a spec we cannot read.
+ *
+ * Best effort: a sibling that does not answer is skipped rather than blocking the install, since
+ * the nonce-verified port test still has to pass afterwards.
+ *
+ * @param {string} ip Our public IP address.
+ * @param {number|string} ownApiPort Our own FluxOS API port, excluded from the scan.
+ * @param {Array<{ip: string}>} locations App locations already known for this IP, as
+ *   registryManager.getRunningAppIpList returns them (passed in to avoid a require cycle).
+ * @returns {Promise<Array<{name: string, ports: number[], apiPort: number}>>}
+ */
+async function assignedPortsSameIpNodes(ip, ownApiPort, locations = []) {
+  const siblingApiPorts = new Set();
+  locations.forEach((loc) => {
+    const apiPort = extractPort(loc.ip);
+    if (apiPort && Number(apiPort) !== Number(ownApiPort)) siblingApiPorts.add(Number(apiPort));
+  });
+
+  const found = [];
+
+  await Promise.all([...siblingApiPorts].map(async (apiPort) => {
+    const res = await serviceHelper.axiosGet(
+      `http://${ip}:${apiPort}/apps/listrunningapps`,
+      { timeout: config.fluxapps.sameIpScanTimeoutMs || 5_000 },
+    ).catch(() => null);
+
+    const containers = res && res.data && res.data.status === 'success' && Array.isArray(res.data.data)
+      ? res.data.data
+      : [];
+
+    containers.forEach((container) => {
+      const raw = String((container.Names || [])[0] || '').replace(/^\//, '').replace(/^(zel|flux)/, '');
+      const name = raw.includes('_') ? raw.split('_').slice(1).join('_') : raw;
+      const ports = [...new Set(
+        (container.Ports || []).map((entry) => Number(entry.PublicPort)).filter(Boolean),
+      )];
+      if (name && ports.length) found.push({ name, ports, apiPort });
+    });
+  }));
+
+  return found;
+}
+
+/**
+ * Refuse an install whose ports another Flux node on our own public IP has already published.
+ *
+ * Each node behind a shared address keeps its own app database and its own docker, so nothing in
+ * the per-node checks can see the conflict: every node binds the port successfully on its own
+ * network namespace, and only one of them ever receives the traffic the router forwards. The
+ * losers run permanently unreachable while still being broadcast to the network as live
+ * instances.
+ *
+ * @param {object} appSpecFormatted - App specifications
+ * @param {string} localSocketAddr - Our own "ip:port" socket address
+ * @param {Array<{ip: string}>} locations App locations already known for this IP
+ * @returns {Promise<boolean>} True when no sibling holds any of our ports
+ * @throws {Error} If a sibling node on this IP already publishes one of them
+ */
+async function ensureSameIpPortsFree(appSpecFormatted, localSocketAddr, locations = []) {
+  const ip = extractIp(localSocketAddr);
+  const ownApiPort = extractPort(localSocketAddr);
+  if (!ip) return true;
+
+  const siblings = await assignedPortsSameIpNodes(ip, ownApiPort, locations).catch((error) => {
+    log.warn(`ensureSameIpPortsFree - could not scan sibling nodes on ${ip}: ${error.message}`);
+    return [];
+  });
+  if (!siblings.length) return true;
+
+  const wanted = [];
+  if (appSpecFormatted.version === 1) {
+    if (appSpecFormatted.port) wanted.push(Number(appSpecFormatted.port));
+  } else if (appSpecFormatted.version <= 3) {
+    (appSpecFormatted.ports || []).forEach((port) => wanted.push(Number(port)));
+  } else {
+    (appSpecFormatted.compose || []).forEach((component) => {
+      (component.ports || []).forEach((port) => wanted.push(Number(port)));
+    });
+  }
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const port of wanted) {
+    const holder = siblings.find((sibling) => sibling.ports.includes(port));
+    // A different instance of the SAME app on a sibling node is a separate matter (instance
+    // placement), and rejecting it here would change existing behaviour, so only a different
+    // application counts as a conflict — mirroring ensureApplicationPortsNotUsed.
+    if (holder && holder.name !== appSpecFormatted.name) {
+      throw new Error(`Flux App ${appSpecFormatted.name} port ${port} is already published by ${holder.name} on Flux node ${ip}:${holder.apiPort} sharing this IP. Installation aborted.`);
+    }
+  }
+
+  return true;
 }
 
 /**
@@ -439,6 +544,10 @@ async function signCheckAppData(message) {
  */
 async function checkInstallingAppPortAvailable(portsToTest = []) {
   const beforeAppInstallTestingServers = [];
+  // One token for this whole test run. Peers echo it back from our test servers, which is what
+  // distinguishes "this port reaches us" from "this port is open at our address" — the two are the
+  // same thing only when we are the only Flux node behind our public IP. See isPortOwnedBy.
+  const portTestToken = crypto.randomBytes(16).toString('hex');
   const isUPNP = upnpService.isUPNP();
   let portsStatus = false;
   const portsNotWorking = new Set();
@@ -491,7 +600,7 @@ async function checkInstallingAppPortAvailable(portsToTest = []) {
           throw new Error('Failed to create map UPNP port');
         }
       }
-      const testHttpServer = new fluxHttpTestServer.FluxHttpTestServer();
+      const testHttpServer = new fluxHttpTestServer.FluxHttpTestServer(portTestToken);
 
       // eslint-disable-next-line no-await-in-loop
       await serviceHelper.delay(config.fluxapps.portTestBindDelayMs);
@@ -532,6 +641,7 @@ async function checkInstallingAppPortAvailable(portsToTest = []) {
       appname: 'appPortsTest',
       ports: portsToTest,
       pubKey,
+      portTestToken,
     };
     const stringData = JSON.stringify(data);
     // eslint-disable-next-line no-await-in-loop
@@ -743,7 +853,9 @@ module.exports = {
   ensureAppUniquePorts,
   assignedPortsInstalledApps,
   assignedPortsGlobalApps,
+  assignedPortsSameIpNodes,
   ensureApplicationPortsNotUsed,
+  ensureSameIpPortsFree,
   restoreFluxPortsSupport,
   restoreAppsPortsSupport,
   restorePortsSupport,

--- a/ZelBack/src/services/fluxNetworkHelper.js
+++ b/ZelBack/src/services/fluxNetworkHelper.js
@@ -321,6 +321,39 @@ async function isPortOpen(ip, port, options = {}) {
 }
 
 /**
+ * Check that a port not only answers, but answers as the node that asked us to test it.
+ *
+ * `isPortOpen` is a bare TCP connect, so it cannot tell "the requester's test server replied" from
+ * "some other process at that address replied". That distinction is invisible on a single-node
+ * host and decisive on a multi-node one: several Flux nodes commonly share one public IP behind a
+ * router that forwards each app port to exactly one of them. A node installing an app whose ports
+ * a sibling already holds gets a passing probe — the sibling answers — and installs an app that is
+ * unreachable from the moment it starts.
+ *
+ * The requester puts a random token on its pre-install test server; we fetch the port over HTTP and
+ * confirm that token comes back. Anything else answering means the address is not the requester's
+ * to use.
+ *
+ * @param {string} ip IP address.
+ * @param {number|string} port Port.
+ * @param {string} token Token the requester published on its test server.
+ * @param {object} options
+ * @returns {Promise<boolean>} True only when the port answered with this exact token.
+ */
+async function isPortOwnedBy(ip, port, token, options = {}) {
+  const timeout = options.timeout || 5_000;
+
+  const res = await serviceHelper.axiosGet(`http://${ip}:${port}/`, { timeout }).catch(() => null);
+  if (!res || !res.data) return false;
+
+  const answered = typeof res.data === 'string'
+    ? res.data
+    : ((res.data.data && res.data.data.token) || '');
+
+  return answered === token;
+}
+
+/**
  * To perform a basic check of current FluxOS version.
  * @param {string} ip IP address.
  * @param {string} port Port. Defaults to config.server.apiport.
@@ -415,7 +448,7 @@ async function checkAppAvailability(req, res) {
       const processedBody = serviceHelper.ensureObject(body);
 
       const {
-        ip, ports, pubKey, signature,
+        ip, ports, pubKey, signature, portTestToken,
       } = processedBody;
 
       const ipPort = processedBody.port;
@@ -439,8 +472,14 @@ async function checkAppAvailability(req, res) {
         const withinRange = portNum >= minPort && portNum <= maxPort;
 
         if (withinRange && !iBP) {
+          // A requester on a recent version publishes a token on its test server, which lets us
+          // prove the port reaches IT rather than merely being open at its address — see
+          // isPortOwnedBy. Requesters that send no token get the old reachability-only check, so
+          // older nodes keep working unchanged.
           // eslint-disable-next-line no-await-in-loop
-          const isOpen = await isPortOpen(ip, port);
+          const isOpen = portTestToken
+            ? await isPortOwnedBy(ip, port, portTestToken)
+            : await isPortOpen(ip, port);
           if (!isOpen) {
             throw new Error(`Flux Applications on ${ip}:${ipPort} are not available. Failed port: ${port}`);
           }
@@ -2341,6 +2380,7 @@ module.exports = {
   lruRateLimit,
   isPortOpen,
   checkAppAvailability,
+  isPortOwnedBy,
   isPortEnterprise,
   isPortBanned,
   isPortUPNPBanned,

--- a/ZelBack/src/services/utils/fluxHttpTestServer.js
+++ b/ZelBack/src/services/utils/fluxHttpTestServer.js
@@ -2,6 +2,19 @@ const http = require('node:http');
 
 class FluxHttpTestServer extends http.Server {
   /**
+   * Identity token echoed to any GET during a pre-install port test.
+   *
+   * A bare TCP connect proves only that SOMETHING answers on ip:port — not that it is us. Where
+   * several Flux nodes sit behind one public IP (a common multi-node setup), the router forwards
+   * the port to exactly one of them, so a peer probing our public IP can be talking to a sibling
+   * node's already-installed app while our own test server sits unreachable behind the same NAT.
+   * The probe passes, the install proceeds, and the app is born unreachable.
+   *
+   * Echoing a per-test nonce turns "the port is open" into "the port reaches ME", which is the
+   * property the caller actually needs.
+   */
+  #token = null;
+  /**
    * The reason this class is necessary is because we allow old nodeJS versions.
    * Anything after v18.2.0 we could just use closeAllConnections(), and this
    * class wouldn't be necessary.
@@ -12,8 +25,19 @@ class FluxHttpTestServer extends http.Server {
 
   #currentConnectionId = 0;
 
-  constructor() {
-    super(() => { });
+  constructor(token = null) {
+    super((req, res) => {
+      // Older peers do a bare TCP connect and never send a request; they are unaffected by this.
+      if (!this.#token) {
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end('flux');
+        return;
+      }
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ status: 'success', data: { token: this.#token } }));
+    });
+
+    this.#token = token;
 
     this.addListener('connection', (socket) => this.#handleConnection(socket));
   }


### PR DESCRIPTION
## Problem

Where several Flux nodes share one public IP — a common multi-node setup — FluxOS can install an app
onto ports a sibling node already publishes. The router forwards each port to exactly one node, so
any install after the first is unreachable from the moment it starts, and nothing reports it: the
container binds fine in its own network namespace, healthchecks pass, and the instance is broadcast
to the network as live.

Both guards miss it:

1. **`ensureApplicationPortsNotUsed`** resolves a sibling's ports from its broadcast specification. A
   v8 enterprise app's `compose` is blank by design, so it contributes no ports and is dropped by
   `if (appPorts.length > 0)` — every enterprise app is exempt. (`assignedPortsInstalledApps` is
   per-node by nature: separate database, separate docker daemon.)

2. **`checkAppAvailability`** probes with `isPortOpen`, a bare TCP connect. It cannot tell the
   requester's test server from anything else answering at that address, so the sibling's existing
   app answers and the check passes — *because* of the collision.

## Fix

Two independent layers; either one closes the observed case.

**Identity in the port test.** `FluxHttpTestServer` echoes a per-run nonce; the peer fetches the port
over HTTP and verifies it (`isPortOwnedBy`). "The port is open" becomes "the port reaches me". A
requester that sends no token gets the old behaviour, and a tokenless test server still answers a
bare TCP connect — older nodes unaffected in both directions.

**Sibling scan.** For each other Flux node on our own IP, read `/apps/listrunningapps` and treat
published `PublicPort`s as taken (`ensureSameIpPortsFree`). Works for enterprise apps because docker
reports real host ports regardless of spec redaction — no decryption, no protocol change, no new
disclosure. Best effort with a 5s timeout, since layer 1 still has to pass.

## Verification

```
sibling holds the port : isPortOpen=true  isPortOwnedBy=false   old passes, new rejects
our own test server    : isPortOwnedBy=true                     free port still installs
legacy (no token)      : isPortOpen=true                        older peers unaffected
```

The `portManager` and `fluxNetworkHelper` unit suites were **not run** — they require MongoDB, which
was unavailable here. `node --check` passes on all five files. Please run
`npm run test:zelback:unit` before merging.
